### PR TITLE
feat(src/tui): add live discovery dashboard flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,10 @@ cargo test
 
 # Run the current Rust binary
 cargo run -- --help
+cargo run
+cargo run -- --json
+
+# Advanced overrides for targeted snapshots or fixtures
 cargo run -- --json --compose proto/tests/fixtures/parser/docker-compose.yml
 cargo run -- --json --host-root /
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -49,6 +49,10 @@ Jellyfin, Nextcloud, Vaultwarden, Gitea, Immich 등을 운영하는 셀프호스
 rustup default stable
 cargo build
 cargo run -- --help
+cargo run
+cargo run -- --json
+
+# 스냅샷/타깃 테스트용 고급 override
 cargo run -- --json --compose proto/tests/fixtures/parser/docker-compose.yml
 cargo run -- --json --host-root /
 ```
@@ -106,6 +110,7 @@ hostveil은 현재 초기 개발 단계입니다. 구현은 두 단계로 계획
 - override 병합과 정규화를 포함한 Compose parser 포팅 및 parity 테스트 추가
 - 기본 Compose 규칙 엔진과 점수화 모델을 Rust로 일부 포팅하고 fixture 테스트로 검증
 - `--host-root`를 통한 SSH posture 및 Docker host exposure 기본 점검 시작
+- 인자 없는 live scan이 host 스캔 + Docker 기반 Compose 자동 발견 + 현재 디렉터리 fallback으로 동작
 
 ## 기여
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Current Rust bootstrap setup from the repository root:
 rustup default stable
 cargo build
 cargo run -- --help
+cargo run
+cargo run -- --json
+
+# Advanced overrides for snapshots or targeted testing
 cargo run -- --json --compose proto/tests/fixtures/parser/docker-compose.yml
 cargo run -- --json --host-root /
 ```
@@ -106,6 +110,7 @@ Current Rust bootstrap status:
 - Compose parser ported with override merging and normalization parity tests
 - Native Compose rule engine and scoring model partially ported with Rust fixture tests
 - Native Linux host checks started for SSH posture and Docker host exposure via `--host-root`
+- No-arg live scan now defaults to host scanning plus Docker-based Compose auto-discovery, with current-directory Compose fallback
 
 ## Contributing
 

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,34 +1,82 @@
 app:
   name: "hostveil"
+  header:
+    subtitle: "Linux Self-Hosting Security Dashboard"
   status:
     bootstrap: "Rust bootstrap is ready; the real TUI and scan engine land next."
     no_target: "No scan target selected yet. Pass --compose PATH to validate the Rust parser pipeline."
     compose_loaded: "Loaded %{count} service(s) from %{path}"
     host_loaded: "Loaded host checks from %{path}"
     compose_and_host_loaded: "Loaded %{count} service(s) from %{path} with host checks enabled"
+    live_discovery: "Live scan: %{project_count} project(s) discovered with host checks enabled"
+    live_host_only: "Live scan: host-only mode"
+    live_docker_missing: "Live scan: Docker unavailable, host-only mode"
+    live_docker_denied: "Live scan: Docker permission denied, host-only mode"
+    live_docker_failed: "Live scan: Docker discovery failed, host-only mode"
   help:
     text: |
       hostveil
 
       Usage:
+        hostveil
+        hostveil --json
         hostveil [--compose PATH] [--host-root PATH] [--json]
         hostveil --help
 
       Options:
-        --compose PATH  parse a Compose file or directory through the Rust pipeline
-        --host-root PATH  inspect host configuration files from a Linux root or snapshot
-        --json          emit scan result JSON instead of launching the TUI
-        -h, --help      show this help message
+        --compose PATH    override live discovery with a specific Compose file or directory
+        --host-root PATH  override the default live host root (/) with a Linux root or snapshot
+        --json            emit scan result JSON instead of launching the TUI
+        -h, --help        show this help message
   hint:
     quit: "Press q or Esc to quit"
     json: "Use --json to inspect the current scan result structure"
+    open_findings: "Press Enter or Right to inspect findings"
+    switch_focus: "Press Tab, Left, or Right to switch focus"
+    list_move: "Use Arrow keys or j/k to move through findings"
+    detail_scroll: "Use Arrow keys, j/k, or PageUp/PageDown to scroll detail"
+    back_overview: "Press q or Esc to return to the overview"
+  footer:
+    quit: "quit"
+    findings: "open findings"
+    json: "export JSON"
   panel:
     status: "Status"
     hints: "Hints"
+    server_status: "Server Status"
+    scan_results: "Scan Results"
+    security_scores: "Security Scores"
+    fix_paths: "Fix Paths"
+    overview_score: "Overview Score"
+    overview_axes: "Axis Scores"
+    overview_activity: "Findings and Adapters"
+    overview_findings: "Top Findings"
     next_steps: "Next Steps"
     next_step_one: "Implement the generalized findings model and scan pipeline"
     next_step_two: "Port the Compose parser and rule engine into Rust"
     next_step_three: "Replace this placeholder with the real dashboard overview"
+    findings_list: "Findings"
+    findings_list_active: "Findings [list focus]"
+    finding_detail: "Detail"
+    finding_detail_active: "Detail [detail focus]"
+  overview:
+    score_caption: "Overall posture"
+    findings_available: "%{count} finding(s) available. Open the findings view for details."
+    no_findings: "No findings detected yet."
+    adapters_none: "No optional adapter status reported yet."
+  server:
+    host_name: "Host"
+    root_path: "Root"
+    docker_version: "Docker"
+    uptime: "Uptime"
+    load: "Load"
+    services_heading: "Services"
+    no_services: "No Compose services loaded yet."
+    no_image: "image unavailable"
+    more_services: "... and %{count} more service(s)"
+    not_scanned: "not scanned"
+    not_loaded: "not loaded"
+    not_available: "n/a"
   summary:
     title: "Current Scan Context"
     none: "No Compose target loaded"
@@ -50,6 +98,61 @@ app:
     io: "application error: %{message}"
     json_export_failed: "failed to serialize the current scan result"
     missing_translation: "missing translation for key: %{key}"
+  finding:
+    header: "Findings Detail"
+    status: "%{index}/%{count} selected | focus: %{focus}"
+    empty_status: "No findings are available yet"
+    empty_title: "No findings yet"
+    empty_description: "Run a scan target or wait for findings to appear."
+    focus_list: "list"
+    focus_detail: "detail"
+    subject_label: "Subject"
+    related_service_label: "Related Service"
+    description_label: "Description"
+    why_label: "Why Risky"
+    fix_label: "How to Fix"
+    evidence_label: "Evidence"
+    no_evidence: "No structured evidence for this finding."
+  result:
+    host_group: "Host"
+    ok: "OK"
+    none: "No grouped scan results yet."
+    single_finding: "1 finding"
+    multi_findings: "%{count} findings"
+    discovery_heading: "Discovery"
+    warnings_heading: "Warnings"
+    docker_available: "available"
+    docker_missing: "missing"
+    docker_permission_denied: "permission denied"
+    docker_failed: "failed: %{detail}"
+  fix:
+    none: "No remediation items are available yet."
+axis:
+  sensitive_data: "Sensitive Data"
+  permissions: "Permissions"
+  exposure: "Exposure"
+  updates: "Supply Chain"
+  host_hardening: "Host Hardening"
+severity:
+  critical: "Critical"
+  high: "High"
+  medium: "Medium"
+  low: "Low"
+scope:
+  service: "Service"
+  image: "Image"
+  host: "Host"
+  project: "Project"
+source:
+  native_compose: "Native Compose"
+  native_host: "Native Host"
+  trivy: "Trivy"
+  lynis: "Lynis"
+  dockle: "Dockle"
+adapter:
+  available: "available"
+  missing: "missing"
+  failed: "failed: %{detail}"
 finding:
   updates:
     latest:

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -1,6 +1,10 @@
-use crate::compose::ComposeParser;
-use crate::domain::ScanResult;
-use crate::host::{HostContext, HostScanner};
+use std::env;
+use std::path::{Path, PathBuf};
+
+use crate::compose::{ComposeParseError, ComposeParser, ComposeProject};
+use crate::discovery::{DockerDiscoveryResult, discover_running_compose_projects, project_summary};
+use crate::domain::{DiscoveredProjectSummary, ScanMode, ScanResult, ServiceSummary};
+use crate::host::{HostContext, HostScanner, collect_host_runtime_info};
 use crate::rules::RuleEngine;
 use crate::scoring;
 
