### PR TITLE
chore(proto/tests): normalize compose fixture formatting

### DIFF
--- a/proto/tests/fixtures/parser/docker-compose.override.yml
+++ b/proto/tests/fixtures/parser/docker-compose.override.yml
@@ -1,7 +1,7 @@
 services:
   web:
     ports:
-      - "127.0.0.1:8443:443"
+    - "127.0.0.1:8443:443"
     environment:
       SHARED: override
       DEBUG: "true"
@@ -9,4 +9,4 @@ services:
   app:
     privileged: true
     cap_add:
-      - NET_ADMIN
+    - NET_ADMIN

--- a/proto/tests/fixtures/parser/docker-compose.yml
+++ b/proto/tests/fixtures/parser/docker-compose.yml
@@ -2,15 +2,15 @@ services:
   web:
     image: nginx
     ports:
-      - "8080:80"
+    - "8080:80"
     environment:
       APP_ENV: production
       SHARED: base
     volumes:
-      - ./html:/usr/share/nginx/html:ro
+    - ./html:/usr/share/nginx/html:ro
 
   app:
     image: ghcr.io/example/app:1.0.0
     user: "1000:1000"
     env_file:
-      - .env
+    - .env

--- a/proto/tests/fixtures/report-scan.yml
+++ b/proto/tests/fixtures/report-scan.yml
@@ -2,7 +2,7 @@ services:
   vaultwarden:
     image: vaultwarden/server:latest
     ports:
-      - "80:80"
+    - "80:80"
     privileged: true
     environment:
       ADMIN_TOKEN: supersecret

--- a/proto/tests/fixtures/rules/exposure-risk.yml
+++ b/proto/tests/fixtures/rules/exposure-risk.yml
@@ -2,19 +2,19 @@ services:
   jellyfin:
     image: jellyfin/jellyfin:10.8.13
     ports:
-      - "0.0.0.0:8096:8096"
+    - "0.0.0.0:8096:8096"
 
   adminer:
     image: adminer:latest
     ports:
-      - "8080:8080"
+    - "8080:8080"
 
   vaultwarden:
     image: vaultwarden/server:1.30.1
     ports:
-      - "80:80"
+    - "80:80"
 
   redis:
     image: redis:7
     ports:
-      - "127.0.0.1:6379:6379"
+    - "127.0.0.1:6379:6379"

--- a/proto/tests/fixtures/rules/permissions-risk.yml
+++ b/proto/tests/fixtures/rules/permissions-risk.yml
@@ -20,16 +20,16 @@ services:
     image: example/socket:1.0
     user: "1000:1000"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+    - /var/run/docker.sock:/var/run/docker.sock
 
   host_home:
     image: example/home:1.0
     user: "1000:1000"
     volumes:
-      - /home/media:/data
+    - /home/media:/data
 
   safe:
     image: example/safe:1.0
     user: "1000:1000"
     volumes:
-      - ./data:/data
+    - ./data:/data

--- a/proto/tests/fixtures/rules/sensitive-risk/docker-compose.yml
+++ b/proto/tests/fixtures/rules/sensitive-risk/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   env_file_secret:
     image: ghcr.io/example/app:1.0.0
     env_file:
-      - .env
+    - .env
 
   safe:
     image: ghcr.io/example/safe:1.0.0

--- a/proto/tests/fixtures/safe-fix.yml
+++ b/proto/tests/fixtures/safe-fix.yml
@@ -2,9 +2,9 @@ services:
   web:
     image: nginx
     ports:
-      - "8080:80"
+    - "8080:80"
 
   app:
     image: ghcr.io/example/app:1.0.0
     ports:
-      - "127.0.0.1:9000:9000"
+    - "127.0.0.1:9000:9000"


### PR DESCRIPTION
## Summary
- align the prototype Docker Compose fixture files with the current YAML serialization style
- reduce formatting-only churn in `quick-fix` and `fix` previews so diffs emphasize real security changes
- keep the change limited to test fixtures with no rule or fix logic updates

## Testing
- `proto/.venv/bin/python -m pytest proto/tests`

Closes #37