### PR TITLE
test(src/rules): add Gitea service fixtures

### DIFF
--- a/src/src/rules/mod.rs
+++ b/src/src/rules/mod.rs
@@ -56,3 +56,64 @@ fn service_finding(
         remediation: crate::domain::RemediationKind::None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::compose::ComposeParser;
+    use crate::domain::Severity;
+
+    use super::RuleEngine;
+
+    fn fixture(service: &str, path: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/services")
+            .join(service)
+            .join(path)
+            .canonicalize()
+            .expect("fixture should exist")
+    }
+
+    #[test]
+    fn gitea_baseline_stays_clear_under_generic_rules() {
+        let project = ComposeParser::parse_path_without_override(fixture("gitea", "baseline.yml"))
+            .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn gitea_vulnerable_fixture_produces_expected_findings() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("gitea", "vulnerable.yml"))
+                .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| (
+                    finding.id.as_str(),
+                    finding.related_service.as_deref().unwrap_or_default(),
+                    finding.severity,
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("exposure.public_binding", "server", Severity::Medium),
+                ("exposure.reverse_proxy_expected", "server", Severity::High),
+                ("permissions.implicit_root", "server", Severity::Medium),
+                ("permissions.implicit_root", "db", Severity::Medium),
+                ("sensitive.default_credential", "server", Severity::Critical),
+                ("sensitive.inline_secret", "server", Severity::High),
+                ("sensitive.inline_secret", "server", Severity::High),
+                ("sensitive.default_credential", "db", Severity::Critical),
+                ("updates.latest_tag", "server", Severity::High),
+                ("updates.major_only_tag", "db", Severity::Low),
+            ]
+        );
+    }
+}

--- a/src/tests/fixtures/services/gitea/baseline.yml
+++ b/src/tests/fixtures/services/gitea/baseline.yml
@@ -1,0 +1,16 @@
+services:
+  server:
+    image: docker.gitea.com/gitea:1.25.5
+    container_name: gitea
+    user: "1000:1000"
+    restart: always
+    environment:
+      USER_UID: "1000"
+      USER_GID: "1000"
+    volumes:
+      - ./gitea:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    ports:
+      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:2222:22"

--- a/src/tests/fixtures/services/gitea/vulnerable.yml
+++ b/src/tests/fixtures/services/gitea/vulnerable.yml
@@ -1,0 +1,34 @@
+services:
+  server:
+    image: docker.gitea.com/gitea:latest
+    container_name: gitea
+    restart: always
+    environment:
+      USER_UID: "1000"
+      USER_GID: "1000"
+      GITEA__database__DB_TYPE: postgres
+      GITEA__database__HOST: db:5432
+      GITEA__database__NAME: gitea
+      GITEA__database__USER: gitea
+      GITEA__database__PASSWD: changeme
+      GITEA__security__SECRET_KEY: supersecret
+      GITEA__security__INTERNAL_TOKEN: supersecret
+    volumes:
+      - ./gitea:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    ports:
+      - "3000:3000"
+      - "222:22"
+    depends_on:
+      - db
+
+  db:
+    image: postgres:14
+    restart: always
+    environment:
+      POSTGRES_USER: gitea
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_DB: gitea
+    volumes:
+      - ./postgres:/var/lib/postgresql/data


### PR DESCRIPTION
## Summary
- add a hardened Gitea Compose baseline and a vulnerable Gitea + Postgres fixture derived from the official Docker docs
- validate the current Rust rules against Gitea-specific exposure, default-user, secret, and tag behavior
- capture the official installation and hardening research directly in issue #14 for later service-aware rule work

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

## Issues
- Closes #14
- Refs #17