### PR TITLE
ci(release): add alpha delivery workflow

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   validate:
-    name: fmt, clippy, test
+    name: fmt, clippy, test, smoke
     runs-on: ubuntu-latest
 
     steps:
@@ -44,3 +44,9 @@ jobs:
 
       - name: Run tests
         run: cargo test --workspace
+
+      - name: Build debug binary
+        run: cargo build --workspace
+
+      - name: Run smoke tests
+        run: ./scripts/smoke-test.sh target/debug/hostveil

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,0 +1,159 @@
+name: Rust Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: rust-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    name: validate release tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test --workspace
+
+      - name: Build release binary for smoke tests
+        run: cargo build --release --workspace
+
+      - name: Run smoke tests
+        run: ./scripts/smoke-test.sh target/release/hostveil
+
+  build:
+    name: build ${{ matrix.target }}
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            linker: ""
+          - target: aarch64-unknown-linux-gnu
+            linker: aarch64-linux-gnu-gcc
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install aarch64 cross compiler
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: sudo apt-get update && sudo apt-get install --yes gcc-aarch64-linux-gnu
+
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --workspace --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
+
+      - name: Package release archive
+        run: |
+          mkdir -p dist/package
+          cp target/${{ matrix.target }}/release/hostveil dist/package/hostveil
+          cp README.md LICENSE dist/package/
+          tar -C dist/package -czf dist/hostveil-${{ github.ref_name }}-${{ matrix.target }}.tar.gz hostveil README.md LICENSE
+
+      - name: Upload packaged archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: hostveil-${{ matrix.target }}
+          path: dist/hostveil-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
+
+  checksums:
+    name: generate checksums
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download packaged archives
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: sha256sum dist/*.tar.gz > dist/SHA256SUMS
+
+      - name: Upload checksums
+        uses: actions/upload-artifact@v4
+        with:
+          name: hostveil-checksums
+          path: dist/SHA256SUMS
+
+  release:
+    name: publish prerelease
+    needs: checksums
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download packaged archives and checksums
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Prepare install script asset
+        run: cp scripts/install.sh dist/install.sh
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true
+          body: |
+            ## Install
+            ```sh
+            curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/install.sh | bash -s -- --version ${{ github.ref_name }} --channel preview
+            ```
+
+            ## Update
+            Rerun the install script with the newer tag, or replace the installed binary manually.
+
+            ## Optional dependencies
+            - Docker improves live Compose discovery when it is available.
+            - Trivy is planned as an optional adapter and is not required for this alpha release.
+
+            ## Known limitations
+            - Linux only
+            - Nextcloud-specific service-aware rules are not included yet
+            - TUI-embedded guided diff review is still deferred from the first alpha
+          files: |
+            dist/*.tar.gz
+            dist/SHA256SUMS
+            dist/install.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "crossterm 0.29.0",
  "indexmap",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Inspired by [Chrome Lighthouse](https://developer.chrome.com/docs/lighthouse/ove
 
 ## Installation
 
-The final packaged Rust binary is not available yet. The Python prototype in `proto/` is now a frozen reference implementation for Compose parsing, scoring, and fix behavior while active product work moves into `src/`.
+Alpha Rust releases are delivered through GitHub Releases as Linux binaries. The Python prototype in `proto/` remains a frozen reference implementation for Compose parsing, scoring, and fix behavior while active product work continues in `src/`.
+
+The first public Rust release is planned as a Linux-only prerelease (`v0.1.0-alpha.N`), not as a stable `v1.0` launch.
 
 Official runtime support for the real product is Linux. If you contribute from Windows, use WSL rather than native PowerShell.
 
@@ -49,6 +51,7 @@ Current Rust setup from the repository root:
 rustup default stable
 cargo build
 cargo run -- --help
+cargo run -- --version
 cargo run
 cargo run -- --json
 
@@ -65,6 +68,20 @@ Current reference prototype setup:
 python3 -m venv proto/.venv
 source proto/.venv/bin/activate
 pip install -e "proto[dev]"
+```
+
+Planned alpha delivery path:
+
+- GitHub Releases tarballs for `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`
+- Published `SHA256SUMS` for release artifact verification
+- A small install script that selects the correct Linux binary for the host architecture
+- Optional external tools such as Docker and Trivy discovered from `PATH` instead of being bundled
+- Alpha updates handled by rerunning the install script or replacing the binary manually
+
+Install a published alpha release:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/<tag>/scripts/install.sh | bash -s -- --version <tag> --channel preview
 ```
 
 ## Usage
@@ -114,6 +131,53 @@ Current Rust implementation status:
 - Native Linux host checks started for SSH posture and Docker host exposure via `--host-root`
 - Initial Rust Compose remediation flow added for previewable `--quick-fix` and `--fix` operations with backup-safe writes
 - No-arg live scan now defaults to host scanning plus Docker-based Compose auto-discovery, with current-directory Compose fallback
+
+## First Alpha Release Plan
+
+The first public Rust release should optimize for safe delivery and fast feedback, not for complete v1 feature coverage.
+
+Must-have for `v0.1.0-alpha.N`:
+
+- Linux-only prerelease scope with clear known limitations
+- Native Compose and host checks through one shared scan result
+- TUI overview plus finding detail navigation for real scan results
+- Minimal headless JSON export for automation and regression snapshots
+- Previewable Compose `--quick-fix` and `--fix` flows with backup-safe writes
+- Release artifacts published through GitHub Releases with checksums
+- An install script for Linux binary download and upgrade
+- Core smoke-test coverage for the supported CLI entry points before publishing
+
+Explicitly deferred from the first alpha:
+
+- Nextcloud-specific service-aware rules
+- Trivy integration as the first optional external adapter
+- TUI-embedded guided diff review before writes
+- Package-manager distribution such as apt, dnf, Homebrew, or AUR
+- Built-in self-update commands
+- Final scoring ADR and stable weighting guarantees
+
+Optional dependency policy for alpha:
+
+- `hostveil` should install and run without Docker or Trivy being present
+- Docker-based live discovery improves Compose coverage when available
+- Trivy remains an optional adapter; if it is missing, scans continue with reduced coverage instead of failing
+- Missing external tools should be shown as coverage or adapter status, not as fatal startup errors
+
+Planned install and update model for alpha:
+
+- Install from GitHub Releases rather than from a package manager
+- Download a single architecture-specific Linux binary archive
+- Verify the archive against `SHA256SUMS`
+- Install to a standard user or system binary path such as `~/.local/bin` or `/usr/local/bin`
+- Update by rerunning the install script or manually replacing the binary with a newer release
+
+Alpha release gates:
+
+- `cargo fmt --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace`
+- Smoke tests for `hostveil`, `hostveil --json`, targeted Compose scans, targeted host scans, and preview-only fix flows
+- Release notes that document supported platforms, optional dependencies, and known limitations
 
 ## Contributing
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${HOSTVEIL_REPO:-seolcu/hostveil}"
+CHANNEL="${HOSTVEIL_CHANNEL:-preview}"
+INSTALL_DIR="${HOSTVEIL_INSTALL_DIR:-}"
+REQUESTED_VERSION=""
+
+usage() {
+  cat <<'EOF'
+Install hostveil from GitHub Releases.
+
+Usage:
+  install.sh [--version TAG] [--channel preview|stable] [--to DIR]
+
+Options:
+  --version TAG   install a specific release tag such as v0.1.0-alpha.1
+  --channel NAME  choose preview or stable when --version is omitted
+  --to DIR        install into a specific binary directory
+  -h, --help      show this help message
+EOF
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --version)
+      (($# >= 2)) || fail "missing value for --version"
+      REQUESTED_VERSION="$2"
+      shift 2
+      ;;
+    --channel)
+      (($# >= 2)) || fail "missing value for --channel"
+      CHANNEL="$2"
+      shift 2
+      ;;
+    --to)
+      (($# >= 2)) || fail "missing value for --to"
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$CHANNEL" in
+  preview|stable) ;;
+  *) fail "unsupported channel: $CHANNEL" ;;
+esac
+
+if command -v curl >/dev/null 2>&1; then
+  fetch_to_file() {
+    curl -fsSL "$1" -o "$2"
+  }
+  fetch_to_stdout() {
+    curl -fsSL "$1"
+  }
+elif command -v wget >/dev/null 2>&1; then
+  fetch_to_file() {
+    wget -qO "$2" "$1"
+  }
+  fetch_to_stdout() {
+    wget -qO- "$1"
+  }
+else
+  fail "curl or wget is required"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  verify_checksum() {
+    local checksums_file="$1"
+    local archive_name="$2"
+    local archive_path="$3"
+    local expected
+    expected="$(grep "  ${archive_name}$" "$checksums_file" || true)"
+    [[ -n "$expected" ]] || fail "no checksum entry found for ${archive_name}"
+    (cd "$(dirname "$archive_path")" && printf '%s\n' "$expected" | sha256sum -c - >/dev/null)
+  }
+elif command -v shasum >/dev/null 2>&1; then
+  verify_checksum() {
+    local checksums_file="$1"
+    local archive_name="$2"
+    local archive_path="$3"
+    local expected_hash
+    expected_hash="$(sed -n "s/^\([0-9a-fA-F]\{64\}\)  ${archive_name}$/\1/p" "$checksums_file")"
+    [[ -n "$expected_hash" ]] || fail "no checksum entry found for ${archive_name}"
+    local actual_hash
+    actual_hash="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
+    [[ "$actual_hash" == "$expected_hash" ]] || fail "checksum verification failed for ${archive_name}"
+  }
+else
+  fail "sha256sum or shasum is required"
+fi
+
+normalize_version() {
+  if [[ "$1" == v* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf 'v%s\n' "$1"
+  fi
+}
+
+extract_first_tag() {
+  sed -n 's/.*"tag_name":"\([^"]*\)".*/\1/p' | head -n 1
+}
+
+resolve_version() {
+  if [[ -n "$REQUESTED_VERSION" ]]; then
+    normalize_version "$REQUESTED_VERSION"
+    return
+  fi
+
+  if [[ "$CHANNEL" == "stable" ]]; then
+    if tag_json="$(fetch_to_stdout "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null)"; then
+      tag_name="$(printf '%s\n' "$tag_json" | extract_first_tag)"
+      [[ -n "$tag_name" ]] || fail "failed to resolve the latest stable release"
+      printf '%s\n' "$tag_name"
+      return
+    fi
+
+    log "No stable release was found; falling back to the latest preview release."
+  fi
+
+  tag_json="$(fetch_to_stdout "https://api.github.com/repos/${REPO}/releases?per_page=1")"
+  tag_name="$(printf '%s\n' "$tag_json" | extract_first_tag)"
+  [[ -n "$tag_name" ]] || fail "failed to resolve the latest preview release"
+  printf '%s\n' "$tag_name"
+}
+
+detect_target() {
+  case "$(uname -m)" in
+    x86_64|amd64)
+      printf '%s\n' "x86_64-unknown-linux-gnu"
+      ;;
+    aarch64|arm64)
+      printf '%s\n' "aarch64-unknown-linux-gnu"
+      ;;
+    *)
+      fail "unsupported architecture: $(uname -m)"
+      ;;
+  esac
+}
+
+resolve_install_dir() {
+  if [[ -n "$INSTALL_DIR" ]]; then
+    printf '%s\n' "$INSTALL_DIR"
+    return
+  fi
+
+  if [[ -d "/usr/local/bin" && -w "/usr/local/bin" ]]; then
+    printf '%s\n' "/usr/local/bin"
+  else
+    printf '%s\n' "${HOME}/.local/bin"
+  fi
+}
+
+tag="$(resolve_version)"
+target="$(detect_target)"
+install_dir="$(resolve_install_dir)"
+archive_name="hostveil-${tag}-${target}.tar.gz"
+archive_url="https://github.com/${REPO}/releases/download/${tag}/${archive_name}"
+checksums_url="https://github.com/${REPO}/releases/download/${tag}/SHA256SUMS"
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+mkdir -p "$install_dir"
+[[ -w "$install_dir" ]] || fail "install directory is not writable: ${install_dir}"
+
+log "Downloading ${archive_name}"
+fetch_to_file "$archive_url" "$tmpdir/$archive_name"
+fetch_to_file "$checksums_url" "$tmpdir/SHA256SUMS"
+verify_checksum "$tmpdir/SHA256SUMS" "$archive_name" "$tmpdir/$archive_name"
+
+mkdir -p "$tmpdir/extract"
+tar -xzf "$tmpdir/$archive_name" -C "$tmpdir/extract"
+[[ -f "$tmpdir/extract/hostveil" ]] || fail "release archive does not contain the hostveil binary"
+
+install -m 0755 "$tmpdir/extract/hostveil" "$install_dir/hostveil"
+
+log "Installed hostveil ${tag} to ${install_dir}/hostveil"
+if [[ ":$PATH:" != *":${install_dir}:"* ]]; then
+  log "Note: ${install_dir} is not currently on PATH."
+fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BINARY_PATH="${1:-$ROOT_DIR/target/debug/hostveil}"
+
+[[ -x "$BINARY_PATH" ]] || {
+  printf 'error: binary is not executable: %s\n' "$BINARY_PATH" >&2
+  exit 1
+}
+
+COMPOSE_FIXTURE="$ROOT_DIR/proto/tests/fixtures/parser/docker-compose.yml"
+TMP_HOST_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_HOST_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOST_ROOT/etc/ssh" "$TMP_HOST_ROOT/proc" "$TMP_HOST_ROOT/var/run"
+printf 'PermitRootLogin yes\nPasswordAuthentication yes\n' > "$TMP_HOST_ROOT/etc/ssh/sshd_config"
+printf 'alpha-smoke\n' > "$TMP_HOST_ROOT/etc/hostname"
+printf '3600.00 0.00\n' > "$TMP_HOST_ROOT/proc/uptime"
+printf '0.10 0.20 0.30 1/100 123\n' > "$TMP_HOST_ROOT/proc/loadavg"
+touch "$TMP_HOST_ROOT/var/run/docker.sock"
+chmod 666 "$TMP_HOST_ROOT/var/run/docker.sock"
+
+VERSION_OUTPUT="$($BINARY_PATH --version)"
+printf '%s\n' "$VERSION_OUTPUT" | grep -q '^hostveil '
+
+$BINARY_PATH --help | grep -q -- '--version'
+$BINARY_PATH --json | grep -q '"scan_mode": "live"'
+$BINARY_PATH --json --compose "$COMPOSE_FIXTURE" | grep -q '"findings"'
+$BINARY_PATH --json --host-root "$TMP_HOST_ROOT" | grep -q '"host_runtime"'
+$BINARY_PATH --quick-fix "$COMPOSE_FIXTURE" --preview-changes | grep -q 'Preview only: no files were modified.'
+$BINARY_PATH --fix "$COMPOSE_FIXTURE" --preview-changes | grep -q 'Preview only: no files were modified.'
+
+set +e
+BARE_OUTPUT="$($BINARY_PATH 2>&1 >/dev/null)"
+BARE_STATUS=$?
+set -e
+
+[[ $BARE_STATUS -ne 0 ]]
+printf '%s\n' "$BARE_OUTPUT" | grep -q 'requires a terminal'
+
+printf 'Smoke tests passed for %s\n' "$BINARY_PATH"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -23,6 +23,7 @@ app:
         hostveil [--compose PATH] [--host-root PATH] [--json]
         hostveil --quick-fix PATH [--preview-changes] [--yes]
         hostveil --fix PATH [--preview-changes] [--yes]
