### PR TITLE
docs(readme): fix Korean language switcher link

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,4 +1,4 @@
-English | **[한국어](README.ko.md)**
+**[English](README.md)** | 한국어
 
 # hostveil
 


### PR DESCRIPTION
## Summary
- make the Korean README point to the English README instead of linking back to itself
- keep the current-language label as plain text so the language switcher behaves as expected

## Testing
- not run (docs-only change)

Closes #46