### PR TITLE
test(src/rules): add Jellyfin service fixtures

### DIFF
--- a/src/src/rules/mod.rs
+++ b/src/src/rules/mod.rs
@@ -56,3 +56,58 @@ fn service_finding(
         remediation: crate::domain::RemediationKind::None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::compose::ComposeParser;
+    use crate::domain::Severity;
+
+    use super::RuleEngine;
+
+    fn fixture(service: &str, path: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/services")
+            .join(service)
+            .join(path)
+            .canonicalize()
+            .expect("fixture should exist")
+    }
+
+    #[test]
+    fn jellyfin_baseline_stays_clear_under_generic_rules() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("jellyfin", "baseline.yml"))
+                .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn jellyfin_vulnerable_fixture_produces_expected_findings() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("jellyfin", "vulnerable.yml"))
+                .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| (
+                    finding.id.as_str(),
+                    finding.related_service.as_deref().unwrap_or_default(),
+                    finding.severity,
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("exposure.public_binding", "jellyfin", Severity::Medium),
+                ("permissions.implicit_root", "jellyfin", Severity::Medium),
+                ("updates.no_tag", "jellyfin", Severity::Medium),
+            ]
+        );
+    }
+}

--- a/src/tests/fixtures/services/jellyfin/baseline.yml
+++ b/src/tests/fixtures/services/jellyfin/baseline.yml
@@ -1,0 +1,17 @@
+services:
+  jellyfin:
+    image: jellyfin/jellyfin:10.11.0
+    container_name: jellyfin
+    user: "1000:1000"
+    restart: unless-stopped
+    environment:
+      JELLYFIN_PublishedServerUrl: "https://media.example.com"
+    ports:
+      - "127.0.0.1:8096:8096/tcp"
+    volumes:
+      - ./config:/config
+      - ./cache:/cache
+      - type: bind
+        source: ./media
+        target: /media
+        read_only: true

--- a/src/tests/fixtures/services/jellyfin/vulnerable.yml
+++ b/src/tests/fixtures/services/jellyfin/vulnerable.yml
@@ -1,0 +1,16 @@
+services:
+  jellyfin:
+    image: jellyfin/jellyfin
+    container_name: jellyfin
+    restart: unless-stopped
+    environment:
+      JELLYFIN_PublishedServerUrl: "http://media.example.com"
+    ports:
+      - "8096:8096/tcp"
+      - "7359:7359/udp"
+    volumes:
+      - ./config:/config
+      - ./cache:/cache
+      - type: bind
+        source: /srv/media
+        target: /media


### PR DESCRIPTION
## Summary
- add a hardened Jellyfin Compose baseline and a vulnerable Jellyfin fixture derived from the official container installation docs
- validate the current Rust rules against Jellyfin-specific exposure, root/default-user, and image-tag behavior
- capture the official installation and hardening research directly in issue #11 for later service-aware rule work

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

## Issues
- Closes #11
- Refs #17