### PR TITLE
feat(src/rules): add Vaultwarden service-aware checks

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -268,3 +268,19 @@ finding:
       description: "%{path} configures Docker to listen on a non-local TCP host."
       why: "A public or broadly reachable Docker API can allow remote container control and host compromise if not strongly protected."
       fix: "Remove the TCP listener or bind it to localhost with strong authentication and network restrictions."
+  vaultwarden:
+    signups_enabled:
+      title: "Vaultwarden signups are left enabled"
+      description: "%{service} sets SIGNUPS_ALLOWED=true."
+      why: "Leaving open registration enabled after initial setup makes it easier for unwanted accounts to be created and expands the public attack surface of a password manager service."
+      fix: "Disable signups after the initial onboarding window or gate account creation through an invite-only workflow."
+    admin_surface_public:
+      title: "Vaultwarden admin surface is reachable from a public bind"
+      description: "%{service} enables the admin token while the service is also published on a public interface."
+      why: "A publicly reachable Vaultwarden deployment with the admin page enabled exposes a high-value management surface to probing, brute force, and credential leakage risks."
+      fix: "Keep Vaultwarden behind a reverse proxy or localhost-only bind and avoid exposing the admin page to the public internet."
+    insecure_domain:
+      title: "Vaultwarden domain is configured for public HTTP"
+      description: "%{service} sets DOMAIN to %{domain}, which is not an HTTPS base URL."
+      why: "Vaultwarden expects a secure context for important web features, and using a public HTTP base URL weakens transport security for a password manager deployment."
+      fix: "Terminate TLS at a reverse proxy and set DOMAIN to the external HTTPS base URL."

--- a/src/src/rules/mod.rs
+++ b/src/src/rules/mod.rs
@@ -1,11 +1,13 @@
 mod exposure;
 mod permissions;
 mod sensitive;
+mod service_aware;
 mod updates;
 
 pub use exposure::{is_public_port, scan_exposure_risk};
 pub use permissions::{classify_sensitive_mount, scan_permission_risk};
 pub use sensitive::scan_sensitive_data;
+pub use service_aware::scan_service_aware_risk;
 pub use updates::{scan_update_risk, split_image_reference};
 
 use crate::compose::ComposeProject;
@@ -21,6 +23,7 @@ impl RuleEngine {
         findings.extend(scan_permission_risk(project));
         findings.extend(scan_sensitive_data(project));
         findings.extend(scan_update_risk(project));
+        findings.extend(scan_service_aware_risk(project));
         findings
     }
 }
@@ -101,15 +104,30 @@ mod tests {
                 ))
                 .collect::<Vec<_>>(),
             vec![
-                ("exposure.public_binding", "vaultwarden", Severity::Medium,),
+                ("exposure.public_binding", "vaultwarden", Severity::Medium),
                 (
                     "exposure.reverse_proxy_expected",
                     "vaultwarden",
                     Severity::High,
                 ),
-                ("permissions.implicit_root", "vaultwarden", Severity::Medium,),
+                ("permissions.implicit_root", "vaultwarden", Severity::Medium),
                 ("sensitive.inline_secret", "vaultwarden", Severity::High),
                 ("updates.latest_tag", "vaultwarden", Severity::High),
+                (
+                    "service.vaultwarden.signups_enabled",
+                    "vaultwarden",
+                    Severity::Medium,
+                ),
+                (
+                    "service.vaultwarden.admin_surface_public",
+                    "vaultwarden",
+                    Severity::High,
+                ),
+                (
+                    "service.vaultwarden.insecure_domain",
+                    "vaultwarden",
+                    Severity::High,
+                ),
             ]
         );
     }

