### PR TITLE
test(src/rules): add Vaultwarden service fixtures

### DIFF
--- a/src/src/rules/mod.rs
+++ b/src/src/rules/mod.rs
@@ -56,3 +56,61 @@ fn service_finding(
         remediation: crate::domain::RemediationKind::None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::compose::ComposeParser;
+    use crate::domain::Severity;
+
+    use super::RuleEngine;
+
+    fn fixture(path: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/services/vaultwarden")
+            .join(path)
+            .canonicalize()
+            .expect("fixture should exist")
+    }
+
+    #[test]
+    fn vaultwarden_baseline_stays_clear_under_generic_rules() {
+        let project = ComposeParser::parse_path_without_override(fixture("baseline.yml"))
+            .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn vaultwarden_vulnerable_fixture_produces_expected_findings() {
+        let project = ComposeParser::parse_path_without_override(fixture("vulnerable.yml"))
+            .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| (
+                    finding.id.as_str(),
+                    finding.related_service.as_deref().unwrap_or_default(),
+                    finding.severity,
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("exposure.public_binding", "vaultwarden", Severity::Medium,),
+                (
+                    "exposure.reverse_proxy_expected",
+                    "vaultwarden",
+                    Severity::High,
+                ),
+                ("permissions.implicit_root", "vaultwarden", Severity::Medium,),
+                ("sensitive.inline_secret", "vaultwarden", Severity::High),
+                ("updates.latest_tag", "vaultwarden", Severity::High),
+            ]
+        );
+    }
+}

--- a/src/tests/fixtures/services/vaultwarden/baseline.yml
+++ b/src/tests/fixtures/services/vaultwarden/baseline.yml
@@ -1,0 +1,15 @@
+services:
+  vaultwarden:
+    image: vaultwarden/server:1.35.4
+    container_name: vaultwarden
+    user: "1000:1000"
+    restart: unless-stopped
+    environment:
+      DOMAIN: "https://vaultwarden.example.com"
+      SIGNUPS_ALLOWED: "false"
+      ADMIN_TOKEN_FILE: "/run/secrets/admin_token"
+    volumes:
+      - ./vw-data:/data
+      - ./secrets:/run/secrets:ro
+    ports:
+      - "127.0.0.1:8000:80"

--- a/src/tests/fixtures/services/vaultwarden/vulnerable.yml
+++ b/src/tests/fixtures/services/vaultwarden/vulnerable.yml
@@ -1,0 +1,13 @@
+services:
+  vaultwarden:
+    image: vaultwarden/server:latest
+    container_name: vaultwarden
+    restart: unless-stopped
+    environment:
+      DOMAIN: "https://vaultwarden.example.com"
+      SIGNUPS_ALLOWED: "true"
+      ADMIN_TOKEN: "supersecret"
+    volumes:
+      - ./vw-data:/data
+    ports:
+      - "8000:80"


### PR DESCRIPTION
## Summary
- add a hardened Vaultwarden Compose baseline and a vulnerable Vaultwarden fixture derived from the project's official Docker/Compose guidance
- validate the current Rust rule engine against the Vaultwarden-specific risky path and keep the hardened baseline free of generic findings
- capture the official installation and hardening research directly in issue #13 so later service-aware rule work has a concrete source-backed starting point

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

## Issues
- Closes #13
- Refs #17