### PR TITLE
test(src/rules): add Immich service fixtures

### DIFF
--- a/src/src/rules/mod.rs
+++ b/src/src/rules/mod.rs
@@ -56,3 +56,90 @@ fn service_finding(
         remediation: crate::domain::RemediationKind::None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::compose::ComposeParser;
+    use crate::domain::Severity;
+
+    use super::RuleEngine;
+
+    fn fixture(service: &str, path: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/services")
+            .join(service)
+            .join(path)
+            .canonicalize()
+            .expect("fixture should exist")
+    }
+
+    #[test]
+    fn immich_baseline_stays_clear_under_generic_rules() {
+        let project = ComposeParser::parse_path_without_override(fixture("immich", "baseline.yml"))
+            .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn immich_vulnerable_fixture_produces_expected_findings() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("immich", "vulnerable.yml"))
+                .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| (
+                    finding.id.as_str(),
+                    finding.related_service.as_deref().unwrap_or_default(),
+                    finding.severity,
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("exposure.public_binding", "immich-server", Severity::Medium),
+                (
+                    "exposure.reverse_proxy_expected",
+                    "immich-server",
+                    Severity::High,
+                ),
+                (
+                    "permissions.implicit_root",
+                    "immich-server",
+                    Severity::Medium
+                ),
+                (
+                    "permissions.implicit_root",
+                    "immich-machine-learning",
+                    Severity::Medium,
+                ),
+                ("permissions.implicit_root", "redis", Severity::Medium),
+                ("permissions.implicit_root", "database", Severity::Medium),
+                (
+                    "sensitive.env_file_plaintext",
+                    "immich-server",
+                    Severity::High
+                ),
+                (
+                    "sensitive.env_file_plaintext",
+                    "immich-machine-learning",
+                    Severity::High,
+                ),
+                ("updates.major_only_tag", "immich-server", Severity::Low),
+                (
+                    "updates.major_only_tag",
+                    "immich-machine-learning",
+                    Severity::Low,
+                ),
+                ("updates.no_tag", "redis", Severity::Medium),
+                ("updates.no_tag", "database", Severity::Medium),
+            ]
+        );
+    }
+}

--- a/src/tests/fixtures/services/immich/baseline.yml
+++ b/src/tests/fixtures/services/immich/baseline.yml
@@ -1,0 +1,40 @@
+services:
+  immich-server:
+    image: ghcr.io/immich-app/immich-server:v2.1.0
+    user: "1000:1000"
+    volumes:
+      - ./library:/data
+      - /etc/localtime:/etc/localtime:ro
+    ports:
+      - "127.0.0.1:2283:2283"
+    depends_on:
+      - redis
+      - database
+    restart: always
+
+  immich-machine-learning:
+    image: ghcr.io/immich-app/immich-machine-learning:v2.1.0
+    user: "1000:1000"
+    volumes:
+      - model-cache:/cache
+    restart: always
+
+  redis:
+    image: docker.io/valkey/valkey:9.0.0
+    user: "1000:1000"
+    restart: always
+
+  database:
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
+    user: "1000:1000"
+    environment:
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+      POSTGRES_USER: postgres
+      POSTGRES_DB: immich
+    volumes:
+      - ./postgres:/var/lib/postgresql/data
+      - ./secrets:/run/secrets:ro
+    restart: always
+
+volumes:
+  model-cache:

--- a/src/tests/fixtures/services/immich/immich.env
+++ b/src/tests/fixtures/services/immich/immich.env
@@ -1,0 +1,6 @@
+UPLOAD_LOCATION=./library
+DB_DATA_LOCATION=./postgres
+IMMICH_VERSION=v2
+DB_PASSWORD=postgres
+DB_USERNAME=postgres
+DB_DATABASE_NAME=immich

--- a/src/tests/fixtures/services/immich/vulnerable.yml
+++ b/src/tests/fixtures/services/immich/vulnerable.yml
@@ -1,0 +1,40 @@
+services:
+  immich-server:
+    image: ghcr.io/immich-app/immich-server:v2
+    volumes:
+      - ${UPLOAD_LOCATION}:/data
+      - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - immich.env
+    ports:
+      - "2283:2283"
+    depends_on:
+      - redis
+      - database
+    restart: always
+
+  immich-machine-learning:
+    image: ghcr.io/immich-app/immich-machine-learning:v2
+    volumes:
+      - model-cache:/cache
+    env_file:
+      - immich.env
+    restart: always
+
+  redis:
+    image: docker.io/valkey/valkey:9@sha256:3eeb09785cd61ec8e3be35f8804c8892080f3ca21934d628abc24ee4ed1698f6
+    restart: always
+
+  database:
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_DB: ${DB_DATABASE_NAME}
+      POSTGRES_INITDB_ARGS: --data-checksums
+    volumes:
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+    restart: always
+
+volumes:
+  model-cache:


### PR DESCRIPTION
## Summary
- add a hardened Immich baseline and a vulnerable multi-service Immich fixture derived from the official recommended Docker Compose release files
- validate the current Rust rules against Immich-specific exposure, env-file secret handling, default-user behavior, and image-tag behavior
- capture the official installation and hardening research directly in issue #15 for later service-aware rule work

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

## Issues
- Closes #15
- Refs #17