### PR TITLE
fix(release): repair installer checksum verification

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   validate:
-    name: fmt, clippy, test, smoke
+    name: fmt, clippy, test, smoke, installer
     runs-on: ubuntu-latest
 
     steps:
@@ -50,3 +50,6 @@ jobs:
 
       - name: Run smoke tests
         run: ./scripts/smoke-test.sh target/debug/hostveil
+
+      - name: Run installer tests
+        run: ./scripts/test-install-script.sh target/debug/hostveil

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -105,7 +105,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate checksums
-        run: sha256sum dist/*.tar.gz > dist/SHA256SUMS
+        run: (cd dist && sha256sum *.tar.gz > SHA256SUMS)
 
       - name: Upload checksums
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "crossterm 0.29.0",
  "indexmap",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO="${HOSTVEIL_REPO:-seolcu/hostveil}"
 CHANNEL="${HOSTVEIL_CHANNEL:-preview}"
 INSTALL_DIR="${HOSTVEIL_INSTALL_DIR:-}"
+DOWNLOAD_BASE_URL="${HOSTVEIL_DOWNLOAD_BASE_URL:-}"
 REQUESTED_VERSION=""
 
 usage() {
@@ -80,31 +81,46 @@ else
   fail "curl or wget is required"
 fi
 
+extract_checksum_hash() {
+  local checksums_file="$1"
+  local archive_name="$2"
+
+  awk -v archive="$archive_name" '
+    NF >= 2 {
+      path = $2
+      if (path == archive || path == ("./" archive) || path == ("dist/" archive)) {
+        print $1
+        exit
+      }
+    }
+  ' "$checksums_file"
+}
+
 if command -v sha256sum >/dev/null 2>&1; then
-  verify_checksum() {
-    local checksums_file="$1"
-    local archive_name="$2"
-    local archive_path="$3"
-    local expected
-    expected="$(grep "  ${archive_name}$" "$checksums_file" || true)"
-    [[ -n "$expected" ]] || fail "no checksum entry found for ${archive_name}"
-    (cd "$(dirname "$archive_path")" && printf '%s\n' "$expected" | sha256sum -c - >/dev/null)
+  hash_file() {
+    sha256sum "$1" | awk '{print $1}'
   }
 elif command -v shasum >/dev/null 2>&1; then
-  verify_checksum() {
-    local checksums_file="$1"
-    local archive_name="$2"
-    local archive_path="$3"
-    local expected_hash
-    expected_hash="$(sed -n "s/^\([0-9a-fA-F]\{64\}\)  ${archive_name}$/\1/p" "$checksums_file")"
-    [[ -n "$expected_hash" ]] || fail "no checksum entry found for ${archive_name}"
-    local actual_hash
-    actual_hash="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
-    [[ "$actual_hash" == "$expected_hash" ]] || fail "checksum verification failed for ${archive_name}"
+  hash_file() {
+    shasum -a 256 "$1" | awk '{print $1}'
   }
 else
   fail "sha256sum or shasum is required"
 fi
+
+verify_checksum() {
+  local checksums_file="$1"
+  local archive_name="$2"
+  local archive_path="$3"
+  local expected_hash
+  local actual_hash
+
+  expected_hash="$(extract_checksum_hash "$checksums_file" "$archive_name")"
+  [[ -n "$expected_hash" ]] || fail "no checksum entry found for ${archive_name}"
+
+  actual_hash="$(hash_file "$archive_path")"
+  [[ "$actual_hash" == "$expected_hash" ]] || fail "checksum verification failed for ${archive_name}"
+}
 
 normalize_version() {
   if [[ "$1" == v* ]]; then
@@ -172,8 +188,15 @@ tag="$(resolve_version)"
 target="$(detect_target)"
 install_dir="$(resolve_install_dir)"
 archive_name="hostveil-${tag}-${target}.tar.gz"
-archive_url="https://github.com/${REPO}/releases/download/${tag}/${archive_name}"
-checksums_url="https://github.com/${REPO}/releases/download/${tag}/SHA256SUMS"
+
+if [[ -n "$DOWNLOAD_BASE_URL" ]]; then
+  download_base_url="$DOWNLOAD_BASE_URL"
+else
+  download_base_url="https://github.com/${REPO}/releases/download/${tag}"
+fi
+
+archive_url="${download_base_url}/${archive_name}"
+checksums_url="${download_base_url}/SHA256SUMS"
 
 tmpdir="$(mktemp -d)"
 cleanup() {

--- a/scripts/test-install-script.sh
+++ b/scripts/test-install-script.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BINARY_PATH="${1:-$ROOT_DIR/target/debug/hostveil}"
+INSTALLER_PATH="$ROOT_DIR/scripts/install.sh"
+
+[[ -x "$BINARY_PATH" ]] || {
+  printf 'error: binary is not executable: %s\n' "$BINARY_PATH" >&2
+  exit 1
+}
+
+detect_target() {
+  case "$(uname -m)" in
+    x86_64|amd64)
+      printf '%s\n' "x86_64-unknown-linux-gnu"
+      ;;
+    aarch64|arm64)
+      printf '%s\n' "aarch64-unknown-linux-gnu"
+      ;;
+    *)
+      printf 'error: unsupported architecture: %s\n' "$(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+run_case() {
+  local checksum_prefix="$1"
+  local case_dir
+  local release_dir
+  local install_dir
+  local target
+  local archive_name
+  local expected_version
+
+  case_dir="$(mktemp -d)"
+  release_dir="$case_dir/release"
+  install_dir="$case_dir/install/bin"
+  target="$(detect_target)"
+  archive_name="hostveil-v0.0.0-test-${target}.tar.gz"
+  expected_version="$($BINARY_PATH --version)"
+
+  mkdir -p "$release_dir/package" "$install_dir"
+  cp "$BINARY_PATH" "$release_dir/package/hostveil"
+  cp "$ROOT_DIR/README.md" "$ROOT_DIR/LICENSE" "$release_dir/package/"
+  tar -C "$release_dir/package" -czf "$release_dir/$archive_name" hostveil README.md LICENSE
+
+  local checksum
+  checksum="$(sha256sum "$release_dir/$archive_name" | awk '{print $1}')"
+  printf '%s  %s%s\n' "$checksum" "$checksum_prefix" "$archive_name" > "$release_dir/SHA256SUMS"
+
+  HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_dir" \
+    bash "$INSTALLER_PATH" --version v0.0.0-test --to "$install_dir"
+
+  [[ -x "$install_dir/hostveil" ]] || {
+    printf 'error: installed binary is missing for checksum prefix %s\n' "$checksum_prefix" >&2
+    exit 1
+  }
+
+  [[ "$($install_dir/hostveil --version)" == "$expected_version" ]] || {
+    printf 'error: installed version mismatch for checksum prefix %s\n' "$checksum_prefix" >&2
+    exit 1
+  }
+
+  rm -rf "$case_dir"
+}
+
+run_case ""
+run_case "dist/"
+
+printf 'Installer tests passed for %s\n' "$BINARY_PATH"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary
- make `scripts/install.sh` verify only the requested archive and accept both the older `dist/<asset>` checksum entries and the basename-only format used going forward
- generate future release `SHA256SUMS` without the `dist/` prefix so published checksums match the installer path cleanly
- add installer regression coverage to CI and bump the Rust prerelease version to `0.1.0-alpha.2`

## Testing
- bash -n scripts/install.sh
- bash -n scripts/test-install-script.sh
- cargo fmt
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo build --workspace
- ./scripts/smoke-test.sh target/debug/hostveil
- ./scripts/test-install-script.sh target/debug/hostveil
- bash scripts/install.sh --version v0.1.0-alpha.1 --to /tmp/hostveil-alpha1-fixed/bin

## Issues
- Closes #81
- Refs #79
- Refs #49