### PR TITLE
chore(release): cut v0.1.0-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "crossterm 0.29.0",
  "indexmap",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary
- bump the Rust package version and lockfile entry from `0.1.0-alpha.3` to `0.1.0-alpha.4`
- align the binary `--version` output with the next prerelease tag before publishing artifacts

## Validation
- cargo fmt
- cargo test
- cargo clippy --all-targets
- bash scripts/test-install-script.sh target/debug/hostveil

## Issues
- Refs #90