@@ -10,42 +14,186 @@ pub fn run(config: &AppConfig) -> Result<ScanResult, AppError> {
     let mut result = ScanResult::default();
     let mut coverage = scoring::Coverage::default();
 
-    if let Some(path) = &config.compose_path {
-        let project = ComposeParser::parse_path(path)?;
-        let findings = RuleEngine.scan(&project);
+    if uses_live_discovery(config) {
+        run_live_scan(&mut result, &mut coverage)?;
+    } else {
+        result.metadata.scan_mode = ScanMode::Explicit;
 
-        result.metadata.compose_root = Some(project.working_dir.clone());
-        result.metadata.compose_file = Some(project.primary_file.clone());
-        result.metadata.loaded_files = project.loaded_files.clone();
-        result.metadata.service_count = project.services.len();
-        result.findings = findings;
-        coverage.compose = true;
-    }
+        if let Some(path) = &config.compose_path {
+            let project = ComposeParser::parse_path(path)?;
+            scan_compose_project(&project, &mut result);
+            coverage.compose = true;
+        }
 
-    if let Some(host_root) = &config.host_root {
-        let findings = HostScanner.scan(&HostContext {
-            root: host_root.clone(),
-        });
-
-        result.metadata.host_root = Some(host_root.clone());
-        result.findings.extend(findings);
-        coverage.host_hardening = true;
+        if let Some(host_root) = &config.host_root {
+            apply_host_scan(host_root.clone(), &mut result);
+            coverage.host_hardening = true;
+        }
     }
 
     result.score_report = scoring::build_score_report_with_coverage(&result.findings, coverage);
-
     Ok(result)
+}
+
+fn uses_live_discovery(config: &AppConfig) -> bool {
+    config.compose_path.is_none() && config.host_root.is_none()
+}
+
+fn run_live_scan(
+    result: &mut ScanResult,
+    coverage: &mut scoring::Coverage,
+) -> Result<(), AppError> {
+    result.metadata.scan_mode = ScanMode::Live;
+
+    let host_root = PathBuf::from("/");
+    apply_host_scan(host_root.clone(), result);
+    coverage.host_hardening = true;
+
+    let discovery = discover_running_compose_projects();
+    result.metadata.docker_status = Some(discovery.status.clone());
+    result.metadata.warnings.extend(discovery.warnings.clone());
+
+    if !discovery.projects.is_empty() {
+        apply_discovered_projects(&discovery, result, coverage)?;
+        if coverage.compose {
+            return Ok(());
+        }
+    }
+
+    apply_current_dir_fallback(result, coverage)
+}
+
+fn apply_discovered_projects(
+    discovery: &DockerDiscoveryResult,
+    result: &mut ScanResult,
+    coverage: &mut scoring::Coverage,
+) -> Result<(), AppError> {
+    for project in &discovery.projects {
+        result
+            .metadata
+            .discovered_projects
+            .push(project_summary(project));
+
+        if let Some(path) = &project.compose_path {
+            match ComposeParser::parse_path(path) {
+                Ok(parsed) => {
+                    scan_compose_project(&parsed, result);
+                    coverage.compose = true;
+                }
+                Err(error) => {
+                    result.metadata.warnings.push(format!(
+                        "Failed to parse discovered project {}: {}",
+                        project.name, error
+                    ));
+                }
+            }
+        } else {
+            result.metadata.warnings.push(format!(
+                "Discovered project {} has no usable compose path.",
+                project.name
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_current_dir_fallback(
+    result: &mut ScanResult,
+    coverage: &mut scoring::Coverage,
+) -> Result<(), AppError> {
+    let current_dir = env::current_dir()?;
+
+    match ComposeParser::parse_path(&current_dir) {
+        Ok(project) => {
+            let summary = DiscoveredProjectSummary {
+                name: project
+                    .primary_file
+                    .parent()
+                    .and_then(Path::file_name)
+                    .and_then(|value| value.to_str())
+                    .unwrap_or("current-directory")
+                    .to_owned(),
+                source: String::from("current_dir"),
+                compose_path: Some(project.primary_file.clone()),
+                working_dir: Some(project.working_dir.clone()),
+                service_count: project.services.len(),
+            };
+            result.metadata.discovered_projects.push(summary);
+            result.metadata.warnings.push(String::from(
+                "Using the current directory as a Compose fallback because no running Compose project was discovered.",
+            ));
+            scan_compose_project(&project, result);
+            coverage.compose = true;
+            Ok(())
+        }
+        Err(ComposeParseError::ComposeFileNotFound { .. }) => Ok(()),
+        Err(ComposeParseError::ComposePathMissing { .. }) => Ok(()),
+        Err(error) => {
+            result.metadata.warnings.push(format!(
+                "Current-directory Compose fallback failed: {error}"
+            ));
+            Ok(())
+        }
+    }
+}
+
+fn scan_compose_project(project: &ComposeProject, result: &mut ScanResult) {
+    let findings = RuleEngine.scan(project);
+
+    if result.metadata.compose_file.is_none() {
+        result.metadata.compose_file = Some(project.primary_file.clone());
+    }
+    if result.metadata.compose_root.is_none() {
+        result.metadata.compose_root = Some(project.working_dir.clone());
+    }
+
+    for file in &project.loaded_files {
+        if !result.metadata.loaded_files.contains(file) {
+            result.metadata.loaded_files.push(file.clone());
+        }
+    }
+
+    for service in project.services.values() {
+        if result
+            .metadata
+            .services
+            .iter()
+            .all(|existing| existing.name != service.name)
+        {
+            result.metadata.services.push(ServiceSummary {
+                name: service.name.clone(),
+                image: service.image.clone(),
+            });
+        }
+    }
+
+    result.metadata.service_count = result.metadata.services.len();
+    result.findings.extend(findings);
+}
+
+fn apply_host_scan(host_root: PathBuf, result: &mut ScanResult) {
+    let context = HostContext {
+        root: host_root.clone(),
+    };
+
+    result.metadata.host_root = Some(host_root);
+    result.metadata.host_runtime = Some(collect_host_runtime_info(&context));
+    result.findings.extend(HostScanner.scan(&context));
 }
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
-    use super::run;
-    use crate::app::{AppConfig, OutputMode};
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::domain::{DockerDiscoveryStatus, ScanMode};
+
+    use super::{apply_current_dir_fallback, run, scan_compose_project};
+    use crate::app::{AppConfig, OutputMode};
+    use crate::compose::ComposeParser;
 
     fn parser_fixture() -> std::path::PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -85,10 +233,13 @@ mod tests {
 
         let result = run(&config).expect("scan should succeed");
 
+        assert_eq!(result.metadata.scan_mode, ScanMode::Explicit);
         assert_eq!(result.metadata.service_count, 2);
         assert_eq!(result.metadata.loaded_files.len(), 2);
         assert!(result.metadata.compose_root.is_some());
         assert!(result.metadata.compose_file.is_some());
+        assert_eq!(result.metadata.services.len(), 2);
+        assert!(result.metadata.host_runtime.is_none());
         assert_eq!(result.findings.len(), 4);
         assert_eq!(
             result.score_report.axis_scores[&crate::domain::Axis::ExcessivePermissions],
@@ -100,10 +251,17 @@ mod tests {
     fn allows_bootstrap_without_scan_target() {
         let config = AppConfig::default();
 
-        let result = run(&config).expect("bootstrap without target should succeed");
+        let result = run(&config).expect("live scan should succeed even without Docker access");
 
-        assert_eq!(result.metadata.service_count, 0);
-        assert!(result.metadata.compose_file.is_none());
+        assert_eq!(result.metadata.scan_mode, ScanMode::Live);
+        assert!(result.metadata.host_root.is_some());
+        assert!(matches!(
+            result.metadata.docker_status,
+            Some(DockerDiscoveryStatus::Available)
+                | Some(DockerDiscoveryStatus::Missing)
+                | Some(DockerDiscoveryStatus::PermissionDenied)
+                | Some(DockerDiscoveryStatus::Failed(_))
+        ));
     }
 
     #[test]
@@ -112,6 +270,12 @@ mod tests {
         write_file(
             &host_root.join("etc/ssh/sshd_config"),
             "PermitRootLogin yes\nPasswordAuthentication yes\n",
+        );
+        write_file(&host_root.join("etc/hostname"), "home-server\n");
+        write_file(&host_root.join("proc/uptime"), "1221720.00 0.00\n");
+        write_file(
+            &host_root.join("proc/loadavg"),
+            "0.42 0.31 0.27 1/100 1234\n",
         );
         write_file(&host_root.join("var/run/docker.sock"), "socket");
         fs::set_permissions(
@@ -131,6 +295,30 @@ mod tests {
 
         assert_eq!(result.metadata.service_count, 2);
         assert_eq!(result.metadata.host_root, Some(host_root.clone()));
+        assert_eq!(
+            result
+                .metadata
+                .host_runtime
+                .as_ref()
+                .and_then(|info| info.hostname.as_deref()),
+            Some("home-server")
+        );
+        assert_eq!(
+            result
+                .metadata
+                .host_runtime
+                .as_ref()
+                .and_then(|info| info.uptime.as_deref()),
+            Some("14d 3h 22m")
+        );
+        assert_eq!(
+            result
+                .metadata
+                .host_runtime
+                .as_ref()
+                .and_then(|info| info.load_average.as_deref()),
+            Some("0.42 0.31 0.27")
+        );
         assert!(
             result
                 .findings
@@ -146,5 +334,62 @@ mod tests {
         assert!(result.score_report.axis_scores[&crate::domain::Axis::HostHardening] < 100);
 
         fs::remove_dir_all(host_root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn current_dir_fallback_loads_compose_project_when_docker_finds_nothing() {
+        let temp_dir = temp_host_root("cwd-fallback");
+        write_file(
+            &temp_dir.join("docker-compose.yml"),
+            concat!(
+                "services:\n",
+                "  demo:\n",
+                "    image: nginx:1.27.5\n",
+                "    ports:\n",
+                "      - \"8080:80\"\n"
+            ),
+        );
+
+        let previous_dir = std::env::current_dir().expect("cwd should be available");
+        std::env::set_current_dir(&temp_dir).expect("cwd should change");
+
+        let mut result = crate::domain::ScanResult::default();
+        let mut coverage = crate::scoring::Coverage::default();
+        apply_current_dir_fallback(&mut result, &mut coverage).expect("fallback should succeed");
+
+        std::env::set_current_dir(previous_dir).expect("cwd should be restored");
+
+        assert!(coverage.compose);
+        assert_eq!(result.metadata.service_count, 1);
+        assert_eq!(result.metadata.discovered_projects.len(), 1);
+        assert_eq!(result.metadata.discovered_projects[0].source, "current_dir");
+
+        fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn compose_projects_can_be_accumulated_from_multiple_sources() {
+        let first =
+            ComposeParser::parse_path(parser_fixture()).expect("first project should parse");
+        let second_dir = temp_host_root("second-compose");
+        write_file(
+            &second_dir.join("docker-compose.yml"),
+            concat!(
+                "services:\n",
+                "  worker:\n",
+                "    image: busybox:1.36\n",
+                "    user: 1000:1000\n"
+            ),
+        );
+        let second = ComposeParser::parse_path(&second_dir).expect("second project should parse");
+
+        let mut result = crate::domain::ScanResult::default();
+        scan_compose_project(&first, &mut result);
+        scan_compose_project(&second, &mut result);
+
+        assert_eq!(result.metadata.service_count, 3);
+        assert_eq!(result.metadata.loaded_files.len(), 3);
+
+        fs::remove_dir_all(second_dir).expect("temp dir should be removed");
     }
 }

--- a/src/src/discovery/docker.rs
+++ b/src/src/discovery/docker.rs
@@ -1,0 +1,230 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::domain::{DiscoveredProjectSummary, DockerDiscoveryStatus};
+
+const DOCKER_PS_FORMAT: &str = "{{.Label \"com.docker.compose.project\"}}\t{{.Label \"com.docker.compose.service\"}}\t{{.Label \"com.docker.compose.project.working_dir\"}}\t{{.Label \"com.docker.compose.project.config_files\"}}\t{{.Image}}";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredContainerService {
+    pub name: String,
+    pub image: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredComposeProject {
+    pub name: String,
+    pub compose_path: Option<PathBuf>,
+    pub working_dir: Option<PathBuf>,
+    pub services: Vec<DiscoveredContainerService>,
+    pub source: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DockerDiscoveryResult {
+    pub status: DockerDiscoveryStatus,
+    pub projects: Vec<DiscoveredComposeProject>,
+    pub warnings: Vec<String>,
+}
+
+pub fn discover_running_compose_projects() -> DockerDiscoveryResult {
+    let output = match Command::new("docker")
+        .args(["ps", "--format", DOCKER_PS_FORMAT])
+        .output()
+    {
+        Ok(output) => output,
+        Err(_) => {
+            return DockerDiscoveryResult {
+                status: DockerDiscoveryStatus::Missing,
+                projects: Vec::new(),
+                warnings: vec![String::from(
+                    "Docker CLI is not available; switching to fallback discovery.",
+                )],
+            };
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        let status = if is_permission_denied(&stderr) {
+            DockerDiscoveryStatus::PermissionDenied
+        } else {
+            DockerDiscoveryStatus::Failed(stderr.clone())
+        };
+        return DockerDiscoveryResult {
+            status,
+            projects: Vec::new(),
+            warnings: vec![if stderr.is_empty() {
+                String::from("Docker discovery failed; switching to fallback discovery.")
+            } else {
+                format!("Docker discovery failed: {stderr}")
+            }],
+        };
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let projects = parse_docker_ps_output(&stdout);
+    let warnings = if projects.is_empty() {
+        vec![String::from(
+            "No running Compose projects were discovered from Docker; checking the current directory.",
+        )]
+    } else {
+        Vec::new()
+    };
+
+    DockerDiscoveryResult {
+        status: DockerDiscoveryStatus::Available,
+        projects,
+        warnings,
+    }
+}
+
+pub fn parse_docker_ps_output(output: &str) -> Vec<DiscoveredComposeProject> {
+    let mut projects = BTreeMap::<String, DiscoveredComposeProject>::new();
+
+    for raw_line in output.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let mut fields = line.splitn(5, '\t');
+        let project_name = fields.next().unwrap_or_default().trim();
+        let service_name = fields.next().unwrap_or_default().trim();
+        let working_dir = normalize_optional_path(fields.next().unwrap_or_default());
+        let config_files = fields.next().unwrap_or_default().trim();
+        let image = normalize_optional_string(fields.next().unwrap_or_default());
+
+        if project_name.is_empty() || service_name.is_empty() {
+            continue;
+        }
+
+        let compose_path = discover_compose_path(config_files, working_dir.as_deref());
+        let project =
+            projects
+                .entry(project_name.to_owned())
+                .or_insert_with(|| DiscoveredComposeProject {
+                    name: project_name.to_owned(),
+                    compose_path: compose_path.clone(),
+                    working_dir: working_dir.clone(),
+                    services: Vec::new(),
+                    source: "docker",
+                });
+
+        if project.compose_path.is_none() {
+            project.compose_path = compose_path;
+        }
+        if project.working_dir.is_none() {
+            project.working_dir = working_dir.clone();
+        }
+        if project
+            .services
+            .iter()
+            .all(|service| service.name != service_name)
+        {
+            project.services.push(DiscoveredContainerService {
+                name: service_name.to_owned(),
+                image,
+            });
+        }
+    }
+
+    projects.into_values().collect()
+}
+
+pub fn project_summary(project: &DiscoveredComposeProject) -> DiscoveredProjectSummary {
+    DiscoveredProjectSummary {
+        name: project.name.clone(),
+        source: project.source.to_owned(),
+        compose_path: project.compose_path.clone(),
+        working_dir: project.working_dir.clone(),
+        service_count: project.services.len(),
+    }
+}
+
+fn discover_compose_path(config_files: &str, working_dir: Option<&Path>) -> Option<PathBuf> {
+    let first_config = config_files
+        .split(',')
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(PathBuf::from);
+
+    if first_config.is_some() {
+        return first_config;
+    }
+
+    working_dir.map(Path::to_path_buf)
+}
+
+fn normalize_optional_path(value: &str) -> Option<PathBuf> {
+    normalize_optional_string(value).map(PathBuf::from)
+}
+
+fn normalize_optional_string(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
+}
+
+fn is_permission_denied(stderr: &str) -> bool {
+    let lowered = stderr.to_ascii_lowercase();
+    lowered.contains("permission denied") || lowered.contains("cannot connect to the docker daemon")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn groups_running_services_into_projects() {
+        let output = concat!(
+            "vaultwarden\tapp\t/srv/vw\t/srv/vw/docker-compose.yml\tvaultwarden/server:1.30.1\n",
+            "vaultwarden\tbackup\t/srv/vw\t/srv/vw/docker-compose.yml\tbusybox:1.36\n",
+            "gitea\tweb\t/srv/gitea\t\tgitea/gitea:1.21\n",
+            "\t\t\t\tnginx:latest\n"
+        );
+
+        let projects = parse_docker_ps_output(output);
+
+        assert_eq!(projects.len(), 2);
+        assert_eq!(projects[0].name, "gitea");
+        assert_eq!(projects[0].services.len(), 1);
+        assert_eq!(projects[0].compose_path, Some(PathBuf::from("/srv/gitea")));
+        assert_eq!(projects[1].name, "vaultwarden");
+        assert_eq!(projects[1].services.len(), 2);
+        assert_eq!(
+            projects[1].compose_path,
+            Some(PathBuf::from("/srv/vw/docker-compose.yml"))
+        );
+    }
+
+    #[test]
+    fn project_summary_captures_display_data() {
+        let project = DiscoveredComposeProject {
+            name: String::from("nextcloud"),
+            compose_path: Some(PathBuf::from("/srv/nextcloud/docker-compose.yml")),
+            working_dir: Some(PathBuf::from("/srv/nextcloud")),
+            services: vec![DiscoveredContainerService {
+                name: String::from("app"),
+                image: Some(String::from("nextcloud:27.1.2")),
+            }],
+            source: "docker",
+        };
+
+        let summary = project_summary(&project);
+
+        assert_eq!(summary.name, "nextcloud");
+        assert_eq!(summary.source, "docker");
+        assert_eq!(summary.service_count, 1);
+    }
+
+    #[test]
+    fn detects_permission_denied_errors() {
+        assert!(is_permission_denied(
+            "permission denied while trying to connect to the Docker daemon socket"
+        ));
+        assert!(is_permission_denied(
+            "Cannot connect to the Docker daemon at unix:///var/run/docker.sock"
+        ));
+    }
+}

--- a/src/src/discovery/mod.rs
+++ b/src/src/discovery/mod.rs
@@ -1,0 +1,6 @@
+mod docker;
+
+pub use docker::{
+    DiscoveredComposeProject, DiscoveredContainerService, DockerDiscoveryResult,
+    discover_running_compose_projects, parse_docker_ps_output, project_summary,
+};

--- a/src/src/domain/mod.rs
+++ b/src/src/domain/mod.rs
@@ -106,6 +106,46 @@ pub struct ScoreReport {
     pub severity_counts: BTreeMap<Severity, usize>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ServiceSummary {
+    pub name: String,
+    pub image: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+pub struct HostRuntimeInfo {
+    pub hostname: Option<String>,
+    pub docker_version: Option<String>,
+    pub uptime: Option<String>,
+    pub load_average: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ScanMode {
+    #[default]
+    Explicit,
+    Live,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", content = "detail", rename_all = "snake_case")]
+pub enum DockerDiscoveryStatus {
+    Available,
+    Missing,
+    PermissionDenied,
+    Failed(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+pub struct DiscoveredProjectSummary {
+    pub name: String,
+    pub source: String,
+    pub compose_path: Option<PathBuf>,
+    pub working_dir: Option<PathBuf>,
+    pub service_count: usize,
+}
+
 impl Default for ScoreReport {
     fn default() -> Self {
         let axis_scores = Axis::ALL.into_iter().map(|axis| (axis, 100)).collect();
@@ -132,11 +172,17 @@ pub enum AdapterStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub struct ScanMetadata {
+    pub scan_mode: ScanMode,
     pub compose_root: Option<PathBuf>,
     pub compose_file: Option<PathBuf>,
     pub host_root: Option<PathBuf>,
+    pub host_runtime: Option<HostRuntimeInfo>,
     pub loaded_files: Vec<PathBuf>,
     pub service_count: usize,
+    pub services: Vec<ServiceSummary>,
+    pub discovered_projects: Vec<DiscoveredProjectSummary>,
+    pub docker_status: Option<DockerDiscoveryStatus>,
+    pub warnings: Vec<String>,
     pub adapters: BTreeMap<String, AdapterStatus>,
 }
 

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -2,10 +2,11 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use serde_json::Value as JsonValue;
 
-use crate::domain::{Axis, Finding, RemediationKind, Scope, Severity, Source};
+use crate::domain::{Axis, Finding, HostRuntimeInfo, RemediationKind, Scope, Severity, Source};
 
 const SSH_CONFIG_PATH: &str = "etc/ssh/sshd_config";
 const DOCKER_DAEMON_CONFIG_PATH: &str = "etc/docker/daemon.json";
@@ -33,6 +34,15 @@ impl HostScanner {
         findings.extend(scan_ssh_hardening(context));
         findings.extend(scan_docker_host_exposure(context));
         findings
+    }
+}
+
+pub fn collect_host_runtime_info(context: &HostContext) -> HostRuntimeInfo {
+    HostRuntimeInfo {
+        hostname: read_hostname(&context.root),
+        docker_version: discover_docker_version(&context.root),
+        uptime: read_uptime(&context.root),
+        load_average: read_load_average(&context.root),
     }
 }
 
@@ -260,6 +270,102 @@ fn resolve_existing_path(root: &Path, relative: &str) -> Option<PathBuf> {
     path.exists().then_some(path)
 }
 
+fn read_hostname(root: &Path) -> Option<String> {
+    let path = resolve_existing_path(root, "etc/hostname")?;
+    let content = fs::read_to_string(path).ok()?;
+    let trimmed = content.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
+}
+
+fn read_uptime(root: &Path) -> Option<String> {
+    let path = resolve_existing_path(root, "proc/uptime")?;
+    let content = fs::read_to_string(path).ok()?;
+    let seconds = parse_uptime_seconds(&content)?;
+    Some(format_uptime(seconds))
+}
+
+fn read_load_average(root: &Path) -> Option<String> {
+    let path = resolve_existing_path(root, "proc/loadavg")?;
+    let content = fs::read_to_string(path).ok()?;
+    parse_load_average(&content)
+}
+
+fn parse_uptime_seconds(content: &str) -> Option<u64> {
+    let seconds = content.split_whitespace().next()?.parse::<f64>().ok()?;
+    Some(seconds.floor() as u64)
+}
+
+fn format_uptime(seconds: u64) -> String {
+    let days = seconds / 86_400;
+    let hours = (seconds % 86_400) / 3_600;
+    let minutes = (seconds % 3_600) / 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h {minutes}m")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else {
+        format!("{minutes}m")
+    }
+}
+
+fn parse_load_average(content: &str) -> Option<String> {
+    let parts = content
+        .split_whitespace()
+        .take(3)
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    (parts.len() == 3).then(|| parts.join(" "))
+}
+
+fn discover_docker_version(root: &Path) -> Option<String> {
+    if !is_live_root(root) {
+        return None;
+    }
+
+    try_command(&["docker", "version", "--format", "{{.Server.Version}}"])
+        .filter(|value| !value.contains("{{"))
+        .or_else(|| {
+            try_command(&["docker", "--version"])
+                .and_then(|output| parse_docker_version_output(&output))
+        })
+        .or_else(|| {
+            try_command(&["dockerd", "--version"])
+                .and_then(|output| parse_docker_version_output(&output))
+        })
+}
+
+fn try_command(command: &[&str]) -> Option<String> {
+    let (program, args) = command.split_first()?;
+    let output = Command::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    (!stdout.is_empty()).then_some(stdout)
+}
+
+fn parse_docker_version_output(output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some((_, rest)) = trimmed.split_once("Docker version ") {
+        let version = rest.split(',').next()?.trim();
+        return (!version.is_empty()).then(|| version.to_owned());
+    }
+
+    Some(trimmed.to_owned())
+}
+
+fn is_live_root(root: &Path) -> bool {
+    root.canonicalize()
+        .map(|path| path == Path::new("/"))
+        .unwrap_or(false)
+}
+
 fn parse_sshd_config(path: &Path) -> std::io::Result<BTreeMap<String, String>> {
     let mut settings = BTreeMap::new();
     let content = fs::read_to_string(path)?;
@@ -421,6 +527,35 @@ mod tests {
         assert!(findings.is_empty());
 
         fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn collects_runtime_info_from_host_snapshot() {
+        let root = temp_host_root("runtime");
+        write_file(&root.join("etc/hostname"), "home-server\n");
+        write_file(&root.join("proc/uptime"), "1221720.00 0.00\n");
+        write_file(&root.join("proc/loadavg"), "0.42 0.31 0.27 1/100 1234\n");
+
+        let info = collect_host_runtime_info(&HostContext { root: root.clone() });
+
+        assert_eq!(info.hostname.as_deref(), Some("home-server"));
+        assert_eq!(info.uptime.as_deref(), Some("14d 3h 22m"));
+        assert_eq!(info.load_average.as_deref(), Some("0.42 0.31 0.27"));
+        assert!(info.docker_version.is_none());
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn parses_docker_version_output() {
+        assert_eq!(
+            super::parse_docker_version_output("Docker version 26.1.4, build deadbeef\n"),
+            Some(String::from("26.1.4"))
+        );
+        assert_eq!(
+            super::parse_docker_version_output("27.0.3\n"),
+            Some(String::from("27.0.3"))
+        );
     }
 
     #[test]

--- a/src/src/lib.rs
+++ b/src/src/lib.rs
@@ -6,6 +6,7 @@ i18n!("locales", fallback = "en");
 pub mod adapters;
 pub mod app;
 pub mod compose;
+pub mod discovery;
 pub mod domain;
 pub mod export;
 pub mod fix;

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -1,30 +1,122 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::io;
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Constraint, Direction, Layout};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Text};
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
 
-use crate::domain::ScanResult;
+use crate::domain::{
+    Axis, DockerDiscoveryStatus, Finding, RemediationKind, ScanMode, ScanResult, Scope, Severity,
+    Source,
+};
 use crate::i18n;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Screen {
+    Overview,
+    Findings,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FindingsFocus {
+    List,
+    Detail,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct BootstrapCopy {
-    title: String,
-    status: String,
-    summary_title: String,
-    summary_lines: Vec<String>,
-    quit_hint: String,
-    json_hint: String,
-    next_steps_title: String,
-    next_steps: [String; 3],
+struct AppState {
+    screen: Screen,
+    findings_focus: FindingsFocus,
+    selected_index: usize,
+    detail_scroll: u16,
+    sorted_indices: Vec<usize>,
+}
+
+impl AppState {
+    fn new(scan_result: &ScanResult) -> Self {
+        Self {
+            screen: Screen::Overview,
+            findings_focus: FindingsFocus::List,
+            selected_index: 0,
+            detail_scroll: 0,
+            sorted_indices: sorted_finding_indices(scan_result),
+        }
+    }
+
+    fn finding_count(&self) -> usize {
+        self.sorted_indices.len()
+    }
+
+    fn selected_finding<'a>(&self, scan_result: &'a ScanResult) -> Option<&'a Finding> {
+        self.sorted_indices
+            .get(self.selected_index)
+            .and_then(|index| scan_result.findings.get(*index))
+    }
+
+    fn open_findings(&mut self) {
+        self.screen = Screen::Findings;
+        self.findings_focus = FindingsFocus::List;
+        self.detail_scroll = 0;
+    }
+
+    fn return_to_overview(&mut self) {
+        self.screen = Screen::Overview;
+        self.findings_focus = FindingsFocus::List;
+        self.detail_scroll = 0;
+    }
+
+    fn select_next(&mut self) {
+        if self.finding_count() > 1 {
+            self.selected_index = (self.selected_index + 1).min(self.finding_count() - 1);
+            self.detail_scroll = 0;
+        }
+    }
+
+    fn select_previous(&mut self) {
+        if self.finding_count() > 1 {
+            self.selected_index = self.selected_index.saturating_sub(1);
+            self.detail_scroll = 0;
+        }
+    }
+
+    fn scroll_detail_down(&mut self, amount: u16) {
+        self.detail_scroll = self.detail_scroll.saturating_add(amount);
+    }
+
+    fn scroll_detail_up(&mut self, amount: u16) {
+        self.detail_scroll = self.detail_scroll.saturating_sub(amount);
+    }
+
+    fn focus_list(&mut self) {
+        self.findings_focus = FindingsFocus::List;
+    }
+
+    fn focus_detail(&mut self) {
+        self.findings_focus = FindingsFocus::Detail;
+    }
+
+    fn toggle_focus(&mut self) {
+        self.findings_focus = match self.findings_focus {
+            FindingsFocus::List => FindingsFocus::Detail,
+            FindingsFocus::Detail => FindingsFocus::List,
+        };
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResultSummaryRow {
+    label: String,
+    severity: Option<Severity>,
+    count: usize,
 }
 
 pub fn run(scan_result: &ScanResult) -> io::Result<()> {
@@ -34,8 +126,9 @@ pub fn run(scan_result: &ScanResult) -> io::Result<()> {
 
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
+    let mut state = AppState::new(scan_result);
 
-    let result = run_event_loop(&mut terminal, scan_result);
+    let result = run_event_loop(&mut terminal, scan_result, &mut state);
 
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
@@ -47,107 +140,775 @@ pub fn run(scan_result: &ScanResult) -> io::Result<()> {
 fn run_event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     scan_result: &ScanResult,
+    state: &mut AppState,
 ) -> io::Result<()> {
-    let copy = bootstrap_copy(scan_result);
-
     loop {
-        terminal.draw(|frame| render_bootstrap(frame, &copy))?;
+        terminal.draw(|frame| render(frame, scan_result, state))?;
 
         if let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
-            && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
+            && handle_key(state, key)
         {
             return Ok(());
         }
     }
 }
 
-fn render_bootstrap(frame: &mut ratatui::Frame<'_>, copy: &BootstrapCopy) {
-    let layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(5),
-            Constraint::Length(6),
-            Constraint::Min(6),
-            Constraint::Length(4),
-        ])
-        .split(frame.area());
-
-    let header = Paragraph::new(Text::from(vec![
-        Line::styled(
-            copy.title.as_str(),
-            Style::default().add_modifier(Modifier::BOLD),
-        ),
-        Line::raw(copy.status.as_str()),
-    ]))
-    .block(
-        Block::default()
-            .title(i18n::tr("app.panel.status"))
-            .borders(Borders::ALL),
-    )
-    .wrap(Wrap { trim: true });
-
-    let summary = Paragraph::new(Text::from(
-        copy.summary_lines
-            .iter()
-            .map(|line| Line::raw(line.as_str()))
-            .collect::<Vec<_>>(),
-    ))
-    .block(
-        Block::default()
-            .title(copy.summary_title.as_str())
-            .borders(Borders::ALL),
-    )
-    .wrap(Wrap { trim: true });
-
-    let body = Paragraph::new(Text::from(vec![
-        Line::styled(
-            copy.next_steps_title.as_str(),
-            Style::default().add_modifier(Modifier::BOLD),
-        ),
-        Line::raw(""),
-        Line::raw(format!("1. {}", copy.next_steps[0])),
-        Line::raw(format!("2. {}", copy.next_steps[1])),
-        Line::raw(format!("3. {}", copy.next_steps[2])),
-    ]))
-    .block(Block::default().borders(Borders::ALL))
-    .wrap(Wrap { trim: true });
-
-    let footer = Paragraph::new(Text::from(vec![
-        Line::raw(copy.quit_hint.as_str()),
-        Line::raw(copy.json_hint.as_str()),
-    ]))
-    .block(
-        Block::default()
-            .title(i18n::tr("app.panel.hints"))
-            .borders(Borders::ALL),
-    )
-    .wrap(Wrap { trim: true });
-
-    frame.render_widget(header, layout[0]);
-    frame.render_widget(summary, layout[1]);
-    frame.render_widget(body, layout[2]);
-    frame.render_widget(footer, layout[3]);
-}
-
-fn bootstrap_copy(scan_result: &ScanResult) -> BootstrapCopy {
-    BootstrapCopy {
-        title: i18n::tr("app.name"),
-        status: compose_status(scan_result),
-        summary_title: i18n::tr("app.summary.title"),
-        summary_lines: compose_summary_lines(scan_result),
-        quit_hint: i18n::tr("app.hint.quit"),
-        json_hint: i18n::tr("app.hint.json"),
-        next_steps_title: i18n::tr("app.panel.next_steps"),
-        next_steps: [
-            i18n::tr("app.panel.next_step_one"),
-            i18n::tr("app.panel.next_step_two"),
-            i18n::tr("app.panel.next_step_three"),
-        ],
+fn handle_key(state: &mut AppState, key: KeyEvent) -> bool {
+    match state.screen {
+        Screen::Overview => handle_overview_key(state, key),
+        Screen::Findings => handle_findings_key(state, key),
     }
 }
 
+fn handle_overview_key(state: &mut AppState, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => true,
+        KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
+            state.open_findings();
+            false
+        }
+        _ => false,
+    }
+}
+
+fn handle_findings_key(state: &mut AppState, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => {
+            state.return_to_overview();
+            false
+        }
+        KeyCode::Tab => {
+            state.toggle_focus();
+            false
+        }
+        KeyCode::Left | KeyCode::Char('h') => {
+            state.focus_list();
+            false
+        }
+        KeyCode::Right | KeyCode::Char('l') | KeyCode::Enter => {
+            state.focus_detail();
+            false
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            match state.findings_focus {
+                FindingsFocus::List => state.select_next(),
+                FindingsFocus::Detail => state.scroll_detail_down(1),
+            }
+            false
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            match state.findings_focus {
+                FindingsFocus::List => state.select_previous(),
+                FindingsFocus::Detail => state.scroll_detail_up(1),
+            }
+            false
+        }
+        KeyCode::PageDown => {
+            state.scroll_detail_down(8);
+            false
+        }
+        KeyCode::PageUp => {
+            state.scroll_detail_up(8);
+            false
+        }
+        _ => false,
+    }
+}
+
+fn render(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, state: &AppState) {
+    match state.screen {
+        Screen::Overview => render_overview(frame, scan_result),
+        Screen::Findings => render_findings(frame, scan_result, state),
+    }
+}
+
+fn render_overview(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(12),
+            Constraint::Length(2),
+        ])
+        .split(frame.area());
+
+    let dashboard = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(layout[1]);
+
+    let top_row = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(dashboard[0]);
+
+    let bottom_row = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(dashboard[1]);
+
+    frame.render_widget(header_banner(), layout[0]);
+    render_server_status_panel(frame, top_row[0], scan_result);
+    render_scan_results_panel(frame, top_row[1], scan_result);
+    render_security_scores_panel(frame, bottom_row[0], scan_result);
+    render_fix_paths_panel(frame, bottom_row[1], scan_result);
+    frame.render_widget(overview_footer(), layout[2]);
+}
+
+fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, state: &AppState) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(10),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+    let content = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(layout[1]);
+
+    frame.render_widget(findings_header(scan_result, state), layout[0]);
+
+    let mut list_state = ListState::default();
+    if state.finding_count() > 0 {
+        list_state.select(Some(state.selected_index));
+    }
+
+    let list = List::new(findings_list_items(scan_result))
+        .block(
+            Block::default()
+                .title(findings_list_title(state.findings_focus))
+                .borders(Borders::ALL)
+                .border_style(focus_border_style(
+                    state.findings_focus == FindingsFocus::List,
+                )),
+        )
+        .highlight_symbol("> ")
+        .highlight_style(Style::default().bg(Color::DarkGray));
+
+    let detail = Paragraph::new(finding_detail_text(scan_result, state))
+        .block(
+            Block::default()
+                .title(findings_detail_title(state.findings_focus))
+                .borders(Borders::ALL)
+                .border_style(focus_border_style(
+                    state.findings_focus == FindingsFocus::Detail,
+                )),
+        )
+        .wrap(Wrap { trim: true })
+        .scroll((state.detail_scroll, 0));
+
+    frame.render_stateful_widget(list, content[0], &mut list_state);
+    frame.render_widget(detail, content[1]);
+    frame.render_widget(findings_footer(state.findings_focus), layout[2]);
+}
+
+fn header_banner() -> Paragraph<'static> {
+    Paragraph::new(Text::from(Line::from(vec![
+        Span::styled(
+            format!("hostveil v{}", env!("CARGO_PKG_VERSION")),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" | "),
+        Span::styled(
+            t!("app.header.subtitle").into_owned(),
+            Style::default().fg(Color::White),
+        ),
+    ])))
+    .alignment(Alignment::Center)
+    .block(Block::default().borders(Borders::TOP | Borders::BOTTOM))
+}
+
+fn render_server_status_panel(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    scan_result: &ScanResult,
+) {
+    let mut lines = vec![
+        kv_line(
+            t!("app.server.host_name").into_owned(),
+            display_hostname(scan_result),
+        ),
+        kv_line(
+            t!("app.server.root_path").into_owned(),
+            display_host_root(scan_result),
+        ),
+        kv_line(
+            t!("app.server.docker_version").into_owned(),
+            display_docker_version(scan_result),
+        ),
+        kv_line(
+            t!("app.server.uptime").into_owned(),
+            display_uptime(scan_result),
+        ),
+        load_line(scan_result),
+        Line::raw(String::new()),
+        Line::styled(
+            t!("app.server.services_heading").into_owned(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ];
+
+    if scan_result.metadata.services.is_empty() {
+        lines.push(Line::raw(t!("app.server.no_services").into_owned()));
+    } else {
+        for service in scan_result.metadata.services.iter().take(4) {
+            lines.push(Line::styled(
+                format!("* {}", service.name),
+                Style::default().fg(Color::Green),
+            ));
+            lines.push(Line::raw(format!(
+                "  {}",
+                service
+                    .image
+                    .clone()
+                    .unwrap_or_else(|| t!("app.server.no_image").into_owned())
+            )));
+        }
+        if scan_result.metadata.services.len() > 4 {
+            lines.push(Line::raw(
+                t!(
+                    "app.server.more_services",
+                    count = scan_result.metadata.services.len() - 4
+                )
+                .into_owned(),
+            ));
+        }
+    }
+
+    frame.render_widget(
+        Paragraph::new(Text::from(lines))
+            .block(
+                Block::default()
+                    .title(t!("app.panel.server_status").into_owned())
+                    .borders(Borders::ALL)
+                    .border_style(panel_border_style()),
+            )
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn render_scan_results_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_result: &ScanResult) {
+    let mut lines = result_summary_lines(scan_result);
+    lines.push(Line::raw(String::new()));
+    lines.extend(severity_total_lines(scan_result));
+
+    if let Some(docker_status) = &scan_result.metadata.docker_status {
+        lines.push(Line::raw(String::new()));
+        lines.push(Line::styled(
+            t!("app.result.discovery_heading").into_owned(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ));
+        lines.push(Line::raw(format!(
+            "Docker: {}",
+            docker_status_label(docker_status)
+        )));
+    }
+
+    if !scan_result.metadata.discovered_projects.is_empty() {
+        for project in scan_result.metadata.discovered_projects.iter().take(3) {
+            lines.push(Line::raw(format!(
+                "* {} ({})",
+                project.name, project.source
+            )));
+        }
+    }
+
+    if !scan_result.metadata.warnings.is_empty() {
+        lines.push(Line::raw(String::new()));
+        lines.push(Line::styled(
+            t!("app.result.warnings_heading").into_owned(),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+        for warning in scan_result.metadata.warnings.iter().take(2) {
+            lines.push(Line::raw(format!("- {}", truncate_text(warning, 52))));
+        }
+    }
+
+    frame.render_widget(
+        Paragraph::new(Text::from(lines))
+            .block(
+                Block::default()
+                    .title(t!("app.panel.scan_results").into_owned())
+                    .borders(Borders::ALL)
+                    .border_style(panel_border_style()),
+            )
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn render_security_scores_panel(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    scan_result: &ScanResult,
+) {
+    let block = Block::default()
+        .title(t!("app.panel.security_scores").into_owned())
+        .borders(Borders::ALL)
+        .border_style(panel_border_style());
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let bar_width = inner.width.saturating_sub(22).max(8) as usize;
+    let mut lines = vec![score_line(
+        t!("app.score.overall").into_owned(),
+        scan_result.score_report.overall,
+        bar_width,
+        true,
+    )];
+    lines.push(Line::raw(String::new()));
+
+    for axis in Axis::ALL {
+        let score = scan_result
+            .score_report
+            .axis_scores
+            .get(&axis)
+            .copied()
+            .unwrap_or(100);
+        lines.push(score_line(axis_label(axis), score, bar_width, false));
+    }
+
+    frame.render_widget(
+        Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false }),
+        inner,
+    );
+}
+
+fn render_fix_paths_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_result: &ScanResult) {
+    let mut lines = remediation_lines(scan_result);
+    if lines.is_empty() {
+        lines.push(Line::raw(t!("app.fix.none").into_owned()));
+    }
+
+    frame.render_widget(
+        Paragraph::new(Text::from(lines))
+            .block(
+                Block::default()
+                    .title(t!("app.panel.fix_paths").into_owned())
+                    .borders(Borders::ALL)
+                    .border_style(panel_border_style()),
+            )
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn overview_footer() -> Paragraph<'static> {
+    Paragraph::new(Text::from(Line::from(vec![
+        hint_span("q", t!("app.footer.quit").into_owned()),
+        Span::raw("  "),
+        hint_span("Enter", t!("app.footer.findings").into_owned()),
+        Span::raw("  "),
+        hint_span("--json", t!("app.footer.json").into_owned()),
+    ])))
+    .alignment(Alignment::Left)
+    .block(Block::default().borders(Borders::TOP))
+}
+
+fn findings_header(scan_result: &ScanResult, state: &AppState) -> Paragraph<'static> {
+    let text = if state.finding_count() == 0 {
+        t!("app.finding.empty_status").into_owned()
+    } else {
+        t!(
+            "app.finding.status",
+            index = state.selected_index + 1,
+            count = state.finding_count(),
+            focus = focus_label(state.findings_focus)
+        )
+        .into_owned()
+    };
+
+    Paragraph::new(Text::from(vec![
+        Line::styled(
+            t!("app.finding.header").into_owned(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Line::raw(format!("{} | {}", text, compose_status(scan_result))),
+    ]))
+    .block(
+        Block::default()
+            .title(t!("app.panel.status").into_owned())
+            .borders(Borders::ALL),
+    )
+    .wrap(Wrap { trim: true })
+}
+
+fn findings_footer(focus: FindingsFocus) -> Paragraph<'static> {
+    let movement = match focus {
+        FindingsFocus::List => t!("app.hint.list_move").into_owned(),
+        FindingsFocus::Detail => t!("app.hint.detail_scroll").into_owned(),
+    };
+
+    Paragraph::new(Text::from(vec![
+        Line::raw(movement),
+        Line::raw(t!("app.hint.switch_focus").into_owned()),
+        Line::raw(t!("app.hint.back_overview").into_owned()),
+    ]))
+    .block(Block::default().borders(Borders::TOP))
+    .wrap(Wrap { trim: true })
+}
+
+fn findings_list_items(scan_result: &ScanResult) -> Vec<ListItem<'static>> {
+    if scan_result.findings.is_empty() {
+        return vec![ListItem::new(t!("app.finding.empty_title").into_owned())];
+    }
+
+    sorted_finding_indices(scan_result)
+        .into_iter()
+        .filter_map(|index| scan_result.findings.get(index))
+        .map(|finding| {
+            let title = format!(
+                "[{}] {}",
+                severity_short_label(finding.severity),
+                finding.title
+            );
+            let meta = format!(
+                "{} | {} | {}",
+                source_label(finding.source),
+                scope_label(finding.scope),
+                finding.subject
+            );
+
+            ListItem::new(Text::from(vec![
+                Line::styled(
+                    title,
+                    severity_style(finding.severity).add_modifier(Modifier::BOLD),
+                ),
+                Line::raw(meta),
+            ]))
+        })
+        .collect()
+}
+
+fn finding_detail_text(scan_result: &ScanResult, state: &AppState) -> Text<'static> {
+    let Some(finding) = state.selected_finding(scan_result) else {
+        return Text::from(vec![
+            Line::styled(
+                t!("app.finding.empty_title").into_owned(),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Line::raw(t!("app.finding.empty_description").into_owned()),
+        ]);
+    };
+
+    let mut lines = vec![
+        Line::styled(
+            finding.title.clone(),
+            severity_style(finding.severity).add_modifier(Modifier::BOLD),
+        ),
+        Line::raw(format!(
+            "{} | {} | {}",
+            source_label(finding.source),
+            scope_label(finding.scope),
+            finding.subject
+        )),
+    ];
+
+    if let Some(service) = &finding.related_service {
+        lines.push(Line::raw(String::new()));
+        lines.push(Line::styled(
+            t!("app.finding.related_service_label").into_owned(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ));
+        lines.push(Line::raw(service.clone()));
+    }
+
+    lines.extend(detail_section(
+        t!("app.finding.description_label").into_owned(),
+        &finding.description,
+    ));
+    lines.extend(detail_section(
+        t!("app.finding.why_label").into_owned(),
+        &finding.why_risky,
+    ));
+    lines.extend(detail_section(
+        t!("app.finding.fix_label").into_owned(),
+        &finding.how_to_fix,
+    ));
+
+    lines.push(Line::raw(String::new()));
+    lines.push(Line::styled(
+        t!("app.finding.evidence_label").into_owned(),
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    if finding.evidence.is_empty() {
+        lines.push(Line::raw(t!("app.finding.no_evidence").into_owned()));
+    } else {
+        for (key, value) in &finding.evidence {
+            lines.push(Line::raw(format!("{}: {}", key, value)));
+        }
+    }
+
+    Text::from(lines)
+}
+
+fn detail_section(label: String, value: &str) -> Vec<Line<'static>> {
+    vec![
+        Line::raw(String::new()),
+        Line::styled(label, Style::default().add_modifier(Modifier::BOLD)),
+        Line::raw(value.to_owned()),
+    ]
+}
+
+fn result_summary_rows(scan_result: &ScanResult) -> Vec<ResultSummaryRow> {
+    let mut rows = scan_result
+        .metadata
+        .services
+        .iter()
+        .map(|service| {
+            (
+                service.name.clone(),
+                ResultSummaryRow {
+                    label: service.name.clone(),
+                    severity: None,
+                    count: 0,
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    if scan_result.metadata.host_root.is_some() {
+        rows.entry(String::from("Host"))
+            .or_insert(ResultSummaryRow {
+                label: t!("app.result.host_group").into_owned(),
+                severity: None,
+                count: 0,
+            });
+    }
+
+    for finding in &scan_result.findings {
+        let key = result_group_key(finding);
+        let label = result_group_label(finding);
+        let entry = rows.entry(key).or_insert(ResultSummaryRow {
+            label,
+            severity: None,
+            count: 0,
+        });
+
+        entry.count += 1;
+        entry.severity = match entry.severity {
+            Some(current) if severity_rank(current) <= severity_rank(finding.severity) => {
+                Some(current)
+            }
+            _ => Some(finding.severity),
+        };
+    }
+
+    rows.into_values().collect()
+}
+
+fn result_summary_lines(scan_result: &ScanResult) -> Vec<Line<'static>> {
+    let rows = result_summary_rows(scan_result);
+    if rows.is_empty() {
+        return vec![Line::raw(t!("app.result.none").into_owned())];
+    }
+
+    rows.into_iter()
+        .map(|row| {
+            let status_text = match row.severity {
+                Some(severity) => severity_label(severity),
+                None => t!("app.result.ok").into_owned(),
+            };
+            let status_style = match row.severity {
+                Some(severity) => severity_style(severity),
+                None => Style::default().fg(Color::Green),
+            };
+
+            Line::from(vec![
+                Span::styled("* ", Style::default().fg(Color::Green)),
+                Span::raw(format!("{: <16}", row.label)),
+                Span::styled(
+                    format!("[{status_text}]"),
+                    status_style.add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(format!("  {}", findings_count_label(row.count))),
+            ])
+        })
+        .collect()
+}
+
+fn severity_total_lines(scan_result: &ScanResult) -> Vec<Line<'static>> {
+    let critical = scan_result
+        .score_report
+        .severity_counts
+        .get(&Severity::Critical)
+        .copied()
+        .unwrap_or_default();
+    let high = scan_result
+        .score_report
+        .severity_counts
+        .get(&Severity::High)
+        .copied()
+        .unwrap_or_default();
+    let medium = scan_result
+        .score_report
+        .severity_counts
+        .get(&Severity::Medium)
+        .copied()
+        .unwrap_or_default();
+    let low = scan_result
+        .score_report
+        .severity_counts
+        .get(&Severity::Low)
+        .copied()
+        .unwrap_or_default();
+
+    vec![
+        Line::raw(format!("Total: {} findings", scan_result.findings.len())),
+        Line::from(vec![
+            Span::styled(
+                format!("{critical} {}", t!("severity.critical").into_owned()),
+                severity_style(Severity::Critical).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!("{high} {}", t!("severity.high").into_owned()),
+                severity_style(Severity::High).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!("{medium} {}", t!("severity.medium").into_owned()),
+                severity_style(Severity::Medium).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!("{low} {}", t!("severity.low").into_owned()),
+                severity_style(Severity::Low).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+    ]
+}
+
+fn remediation_lines(scan_result: &ScanResult) -> Vec<Line<'static>> {
+    sorted_finding_indices(scan_result)
+        .into_iter()
+        .take(4)
+        .filter_map(|index| scan_result.findings.get(index))
+        .map(|finding| {
+            let (label, style) = remediation_badge(finding.remediation);
+            let text = truncate_text(
+                if finding.how_to_fix.trim().is_empty() {
+                    &finding.title
+                } else {
+                    &finding.how_to_fix
+                },
+                46,
+            );
+
+            Line::from(vec![
+                Span::styled(format!("[{}]", label), style.add_modifier(Modifier::BOLD)),
+                Span::raw("  "),
+                Span::raw(text),
+            ])
+        })
+        .collect()
+}
+
+fn score_line(label: String, score: u8, bar_width: usize, emphasize: bool) -> Line<'static> {
+    let filled = ((score as usize * bar_width) / 100).min(bar_width);
+    let empty = bar_width.saturating_sub(filled);
+    let label = format!("{label: <18}");
+    let score_text = format!("{score: >3}");
+    let filled_bar = "#".repeat(filled);
+    let empty_bar = "-".repeat(empty);
+
+    Line::from(vec![
+        Span::styled(
+            label,
+            if emphasize {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            },
+        ),
+        Span::raw(" "),
+        Span::styled(score_text, score_style(score).add_modifier(Modifier::BOLD)),
+        Span::raw("  "),
+        Span::styled(filled_bar, score_style(score)),
+        Span::styled(empty_bar, Style::default().fg(Color::DarkGray)),
+    ])
+}
+
+fn result_group_key(finding: &Finding) -> String {
+    finding
+        .related_service
+        .clone()
+        .unwrap_or_else(|| match finding.scope {
+            Scope::Host => String::from("Host"),
+            _ => finding.subject.clone(),
+        })
+}
+
+fn result_group_label(finding: &Finding) -> String {
+    if finding.scope == Scope::Host {
+        t!("app.result.host_group").into_owned()
+    } else {
+        finding
+            .related_service
+            .clone()
+            .unwrap_or_else(|| finding.subject.clone())
+    }
+}
+
+fn sorted_finding_indices(scan_result: &ScanResult) -> Vec<usize> {
+    let mut indices = (0..scan_result.findings.len()).collect::<Vec<_>>();
+    indices.sort_by(|left, right| {
+        compare_findings(&scan_result.findings[*left], &scan_result.findings[*right])
+    });
+    indices
+}
+
+fn compare_findings(left: &Finding, right: &Finding) -> Ordering {
+    severity_rank(left.severity)
+        .cmp(&severity_rank(right.severity))
+        .then_with(|| left.title.cmp(&right.title))
+        .then_with(|| source_label(left.source).cmp(&source_label(right.source)))
+        .then_with(|| scope_label(left.scope).cmp(&scope_label(right.scope)))
+        .then_with(|| left.subject.cmp(&right.subject))
+        .then_with(|| left.id.cmp(&right.id))
+}
+
 fn compose_status(scan_result: &ScanResult) -> String {
+    if scan_result.metadata.scan_mode == ScanMode::Live {
+        return match &scan_result.metadata.docker_status {
+            Some(DockerDiscoveryStatus::Available)
+                if !scan_result.metadata.discovered_projects.is_empty() =>
+            {
+                t!(
+                    "app.status.live_discovery",
+                    project_count = scan_result.metadata.discovered_projects.len()
+                )
+                .into_owned()
+            }
+            Some(DockerDiscoveryStatus::Missing) => {
+                t!("app.status.live_docker_missing").into_owned()
+            }
+            Some(DockerDiscoveryStatus::PermissionDenied) => {
+                t!("app.status.live_docker_denied").into_owned()
+            }
+            Some(DockerDiscoveryStatus::Failed(_)) => {
+                t!("app.status.live_docker_failed").into_owned()
+            }
+            _ => t!("app.status.live_host_only").into_owned(),
+        };
+    }
+
     match (
         &scan_result.metadata.compose_file,
         &scan_result.metadata.host_root,
@@ -165,84 +926,473 @@ fn compose_status(scan_result: &ScanResult) -> String {
     }
 }
 
-fn compose_summary_lines(scan_result: &ScanResult) -> Vec<String> {
-    let metadata = &scan_result.metadata;
-    let mut lines = Vec::new();
-
-    if let Some(path) = &metadata.compose_file {
-        lines.push(i18n::tr_summary_compose_file(&path.display().to_string()));
-    }
-    if let Some(path) = &metadata.compose_root {
-        lines.push(i18n::tr_summary_compose_root(&path.display().to_string()));
-    }
-    if let Some(path) = &metadata.host_root {
-        lines.push(i18n::tr_summary_host_root(&path.display().to_string()));
-    }
-    if metadata.loaded_files.is_empty() && metadata.host_root.is_none() {
-        lines.push(i18n::tr("app.summary.none"));
+fn findings_count_label(count: usize) -> String {
+    if count == 1 {
+        t!("app.result.single_finding").into_owned()
     } else {
-        if !metadata.loaded_files.is_empty() {
-            lines.push(i18n::tr_summary_loaded_files(metadata.loaded_files.len()));
-            lines.push(i18n::tr_summary_service_count(metadata.service_count));
+        t!("app.result.multi_findings", count = count).into_owned()
+    }
+}
+
+fn docker_status_label(status: &DockerDiscoveryStatus) -> String {
+    match status {
+        DockerDiscoveryStatus::Available => t!("app.result.docker_available").into_owned(),
+        DockerDiscoveryStatus::Missing => t!("app.result.docker_missing").into_owned(),
+        DockerDiscoveryStatus::PermissionDenied => {
+            t!("app.result.docker_permission_denied").into_owned()
         }
-        lines.push(i18n::tr_summary_finding_count(scan_result.findings.len()));
-        lines.push(i18n::tr_summary_overall_score(
-            scan_result.score_report.overall,
-        ));
+        DockerDiscoveryStatus::Failed(detail) => {
+            t!("app.result.docker_failed", detail = detail.as_str()).into_owned()
+        }
+    }
+}
+
+fn display_host_root(scan_result: &ScanResult) -> String {
+    scan_result
+        .metadata
+        .host_root
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| t!("app.server.not_scanned").into_owned())
+}
+
+fn display_hostname(scan_result: &ScanResult) -> String {
+    scan_result
+        .metadata
+        .host_runtime
+        .as_ref()
+        .and_then(|runtime| runtime.hostname.clone())
+        .unwrap_or_else(|| t!("app.server.not_available").into_owned())
+}
+
+fn display_docker_version(scan_result: &ScanResult) -> String {
+    scan_result
+        .metadata
+        .host_runtime
+        .as_ref()
+        .and_then(|runtime| runtime.docker_version.clone())
+        .unwrap_or_else(|| t!("app.server.not_available").into_owned())
+}
+
+fn display_uptime(scan_result: &ScanResult) -> String {
+    scan_result
+        .metadata
+        .host_runtime
+        .as_ref()
+        .and_then(|runtime| runtime.uptime.clone())
+        .unwrap_or_else(|| t!("app.server.not_available").into_owned())
+}
+
+fn load_line(scan_result: &ScanResult) -> Line<'static> {
+    let load = scan_result
+        .metadata
+        .host_runtime
+        .as_ref()
+        .and_then(|runtime| runtime.load_average.clone())
+        .unwrap_or_else(|| t!("app.server.not_available").into_owned());
+
+    let bar = load_bar(scan_result).unwrap_or_else(|| String::from("----------"));
+
+    Line::from(vec![
+        Span::styled(
+            format!("{:<14}", t!("app.server.load").into_owned()),
+            Style::default().fg(Color::Cyan),
+        ),
+        Span::raw(load),
+        Span::raw(" "),
+        Span::styled(bar, Style::default().fg(Color::Green)),
+    ])
+}
+
+fn load_bar(scan_result: &ScanResult) -> Option<String> {
+    let runtime = scan_result.metadata.host_runtime.as_ref()?;
+    let first = runtime
+        .load_average
+        .as_deref()?
+        .split_whitespace()
+        .next()?
+        .parse::<f32>()
+        .ok()?;
+    let filled = ((first / 2.0) * 10.0).clamp(0.0, 10.0).round() as usize;
+
+    Some(format!("{}{}", "#".repeat(filled), "-".repeat(10 - filled)))
+}
+
+fn kv_line(label: String, value: String) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{label: <14}"), Style::default().fg(Color::Cyan)),
+        Span::raw(value),
+    ])
+}
+
+fn findings_list_title(focus: FindingsFocus) -> String {
+    if focus == FindingsFocus::List {
+        t!("app.panel.findings_list_active").into_owned()
+    } else {
+        t!("app.panel.findings_list").into_owned()
+    }
+}
+
+fn findings_detail_title(focus: FindingsFocus) -> String {
+    if focus == FindingsFocus::Detail {
+        t!("app.panel.finding_detail_active").into_owned()
+    } else {
+        t!("app.panel.finding_detail").into_owned()
+    }
+}
+
+fn focus_label(focus: FindingsFocus) -> String {
+    match focus {
+        FindingsFocus::List => t!("app.finding.focus_list").into_owned(),
+        FindingsFocus::Detail => t!("app.finding.focus_detail").into_owned(),
+    }
+}
+
+fn panel_border_style() -> Style {
+    Style::default().fg(Color::Cyan)
+}
+
+fn focus_border_style(active: bool) -> Style {
+    if active {
+        Style::default().fg(Color::Green)
+    } else {
+        panel_border_style()
+    }
+}
+
+fn hint_span(key: &str, label: String) -> Span<'static> {
+    Span::styled(format!("[{key}] {label}"), Style::default().fg(Color::Cyan))
+}
+
+fn truncate_text(value: &str, max_chars: usize) -> String {
+    let count = value.chars().count();
+    if count <= max_chars {
+        return value.to_owned();
     }
 
-    lines
+    value
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>()
+        + "..."
+}
+
+fn severity_rank(severity: Severity) -> u8 {
+    match severity {
+        Severity::Critical => 0,
+        Severity::High => 1,
+        Severity::Medium => 2,
+        Severity::Low => 3,
+    }
+}
+
+fn severity_label(severity: Severity) -> String {
+    match severity {
+        Severity::Critical => t!("severity.critical").into_owned(),
+        Severity::High => t!("severity.high").into_owned(),
+        Severity::Medium => t!("severity.medium").into_owned(),
+        Severity::Low => t!("severity.low").into_owned(),
+    }
+}
+
+fn severity_short_label(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Critical => "CRIT",
+        Severity::High => "HIGH",
+        Severity::Medium => "MED",
+        Severity::Low => "LOW",
+    }
+}
+
+fn axis_label(axis: Axis) -> String {
+    match axis {
+        Axis::SensitiveData => t!("axis.sensitive_data").into_owned(),
+        Axis::ExcessivePermissions => t!("axis.permissions").into_owned(),
+        Axis::UnnecessaryExposure => t!("axis.exposure").into_owned(),
+        Axis::UpdateSupplyChainRisk => t!("axis.updates").into_owned(),
+        Axis::HostHardening => t!("axis.host_hardening").into_owned(),
+    }
+}
+
+fn source_label(source: Source) -> String {
+    match source {
+        Source::NativeCompose => t!("source.native_compose").into_owned(),
+        Source::NativeHost => t!("source.native_host").into_owned(),
+        Source::Trivy => t!("source.trivy").into_owned(),
+        Source::Lynis => t!("source.lynis").into_owned(),
+        Source::Dockle => t!("source.dockle").into_owned(),
+    }
+}
+
+fn scope_label(scope: Scope) -> String {
+    match scope {
+        Scope::Service => t!("scope.service").into_owned(),
+        Scope::Image => t!("scope.image").into_owned(),
+        Scope::Host => t!("scope.host").into_owned(),
+        Scope::Project => t!("scope.project").into_owned(),
+    }
+}
+
+fn remediation_badge(remediation: RemediationKind) -> (&'static str, Style) {
+    match remediation {
+        RemediationKind::Safe => ("SAFE", Style::default().fg(Color::Green)),
+        RemediationKind::Guided => ("GUIDED", Style::default().fg(Color::Yellow)),
+        RemediationKind::None => ("MANUAL", Style::default().fg(Color::Blue)),
+    }
+}
+
+fn severity_style(severity: Severity) -> Style {
+    Style::default().fg(match severity {
+        Severity::Critical => Color::Red,
+        Severity::High => Color::LightRed,
+        Severity::Medium => Color::Yellow,
+        Severity::Low => Color::Green,
+    })
+}
+
+fn score_style(score: u8) -> Style {
+    Style::default().fg(if score >= 80 {
+        Color::Green
+    } else if score >= 60 {
+        Color::Yellow
+    } else {
+        Color::LightRed
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
-    use super::bootstrap_copy;
-    use crate::domain::{ScanMetadata, ScanResult};
+    use ratatui::Terminal;
+    use ratatui::backend::{Backend, TestBackend};
 
-    #[test]
-    fn bootstrap_copy_contains_expected_text() {
-        let copy = bootstrap_copy(&ScanResult::default());
+    use super::*;
+    use crate::domain::{
+        AdapterStatus, DiscoveredProjectSummary, DockerDiscoveryStatus, HostRuntimeInfo,
+        ScoreReport, ServiceSummary,
+    };
 
-        assert_eq!(copy.title, "hostveil");
-        assert!(copy.status.contains("No scan target selected yet"));
-        assert!(copy.quit_hint.contains('q'));
-        assert_eq!(copy.next_steps.len(), 3);
-        assert!(
-            copy.summary_lines
-                .iter()
-                .any(|line| line.contains("No Compose target loaded"))
-        );
-    }
-
-    #[test]
-    fn bootstrap_copy_reflects_loaded_compose_target() {
-        let copy = bootstrap_copy(&ScanResult {
-            metadata: ScanMetadata {
+    fn sample_result() -> ScanResult {
+        ScanResult {
+            findings: vec![
+                Finding {
+                    id: String::from("exposure.admin_interface_public"),
+                    axis: Axis::UnnecessaryExposure,
+                    severity: Severity::Critical,
+                    scope: Scope::Service,
+                    source: Source::NativeCompose,
+                    subject: String::from("adminer"),
+                    related_service: Some(String::from("adminer")),
+                    title: String::from("Admin interface is exposed publicly"),
+                    description: String::from(
+                        "adminer exposes an administrative interface on 8080:8080.",
+                    ),
+                    why_risky: String::from(
+                        "Public admin panels invite brute force and exploit attempts.",
+                    ),
+                    how_to_fix: String::from("Put the admin interface behind a private network."),
+                    evidence: BTreeMap::from([(String::from("port"), String::from("8080:8080"))]),
+                    remediation: RemediationKind::Guided,
+                },
+                Finding {
+                    id: String::from("host.ssh_root_login_enabled"),
+                    axis: Axis::HostHardening,
+                    severity: Severity::High,
+                    scope: Scope::Host,
+                    source: Source::NativeHost,
+                    subject: String::from("/etc/ssh/sshd_config"),
+                    related_service: None,
+                    title: String::from("SSH root login is enabled"),
+                    description: String::from("/etc/ssh/sshd_config allows root login."),
+                    why_risky: String::from("Attackers can target a direct root login."),
+                    how_to_fix: String::from("Set PermitRootLogin no."),
+                    evidence: BTreeMap::from([(
+                        String::from("path"),
+                        String::from("/etc/ssh/sshd_config"),
+                    )]),
+                    remediation: RemediationKind::None,
+                },
+                Finding {
+                    id: String::from("updates.latest_tag"),
+                    axis: Axis::UpdateSupplyChainRisk,
+                    severity: Severity::Low,
+                    scope: Scope::Service,
+                    source: Source::NativeCompose,
+                    subject: String::from("vaultwarden"),
+                    related_service: Some(String::from("vaultwarden")),
+                    title: String::from("Image uses the latest tag"),
+                    description: String::from("vaultwarden uses latest."),
+                    why_risky: String::from("Moving tags hurt reproducibility."),
+                    how_to_fix: String::from("Pin the image to a specific version."),
+                    evidence: BTreeMap::new(),
+                    remediation: RemediationKind::Safe,
+                },
+            ],
+            score_report: ScoreReport {
+                overall: 61,
+                axis_scores: BTreeMap::from([
+                    (Axis::SensitiveData, 100),
+                    (Axis::ExcessivePermissions, 100),
+                    (Axis::UnnecessaryExposure, 25),
+                    (Axis::UpdateSupplyChainRisk, 80),
+                    (Axis::HostHardening, 65),
+                ]),
+                severity_counts: BTreeMap::from([
+                    (Severity::Critical, 1),
+                    (Severity::High, 1),
+                    (Severity::Medium, 0),
+                    (Severity::Low, 1),
+                ]),
+            },
+            metadata: crate::domain::ScanMetadata {
+                scan_mode: ScanMode::Live,
                 compose_root: Some(PathBuf::from("/srv/demo")),
                 compose_file: Some(PathBuf::from("/srv/demo/docker-compose.yml")),
                 host_root: Some(PathBuf::from("/")),
+                host_runtime: Some(HostRuntimeInfo {
+                    hostname: Some(String::from("home-server")),
+                    docker_version: Some(String::from("24.0.7")),
+                    uptime: Some(String::from("14d 3h 22m")),
+                    load_average: Some(String::from("0.42 0.31 0.27")),
+                }),
                 loaded_files: vec![
                     PathBuf::from("/srv/demo/docker-compose.yml"),
                     PathBuf::from("/srv/demo/docker-compose.override.yml"),
                 ],
                 service_count: 2,
-                ..ScanMetadata::default()
+                services: vec![
+                    ServiceSummary {
+                        name: String::from("adminer"),
+                        image: Some(String::from("adminer:latest")),
+                    },
+                    ServiceSummary {
+                        name: String::from("vaultwarden"),
+                        image: Some(String::from("vaultwarden/server:1.30.1")),
+                    },
+                ],
+                discovered_projects: vec![DiscoveredProjectSummary {
+                    name: String::from("demo"),
+                    source: String::from("docker"),
+                    compose_path: Some(PathBuf::from("/srv/demo/docker-compose.yml")),
+                    working_dir: Some(PathBuf::from("/srv/demo")),
+                    service_count: 2,
+                }],
+                docker_status: Some(DockerDiscoveryStatus::Available),
+                warnings: vec![String::from(
+                    "Using the current directory as a Compose fallback because no running Compose project was discovered.",
+                )],
+                adapters: BTreeMap::from([
+                    (String::from("lynis"), AdapterStatus::Available),
+                    (String::from("trivy"), AdapterStatus::Missing),
+                ]),
             },
-            ..ScanResult::default()
-        });
+        }
+    }
 
-        assert!(copy.status.contains("host checks enabled"));
-        assert!(
-            copy.summary_lines
-                .iter()
-                .any(|line| line.contains("Compose file: /srv/demo/docker-compose.yml"))
+    #[test]
+    fn overview_navigation_opens_findings() {
+        let mut state = AppState::new(&sample_result());
+
+        let should_exit = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, crossterm::event::KeyModifiers::NONE),
         );
-        assert!(
-            copy.summary_lines
-                .iter()
-                .any(|line| line.contains("Host root: /"))
+
+        assert!(!should_exit);
+        assert_eq!(state.screen, Screen::Findings);
+        assert_eq!(state.findings_focus, FindingsFocus::List);
+    }
+
+    #[test]
+    fn findings_navigation_moves_selection_and_scrolls_detail() {
+        let result = sample_result();
+        let mut state = AppState::new(&result);
+        state.open_findings();
+
+        handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, crossterm::event::KeyModifiers::NONE),
         );
+        assert_eq!(state.selected_index, 1);
+
+        handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Tab, crossterm::event::KeyModifiers::NONE),
+        );
+        assert_eq!(state.findings_focus, FindingsFocus::Detail);
+
+        handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::PageDown, crossterm::event::KeyModifiers::NONE),
+        );
+        assert!(state.detail_scroll > 0);
+
+        handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Esc, crossterm::event::KeyModifiers::NONE),
+        );
+        assert_eq!(state.screen, Screen::Overview);
+    }
+
+    #[test]
+    fn overview_renders_mockup_like_sections_in_80x24() {
+        let result = sample_result();
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal should build");
+
+        terminal
+            .draw(|frame| render(frame, &result, &AppState::new(&result)))
+            .expect("overview should render");
+
+        let content = buffer_to_string(terminal.backend());
+
+        assert!(content.contains("Linux Self-Hosting Security Dashboard"));
+        assert!(content.contains("Server Status"));
+        assert!(content.contains("Scan Results"));
+        assert!(content.contains("Security Scores"));
+        assert!(content.contains("Fix Paths"));
+        assert!(content.contains("61"));
+        assert!(content.contains("adminer"));
+        assert!(content.contains("home-server"));
+        assert!(content.contains("24.0.7"));
+        assert!(content.contains("14d 3h 22m"));
+        assert!(content.contains("0.42 0.31 0.27"));
+        assert!(content.contains("GUIDED"));
+    }
+
+    #[test]
+    fn findings_view_renders_selected_finding_details() {
+        let result = sample_result();
+        let mut state = AppState::new(&result);
+        state.open_findings();
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal should build");
+
+        terminal
+            .draw(|frame| render(frame, &result, &state))
+            .expect("findings view should render");
+
+        let content = buffer_to_string(terminal.backend());
+
+        assert!(content.contains("Findings [list focus]"));
+        assert!(content.contains("Detail"));
+        assert!(content.contains("Admin interface is exposed publicly"));
+        assert!(content.contains("Native Compose"));
+        assert!(content.contains("Service"));
+        assert!(content.contains("adminer"));
+    }
+
+    fn buffer_to_string(backend: &TestBackend) -> String {
+        let area = backend.size().expect("backend should have a size");
+        let buffer = backend.buffer();
+        let mut output = String::new();
+
+        for y in 0..area.height {
+            for x in 0..area.width {
+                output.push_str(buffer[(x, y)].symbol());
+            }
+            output.push('\n');
+        }
+
+        output
     }
 }


### PR DESCRIPTION
## Summary
- make `hostveil` without arguments run a live host scan by default, then attempt Docker-based Compose discovery with current-directory fallback
- reshape the Rust TUI overview to match the intended dashboard-style layout and add findings/detail navigation with keyboard focus controls
- surface host runtime context, discovery status, discovered projects, and warnings through both the TUI and JSON output

## Testing
- `cargo build`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo run -- --help`
- `cargo run -- --json`

## Issues
- Closes #25
- Closes #26
- Refs #49
- Refs #50
- Refs #53