### PR TITLE
chore(release): define SemVer release policy

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -28,6 +28,26 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
+
+      - name: Verify tag matches Cargo version
+        run: |
+          [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            printf 'error: release tags must use vX.Y.Z\n' >&2
+            exit 1
+          }
+
+          tag_version="${GITHUB_REF_NAME#v}"
+          cargo_version="$(sed -n 's/^version = "\([^"]*\)"$/\1/p' src/Cargo.toml)"
+
+          [[ -n "${cargo_version}" ]] || {
+            printf 'error: failed to read version from src/Cargo.toml\n' >&2
+            exit 1
+          }
+
+          [[ "${tag_version}" == "${cargo_version}" ]] || {
+            printf 'error: tag %s does not match Cargo version %s\n' "${GITHUB_REF_NAME}" "${cargo_version}" >&2
+            exit 1
+          }
 
       - name: Check formatting
         run: cargo fmt --check
@@ -59,7 +79,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -114,13 +134,13 @@ jobs:
           path: dist/SHA256SUMS
 
   release:
-    name: publish prerelease
+    name: publish release
     needs: checksums
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download packaged archives and checksums
         uses: actions/download-artifact@v4
@@ -134,12 +154,11 @@ jobs:
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
           body: |
             ## Install
             ```sh
-            curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/install.sh | bash -s -- --channel preview
+            curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/install.sh | bash
             ```
 
             After the first install, use the installed `hostveil` command for lifecycle actions.
@@ -169,12 +188,12 @@ jobs:
 
             ## Optional dependencies
             - Docker improves live Compose discovery when it is available.
-            - Trivy is planned as an optional adapter and is not required for this alpha release.
+            - Trivy is planned as an optional adapter and is not required for this release.
 
             ## Known limitations
             - Linux only
             - Nextcloud-specific service-aware rules are not included yet
-            - TUI-embedded guided diff review is still deferred from the first alpha
+            - TUI-embedded guided diff review is still deferred from the current release scope
           files: |
             dist/*.tar.gz
             dist/SHA256SUMS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,13 @@ hostveil/
 - `Cargo.lock` must be committed — hostveil is a binary crate
 - Run `cargo clippy` and `cargo fmt` before committing
 
+**Versioning and releases:**
+- Use SemVer `X.Y.Z` for the crate and binary version
+- Use annotated Git tags in the form `vX.Y.Z`
+- Stay on `0.Y.Z` until the project is intentionally ready for `1.0.0`
+- Treat version bumps as release work, not as routine feature work
+- Keep `src/Cargo.toml`, `Cargo.lock`, and the release tag aligned
+
 **Python (when proto/ exists):**
 - Use a virtual environment; do not commit `.venv/`
 - Follow the project's rule engine interface so logic ports cleanly to Rust

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,38 @@ refactor(proto): extract rule engine into separate module
 - Do not end the summary line with a period
 - Body is optional but encouraged for non-trivial changes
 
+## Versioning And Releases
+
+We use **Semantic Versioning** for shipped versions.
+
+- Package and binary version format: `X.Y.Z`
+- Git tag format: `vX.Y.Z`
+- Do not use `-alpha`, `-beta`, or other prerelease suffixes in normal release tags
+- Until the project declares stable compatibility, stay on the `0.Y.Z` line instead of jumping to `1.0.0`
+
+### How To Bump Versions
+
+- Bump **patch** (`0.4.2` -> `0.4.3`) for bug fixes, install/update flow fixes, reliability improvements, and other backward-compatible polish
+- Bump **minor** (`0.4.2` -> `0.5.0`) for new user-visible features, new commands, new rule coverage, or materially expanded functionality
+- Bump **major** (`1.4.2` -> `2.0.0`) only for intentional breaking compatibility changes after `1.0.0`
+- Use `1.0.0` only when the project is ready to treat CLI behavior, release policy, and compatibility expectations as stable
+
+### When To Bump Versions
+
+- Do **not** bump the version in every feature PR
+- Bump the version only in a dedicated release change when `main` is ready to ship
+- Keep `src/Cargo.toml` and `Cargo.lock` aligned in the same change
+- Release commits should use a dedicated message such as `chore(release): bump version to v0.5.0`
+
+### When Releases Happen
+
+- Create a GitHub Release only from `main`
+- Release only when there is a meaningful shipped change since the previous tag
+- Docs-only changes normally ship with the next code release instead of triggering a standalone release
+- After the release change is merged, create and push an annotated tag `vX.Y.Z` from that `main` commit
+- The tag push is the only thing that should trigger the release workflow
+- The pushed tag must match the version in `src/Cargo.toml`
+
 ## Development Setup
 
 The product is now entering the Rust implementation phase.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.1.0-alpha.5"
+version = "0.1.0"
 dependencies = [
  "crossterm 0.29.0",
  "indexmap",

--- a/README.ko.md
+++ b/README.ko.md
@@ -39,9 +39,9 @@ Jellyfin, Nextcloud, Vaultwarden, Gitea, Immich 등을 운영하는 셀프호스
 
 ## 설치
 
-Alpha Rust 릴리스는 GitHub Releases를 통해 Linux 바이너리로 제공합니다. `proto/` 안의 Python 프로토타입은 Compose 파싱, 점수화, 수정 흐름을 설명하는 고정된 참고 구현으로 유지되고, 실제 제품 개발은 `src/`에서 진행합니다.
+Rust 릴리스는 GitHub Releases를 통해 Linux 바이너리로 제공합니다. `proto/` 안의 Python 프로토타입은 Compose 파싱, 점수화, 수정 흐름을 설명하는 고정된 참고 구현으로 유지되고, 실제 제품 개발은 `src/`에서 진행합니다.
 
-첫 공개 Rust 릴리스는 안정화된 `v1.0`이 아니라 Linux 전용 프리릴리스(`v0.1.0-alpha.N`)입니다.
+hostveil 릴리스 태그는 `vX.Y.Z`, 크레이트와 바이너리 버전은 `X.Y.Z` 형식을 사용합니다. 호환성을 의도적으로 안정화했다고 선언하기 전까지는 prerelease 접미사 대신 `0.Y.Z` 라인을 유지합니다.
 
 실제 제품의 공식 런타임 지원 대상은 Linux입니다. Windows에서 개발할 경우 native PowerShell 대신 WSL 사용을 권장합니다.
 
@@ -59,7 +59,7 @@ cargo run -- --json --compose proto/tests/fixtures/parser/docker-compose.yml
 cargo run -- --json --host-root /
 ```
 
-현재 alpha 전달 경로:
+현재 릴리스 전달 경로:
 
 - `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`용 GitHub Releases tarball
 - 릴리스 아티팩트 검증용 `SHA256SUMS`
@@ -67,10 +67,10 @@ cargo run -- --json --host-root /
 - Docker, Trivy 같은 외부 도구는 번들하지 않고 `PATH`에서 선택적으로 탐지
 - 첫 설치는 installer script로, 이후 업그레이드/자동 업데이트 토글/삭제는 설치된 `hostveil` 명령으로 수행
 
-최신 preview 릴리스 설치:
+최신 릴리스 설치:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --channel preview
+curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
 ```
 
 최초 설치 이후 라이프사이클 명령:
@@ -136,6 +136,17 @@ hostveil은 현재 초기 개발 단계입니다. 구현은 두 단계로 계획
 - 기본 Compose 규칙 엔진과 점수화 모델을 Rust로 일부 포팅하고 fixture 테스트로 검증
 - `--host-root`를 통한 SSH posture 및 Docker host exposure 기본 점검 시작
 - 인자 없는 live scan이 host 스캔 + Docker 기반 Compose 자동 발견 + 현재 디렉터리 fallback으로 동작
+
+## 릴리스 규칙
+
+hostveil은 접미사 없는 SemVer를 사용합니다. 크레이트/바이너리 버전은 `X.Y.Z`, Git 태그는 `vX.Y.Z`입니다.
+
+- `1.0.0`을 선언하기 전까지는 `0.Y.Z` 라인을 유지합니다.
+- 하위 호환 버그 수정, 설치/업데이트 흐름 수정, 안정성 개선은 patch를 올립니다.
+- 새 기능, 새 명령, 사용자에게 보이는 범위 확장은 minor를 올립니다.
+- 버전은 모든 PR마다 올리지 않고, 배포 준비가 끝난 시점의 전용 release 변경에서만 올립니다.
+- GitHub Release는 `main`에서 만든 annotated tag `vX.Y.Z`를 푸시할 때만 생성합니다.
+- 태그, `src/Cargo.toml`, `Cargo.lock`의 버전은 항상 일치해야 합니다.
 
 ## 기여
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Inspired by [Chrome Lighthouse](https://developer.chrome.com/docs/lighthouse/ove
 
 ## Installation
 
-Alpha Rust releases are delivered through GitHub Releases as Linux binaries. The Python prototype in `proto/` remains a frozen reference implementation for Compose parsing, scoring, and fix behavior while active product work continues in `src/`.
+Rust releases are delivered through GitHub Releases as Linux binaries. The Python prototype in `proto/` remains a frozen reference implementation for Compose parsing, scoring, and fix behavior while active product work continues in `src/`.
 
-The first public Rust release is planned as a Linux-only prerelease (`v0.1.0-alpha.N`), not as a stable `v1.0` launch.
+hostveil release tags follow `vX.Y.Z`, while the crate and binary version use `X.Y.Z`. Until compatibility is intentionally declared stable, releases stay on the `0.Y.Z` line instead of using prerelease suffixes.
 
 Official runtime support for the real product is Linux. If you contribute from Windows, use WSL rather than native PowerShell.
 
@@ -70,7 +70,7 @@ source proto/.venv/bin/activate
 pip install -e "proto[dev]"
 ```
 
-Current alpha delivery path:
+Current release delivery path:
 
 - GitHub Releases tarballs for `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`
 - Published `SHA256SUMS` for release artifact verification
@@ -78,21 +78,21 @@ Current alpha delivery path:
 - Optional external tools such as Docker and Trivy discovered from `PATH` instead of being bundled
 - First-install bootstrap via installer script, then installed lifecycle commands for upgrade, launch-time auto-upgrade, and uninstall
 
-Install the latest preview release:
+Install the latest release:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --channel preview
+curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
 ```
 
 After the first install, use the installed `hostveil` command for lifecycle actions.
 
-Upgrade an existing installation to the latest release on its saved channel:
+Upgrade an existing installation to the latest available release:
 
 ```sh
 hostveil upgrade
 ```
 
-Automatic upgrades are enabled by default. Every `hostveil` launch checks the saved release channel and upgrades before starting if a newer version is available.
+Automatic upgrades are enabled by default. Every `hostveil` launch checks the saved install metadata and upgrades before starting if a newer version is available.
 
 Disable automatic upgrades:
 
@@ -160,13 +160,21 @@ Current Rust implementation status:
 - Initial Rust Compose remediation flow added for previewable `--quick-fix` and `--fix` operations with backup-safe writes
 - No-arg live scan now defaults to host scanning plus Docker-based Compose auto-discovery, with current-directory Compose fallback
 
-## First Alpha Release Plan
+## Release Policy
 
-The first public Rust release should optimize for safe delivery and fast feedback, not for complete v1 feature coverage.
+hostveil release versions follow standard SemVer without suffixes: `X.Y.Z` for the crate and binary, and `vX.Y.Z` for Git tags.
 
-Must-have for `v0.1.0-alpha.N`:
+- Stay on `0.Y.Z` until the project is intentionally ready for `1.0.0`
+- Bump patch for backward-compatible fixes, install/update flow fixes, and shipped polish
+- Bump minor for new user-visible features, command surface changes, and materially expanded rule or adapter coverage
+- Reserve `1.0.0` for the point where compatibility expectations become intentionally stable
+- Do not bump versions in every PR; version changes should land as dedicated release work
+- Create GitHub Releases only from annotated `vX.Y.Z` tags pushed from `main`
+- The release tag must match `src/Cargo.toml` and `Cargo.lock`
 
-- Linux-only prerelease scope with clear known limitations
+Current release priorities:
+
+- Linux-only scope with clear known limitations
 - Native Compose and host checks through one shared scan result
 - TUI overview plus finding detail navigation for real scan results
 - Minimal headless JSON export for automation and regression snapshots
@@ -175,7 +183,7 @@ Must-have for `v0.1.0-alpha.N`:
 - An install script for first install plus installed lifecycle commands for later upgrades
 - Core smoke-test coverage for the supported CLI entry points before publishing
 
-Explicitly deferred from the first alpha:
+Explicitly deferred from the current early-release scope:
 
 - Nextcloud-specific service-aware rules
 - Trivy integration as the first optional external adapter
@@ -183,14 +191,14 @@ Explicitly deferred from the first alpha:
 - Package-manager distribution such as apt, dnf, Homebrew, or AUR
 - Final scoring ADR and stable weighting guarantees
 
-Optional dependency policy for alpha:
+Optional dependency policy for current releases:
 
 - `hostveil` should install and run without Docker or Trivy being present
 - Docker-based live discovery improves Compose coverage when available
 - Trivy remains an optional adapter; if it is missing, scans continue with reduced coverage instead of failing
 - Missing external tools should be shown as coverage or adapter status, not as fatal startup errors
 
-Planned install and update model for alpha:
+Planned install and update model for current releases:
 
 - Install from GitHub Releases rather than from a package manager
 - Download a single architecture-specific Linux binary archive
@@ -198,7 +206,7 @@ Planned install and update model for alpha:
 - Install to a standard user or system binary path such as `~/.local/bin` or `/usr/local/bin`
 - Track install metadata so launch-time auto-upgrade and installed `hostveil upgrade` / `hostveil uninstall` actions work cleanly
 
-Alpha release gates:
+Release gates:
 
 - `cargo fmt --check`
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,20 +51,20 @@ usage() {
 Manage hostveil Linux installs from GitHub Releases.
 
 Usage:
-  install.sh [--channel preview|stable] [--version TAG] [--to DIR]
-  install.sh --upgrade [--channel preview|stable] [--version TAG] [--to DIR]
+  install.sh [--version TAG] [--to DIR]
+  install.sh --upgrade [--version TAG] [--to DIR]
   install.sh --disable-auto-upgrade
   install.sh --enable-auto-upgrade
   install.sh --uninstall [--to DIR]
 
 After first install, prefer the installed hostveil command:
-  hostveil upgrade [--channel preview|stable] [--version TAG]
+  hostveil upgrade [--version TAG]
   hostveil auto-upgrade enable|disable
   hostveil uninstall
 
 Options:
   --version TAG            install or upgrade to a specific release tag
-  --channel NAME           choose preview or stable when --version is omitted
+  --channel NAME           legacy compatibility option; current documented releases use a single track
   --to DIR                 install into a specific binary directory
   --upgrade                upgrade an existing install using saved metadata
   --disable-auto-upgrade   stop checking for upgrades when hostveil launches

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.1.0-alpha.5"
+version = "0.1.0"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -23,7 +23,7 @@ app:
         hostveil [--compose PATH] [--host-root PATH] [--json]
         hostveil --quick-fix PATH [--preview-changes] [--yes]
         hostveil --fix PATH [--preview-changes] [--yes]
-        hostveil upgrade [--channel preview|stable] [--version TAG]
+        hostveil upgrade [--version TAG]
         hostveil uninstall
         hostveil auto-upgrade enable
         hostveil auto-upgrade disable
@@ -32,7 +32,7 @@ app:
 
       Lifecycle:
         First install:
-          curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --channel preview
+          curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
         After install:
           hostveil upgrade
           hostveil uninstall


### PR DESCRIPTION
## Summary
- document a single `X.Y.Z` versioning policy and `vX.Y.Z` release tagging flow across the repo
- align install and help text with the no-suffix release model and set the crate version to `0.1.0`
- enforce tag-to-Cargo version matching in the release workflow and move checkout actions to `v5` to clear the Node.js deprecation warning

## Testing
- cargo fmt --all
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo run -- --help
- ./scripts/smoke-test.sh target/debug/hostveil
- ./scripts/test-install-script.sh target/debug/hostveil

Refs #94