--- a/src/src/rules/service_aware.rs
+++ b/src/src/rules/service_aware.rs
@@ -1,0 +1,189 @@
+use std::collections::BTreeMap;
+
+use crate::compose::{ComposeProject, ComposeService};
+use crate::domain::{Axis, Finding, Severity};
+
+use super::exposure::is_public_port;
+use super::{ServiceFindingText, service_finding};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServiceKind {
+    Vaultwarden,
+}
+
+pub fn scan_service_aware_risk(project: &ComposeProject) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    for service in project.services.values() {
+        let Some(kind) = detect_service_kind(service) else {
+            continue;
+        };
+
+        match kind {
+            ServiceKind::Vaultwarden => findings.extend(scan_vaultwarden_risk(service)),
+        }
+    }
+
+    findings
+}
+
+fn detect_service_kind(service: &ComposeService) -> Option<ServiceKind> {
+    let haystack = format!(
+        "{} {}",
+        service.name,
+        service.image.as_deref().unwrap_or_default()
+    )
+    .to_lowercase();
+
+    if haystack.contains("vaultwarden") {
+        Some(ServiceKind::Vaultwarden)
+    } else {
+        None
+    }
+}
+
+fn scan_vaultwarden_risk(service: &ComposeService) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let publicly_exposed = service.ports.iter().any(is_public_port);
+
+    if env_truthy(service, "SIGNUPS_ALLOWED") {
+        findings.push(service_finding(
+            "service.vaultwarden.signups_enabled",
+            Axis::UnnecessaryExposure,
+            Severity::Medium,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.vaultwarden.signups_enabled.title").into_owned(),
+                description: t!(
+                    "finding.vaultwarden.signups_enabled.description",
+                    service = service.name.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.vaultwarden.signups_enabled.why").into_owned(),
+                how_to_fix: t!("finding.vaultwarden.signups_enabled.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("variable"), String::from("SIGNUPS_ALLOWED"))]),
+        ));
+    }
+
+    if publicly_exposed && admin_token_configured(service) {
+        findings.push(service_finding(
+            "service.vaultwarden.admin_surface_public",
+            Axis::UnnecessaryExposure,
+            Severity::High,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.vaultwarden.admin_surface_public.title").into_owned(),
+                description: t!(
+                    "finding.vaultwarden.admin_surface_public.description",
+                    service = service.name.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.vaultwarden.admin_surface_public.why").into_owned(),
+                how_to_fix: t!("finding.vaultwarden.admin_surface_public.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("variable"), String::from("ADMIN_TOKEN")),
+                (
+                    String::from("public_port_count"),
+                    service.ports.len().to_string(),
+                ),
+            ]),
+        ));
+    }
+
+    if publicly_exposed
+        && let Some(domain) = env_value(service, "DOMAIN")
+        && domain.starts_with("http://")
+    {
+        findings.push(service_finding(
+            "service.vaultwarden.insecure_domain",
+            Axis::UnnecessaryExposure,
+            Severity::High,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.vaultwarden.insecure_domain.title").into_owned(),
+                description: t!(
+                    "finding.vaultwarden.insecure_domain.description",
+                    service = service.name.as_str(),
+                    domain = domain
+                )
+                .into_owned(),
+                why_risky: t!("finding.vaultwarden.insecure_domain.why").into_owned(),
+                how_to_fix: t!("finding.vaultwarden.insecure_domain.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("domain"), domain.to_owned())]),
+        ));
+    }
+
+    findings
+}
+
+fn env_truthy(service: &ComposeService, key: &str) -> bool {
+    env_value(service, key).is_some_and(|value| {
+        matches!(
+            value.to_ascii_lowercase().as_str(),
+            "true" | "yes" | "on" | "1"
+        )
+    })
+}
+
+fn env_value<'a>(service: &'a ComposeService, key: &str) -> Option<&'a str> {
+    service
+        .environment
+        .get(key)
+        .and_then(|value| value.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn admin_token_configured(service: &ComposeService) -> bool {
+    env_value(service, "ADMIN_TOKEN").is_some() || env_value(service, "ADMIN_TOKEN_FILE").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::compose::ComposeParser;
+
+    use super::scan_service_aware_risk;
+
+    fn fixture(path: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/services/vaultwarden")
+            .join(path)
+            .canonicalize()
+            .expect("fixture should exist")
+    }
+
+    #[test]
+    fn vaultwarden_baseline_avoids_service_specific_findings() {
+        let project = ComposeParser::parse_path_without_override(fixture("baseline.yml"))
+            .expect("project should parse");
+
+        let findings = scan_service_aware_risk(&project);
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn vaultwarden_vulnerable_fixture_triggers_service_specific_findings() {
+        let project = ComposeParser::parse_path_without_override(fixture("vulnerable.yml"))
+            .expect("project should parse");
+
+        let findings = scan_service_aware_risk(&project);
+
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| finding.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "service.vaultwarden.signups_enabled",
+                "service.vaultwarden.admin_surface_public",
+                "service.vaultwarden.insecure_domain",
+            ]
+        );
+    }
+}

--- a/src/tests/fixtures/services/vaultwarden/vulnerable.yml
+++ b/src/tests/fixtures/services/vaultwarden/vulnerable.yml
@@ -4,7 +4,7 @@ services:
     container_name: vaultwarden
     restart: unless-stopped
     environment:
-      DOMAIN: "https://vaultwarden.example.com"
+      DOMAIN: "http://vaultwarden.example.com"
       SIGNUPS_ALLOWED: "true"
       ADMIN_TOKEN: "supersecret"
     volumes:


### PR DESCRIPTION
## Summary
- add a minimal service-aware rule path to the Rust rule engine and use it to recognize Vaultwarden services from names and images
- flag Vaultwarden-specific risky patterns that generic Compose checks do not cover well yet: open signups, a publicly reachable admin surface, and public HTTP domain configuration
- extend the existing Vaultwarden fixture so the new stable finding IDs and severities are asserted in Rust tests

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

## Notes
- this PR is stacked on top of #68 because it reuses the Vaultwarden fixture work from that branch

## Issues
- Closes #72
- Refs #16