### PR TITLE
ci: add Rust validation workflow

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,46 @@
+name: Rust CI
+
+on:
+  push:
+    branches:
+      - main
+      - feat/**
+      - fix/**
+      - docs/**
+      - refactor/**
+      - chore/**
+      - ci/**
+  pull_request:
+
+concurrency:
+  group: rust-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: fmt, clippy, test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test --workspace


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs Rust validation on Ubuntu for pushes and pull requests
- install the stable Rust toolchain with `rustfmt` and `clippy`, cache cargo artifacts, and run `cargo fmt --check`, `cargo clippy`, and `cargo test`
- give the repository an initial automated review gate while the broader release automation in #28 remains open

## Verification
- reviewed the workflow structure and command set against the current Cargo workspace layout
- static review found no obvious trigger, action, or command issues

## Issues
- Refs #28