+        hostveil --version
         hostveil --help
 
       Options:
@@ -33,7 +34,10 @@ app:
         --preview-changes show the planned diff without writing any files
         --yes             apply the reviewed changes without an interactive confirmation prompt
         --json            emit scan result JSON instead of launching the TUI
+        -V, --version     show version information
         -h, --help        show this help message
+  version:
+    text: "%{name} %{version}"
   hint:
     quit: "Press q or Esc to quit"
     json: "Use --json to inspect the current scan result structure"
@@ -115,6 +119,7 @@ app:
     io: "application error: %{message}"
     fix_serialize: "failed to serialize the updated compose file: %{message}"
     json_export_failed: "failed to serialize the current scan result"
+    tui_requires_terminal: "the interactive TUI requires a terminal; use --json for non-interactive runs"
     missing_translation: "missing translation for key: %{key}"
   finding:
     header: "Findings Detail"

--- a/src/src/app/config.rs
+++ b/src/src/app/config.rs
@@ -13,6 +13,7 @@ pub enum OutputMode {
 pub struct AppConfig {
     pub output_mode: OutputMode,
     pub show_help: bool,
+    pub show_version: bool,
     pub compose_path: Option<PathBuf>,
     pub host_root: Option<PathBuf>,
     pub fix_mode: Option<FixMode>,
@@ -26,6 +27,7 @@ impl Default for AppConfig {
         Self {
             output_mode: OutputMode::Tui,
             show_help: false,
+            show_version: false,
             compose_path: None,
             host_root: None,
             fix_mode: None,
@@ -45,6 +47,7 @@ impl AppConfig {
             match argument.as_str() {
                 "--json" => config.output_mode = OutputMode::Json,
                 "-h" | "--help" => config.show_help = true,
+                "-V" | "--version" => config.show_version = true,
                 "--preview-changes" => config.preview_changes = true,
                 "--yes" => config.assume_yes = true,
                 "--compose" => {
@@ -160,6 +163,7 @@ mod tests {
 
         assert_eq!(config.output_mode, OutputMode::Tui);
         assert!(!config.show_help);
+        assert!(!config.show_version);
         assert!(config.fix_mode.is_none());
     }
 
@@ -200,6 +204,13 @@ mod tests {
         let config = AppConfig::parse([String::from("--help")]).expect("config should parse");
 
         assert!(config.show_help);
+    }
+
+    #[test]
+    fn parses_version_flag() {
+        let config = AppConfig::parse([String::from("--version")]).expect("config should parse");
+
+        assert!(config.show_version);
     }
 
     #[test]

--- a/src/src/app/mod.rs
+++ b/src/src/app/mod.rs
@@ -4,7 +4,7 @@ mod scan;
 pub use config::{AppConfig, OutputMode};
 
 use std::fmt;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 
 use crate::compose::ComposeParseError;
 use crate::export;
@@ -17,6 +17,7 @@ pub enum AppError {
     UnknownArgument(String),
     MissingArgumentValue(&'static str),
     InvalidArgumentCombination(String),
+    TuiRequiresTerminal,
     ComposeParse(ComposeParseError),
     Fix(FixError),
     Io(io::Error),
@@ -32,6 +33,7 @@ impl fmt::Display for AppError {
             Self::InvalidArgumentCombination(message) => {
                 write!(f, "{}", i18n::tr_invalid_argument_combination(message))
             }
+            Self::TuiRequiresTerminal => write!(f, "{}", i18n::tr_tui_requires_terminal()),
             Self::ComposeParse(error) => write!(f, "{}", i18n::tr_compose_parse_error(error)),
             Self::Fix(error) => write!(f, "{error}"),
             Self::Io(error) => write!(f, "{}", i18n::tr_io_error(&error.to_string())),
@@ -64,6 +66,14 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
 
     if config.show_help {
         print!("{}", i18n::tr("app.help.text"));
+        return Ok(());
+    }
+
+    if config.show_version {
+        println!(
+            "{}",
+            i18n::tr_version(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+        );
         return Ok(());
     }
 
@@ -100,7 +110,12 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
     let scan_result = scan::run(&config)?;
 
     match config.output_mode {
-        OutputMode::Tui => tui::run(&scan_result)?,
+        OutputMode::Tui => {
+            if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+                return Err(AppError::TuiRequiresTerminal);
+            }
+            tui::run(&scan_result)?;
+        }
         OutputMode::Json => {
             print!("{}", export::scan_result_json(&scan_result));
         }

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -227,6 +227,7 @@ mod tests {
         let config = AppConfig {
             output_mode: OutputMode::Json,
             show_help: false,
+            show_version: false,
             compose_path: Some(parser_fixture()),
             host_root: None,
             fix_mode: None,
@@ -303,6 +304,7 @@ mod tests {
         let config = AppConfig {
             output_mode: OutputMode::Json,
             show_help: false,
+            show_version: false,
             compose_path: Some(parser_fixture()),
             host_root: Some(host_root.clone()),
             fix_mode: None,

--- a/src/src/i18n/mod.rs
+++ b/src/src/i18n/mod.rs
@@ -24,6 +24,10 @@ pub fn tr_unknown_argument(argument: &str) -> String {
     t!("app.error.unknown_argument", argument = argument).into_owned()
 }
 
+pub fn tr_version(name: &str, version: &str) -> String {
+    t!("app.version.text", name = name, version = version).into_owned()
+}
+
 pub fn tr_missing_argument_value(flag: &str) -> String {
     t!("app.error.missing_argument_value", flag = flag).into_owned()
 }
@@ -66,6 +70,10 @@ pub fn tr_compose_parse_error(error: &ComposeParseError) -> String {
 
 pub fn tr_io_error(message: &str) -> String {
     t!("app.error.io", message = message).into_owned()
+}
+
+pub fn tr_tui_requires_terminal() -> String {
+    t!("app.error.tui_requires_terminal").into_owned()
 }
 
 pub fn tr_status_compose_loaded(path: &str, count: usize) -> String {
@@ -119,7 +127,8 @@ mod tests {
         tr, tr_compose_parse_error, tr_invalid_argument_combination, tr_io_error,
         tr_missing_argument_value, tr_status_compose_and_host_loaded, tr_status_compose_loaded,
         tr_status_host_loaded, tr_summary_finding_count, tr_summary_host_root,
-        tr_summary_overall_score, tr_summary_service_count, tr_unknown_argument,
+        tr_summary_overall_score, tr_summary_service_count, tr_tui_requires_terminal,
+        tr_unknown_argument, tr_version,
     };
     use crate::compose::ComposeParseError;
 
@@ -142,6 +151,14 @@ mod tests {
     }
 
     #[test]
+    fn formats_version_message() {
+        assert_eq!(
+            tr_version("hostveil", "0.1.0-alpha.1"),
+            "hostveil 0.1.0-alpha.1"
+        );
+    }
+
+    #[test]
     fn falls_back_for_unknown_key() {
         assert_eq!(
             tr("does.not.exist"),
@@ -152,6 +169,14 @@ mod tests {
     #[test]
     fn formats_io_error_message() {
         assert_eq!(tr_io_error("boom"), "application error: boom");
+    }
+
+    #[test]
+    fn formats_tui_requires_terminal_message() {
+        assert_eq!(
+            tr_tui_requires_terminal(),
+            "the interactive TUI requires a terminal; use --json for non-interactive runs"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add alpha release automation for Linux GitHub Releases artifacts, checksums, and installer delivery
- add `--version`, clearer non-interactive TUI handling, and smoke-test coverage for release gates
- document the alpha install, update, and optional dependency policy in the README

## Testing
- cargo fmt
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo build --release --workspace
- ./scripts/smoke-test.sh target/release/hostveil

## Issues
- Closes #79
- Closes #28
- Refs #49