### PR TITLE
fix(src/tui): refresh stale dashboard copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The final packaged Rust binary is not available yet. The Python prototype in `pr
 
 Official runtime support for the real product is Linux. If you contribute from Windows, use WSL rather than native PowerShell.
 
-Current Rust bootstrap setup from the repository root:
+Current Rust setup from the repository root:
 
 ```sh
 rustup default stable
@@ -100,12 +100,12 @@ Planned Rust v1 scope:
 - TUI-first workflow plus minimal headless JSON export
 - Linux-only runtime support with contributor setup documented for WSL
 
-Current Rust bootstrap status:
+Current Rust implementation status:
 
 - Cargo workspace initialized at the repository root
 - Active Rust crate scaffolded under `src/`
 - Pinned stable toolchain via `rust-toolchain.toml`
-- `ratatui` + `crossterm` TUI bootstrap wired and localized through `rust-i18n`
+- `ratatui` + `crossterm` TUI wired and localized through `rust-i18n`
 - Generalized Rust scan result model and minimal JSON export path working
 - Compose parser ported with override merging and normalization parity tests
 - Native Compose rule engine and scoring model partially ported with Rust fixture tests

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -3,8 +3,8 @@ app:
   header:
     subtitle: "Linux Self-Hosting Security Dashboard"
   status:
-    bootstrap: "Rust bootstrap is ready; the real TUI and scan engine land next."
-    no_target: "No scan target selected yet. Pass --compose PATH to validate the Rust parser pipeline."
+    bootstrap: "Rust scan, TUI, and JSON export are available for active development."
+    no_target: "No explicit target was provided. Run without arguments for live discovery, or pass --compose PATH / --host-root PATH for a targeted scan."
     compose_loaded: "Loaded %{count} service(s) from %{path}"
     host_loaded: "Loaded host checks from %{path}"
     compose_and_host_loaded: "Loaded %{count} service(s) from %{path} with host checks enabled"
@@ -56,9 +56,9 @@ app:
     overview_activity: "Findings and Adapters"
     overview_findings: "Top Findings"
     next_steps: "Next Steps"
-    next_step_one: "Implement the generalized findings model and scan pipeline"
-    next_step_two: "Port the Compose parser and rule engine into Rust"
-    next_step_three: "Replace this placeholder with the real dashboard overview"
+    next_step_one: "Review the highest-severity findings first"
+    next_step_two: "Use --json for automation and regression snapshots"
+    next_step_three: "Use --compose PATH or --host-root PATH for targeted scans"
     findings_list: "Findings"
     findings_list_active: "Findings [list focus]"
     finding_detail: "Detail"
@@ -83,7 +83,7 @@ app:
     not_available: "n/a"
   summary:
     title: "Current Scan Context"
-    none: "No Compose target loaded"
+    none: "No Compose project was loaded in this scan"
     compose_file: "Compose file: %{path}"
     compose_root: "Working directory: %{path}"
     host_root: "Host root: %{path}"

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -248,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn allows_bootstrap_without_scan_target() {
+    fn allows_live_scan_without_explicit_target() {
         let config = AppConfig::default();
 
         let result = run(&config).expect("live scan should succeed even without Docker access");

--- a/src/src/i18n/mod.rs
+++ b/src/src/i18n/mod.rs
@@ -125,6 +125,14 @@ mod tests {
     }
 
     #[test]
+    fn returns_updated_no_target_copy() {
+        assert_eq!(
+            tr("app.status.no_target"),
+            "No explicit target was provided. Run without arguments for live discovery, or pass --compose PATH / --host-root PATH for a targeted scan."
+        );
+    }
+
+    #[test]
     fn formats_unknown_argument_message() {
         assert_eq!(tr_unknown_argument("--bad"), "unknown argument: --bad");
     }


### PR DESCRIPTION
## Summary
- replace stale Rust dashboard and status copy that still described the app as a bootstrap placeholder
- update the no-target guidance to reflect the current live discovery default and targeted scan flags
- refresh the README wording and add a small i18n assertion for the updated copy

## Verification
- `cargo` is not installed in this execution environment, so Rust formatting/tests could not be run here
- verified the affected wording paths directly and added a focused translation test for the new no-target status copy

## Issues
- Refs #62