### PR TITLE
feat(src): integrate external security tooling and setup flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +93,18 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -223,6 +241,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +266,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -254,10 +290,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
 
 [[package]]
 name = "glob"
@@ -317,6 +372,7 @@ name = "hostveil"
 version = "0.1.0"
 dependencies = [
  "crossterm 0.29.0",
+ "dialoguer",
  "indexmap",
  "ratatui",
  "rust-i18n",
@@ -324,6 +380,12 @@ dependencies = [
  "serde_json",
  "serde_yaml",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -410,6 +472,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -522,6 +590,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +616,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ratatui"
@@ -786,6 +870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +970,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +1070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1096,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "winapi"
@@ -1115,6 +1276,100 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Status: Early Development](https://img.shields.io/badge/status-early%20development-orange)](https://github.com/seolcu/hostveil)
 
-Jellyfin, Nextcloud, Vaultwarden, Gitea, Immich 등을 운영하는 셀프호스터는 보안 상태를 확인하기 위해 Lynis, Trivy, Dockle, Docker Bench, Fail2ban, CrowdSec 같은 도구를 각각 따로 설치하고 해석해야 합니다. hostveil은 이런 신호를 하나의 터미널 중심 워크플로로 통합하는 것을 목표로 합니다. 심각도 순으로 정렬된 점수화된 발견 사항, 셀프호스팅 맥락에 맞춘 설명, 그리고 구체적인 해결 가이드를 한 번에 제공합니다.
+Jellyfin, Nextcloud, Vaultwarden, Gitea, Immich 등을 운영하는 셀프호스터는 보안 상태를 확인하기 위해 Lynis, Trivy, Dockle, Docker Bench, Fail2ban 같은 도구를 각각 따로 설치하고 해석해야 합니다. hostveil은 이런 신호를 하나의 터미널 중심 워크플로로 통합하는 것을 목표로 합니다. 심각도 순으로 정렬된 점수화된 발견 사항, 셀프호스팅 맥락에 맞춘 설명, 그리고 구체적인 해결 가이드를 한 번에 제공합니다.
 
 [Chrome Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) (실행 가능한 가이드를 포함한 점수화 감사)와 [btop](https://github.com/aristocratos/btop) (경량 TUI 디자인)에서 영감을 받았습니다.
 
@@ -71,6 +71,20 @@ cargo run -- --json --host-root /
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
+```
+
+터미널이 가능하면 installer는 설치 직후 `hostveil setup`으로 넘어가 Lynis, Trivy, Fail2Ban 같은 추천 도구를 바로 설치하고 기본 설정까지 진행할 수 있습니다.
+
+나중에 다시 setup을 실행하려면:
+
+```sh
+hostveil setup
+```
+
+무인 설치에서는 bootstrap 단계에서 설치할 도구를 명시할 수 있습니다.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --with-tools lynis,trivy,fail2ban
 ```
 
 최초 설치 이후 라이프사이클 명령:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Status: Early Development](https://img.shields.io/badge/status-early%20development-orange)](https://github.com/seolcu/hostveil)
 
-Self-hosters running Jellyfin, Nextcloud, Vaultwarden, Gitea, or Immich typically need to run and interpret several separate security tools — Lynis, Trivy, Dockle, Docker Bench, Fail2ban, CrowdSec, and more — with results scattered across all of them. hostveil is intended to consolidate those signals into one terminal-first workflow: scored findings, prioritized by severity, explained in self-hosting terms, and paired with concrete fix guidance.
+Self-hosters running Jellyfin, Nextcloud, Vaultwarden, Gitea, or Immich typically need to run and interpret several separate security tools — Lynis, Trivy, Dockle, Docker Bench, Fail2ban, and more — with results scattered across all of them. hostveil is intended to consolidate those signals into one terminal-first workflow: scored findings, prioritized by severity, explained in self-hosting terms, and paired with concrete fix guidance.
 
 Inspired by [Chrome Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) (scored audits with actionable guidance) and [btop](https://github.com/aristocratos/btop) (lightweight TUI design).
 
@@ -75,7 +75,7 @@ Current release delivery path:
 - GitHub Releases tarballs for `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`
 - Published `SHA256SUMS` for release artifact verification
 - A small install script that selects the correct Linux binary for the host architecture
-- Optional external tools such as Docker and Trivy discovered from `PATH` instead of being bundled
+- Optional external tools such as Lynis, Trivy, and Fail2Ban can be installed through a post-install setup flow instead of being bundled
 - First-install bootstrap via installer script, then installed lifecycle commands for upgrade, launch-time auto-upgrade, and uninstall
 
 Install the latest release:
@@ -85,6 +85,20 @@ curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/instal
 ```
 
 After the first install, use the installed `hostveil` command for lifecycle actions.
+
+If a terminal is available, the installer can also hand off to `hostveil setup` so you can install recommended optional tools such as Lynis, Trivy, and Fail2Ban right away.
+
+Run the setup flow again later:
+
+```sh
+hostveil setup
+```
+
+For unattended installs, you can explicitly pick tools during bootstrap:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --with-tools lynis,trivy,fail2ban
+```
 
 Upgrade an existing installation to the latest available release:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,6 +45,10 @@ REQUESTED_VERSION=""
 ACTION="install"
 AUTO_UPGRADE_SETTING="enabled"
 metadata_loaded=0
+SETUP_TOOLS=""
+SETUP_TOOLS_SET=0
+SKIP_SETUP=0
+SETUP_ASSUME_YES=0
 
 usage() {
   cat <<'EOF'
@@ -56,8 +60,10 @@ Usage:
   install.sh --disable-auto-upgrade
   install.sh --enable-auto-upgrade
   install.sh --uninstall [--to DIR]
+  install.sh [--version TAG] [--to DIR] [--with-tools LIST] [--yes]
 
 After first install, prefer the installed hostveil command:
+  hostveil setup
   hostveil upgrade [--version TAG]
   hostveil auto-upgrade enable|disable
   hostveil uninstall
@@ -66,10 +72,13 @@ Options:
   --version TAG            install or upgrade to a specific release tag
   --channel NAME           legacy compatibility option; current documented releases use a single track
   --to DIR                 install into a specific binary directory
+  --with-tools LIST        comma-separated optional tools to install after hostveil is installed
   --upgrade                upgrade an existing install using saved metadata
   --disable-auto-upgrade   stop checking for upgrades when hostveil launches
   --enable-auto-upgrade    resume checking for upgrades when hostveil launches
+  --skip-setup             skip the post-install optional tool setup flow
   --uninstall              remove hostveil and related lifecycle files
+  --yes                    accept the recommended post-install tool setup without prompting
   -h, --help               show this help message
 EOF
 }
@@ -111,6 +120,20 @@ while (($# > 0)); do
       INSTALL_DIR="$2"
       INSTALL_DIR_SET=1
       shift 2
+      ;;
+    --with-tools)
+      (($# >= 2)) || fail "missing value for --with-tools"
+      SETUP_TOOLS="$2"
+      SETUP_TOOLS_SET=1
+      shift 2
+      ;;
+    --skip-setup|--without-tools)
+      SKIP_SETUP=1
+      shift
+      ;;
+    --yes)
+      SETUP_ASSUME_YES=1
+      shift
       ;;
     --upgrade)
       set_action "upgrade"
@@ -589,6 +612,41 @@ prune_empty_dir() {
   fi
 }
 
+tty_is_available() {
+  [[ -t 1 && -r /dev/tty && -w /dev/tty ]]
+}
+
+run_post_install_setup() {
+  local wrapper_path
+  local setup_args=(setup)
+
+  if [[ "$ACTION" != "install" ]] || (( SKIP_SETUP == 1 )) || [[ "${HOSTVEIL_INSTALLER_SKIP_SETUP:-}" == "1" ]]; then
+    return
+  fi
+
+  wrapper_path="$(resolve_wrapper_path)"
+  [[ -x "$wrapper_path" ]] || return
+
+  if (( SETUP_TOOLS_SET == 1 )); then
+    setup_args+=(--yes --tools "$SETUP_TOOLS")
+    log "Running post-install setup for: ${SETUP_TOOLS}"
+  elif (( SETUP_ASSUME_YES == 1 )); then
+    setup_args+=(--yes)
+    log "Running post-install setup with the recommended tool defaults"
+  elif tty_is_available; then
+    log "Launching the post-install setup wizard"
+  else
+    log "Skipping optional tool setup because no interactive terminal was detected. Run 'hostveil setup' later."
+    return
+  fi
+
+  if tty_is_available; then
+    HOSTVEIL_SKIP_AUTO_UPGRADE=1 "$wrapper_path" "${setup_args[@]}" </dev/tty >/dev/tty 2>/dev/tty
+  else
+    HOSTVEIL_SKIP_AUTO_UPGRADE=1 "$wrapper_path" "${setup_args[@]}"
+  fi
+}
+
 perform_install() {
   local tag
   local target
@@ -643,6 +701,8 @@ perform_install() {
   if ! install_dir_is_available_on_path "$INSTALL_DIR"; then
     log "Note: ${INSTALL_DIR} is not currently on PATH."
   fi
+
+  run_post_install_setup
 }
 
 perform_upgrade() {
@@ -686,12 +746,19 @@ perform_uninstall() {
 }
 
 validate_action() {
+  if (( SKIP_SETUP == 1 )) && (( SETUP_TOOLS_SET == 1 )); then
+    fail "choose either --skip-setup or --with-tools"
+  fi
+
   case "$ACTION" in
     install|upgrade)
       ;;
     enable-auto-upgrade|disable-auto-upgrade|uninstall)
       if [[ -n "$REQUESTED_VERSION" ]]; then
         fail "--version is not supported with --${ACTION}"
+      fi
+      if (( SETUP_TOOLS_SET == 1 )) || (( SKIP_SETUP == 1 )) || (( SETUP_ASSUME_YES == 1 )); then
+        fail "setup flags are only supported during install"
       fi
       ;;
     *)

--- a/scripts/test-install-script.sh
+++ b/scripts/test-install-script.sh
@@ -306,10 +306,59 @@ run_upgrade_auto_uninstall_case() {
   rm -rf "$case_dir"
 }
 
+run_post_install_setup_handoff_case() {
+  local case_dir
+  local release_dir
+  local install_dir
+  local setup_log
+  local archive_name
+  local checksum
+
+  case_dir="$(mktemp -d)"
+  release_dir="$case_dir/release"
+  install_dir="$case_dir/install/bin"
+  setup_log="$case_dir/setup.log"
+  archive_name="hostveil-v0.0.9-test-${TARGET_TRIPLE}.tar.gz"
+
+  mkdir -p "$release_dir/package"
+  cat > "$release_dir/package/hostveil" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  --version)
+    printf 'hostveil 0.0.9-test\n'
+    ;;
+  setup)
+    printf '%s\n' "$*" > "${HOSTVEIL_SETUP_LOG:?}"
+    ;;
+  *)
+    printf 'fake hostveil received: %s\n' "$*"
+    ;;
+esac
+EOF
+  chmod 0755 "$release_dir/package/hostveil"
+  cp "$ROOT_DIR/README.md" "$ROOT_DIR/LICENSE" "$release_dir/package/"
+  tar -C "$release_dir/package" -czf "$release_dir/$archive_name" hostveil README.md LICENSE
+  checksum="$(sha256sum "$release_dir/$archive_name" | awk '{print $1}')"
+  printf '%s  %s\n' "$checksum" "$archive_name" > "$release_dir/SHA256SUMS"
+
+  HOSTVEIL_SETUP_LOG="$setup_log" \
+    XDG_STATE_HOME="$case_dir/state" \
+    HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_dir" \
+    HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
+    bash "$INSTALLER_PATH" --version v0.0.9-test --to "$install_dir" --with-tools lynis,trivy
+
+  assert_file_contains "$setup_log" 'setup --yes --tools lynis,trivy'
+
+  rm -rf "$case_dir"
+}
+
 run_install_case ""
 run_install_case "dist/"
 run_latest_install_case
 run_login_path_detection_case
 run_upgrade_auto_uninstall_case
+run_post_install_setup_handoff_case
 
 printf 'Installer tests passed for %s\n' "$BINARY_PATH"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 
 [dependencies]
 crossterm = "0.29"
+dialoguer = "0.12"
 indexmap = { version = "2", features = ["serde"] }
 ratatui = "0.29"
 rust-i18n = "3"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -21,6 +21,7 @@ app:
         hostveil
         hostveil --json
         hostveil [--compose PATH] [--host-root PATH] [--json]
+        hostveil setup [--tool NAME]... [--tools LIST] [--yes]
         hostveil --quick-fix PATH [--preview-changes] [--yes]
         hostveil --fix PATH [--preview-changes] [--yes]
         hostveil upgrade [--version TAG]
@@ -34,6 +35,7 @@ app:
         First install:
           curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
         After install:
+          hostveil setup
           hostveil upgrade
           hostveil uninstall
           hostveil auto-upgrade enable|disable
@@ -41,6 +43,8 @@ app:
       Options:
         --compose PATH    override live discovery with a specific Compose file or directory
         --host-root PATH  override the default live host root (/) with a Linux root or snapshot
+        --tool NAME       select a setup tool explicitly for hostveil setup (repeatable)
+        --tools LIST      comma-separated setup tool list for unattended setup runs
         --quick-fix PATH  preview or apply safe Compose-only fixes for a specific file or directory
         --fix PATH        preview or apply safe and guided Compose review changes for a specific file or directory
         --preview-changes show the planned diff without writing any files
@@ -103,10 +107,11 @@ app:
     load: "Load"
     controls: "Defenses"
     fail2ban: "Fail2ban"
-    crowdsec: "CrowdSec"
     control_enabled: "enabled"
     control_installed: "installed"
     control_not_detected: "not detected"
+    control_jails: "%{count} jails"
+    control_banned_ips: "%{count} banned"
     services_heading: "Services"
     no_services: "No Compose services loaded yet."
     no_image: "image unavailable"
@@ -124,6 +129,40 @@ app:
     service_count: "Service count: %{count}"
     overall_score: "Overall score: %{score}"
     finding_count: "Finding count: %{count}"
+  adapter:
+    lynis_pentest_mode: "Lynis ran in unprivileged pentest mode; some root-only checks may be omitted."
+    lynis_non_zero_exit: "Lynis exited with a non-zero status: %{detail}. Parsed the available report anyway."
+    lynis_report_missing: "Lynis did not produce a report file."
+  setup:
+    heading: "hostveil setup"
+    detected_os: "Detected OS: %{name}"
+    selected_tools: "Selected tools: %{tools}"
+    planned_changes: "Planned changes"
+    prompt_tools: "Select the optional tools to install and configure"
+    prompt_confirm: "Apply this setup plan?"
+    skipped: "Setup skipped. Run `hostveil setup` later to configure optional tools."
+    requesting_sudo: "Requesting sudo access for package installation and system configuration..."
+    running_step: "Running: %{step}"
+    verification_heading: "Verification"
+    complete: "Setup complete. Re-run `hostveil setup` any time to adjust the installed tool set."
+    check_failed: "%{command} could not be verified: %{detail}"
+    error:
+      unsupported_os: "hostveil setup does not yet support automatic dependency installation on"
+    step:
+      dnf_install: "Install packages with dnf: %{packages}"
+      apt_install: "Install packages with apt: %{packages}"
+      trivy_repo: "Add the upstream Trivy APT repository"
+      fail2ban_baseline: "Write a managed Fail2Ban sshd baseline and enable the service"
+    tool:
+      lynis:
+        name: "Lynis"
+        prompt: "Lynis: host auditing and hardening checks"
+      trivy:
+        name: "Trivy"
+        prompt: "Trivy: image and container vulnerability scanning"
+      fail2ban:
+        name: "Fail2Ban"
+        prompt: "Fail2Ban: basic intrusion-prevention for SSH"
   error:
     unknown_argument: "unknown argument: %{argument}"
     missing_argument_value: "missing value for argument: %{flag}"
@@ -162,6 +201,7 @@ app:
     single_finding: "1 finding"
     multi_findings: "%{count} findings"
     discovery_heading: "Discovery"
+    adapters_heading: "Adapters"
     warnings_heading: "Warnings"
     docker_available: "available"
     docker_missing: "missing"
@@ -206,8 +246,24 @@ source:
 adapter:
   available: "available"
   missing: "missing"
+  skipped: "skipped: %{detail}"
   failed: "failed: %{detail}"
+  reason:
+    no_image_targets: "no image targets were discovered"
+    host_not_scanned: "host scanning was not requested"
+    live_host_only: "a live host scan rooted at / is required"
 finding:
+  lynis:
+    host_warnings:
+      title: "Lynis reported host hardening warnings"
+      description: "Lynis reported %{count} warning(s) for %{subject} with hardening index %{index}."
+      why: "Lynis warnings usually point to host-level hardening gaps that expand the attack surface or weaken recovery after compromise."
+      fix: "Review the reported Lynis warnings first, apply the highest-impact host hardening changes, and rerun the audit to confirm the result."
+    host_suggestions:
+      title: "Lynis reported additional hardening suggestions"
+      description: "Lynis reported %{count} suggestion(s) for %{subject} with hardening index %{index}."
+      why: "Even when they are not immediate break-fix items, accumulated hardening suggestions often reveal a weaker default host posture than intended."
+      fix: "Work through the Lynis suggestions that fit this host's role and rerun the audit after each hardening pass."
   trivy:
     image_vulnerabilities:
       title: "Image has known vulnerabilities"
@@ -324,11 +380,16 @@ finding:
       description: "%{path} configures Docker to listen on a non-local TCP host."
       why: "A public or broadly reachable Docker API can allow remote container control and host compromise if not strongly protected."
       fix: "Remove the TCP listener or bind it to localhost with strong authentication and network restrictions."
+    fail2ban_not_enabled:
+      title: "Fail2ban is installed but not active"
+      description: "%{path} shows local Fail2ban markers, but no enabled service marker was detected."
+      why: "Installing Fail2ban without enabling the service or a real jail leaves repeated login abuse and noisy scanning unmitigated."
+      fix: "Enable the Fail2ban service, configure at least one real jail such as sshd, and verify the client can report active status."
     defensive_controls_missing:
       title: "No intrusion-prevention control was detected"
-      description: "%{path} does not show local markers for Fail2ban or CrowdSec."
+      description: "%{path} does not show local markers for Fail2ban."
       why: "Basic blocking or ban automation can slow down repeated password attacks, scanning, and other noisy abuse against exposed services."
-      fix: "Install and enable at least one host-level defensive control such as Fail2ban or CrowdSec, then verify it is protecting the services you expose."
+      fix: "Install and enable Fail2ban, then verify it is protecting the services you expose."
   vaultwarden:
     signups_enabled:
       title: "Vaultwarden signups are left enabled"

--- a/src/src/adapters/lynis.rs
+++ b/src/src/adapters/lynis.rs
@@ -1,0 +1,474 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::domain::{AdapterStatus, Axis, Finding, RemediationKind, Scope, Severity, Source};
+
+const LIVE_HOST_ROOT: &str = "/";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LynisScanOutput {
+    pub status: AdapterStatus,
+    pub findings: Vec<Finding>,
+    pub warnings: Vec<String>,
+}
+
+pub fn scan(host_root: Option<&Path>) -> LynisScanOutput {
+    let mut output = LynisScanOutput {
+        status: AdapterStatus::Skipped(t!("adapter.reason.host_not_scanned").into_owned()),
+        findings: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    let Some(host_root) = host_root else {
+        return output;
+    };
+
+    if host_root != Path::new(LIVE_HOST_ROOT) {
+        output.status = AdapterStatus::Skipped(t!("adapter.reason.live_host_only").into_owned());
+        return output;
+    }
+
+    match detect_lynis() {
+        LynisAvailability::Missing => {
+            output.status = AdapterStatus::Missing;
+            return output;
+        }
+        LynisAvailability::Available => {
+            output.status = AdapterStatus::Available;
+        }
+        LynisAvailability::Failed(detail) => {
+            output.status = AdapterStatus::Failed(detail);
+            return output;
+        }
+    }
+
+    let mode = if is_effective_root() {
+        LynisMode::Full
+    } else {
+        output
+            .warnings
+            .push(t!("app.adapter.lynis_pentest_mode").into_owned());
+        LynisMode::Pentest
+    };
+
+    let temp_files = temp_report_files();
+    let command_result = run_lynis(mode, &temp_files);
+    let report_text = fs::read_to_string(&temp_files.report_file);
+    cleanup_temp_files(&temp_files);
+
+    let report_text = match report_text {
+        Ok(report_text) => report_text,
+        Err(_) => {
+            output.status = match command_result {
+                Ok(command_result) if !command_result.success => AdapterStatus::Failed(
+                    command_result
+                        .detail
+                        .unwrap_or_else(|| t!("app.adapter.lynis_report_missing").into_owned()),
+                ),
+                Ok(_) => AdapterStatus::Failed(t!("app.adapter.lynis_report_missing").into_owned()),
+                Err(error) => AdapterStatus::Failed(error),
+            };
+            return output;
+        }
+    };
+
+    let report = match parse_report(&report_text) {
+        Ok(report) => report,
+        Err(error) => {
+            output.status = AdapterStatus::Failed(error);
+            return output;
+        }
+    };
+
+    match command_result {
+        Ok(command_result) => {
+            if !command_result.success {
+                let detail = command_result
+                    .detail
+                    .unwrap_or_else(|| t!("app.server.not_available").into_owned());
+                output.warnings.push(
+                    t!("app.adapter.lynis_non_zero_exit", detail = detail.as_str()).into_owned(),
+                );
+            }
+        }
+        Err(error) => {
+            output.status = AdapterStatus::Failed(error);
+            return output;
+        }
+    }
+
+    output.findings = report_to_findings(&report, host_root, mode);
+    output
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LynisMode {
+    Full,
+    Pentest,
+}
+
+impl LynisMode {
+    fn as_evidence_value(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Pentest => "pentest",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LynisAvailability {
+    Available,
+    Missing,
+    Failed(String),
+}
+
+fn detect_lynis() -> LynisAvailability {
+    let output = Command::new("lynis")
+        .arg("--version")
+        .env("NO_COLOR", "1")
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => LynisAvailability::Available,
+        Ok(output) => LynisAvailability::Failed(command_detail(&output.stderr, &output.stdout)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => LynisAvailability::Missing,
+        Err(error) => LynisAvailability::Failed(error.to_string()),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LynisTempFiles {
+    report_file: PathBuf,
+    log_file: PathBuf,
+}
+
+fn temp_report_files() -> LynisTempFiles {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should move forward")
+        .as_nanos();
+    let prefix = format!("hostveil-lynis-{}-{nanos}", std::process::id());
+
+    LynisTempFiles {
+        report_file: env::temp_dir().join(format!("{prefix}.report.dat")),
+        log_file: env::temp_dir().join(format!("{prefix}.log")),
+    }
+}
+
+fn cleanup_temp_files(files: &LynisTempFiles) {
+    let _ = fs::remove_file(&files.report_file);
+    let _ = fs::remove_file(&files.log_file);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LynisCommandResult {
+    success: bool,
+    detail: Option<String>,
+}
+
+fn run_lynis(mode: LynisMode, files: &LynisTempFiles) -> Result<LynisCommandResult, String> {
+    let mut command = Command::new("lynis");
+    command
+        .args(["audit", "system", "--cronjob", "--quiet", "--nocolors"])
+        .arg("--report-file")
+        .arg(&files.report_file)
+        .arg("--logfile")
+        .arg(&files.log_file)
+        .env("NO_COLOR", "1");
+
+    if mode == LynisMode::Pentest {
+        command.arg("--pentest");
+    }
+
+    let output = command.output().map_err(|error| error.to_string())?;
+
+    Ok(LynisCommandResult {
+        success: output.status.success(),
+        detail: Some(command_detail(&output.stderr, &output.stdout)),
+    })
+}
+
+fn is_effective_root() -> bool {
+    let Ok(output) = Command::new("id").arg("-u").output() else {
+        return false;
+    };
+
+    output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "0"
+}
+
+fn command_detail(stderr: &[u8], stdout: &[u8]) -> String {
+    let stderr = String::from_utf8_lossy(stderr);
+    if !stderr.trim().is_empty() {
+        return stderr.trim().to_owned();
+    }
+
+    let stdout = String::from_utf8_lossy(stdout);
+    if !stdout.trim().is_empty() {
+        return stdout.trim().to_owned();
+    }
+
+    String::from("command returned no error detail")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct LynisReport {
+    hostname: Option<String>,
+    hardening_index: Option<u8>,
+    tests_done: Option<usize>,
+    warnings: Vec<LynisEntry>,
+    suggestions: Vec<LynisEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LynisEntry {
+    test_id: String,
+    message: String,
+    details: String,
+    solution: Option<String>,
+}
+
+fn parse_report(text: &str) -> Result<LynisReport, String> {
+    let mut report = LynisReport::default();
+
+    for raw_line in text.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with('[') {
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+
+        match key.trim() {
+            "hostname" => report.hostname = normalize_optional(value),
+            "hardening_index" => report.hardening_index = value.trim().parse::<u8>().ok(),
+            "lynis_tests_done" => report.tests_done = value.trim().parse::<usize>().ok(),
+            "warning[]" => {
+                if let Some(entry) = parse_pipe_entry(value) {
+                    report.warnings.push(entry);
+                }
+            }
+            "suggestion[]" => {
+                if let Some(entry) = parse_pipe_entry(value) {
+                    report.suggestions.push(entry);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if report.hostname.is_none()
+        && report.hardening_index.is_none()
+        && report.warnings.is_empty()
+        && report.suggestions.is_empty()
+    {
+        return Err(String::from("failed to parse Lynis report contents"));
+    }
+
+    Ok(report)
+}
+
+fn parse_pipe_entry(value: &str) -> Option<LynisEntry> {
+    let mut parts = value.split('|');
+    let test_id = parts.next()?.trim();
+    let message = parts.next()?.trim();
+    let details = parts.next().unwrap_or_default().trim();
+    let solution = normalize_optional(parts.next().unwrap_or_default());
+
+    if test_id.is_empty() || message.is_empty() {
+        return None;
+    }
+
+    Some(LynisEntry {
+        test_id: test_id.to_owned(),
+        message: message.to_owned(),
+        details: details.to_owned(),
+        solution,
+    })
+}
+
+fn normalize_optional(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty() && trimmed != "-").then(|| trimmed.to_owned())
+}
+
+fn report_to_findings(report: &LynisReport, host_root: &Path, mode: LynisMode) -> Vec<Finding> {
+    let subject = report
+        .hostname
+        .clone()
+        .unwrap_or_else(|| host_root.display().to_string());
+    let hardening_index = report
+        .hardening_index
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| t!("app.server.not_available").into_owned());
+
+    let mut findings = Vec::new();
+
+    if !report.warnings.is_empty() {
+        findings.push(Finding {
+            id: String::from("lynis.host_warnings"),
+            axis: Axis::HostHardening,
+            severity: Severity::High,
+            scope: Scope::Host,
+            source: Source::Lynis,
+            subject: subject.clone(),
+            related_service: None,
+            title: t!("finding.lynis.host_warnings.title").into_owned(),
+            description: t!(
+                "finding.lynis.host_warnings.description",
+                count = report.warnings.len(),
+                subject = subject.as_str(),
+                index = hardening_index.as_str()
+            )
+            .into_owned(),
+            why_risky: t!("finding.lynis.host_warnings.why").into_owned(),
+            how_to_fix: t!("finding.lynis.host_warnings.fix").into_owned(),
+            evidence: entry_evidence(&report.warnings, report, mode, "warnings_total"),
+            remediation: RemediationKind::None,
+        });
+    }
+
+    if !report.suggestions.is_empty() {
+        findings.push(Finding {
+            id: String::from("lynis.host_suggestions"),
+            axis: Axis::HostHardening,
+            severity: Severity::Low,
+            scope: Scope::Host,
+            source: Source::Lynis,
+            subject: subject.clone(),
+            related_service: None,
+            title: t!("finding.lynis.host_suggestions.title").into_owned(),
+            description: t!(
+                "finding.lynis.host_suggestions.description",
+                count = report.suggestions.len(),
+                subject = subject.as_str(),
+                index = hardening_index.as_str()
+            )
+            .into_owned(),
+            why_risky: t!("finding.lynis.host_suggestions.why").into_owned(),
+            how_to_fix: t!("finding.lynis.host_suggestions.fix").into_owned(),
+            evidence: entry_evidence(&report.suggestions, report, mode, "suggestions_total"),
+            remediation: RemediationKind::None,
+        });
+    }
+
+    findings
+}
+
+fn entry_evidence(
+    entries: &[LynisEntry],
+    report: &LynisReport,
+    mode: LynisMode,
+    total_key: &str,
+) -> BTreeMap<String, String> {
+    let mut evidence = BTreeMap::from([(String::from(total_key), entries.len().to_string())]);
+    evidence.insert(String::from("mode"), mode.as_evidence_value().to_owned());
+
+    if let Some(hardening_index) = report.hardening_index {
+        evidence.insert(String::from("hardening_index"), hardening_index.to_string());
+    }
+    if let Some(tests_done) = report.tests_done {
+        evidence.insert(String::from("tests_done"), tests_done.to_string());
+    }
+
+    let sample_ids = entries
+        .iter()
+        .take(5)
+        .map(|entry| entry.test_id.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if !sample_ids.is_empty() {
+        evidence.insert(String::from("sample_test_ids"), sample_ids);
+    }
+
+    let sample_messages = entries
+        .iter()
+        .take(3)
+        .map(|entry| {
+            if entry.details.is_empty() {
+                entry.message.clone()
+            } else {
+                format!("{} ({})", entry.message, entry.details)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" | ");
+    if !sample_messages.is_empty() {
+        evidence.insert(String::from("sample_messages"), sample_messages);
+    }
+
+    let sample_solutions = entries
+        .iter()
+        .filter_map(|entry| entry.solution.as_deref())
+        .take(2)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    if !sample_solutions.is_empty() {
+        evidence.insert(String::from("sample_solutions"), sample_solutions);
+    }
+
+    evidence
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_when_host_scan_was_not_requested() {
+        let output = scan(None);
+
+        assert_eq!(
+            output.status,
+            AdapterStatus::Skipped(t!("adapter.reason.host_not_scanned").into_owned())
+        );
+    }
+
+    #[test]
+    fn skips_when_host_root_is_not_live() {
+        let output = scan(Some(Path::new("/snapshots/server-root")));
+
+        assert_eq!(
+            output.status,
+            AdapterStatus::Skipped(t!("adapter.reason.live_host_only").into_owned())
+        );
+    }
+
+    #[test]
+    fn summarizes_report_fixture_into_host_findings() {
+        let report = parse_report(include_str!(
+            "../../tests/fixtures/adapters/lynis-report.dat"
+        ))
+        .expect("fixture should parse");
+
+        assert_eq!(report.hostname.as_deref(), Some("demo-host"));
+        assert_eq!(report.hardening_index, Some(67));
+        assert_eq!(report.warnings.len(), 2);
+        assert_eq!(report.suggestions.len(), 1);
+
+        let findings = report_to_findings(&report, Path::new("/"), LynisMode::Pentest);
+        assert_eq!(findings.len(), 2);
+        assert_eq!(findings[0].source, Source::Lynis);
+        assert_eq!(findings[0].axis, Axis::HostHardening);
+        assert_eq!(findings[0].severity, Severity::High);
+        assert_eq!(findings[1].severity, Severity::Low);
+        assert_eq!(findings[0].subject, "demo-host");
+        assert_eq!(
+            findings[0]
+                .evidence
+                .get("sample_test_ids")
+                .map(String::as_str),
+            Some("AUTH-9286, SSH-7408")
+        );
+        assert_eq!(
+            findings[1].evidence.get("mode").map(String::as_str),
+            Some("pentest")
+        );
+    }
+}

--- a/src/src/adapters/mod.rs
+++ b/src/src/adapters/mod.rs
@@ -1,5 +1,6 @@
 use crate::domain::Finding;
 
+pub mod lynis;
 pub mod trivy;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/src/adapters/trivy.rs
+++ b/src/src/adapters/trivy.rs
@@ -23,6 +23,12 @@ pub fn scan(services: &[ServiceSummary]) -> TrivyScanOutput {
     let mut successful_scans = 0_usize;
     let mut first_scan_error: Option<String> = None;
 
+    let images = dedup_images(services);
+    if images.is_empty() {
+        output.status = AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned());
+        return output;
+    }
+
     match detect_trivy() {
         TrivyAvailability::Missing => {
             output.status = AdapterStatus::Missing;
@@ -35,11 +41,6 @@ pub fn scan(services: &[ServiceSummary]) -> TrivyScanOutput {
             output.status = AdapterStatus::Failed(detail);
             return output;
         }
-    }
-
-    let images = dedup_images(services);
-    if images.is_empty() {
-        return output;
     }
 
     for image in images {
@@ -445,5 +446,16 @@ mod tests {
             output.status,
             AdapterStatus::Failed(String::from("registry denied access"))
         );
+    }
+
+    #[test]
+    fn skips_when_no_image_targets_are_available() {
+        let output = scan(&[]);
+
+        assert_eq!(
+            output.status,
+            AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned())
+        );
+        assert!(output.findings.is_empty());
     }
 }

--- a/src/src/app/config.rs
+++ b/src/src/app/config.rs
@@ -27,12 +27,47 @@ impl LifecycleCommand {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SetupTool {
+    Lynis,
+    Trivy,
+    Fail2Ban,
+}
+
+impl SetupTool {
+    pub const ALL: [Self; 3] = [Self::Lynis, Self::Trivy, Self::Fail2Ban];
+
+    pub fn from_arg(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "lynis" => Some(Self::Lynis),
+            "trivy" => Some(Self::Trivy),
+            "fail2ban" => Some(Self::Fail2Ban),
+            _ => None,
+        }
+    }
+
+    pub fn cli_name(self) -> &'static str {
+        match self {
+            Self::Lynis => "lynis",
+            Self::Trivy => "trivy",
+            Self::Fail2Ban => "fail2ban",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SetupConfig {
+    pub selected_tools: Option<Vec<SetupTool>>,
+    pub assume_yes: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppConfig {
     pub output_mode: OutputMode,
     pub show_help: bool,
     pub show_version: bool,
     pub lifecycle_command: Option<LifecycleCommand>,
+    pub setup_command: Option<SetupConfig>,
     pub compose_path: Option<PathBuf>,
     pub host_root: Option<PathBuf>,
     pub fix_mode: Option<FixMode>,
@@ -48,6 +83,7 @@ impl Default for AppConfig {
             show_help: false,
             show_version: false,
             lifecycle_command: None,
+            setup_command: None,
             compose_path: None,
             host_root: None,
             fix_mode: None,
@@ -64,6 +100,7 @@ impl AppConfig {
 
         if let Some(command) = args.first() {
             match command.as_str() {
+                "setup" => return Self::parse_setup(args.into_iter().skip(1)),
                 "upgrade" => return Self::parse_upgrade(args.into_iter().skip(1)),
                 "uninstall" => return Self::parse_uninstall(args.into_iter().skip(1)),
                 "auto-upgrade" => return Self::parse_auto_upgrade(args.into_iter().skip(1)),
@@ -135,6 +172,54 @@ impl AppConfig {
             }
         }
 
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn parse_setup(args: impl IntoIterator<Item = String>) -> Result<Self, AppError> {
+        let mut config = Self::default();
+        let mut setup = SetupConfig::default();
+        let mut selected_tools = Vec::new();
+        let mut args = args.into_iter();
+
+        while let Some(argument) = args.next() {
+            match argument.as_str() {
+                "--yes" => setup.assume_yes = true,
+                "--tool" => {
+                    let value = args
+                        .next()
+                        .ok_or(AppError::MissingArgumentValue("--tool"))?;
+                    push_setup_tool(&mut selected_tools, &value)?;
+                }
+                _ if argument.starts_with("--tool=") => {
+                    let value = argument.trim_start_matches("--tool=");
+                    if value.is_empty() {
+                        return Err(AppError::MissingArgumentValue("--tool"));
+                    }
+                    push_setup_tool(&mut selected_tools, value)?;
+                }
+                "--tools" => {
+                    let value = args
+                        .next()
+                        .ok_or(AppError::MissingArgumentValue("--tools"))?;
+                    parse_setup_tool_list(&mut selected_tools, &value)?;
+                }
+                _ if argument.starts_with("--tools=") => {
+                    let value = argument.trim_start_matches("--tools=");
+                    if value.is_empty() {
+                        return Err(AppError::MissingArgumentValue("--tools"));
+                    }
+                    parse_setup_tool_list(&mut selected_tools, value)?;
+                }
+                "-h" | "--help" => config.show_help = true,
+                _ => return Err(AppError::UnknownArgument(argument)),
+            }
+        }
+
+        if !selected_tools.is_empty() {
+            setup.selected_tools = Some(selected_tools);
+        }
+        config.setup_command = Some(setup);
         config.validate()?;
         Ok(config)
     }
@@ -228,6 +313,10 @@ impl AppConfig {
     }
 
     fn validate(&self) -> Result<(), AppError> {
+        if self.setup_command.is_some() {
+            return Ok(());
+        }
+
         if self.lifecycle_command.is_some() {
             return Ok(());
         }
@@ -275,9 +364,40 @@ impl AppConfig {
     }
 }
 
+fn push_setup_tool(tools: &mut Vec<SetupTool>, value: &str) -> Result<(), AppError> {
+    let tool = SetupTool::from_arg(value).ok_or_else(|| {
+        AppError::InvalidArgumentCombination(format!("unsupported setup tool: {value}"))
+    })?;
+    if !tools.contains(&tool) {
+        tools.push(tool);
+    }
+    Ok(())
+}
+
+fn parse_setup_tool_list(tools: &mut Vec<SetupTool>, value: &str) -> Result<(), AppError> {
+    let mut parsed_any = false;
+
+    for entry in value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+    {
+        parsed_any = true;
+        push_setup_tool(tools, entry)?;
+    }
+
+    if parsed_any {
+        Ok(())
+    } else {
+        Err(AppError::InvalidArgumentCombination(String::from(
+            "--tools requires at least one tool name",
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{AppConfig, LifecycleCommand, OutputMode};
+    use super::{AppConfig, LifecycleCommand, OutputMode, SetupTool};
     use crate::fix::FixMode;
 
     #[test]
@@ -288,6 +408,7 @@ mod tests {
         assert!(!config.show_help);
         assert!(!config.show_version);
         assert!(config.lifecycle_command.is_none());
+        assert!(config.setup_command.is_none());
         assert!(config.fix_mode.is_none());
     }
 
@@ -451,6 +572,46 @@ mod tests {
     fn rejects_auto_upgrade_without_mode() {
         let error = AppConfig::parse([String::from("auto-upgrade")])
             .expect_err("auto-upgrade should require a mode");
+
+        assert!(matches!(
+            error,
+            super::AppError::InvalidArgumentCombination(_)
+        ));
+    }
+
+    #[test]
+    fn parses_setup_command_with_explicit_tools() {
+        let config = AppConfig::parse([
+            String::from("setup"),
+            String::from("--tools=lynis,fail2ban"),
+            String::from("--tool"),
+            String::from("trivy"),
+            String::from("--yes"),
+        ])
+        .expect("setup command should parse");
+
+        let setup = config
+            .setup_command
+            .expect("setup command should be captured");
+        assert!(setup.assume_yes);
+        assert_eq!(
+            setup.selected_tools,
+            Some(vec![
+                SetupTool::Lynis,
+                SetupTool::Fail2Ban,
+                SetupTool::Trivy
+            ])
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_setup_tool() {
+        let error = AppConfig::parse([
+            String::from("setup"),
+            String::from("--tool"),
+            String::from("dockle"),
+        ])
+        .expect_err("unknown setup tool should be rejected");
 
         assert!(matches!(
             error,

--- a/src/src/app/mod.rs
+++ b/src/src/app/mod.rs
@@ -1,7 +1,8 @@
 mod config;
 mod scan;
+mod setup;
 
-pub use config::{AppConfig, OutputMode};
+pub use config::{AppConfig, OutputMode, SetupConfig, SetupTool};
 
 use std::fmt;
 use std::io::{self, IsTerminal, Write};
@@ -83,6 +84,10 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
             i18n::tr_version(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
         );
         return Ok(());
+    }
+
+    if let Some(setup_config) = config.setup_command.as_ref() {
+        return setup::run(setup_config);
     }
 
     if let Some(command) = config.lifecycle_command {

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -46,6 +46,14 @@ fn apply_external_adapters(result: &mut ScanResult) {
         .insert(String::from("trivy"), trivy_output.status);
     result.metadata.warnings.extend(trivy_output.warnings);
     result.findings.extend(trivy_output.findings);
+
+    let lynis_output = adapters::lynis::scan(result.metadata.host_root.as_deref());
+    result
+        .metadata
+        .adapters
+        .insert(String::from("lynis"), lynis_output.status);
+    result.metadata.warnings.extend(lynis_output.warnings);
+    result.findings.extend(lynis_output.findings);
 }
 
 fn uses_live_discovery(config: &AppConfig) -> bool {
@@ -182,10 +190,13 @@ fn apply_host_scan(host_root: PathBuf, result: &mut ScanResult) {
     let context = HostContext {
         root: host_root.clone(),
     };
+    let runtime_info = collect_host_runtime_info(&context);
 
     result.metadata.host_root = Some(host_root);
-    result.metadata.host_runtime = Some(collect_host_runtime_info(&context));
-    result.findings.extend(HostScanner.scan(&context));
+    result.metadata.host_runtime = Some(runtime_info.clone());
+    result
+        .findings
+        .extend(HostScanner.scan_with_runtime(&context, &runtime_info));
 }
 
 #[cfg(test)]
@@ -235,6 +246,7 @@ mod tests {
             show_help: false,
             show_version: false,
             lifecycle_command: None,
+            setup_command: None,
             compose_path: Some(parser_fixture()),
             host_root: None,
             fix_mode: None,
@@ -253,8 +265,75 @@ mod tests {
 
         assert!(matches!(
             status,
-            AdapterStatus::Available | AdapterStatus::Missing | AdapterStatus::Failed(_)
+            AdapterStatus::Available
+                | AdapterStatus::Missing
+                | AdapterStatus::Skipped(_)
+                | AdapterStatus::Failed(_)
         ));
+    }
+
+    #[test]
+    fn records_lynis_as_skipped_for_compose_only_scans() {
+        let config = AppConfig {
+            output_mode: OutputMode::Json,
+            show_help: false,
+            show_version: false,
+            lifecycle_command: None,
+            setup_command: None,
+            compose_path: Some(parser_fixture()),
+            host_root: None,
+            fix_mode: None,
+            fix_target_path: None,
+            preview_changes: false,
+            assume_yes: false,
+        };
+
+        let result = run(&config).expect("scan should succeed");
+
+        let status = result
+            .metadata
+            .adapters
+            .get("lynis")
+            .expect("scan should always record Lynis adapter status");
+
+        assert!(matches!(status, AdapterStatus::Skipped(_)));
+    }
+
+    #[test]
+    fn records_lynis_as_skipped_for_host_snapshots() {
+        let host_root = temp_host_root("lynis-snapshot");
+        write_file(&host_root.join("etc/hostname"), "snapshot-host\n");
+        write_file(&host_root.join("proc/uptime"), "60.00 0.00\n");
+        write_file(
+            &host_root.join("proc/loadavg"),
+            "0.01 0.01 0.00 1/100 123\n",
+        );
+
+        let config = AppConfig {
+            output_mode: OutputMode::Json,
+            show_help: false,
+            show_version: false,
+            lifecycle_command: None,
+            setup_command: None,
+            compose_path: None,
+            host_root: Some(host_root.clone()),
+            fix_mode: None,
+            fix_target_path: None,
+            preview_changes: false,
+            assume_yes: false,
+        };
+
+        let result = run(&config).expect("snapshot host scan should succeed");
+
+        let status = result
+            .metadata
+            .adapters
+            .get("lynis")
+            .expect("scan should always record Lynis adapter status");
+
+        assert!(matches!(status, AdapterStatus::Skipped(_)));
+
+        fs::remove_dir_all(host_root).expect("temp root should be removed");
     }
 
     #[test]
@@ -264,6 +343,7 @@ mod tests {
             show_help: false,
             show_version: false,
             lifecycle_command: None,
+            setup_command: None,
             compose_path: Some(parser_fixture()),
             host_root: None,
             fix_mode: None,
@@ -326,10 +406,6 @@ mod tests {
             &host_root.join("etc/systemd/system/multi-user.target.wants/fail2ban.service"),
             "enabled\n",
         );
-        write_file(
-            &host_root.join("etc/crowdsec/config.yaml"),
-            "api:\n  server:\n",
-        );
         write_file(&host_root.join("var/run/docker.sock"), "socket");
         fs::set_permissions(
             host_root.join("var/run/docker.sock"),
@@ -342,6 +418,7 @@ mod tests {
             show_help: false,
             show_version: false,
             lifecycle_command: None,
+            setup_command: None,
             compose_path: Some(parser_fixture()),
             host_root: Some(host_root.clone()),
             fix_mode: None,
@@ -385,14 +462,6 @@ mod tests {
                 .as_ref()
                 .map(|info| info.fail2ban),
             Some(crate::domain::DefensiveControlStatus::Enabled)
-        );
-        assert_eq!(
-            result
-                .metadata
-                .host_runtime
-                .as_ref()
-                .map(|info| info.crowdsec),
-            Some(crate::domain::DefensiveControlStatus::Installed)
         );
         assert!(
             result

--- a/src/src/app/setup.rs
+++ b/src/src/app/setup.rs
@@ -1,0 +1,690 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{self, IsTerminal, Write};
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use dialoguer::{Confirm, MultiSelect, theme::ColorfulTheme};
+
+use super::{AppError, SetupConfig, SetupTool};
+
+const OS_RELEASE_PATH: &str = "/etc/os-release";
+const TRIVY_APT_KEY_URL: &str = "https://aquasecurity.github.io/trivy-repo/deb/public.key";
+const TRIVY_APT_KEYRING_PATH: &str = "/etc/apt/keyrings/trivy.gpg";
+const TRIVY_APT_SOURCE_PATH: &str = "/etc/apt/sources.list.d/trivy.list";
+const TRIVY_APT_SOURCE_LINE: &str = "deb [signed-by=/etc/apt/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main\n";
+const FAIL2BAN_BASELINE_PATH: &str = "/etc/fail2ban/jail.d/hostveil.local";
+const FAIL2BAN_BASELINE_CONTENT: &str = concat!(
+    "[sshd]\n",
+    "enabled = true\n",
+    "backend = systemd\n",
+    "bantime = 1h\n",
+    "findtime = 10m\n",
+    "maxretry = 5\n"
+);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SetupPlan {
+    distro: DistroInfo,
+    tools: Vec<SetupTool>,
+    steps: Vec<SetupStep>,
+}
+
+impl SetupPlan {
+    fn new(distro: DistroInfo, tools: Vec<SetupTool>) -> Result<Self, AppError> {
+        let mut package_set = Vec::new();
+        let mut steps = Vec::new();
+
+        for tool in &tools {
+            if *tool == SetupTool::Trivy && distro.family == DistroFamily::Debian {
+                steps.push(SetupStep::ConfigureTrivyAptRepo);
+            }
+            package_set.push(tool.package_name().to_owned());
+        }
+
+        package_set.sort();
+        package_set.dedup();
+
+        match distro.family {
+            DistroFamily::Fedora => steps.push(SetupStep::DnfInstall(package_set)),
+            DistroFamily::Debian => steps.push(SetupStep::AptInstall(package_set)),
+            DistroFamily::Unsupported => {
+                return Err(AppError::Io(io::Error::other(format!(
+                    "{} {}",
+                    t!("app.setup.error.unsupported_os").into_owned(),
+                    distro.pretty_name
+                ))));
+            }
+        }
+
+        if tools.contains(&SetupTool::Fail2Ban) {
+            steps.push(SetupStep::ConfigureFail2BanBaseline);
+        }
+
+        Ok(Self {
+            distro,
+            tools,
+            steps,
+        })
+    }
+
+    fn requires_privileges(&self) -> bool {
+        !self.steps.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SetupStep {
+    DnfInstall(Vec<String>),
+    AptInstall(Vec<String>),
+    ConfigureTrivyAptRepo,
+    ConfigureFail2BanBaseline,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DistroInfo {
+    family: DistroFamily,
+    pretty_name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DistroFamily {
+    Fedora,
+    Debian,
+    Unsupported,
+}
+
+pub fn run(config: &SetupConfig) -> Result<(), AppError> {
+    let tools = resolve_requested_tools(config)?;
+    if tools.is_empty() {
+        println!("{}", t!("app.setup.skipped").into_owned());
+        return Ok(());
+    }
+
+    let distro = detect_distro()?;
+    let plan = SetupPlan::new(distro, tools)?;
+
+    print_plan(&plan);
+
+    if !config.assume_yes && io::stdin().is_terminal() && io::stdout().is_terminal() {
+        let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(t!("app.setup.prompt_confirm").into_owned())
+            .default(true)
+            .interact()
+            .map_err(|error| AppError::Io(io::Error::other(error.to_string())))?;
+        if !confirmed {
+            println!("{}", t!("app.setup.skipped").into_owned());
+            return Ok(());
+        }
+    }
+
+    if plan.requires_privileges() {
+        ensure_sudo_session()?;
+    }
+
+    execute_plan(&plan)?;
+    print_verification(&plan);
+
+    Ok(())
+}
+
+fn resolve_requested_tools(config: &SetupConfig) -> Result<Vec<SetupTool>, AppError> {
+    if let Some(selected_tools) = &config.selected_tools {
+        return Ok(selected_tools.clone());
+    }
+
+    if config.assume_yes {
+        return Ok(recommended_tools());
+    }
+
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(AppError::InvalidArgumentCombination(String::from(
+            "setup requires a terminal or explicit --tools/--tool selection; use --yes to accept the recommended defaults",
+        )));
+    }
+
+    let labels = SetupTool::ALL
+        .into_iter()
+        .map(SetupTool::prompt_label)
+        .collect::<Vec<_>>();
+    let defaults = SetupTool::ALL
+        .into_iter()
+        .map(|tool| tool.recommended())
+        .collect::<Vec<_>>();
+
+    let selection = MultiSelect::with_theme(&ColorfulTheme::default())
+        .with_prompt(t!("app.setup.prompt_tools").into_owned())
+        .items(&labels)
+        .defaults(&defaults)
+        .report(false)
+        .interact_opt()
+        .map_err(|error| AppError::Io(io::Error::other(error.to_string())))?;
+
+    let Some(selection) = selection else {
+        return Ok(Vec::new());
+    };
+
+    Ok(selection
+        .into_iter()
+        .map(|index| SetupTool::ALL[index])
+        .collect())
+}
+
+fn recommended_tools() -> Vec<SetupTool> {
+    SetupTool::ALL
+        .into_iter()
+        .filter(|tool| tool.recommended())
+        .collect()
+}
+
+fn detect_distro() -> Result<DistroInfo, AppError> {
+    let text = fs::read_to_string(OS_RELEASE_PATH)?;
+    Ok(parse_os_release(&text))
+}
+
+fn parse_os_release(text: &str) -> DistroInfo {
+    let mut values = BTreeMap::new();
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        values.insert(key.trim().to_owned(), trim_os_release_value(value));
+    }
+
+    let pretty_name = values
+        .get("PRETTY_NAME")
+        .cloned()
+        .or_else(|| values.get("NAME").cloned())
+        .unwrap_or_else(|| String::from("Linux"));
+
+    let id = values.get("ID").map(|value| value.to_ascii_lowercase());
+    let id_like = values
+        .get("ID_LIKE")
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_default();
+
+    let family = match id.as_deref() {
+        Some("fedora") | Some("rhel") | Some("centos") => DistroFamily::Fedora,
+        Some("debian") | Some("ubuntu") => DistroFamily::Debian,
+        _ if id_like.contains("fedora") || id_like.contains("rhel") => DistroFamily::Fedora,
+        _ if id_like.contains("debian") => DistroFamily::Debian,
+        _ => DistroFamily::Unsupported,
+    };
+
+    DistroInfo {
+        family,
+        pretty_name,
+    }
+}
+
+fn trim_os_release_value(value: &str) -> String {
+    value.trim().trim_matches('"').trim_matches('\'').to_owned()
+}
+
+fn print_plan(plan: &SetupPlan) {
+    println!("{}", t!("app.setup.heading").into_owned());
+    println!(
+        "{}",
+        t!(
+            "app.setup.detected_os",
+            name = plan.distro.pretty_name.as_str()
+        )
+        .into_owned()
+    );
+    println!(
+        "{}",
+        t!(
+            "app.setup.selected_tools",
+            tools = plan
+                .tools
+                .iter()
+                .map(|tool| tool.display_name())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+        .into_owned()
+    );
+    println!();
+    println!("{}", t!("app.setup.planned_changes").into_owned());
+
+    for step in &plan.steps {
+        println!("- {}", step.summary());
+    }
+
+    println!();
+}
+
+fn execute_plan(plan: &SetupPlan) -> Result<(), AppError> {
+    for step in &plan.steps {
+        println!(
+            "{}",
+            t!("app.setup.running_step", step = step.summary()).into_owned()
+        );
+        match step {
+            SetupStep::DnfInstall(packages) => {
+                let args = vec!["install", "-y"]
+                    .into_iter()
+                    .chain(packages.iter().map(String::as_str))
+                    .collect::<Vec<_>>();
+                run_privileged_command("dnf", &args)?;
+            }
+            SetupStep::AptInstall(packages) => {
+                run_privileged_command("apt-get", &["update"])?;
+                let args = vec!["install", "-y"]
+                    .into_iter()
+                    .chain(packages.iter().map(String::as_str))
+                    .collect::<Vec<_>>();
+                run_privileged_command("apt-get", &args)?;
+            }
+            SetupStep::ConfigureTrivyAptRepo => {
+                configure_trivy_apt_repo()?;
+            }
+            SetupStep::ConfigureFail2BanBaseline => {
+                configure_fail2ban_baseline()?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn configure_trivy_apt_repo() -> Result<(), AppError> {
+    run_privileged_command("apt-get", &["update"])?;
+    run_privileged_command(
+        "apt-get",
+        &["install", "-y", "ca-certificates", "curl", "gnupg"],
+    )?;
+    run_privileged_command("install", &["-d", "-m", "0755", "/etc/apt/keyrings"])?;
+
+    let key_bytes = capture_command_bytes("curl", &["-fsSL", TRIVY_APT_KEY_URL])?;
+    run_privileged_command_with_stdin(
+        "gpg",
+        &[
+            "--dearmor",
+            "--batch",
+            "--yes",
+            "-o",
+            TRIVY_APT_KEYRING_PATH,
+        ],
+        &key_bytes,
+    )?;
+
+    install_root_file(
+        TRIVY_APT_SOURCE_PATH,
+        "0644",
+        TRIVY_APT_SOURCE_LINE.as_bytes(),
+    )?;
+    Ok(())
+}
+
+fn configure_fail2ban_baseline() -> Result<(), AppError> {
+    install_root_file(
+        FAIL2BAN_BASELINE_PATH,
+        "0644",
+        FAIL2BAN_BASELINE_CONTENT.as_bytes(),
+    )?;
+    run_privileged_command("fail2ban-client", &["-t"])?;
+    run_privileged_command("systemctl", &["enable", "--now", "fail2ban"])?;
+    run_privileged_command("fail2ban-client", &["status"])?;
+    run_privileged_command("fail2ban-client", &["status", "sshd"])?;
+    Ok(())
+}
+
+fn print_verification(plan: &SetupPlan) {
+    println!();
+    println!("{}", t!("app.setup.verification_heading").into_owned());
+
+    for tool in &plan.tools {
+        match tool {
+            SetupTool::Lynis => print_command_check("lynis", &["--version"]),
+            SetupTool::Trivy => print_command_check("trivy", &["--version"]),
+            SetupTool::Fail2Ban => {
+                print_command_check("systemctl", &["is-enabled", "fail2ban"]);
+                print_command_check("systemctl", &["is-active", "fail2ban"]);
+            }
+        }
+    }
+
+    println!();
+    println!("{}", t!("app.setup.complete").into_owned());
+}
+
+fn print_command_check(program: &str, args: &[&str]) {
+    match run_command(program, args) {
+        Ok(output) => println!("- {}", output),
+        Err(error) => println!(
+            "- {}",
+            t!(
+                "app.setup.check_failed",
+                command = format_command(program, args).as_str(),
+                detail = error.as_str()
+            )
+            .into_owned()
+        ),
+    }
+}
+
+fn ensure_sudo_session() -> Result<(), AppError> {
+    if is_effective_root() {
+        return Ok(());
+    }
+
+    if !command_exists("sudo") {
+        return Err(AppError::Io(io::Error::other(String::from(
+            "sudo is required for setup operations but was not found on PATH",
+        ))));
+    }
+
+    if run_command("sudo", &["-n", "true"]).is_ok() {
+        return Ok(());
+    }
+
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(AppError::Io(io::Error::other(String::from(
+            "sudo needs a password but no interactive terminal is available",
+        ))));
+    }
+
+    println!("{}", t!("app.setup.requesting_sudo").into_owned());
+    run_command("sudo", &["-v"]).map(|_| ()).map_err(|error| {
+        AppError::Io(io::Error::other(format!(
+            "failed to obtain sudo credentials: {error}"
+        )))
+    })
+}
+
+fn command_exists(program: &str) -> bool {
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "command -v {} >/dev/null 2>&1",
+            shell_escape(program)
+        ))
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn shell_escape(value: &str) -> String {
+    value.replace('"', "\\\"")
+}
+
+fn is_effective_root() -> bool {
+    run_command("id", &["-u"])
+        .map(|output| output.trim() == "0")
+        .unwrap_or(false)
+}
+
+fn run_command(program: &str, args: &[&str]) -> Result<String, String> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .map_err(|error| error.to_string())?;
+    command_output_to_result(program, args, output)
+}
+
+fn capture_command_bytes(program: &str, args: &[&str]) -> Result<Vec<u8>, AppError> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .map_err(|error| AppError::Io(io::Error::other(error.to_string())))?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        Err(AppError::Io(io::Error::other(command_error_detail(
+            program, args, &output,
+        ))))
+    }
+}
+
+fn run_privileged_command(program: &str, args: &[&str]) -> Result<String, AppError> {
+    let output = privileged_command(program, args)
+        .output()
+        .map_err(|error| AppError::Io(io::Error::other(error.to_string())))?;
+    command_output_to_result(program, args, output)
+        .map_err(|error| AppError::Io(io::Error::other(error)))
+}
+
+fn run_privileged_command_with_stdin(
+    program: &str,
+    args: &[&str],
+    stdin_bytes: &[u8],
+) -> Result<(), AppError> {
+    let mut child = privileged_command(program, args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| AppError::Io(io::Error::other(error.to_string())))?;
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin.write_all(stdin_bytes)?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|error| AppError::Io(io::Error::other(error.to_string())))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(AppError::Io(io::Error::other(command_error_detail(
+            program, args, &output,
+        ))))
+    }
+}
+
+fn privileged_command(program: &str, args: &[&str]) -> Command {
+    if is_effective_root() {
+        let mut command = Command::new(program);
+        command.args(args);
+        command
+    } else {
+        let mut command = Command::new("sudo");
+        command.arg(program).args(args);
+        command
+    }
+}
+
+fn command_output_to_result(
+    program: &str,
+    args: &[&str],
+    output: Output,
+) -> Result<String, String> {
+    if !output.status.success() {
+        return Err(command_error_detail(program, args, &output));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if stdout.is_empty() {
+        Ok(format_command(program, args))
+    } else {
+        Ok(stdout)
+    }
+}
+
+fn command_error_detail(program: &str, args: &[&str], output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if !stderr.is_empty() {
+        return format!("{}: {}", format_command(program, args), stderr);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if !stdout.is_empty() {
+        return format!("{}: {}", format_command(program, args), stdout);
+    }
+
+    format!(
+        "{} exited with status {}",
+        format_command(program, args),
+        output.status
+    )
+}
+
+fn format_command(program: &str, args: &[&str]) -> String {
+    if args.is_empty() {
+        program.to_owned()
+    } else {
+        format!("{} {}", program, args.join(" "))
+    }
+}
+
+fn install_root_file(destination: &str, mode: &str, content: &[u8]) -> Result<(), AppError> {
+    let temp_path = temp_path("setup");
+    fs::write(&temp_path, content)?;
+
+    let source = temp_path
+        .to_str()
+        .ok_or_else(|| AppError::Io(io::Error::other("temporary path is not valid UTF-8")))?
+        .to_owned();
+
+    let result =
+        run_privileged_command("install", &["-D", "-m", mode, source.as_str(), destination]);
+    let _ = fs::remove_file(&temp_path);
+    result.map(|_| ())
+}
+
+fn temp_path(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should move forward")
+        .as_nanos();
+    std::env::temp_dir().join(format!("hostveil-{prefix}-{}-{nanos}", std::process::id()))
+}
+
+impl SetupTool {
+    fn recommended(self) -> bool {
+        true
+    }
+
+    fn package_name(self) -> &'static str {
+        self.cli_name()
+    }
+
+    fn display_name(self) -> String {
+        match self {
+            Self::Lynis => t!("app.setup.tool.lynis.name").into_owned(),
+            Self::Trivy => t!("app.setup.tool.trivy.name").into_owned(),
+            Self::Fail2Ban => t!("app.setup.tool.fail2ban.name").into_owned(),
+        }
+    }
+
+    fn prompt_label(self) -> String {
+        match self {
+            Self::Lynis => t!("app.setup.tool.lynis.prompt").into_owned(),
+            Self::Trivy => t!("app.setup.tool.trivy.prompt").into_owned(),
+            Self::Fail2Ban => t!("app.setup.tool.fail2ban.prompt").into_owned(),
+        }
+    }
+}
+
+impl SetupStep {
+    fn summary(&self) -> String {
+        match self {
+            Self::DnfInstall(packages) => t!(
+                "app.setup.step.dnf_install",
+                packages = packages.join(", ").as_str()
+            )
+            .into_owned(),
+            Self::AptInstall(packages) => t!(
+                "app.setup.step.apt_install",
+                packages = packages.join(", ").as_str()
+            )
+            .into_owned(),
+            Self::ConfigureTrivyAptRepo => t!("app.setup.step.trivy_repo").into_owned(),
+            Self::ConfigureFail2BanBaseline => t!("app.setup.step.fail2ban_baseline").into_owned(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_fedora_os_release() {
+        let distro = parse_os_release(
+            r#"
+NAME="Fedora Linux"
+PRETTY_NAME="Fedora Linux 43"
+ID=fedora
+VERSION_ID=43
+ID_LIKE="fedora"
+"#,
+        );
+
+        assert_eq!(distro.family, DistroFamily::Fedora);
+        assert_eq!(distro.pretty_name, "Fedora Linux 43");
+    }
+
+    #[test]
+    fn parses_ubuntu_as_debian_family() {
+        let distro = parse_os_release(
+            r#"
+PRETTY_NAME="Ubuntu 24.04.4 LTS"
+ID=ubuntu
+ID_LIKE=debian
+"#,
+        );
+
+        assert_eq!(distro.family, DistroFamily::Debian);
+    }
+
+    #[test]
+    fn builds_fedora_plan_without_extra_repo_step() {
+        let plan = SetupPlan::new(
+            DistroInfo {
+                family: DistroFamily::Fedora,
+                pretty_name: String::from("Fedora Linux 43"),
+            },
+            vec![SetupTool::Lynis, SetupTool::Trivy, SetupTool::Fail2Ban],
+        )
+        .expect("fedora plan should build");
+
+        assert_eq!(
+            plan.steps,
+            vec![
+                SetupStep::DnfInstall(vec![
+                    String::from("fail2ban"),
+                    String::from("lynis"),
+                    String::from("trivy"),
+                ]),
+                SetupStep::ConfigureFail2BanBaseline,
+            ]
+        );
+    }
+
+    #[test]
+    fn builds_debian_plan_with_trivy_repo_step() {
+        let plan = SetupPlan::new(
+            DistroInfo {
+                family: DistroFamily::Debian,
+                pretty_name: String::from("Ubuntu 24.04.4 LTS"),
+            },
+            vec![SetupTool::Trivy, SetupTool::Fail2Ban],
+        )
+        .expect("debian plan should build");
+
+        assert_eq!(
+            plan.steps,
+            vec![
+                SetupStep::ConfigureTrivyAptRepo,
+                SetupStep::AptInstall(vec![String::from("fail2ban"), String::from("trivy"),]),
+                SetupStep::ConfigureFail2BanBaseline,
+            ]
+        );
+    }
+
+    #[test]
+    fn temp_path_uses_requested_prefix() {
+        let path = temp_path("trivy");
+        let path_text = path.display().to_string();
+
+        assert!(path_text.contains("hostveil-trivy-"));
+    }
+}

--- a/src/src/domain/mod.rs
+++ b/src/src/domain/mod.rs
@@ -119,7 +119,8 @@ pub struct HostRuntimeInfo {
     pub uptime: Option<String>,
     pub load_average: Option<String>,
     pub fail2ban: DefensiveControlStatus,
-    pub crowdsec: DefensiveControlStatus,
+    pub fail2ban_jails: Option<usize>,
+    pub fail2ban_banned_ips: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Default)]
@@ -178,6 +179,7 @@ impl Default for ScoreReport {
 pub enum AdapterStatus {
     Available,
     Missing,
+    Skipped(String),
     Failed(String),
 }
 

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -26,18 +26,6 @@ const FAIL2BAN_ENABLED_MARKERS: [&str; 2] = [
     "etc/systemd/system/multi-user.target.wants/fail2ban.service",
     "etc/systemd/system/default.target.wants/fail2ban.service",
 ];
-const CROWDSEC_INSTALL_MARKERS: [&str; 6] = [
-    "etc/crowdsec",
-    "usr/bin/crowdsec",
-    "usr/bin/cscli",
-    "usr/local/bin/cscli",
-    "lib/systemd/system/crowdsec.service",
-    "usr/lib/systemd/system/crowdsec.service",
-];
-const CROWDSEC_ENABLED_MARKERS: [&str; 2] = [
-    "etc/systemd/system/multi-user.target.wants/crowdsec.service",
-    "etc/systemd/system/default.target.wants/crowdsec.service",
-];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostContext {
@@ -57,31 +45,48 @@ pub struct HostScanner;
 
 impl HostScanner {
     pub fn scan(&self, context: &HostContext) -> Vec<Finding> {
+        let runtime = collect_host_runtime_info(context);
+        self.scan_with_runtime(context, &runtime)
+    }
+
+    pub fn scan_with_runtime(
+        &self,
+        context: &HostContext,
+        runtime: &HostRuntimeInfo,
+    ) -> Vec<Finding> {
         let mut findings = Vec::new();
         findings.extend(scan_ssh_hardening(context));
         findings.extend(scan_docker_host_exposure(context));
-        findings.extend(scan_defensive_controls(context));
+        findings.extend(scan_defensive_controls(context, runtime));
         findings
     }
 }
 
 pub fn collect_host_runtime_info(context: &HostContext) -> HostRuntimeInfo {
+    let controls = collect_defensive_controls_snapshot(&context.root);
+
     HostRuntimeInfo {
         hostname: read_hostname(&context.root),
         docker_version: discover_docker_version(&context.root),
         uptime: read_uptime(&context.root),
         load_average: read_load_average(&context.root),
-        fail2ban: detect_defensive_control(
-            &context.root,
-            &FAIL2BAN_INSTALL_MARKERS,
-            &FAIL2BAN_ENABLED_MARKERS,
-        ),
-        crowdsec: detect_defensive_control(
-            &context.root,
-            &CROWDSEC_INSTALL_MARKERS,
-            &CROWDSEC_ENABLED_MARKERS,
-        ),
+        fail2ban: controls.fail2ban_status,
+        fail2ban_jails: controls.fail2ban_jails,
+        fail2ban_banned_ips: controls.fail2ban_banned_ips,
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct DefensiveControlsSnapshot {
+    fail2ban_status: DefensiveControlStatus,
+    fail2ban_jails: Option<usize>,
+    fail2ban_banned_ips: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct Fail2BanLiveSummary {
+    jails: Option<usize>,
+    banned_ips: Option<usize>,
 }
 
 fn host_finding(
@@ -303,49 +308,53 @@ fn scan_docker_host_exposure(context: &HostContext) -> Vec<Finding> {
     findings
 }
 
-fn scan_defensive_controls(context: &HostContext) -> Vec<Finding> {
-    let fail2ban_present = has_any_marker(&context.root, &FAIL2BAN_INSTALL_MARKERS)
-        || has_any_marker(&context.root, &FAIL2BAN_ENABLED_MARKERS);
-    let crowdsec_present = has_any_marker(&context.root, &CROWDSEC_INSTALL_MARKERS)
-        || has_any_marker(&context.root, &CROWDSEC_ENABLED_MARKERS);
-
-    if fail2ban_present || crowdsec_present {
-        return Vec::new();
+fn scan_defensive_controls(context: &HostContext, runtime: &HostRuntimeInfo) -> Vec<Finding> {
+    match runtime.fail2ban {
+        DefensiveControlStatus::Enabled => Vec::new(),
+        DefensiveControlStatus::Installed => vec![host_finding(
+            "host.fail2ban_not_enabled",
+            Severity::Medium,
+            &context.root,
+            HostFindingText {
+                title: t!("finding.host.fail2ban_not_enabled.title").into_owned(),
+                description: t!(
+                    "finding.host.fail2ban_not_enabled.description",
+                    path = context.root.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.fail2ban_not_enabled.why").into_owned(),
+                how_to_fix: t!("finding.host.fail2ban_not_enabled.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), context.root.display().to_string()),
+                (String::from("control"), String::from("fail2ban")),
+            ]),
+        )],
+        DefensiveControlStatus::NotDetected => vec![host_finding(
+            "host.defensive_controls_missing",
+            Severity::Low,
+            &context.root,
+            HostFindingText {
+                title: t!("finding.host.defensive_controls_missing.title").into_owned(),
+                description: t!(
+                    "finding.host.defensive_controls_missing.description",
+                    path = context.root.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.defensive_controls_missing.why").into_owned(),
+                how_to_fix: t!("finding.host.defensive_controls_missing.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), context.root.display().to_string()),
+                (String::from("checked_controls"), String::from("fail2ban")),
+            ]),
+        )],
     }
-
-    vec![host_finding(
-        "host.defensive_controls_missing",
-        Severity::Low,
-        &context.root,
-        HostFindingText {
-            title: t!("finding.host.defensive_controls_missing.title").into_owned(),
-            description: t!(
-                "finding.host.defensive_controls_missing.description",
-                path = context.root.display().to_string()
-            )
-            .into_owned(),
-            why_risky: t!("finding.host.defensive_controls_missing.why").into_owned(),
-            how_to_fix: t!("finding.host.defensive_controls_missing.fix").into_owned(),
-        },
-        BTreeMap::from([
-            (String::from("path"), context.root.display().to_string()),
-            (
-                String::from("checked_controls"),
-                String::from("fail2ban,crowdsec"),
-            ),
-        ]),
-    )]
 }
 
 fn resolve_existing_path(root: &Path, relative: &str) -> Option<PathBuf> {
     let path = root.join(relative);
     path.exists().then_some(path)
-}
-
-fn has_any_marker(root: &Path, markers: &[&str]) -> bool {
-    markers
-        .iter()
-        .any(|marker| resolve_existing_path(root, marker).is_some())
 }
 
 fn detect_defensive_control(
@@ -366,6 +375,231 @@ fn detect_defensive_control(
     } else {
         DefensiveControlStatus::NotDetected
     }
+}
+
+fn collect_defensive_controls_snapshot(root: &Path) -> DefensiveControlsSnapshot {
+    let mut snapshot = DefensiveControlsSnapshot {
+        fail2ban_status: detect_defensive_control(
+            root,
+            &FAIL2BAN_INSTALL_MARKERS,
+            &FAIL2BAN_ENABLED_MARKERS,
+        ),
+        fail2ban_jails: count_enabled_fail2ban_jails(root),
+        ..DefensiveControlsSnapshot::default()
+    };
+
+    if !is_live_root(root) {
+        return snapshot;
+    }
+
+    if let Some(live) = collect_fail2ban_live_summary() {
+        snapshot.fail2ban_status = DefensiveControlStatus::Enabled;
+        if live.jails.is_some() {
+            snapshot.fail2ban_jails = live.jails;
+        }
+        snapshot.fail2ban_banned_ips = live.banned_ips;
+    }
+
+    snapshot
+}
+
+fn count_enabled_fail2ban_jails(root: &Path) -> Option<usize> {
+    let mut parser = Fail2BanJailParser::default();
+    let mut parsed_any_file = false;
+
+    for path in fail2ban_jail_config_paths(root) {
+        let Ok(text) = fs::read_to_string(&path) else {
+            continue;
+        };
+        parsed_any_file = true;
+        parser.apply(&text);
+    }
+
+    parsed_any_file.then(|| parser.enabled_jail_count())
+}
+
+fn fail2ban_jail_config_paths(root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    paths.push(root.join("etc/fail2ban/jail.conf"));
+    paths.extend(sorted_fail2ban_dir_entries(
+        root,
+        "etc/fail2ban/jail.d",
+        "conf",
+    ));
+    paths.push(root.join("etc/fail2ban/jail.local"));
+    paths.extend(sorted_fail2ban_dir_entries(
+        root,
+        "etc/fail2ban/jail.d",
+        "local",
+    ));
+
+    paths
+}
+
+fn sorted_fail2ban_dir_entries(root: &Path, relative_dir: &str, extension: &str) -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(root.join(relative_dir)) else {
+        return Vec::new();
+    };
+
+    let mut paths = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some(extension))
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
+}
+
+#[derive(Debug, Default)]
+struct Fail2BanJailParser {
+    default_enabled: bool,
+    sections: BTreeMap<String, Option<bool>>,
+}
+
+impl Fail2BanJailParser {
+    fn apply(&mut self, text: &str) {
+        let mut current_section: Option<String> = None;
+
+        for raw_line in text.lines() {
+            let line = strip_ini_comments(raw_line);
+            if line.is_empty() {
+                continue;
+            }
+
+            if let Some(section) = parse_ini_section(line) {
+                current_section = Some(section.clone());
+                if !is_special_fail2ban_section(&section) {
+                    self.sections.entry(section).or_insert(None);
+                }
+                continue;
+            }
+
+            let Some(section) = current_section.as_deref() else {
+                continue;
+            };
+            let Some((key, value)) = parse_ini_key_value(line) else {
+                continue;
+            };
+            if !key.eq_ignore_ascii_case("enabled") {
+                continue;
+            }
+            let Some(enabled) = parse_ini_bool(value) else {
+                continue;
+            };
+
+            if section.eq_ignore_ascii_case("DEFAULT") {
+                self.default_enabled = enabled;
+            } else if !is_special_fail2ban_section(section) {
+                self.sections.insert(section.to_owned(), Some(enabled));
+            }
+        }
+    }
+
+    fn enabled_jail_count(&self) -> usize {
+        self.sections
+            .values()
+            .filter(|enabled| enabled.unwrap_or(self.default_enabled))
+            .count()
+    }
+}
+
+fn strip_ini_comments(line: &str) -> &str {
+    let trimmed = line.trim();
+    if trimmed.starts_with('#') || trimmed.starts_with(';') {
+        return "";
+    }
+
+    let hash_index = line.find('#');
+    let semicolon_index = line.find(" ;").map(|index| index + 1);
+    let comment_index = match (hash_index, semicolon_index) {
+        (Some(hash), Some(semicolon)) => Some(hash.min(semicolon)),
+        (Some(hash), None) => Some(hash),
+        (None, Some(semicolon)) => Some(semicolon),
+        (None, None) => None,
+    };
+
+    line[..comment_index.unwrap_or(line.len())].trim()
+}
+
+fn parse_ini_section(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    trimmed
+        .strip_prefix('[')?
+        .strip_suffix(']')
+        .map(str::trim)
+        .filter(|section| !section.is_empty())
+        .map(str::to_owned)
+}
+
+fn parse_ini_key_value(line: &str) -> Option<(&str, &str)> {
+    let (key, value) = line.split_once('=')?;
+    Some((key.trim(), value.trim()))
+}
+
+fn parse_ini_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+fn is_special_fail2ban_section(section: &str) -> bool {
+    section.eq_ignore_ascii_case("DEFAULT") || section.eq_ignore_ascii_case("INCLUDES")
+}
+
+fn collect_fail2ban_live_summary() -> Option<Fail2BanLiveSummary> {
+    try_command(&["fail2ban-client", "ping"])?;
+
+    let status_output = try_command(&["fail2ban-client", "status"]);
+    let Some(status_output) = status_output else {
+        return Some(Fail2BanLiveSummary::default());
+    };
+
+    let jails = parse_fail2ban_jails(&status_output);
+    let mut total_banned = 0usize;
+    let mut parsed_any_banned = jails.is_empty();
+
+    for jail in &jails {
+        let Some(jail_output) = try_command(&["fail2ban-client", "status", jail.as_str()]) else {
+            continue;
+        };
+        let Some(currently_banned) = parse_fail2ban_currently_banned(&jail_output) else {
+            continue;
+        };
+        total_banned += currently_banned;
+        parsed_any_banned = true;
+    }
+
+    Some(Fail2BanLiveSummary {
+        jails: Some(jails.len()),
+        banned_ips: parsed_any_banned.then_some(total_banned),
+    })
+}
+
+fn parse_fail2ban_jails(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .find_map(|line| line.split_once("Jail list:"))
+        .map(|(_, list)| {
+            list.split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_fail2ban_currently_banned(output: &str) -> Option<usize> {
+    parse_labeled_usize(output, "Currently banned:")
+}
+
+fn parse_labeled_usize(output: &str, label: &str) -> Option<usize> {
+    output.lines().find_map(|line| {
+        let (_, value) = line.trim().split_once(label)?;
+        value.trim().parse::<usize>().ok()
+    })
 }
 
 fn read_hostname(root: &Path) -> Option<String> {
@@ -618,6 +852,10 @@ mod tests {
             &root.join("etc/fail2ban/jail.local"),
             "[sshd]\nenabled = true\n",
         );
+        write_file(
+            &root.join("etc/systemd/system/multi-user.target.wants/fail2ban.service"),
+            "enabled\n",
+        );
         write_file(&root.join(DOCKER_SOCKET_PATH), "socket");
         fs::set_permissions(
             root.join(DOCKER_SOCKET_PATH),
@@ -644,7 +882,6 @@ mod tests {
             &root.join("etc/systemd/system/multi-user.target.wants/fail2ban.service"),
             "enabled\n",
         );
-        write_file(&root.join("etc/crowdsec/config.yaml"), "api:\n  server:\n");
         write_file(&root.join("proc/uptime"), "1221720.00 0.00\n");
         write_file(&root.join("proc/loadavg"), "0.42 0.31 0.27 1/100 1234\n");
 
@@ -655,18 +892,79 @@ mod tests {
         assert_eq!(info.load_average.as_deref(), Some("0.42 0.31 0.27"));
         assert!(info.docker_version.is_none());
         assert_eq!(info.fail2ban, DefensiveControlStatus::Enabled);
-        assert_eq!(info.crowdsec, DefensiveControlStatus::Installed);
+        assert_eq!(info.fail2ban_jails, Some(1));
+        assert_eq!(info.fail2ban_banned_ips, None);
 
         fs::remove_dir_all(root).expect("temp root should be removed");
     }
 
     #[test]
-    fn defensive_control_finding_is_cleared_when_crowdsec_exists() {
-        let root = temp_host_root("crowdsec-present");
-        write_file(&root.join("etc/crowdsec/config.yaml"), "api:\n  server:\n");
+    fn counts_enabled_fail2ban_jails_from_config_precedence_order() {
+        let root = temp_host_root("fail2ban-config-order");
+        write_file(
+            &root.join("etc/fail2ban/jail.conf"),
+            concat!(
+                "[DEFAULT]\n",
+                "enabled = false\n",
+                "\n",
+                "[sshd]\n",
+                "enabled = false\n",
+                "\n",
+                "[nginx-http-auth]\n",
+                "enabled = false\n"
+            ),
+        );
+        write_file(
+            &root.join("etc/fail2ban/jail.d/10-enable-sshd.local"),
+            "[sshd]\nenabled = true ; keep sshd enabled\n",
+        );
+        write_file(
+            &root.join("etc/fail2ban/jail.d/20-enable-default.local"),
+            "[DEFAULT]\nenabled = true\n",
+        );
+        write_file(
+            &root.join("etc/fail2ban/jail.d/30-disable-nginx.local"),
+            "[nginx-http-auth]\nenabled = false\n",
+        );
+
+        let count = count_enabled_fail2ban_jails(&root);
+
+        assert_eq!(count, Some(1));
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn defensive_control_missing_finding_is_cleared_when_fail2ban_is_enabled() {
+        let root = temp_host_root("fail2ban-enabled");
+        write_file(
+            &root.join("etc/systemd/system/multi-user.target.wants/fail2ban.service"),
+            "enabled\n",
+        );
 
         let findings = HostScanner.scan(&HostContext { root: root.clone() });
 
+        assert!(
+            findings
+                .iter()
+                .all(|finding| finding.id != "host.defensive_controls_missing")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn reports_fail2ban_when_installed_but_not_enabled() {
+        let root = temp_host_root("fail2ban-installed");
+        write_file(&root.join("etc/fail2ban/jail.local"), "[DEFAULT]\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.fail2ban_not_enabled")
+        );
         assert!(
             findings
                 .iter()
@@ -706,5 +1004,29 @@ mod tests {
         assert_eq!(parsed.get("permitrootlogin"), Some(&String::from("no")));
 
         fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn parses_fail2ban_status_output() {
+        let jails = parse_fail2ban_jails(concat!(
+            "Status\n",
+            "|- Number of jail:  2\n",
+            "`- Jail list: sshd, nginx-http-auth\n"
+        ));
+
+        assert_eq!(
+            jails,
+            vec![String::from("sshd"), String::from("nginx-http-auth")]
+        );
+        assert_eq!(
+            parse_fail2ban_currently_banned(concat!(
+                "Status for the jail: sshd\n",
+                "|- Filter\n",
+                "|  |- Currently failed: 0\n",
+                "`- Actions\n",
+                "   |- Currently banned: 3\n"
+            )),
+            Some(3)
+        );
     }
 }

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -19,8 +19,8 @@ use ratatui::widgets::{
 };
 
 use crate::domain::{
-    Axis, DefensiveControlStatus, DockerDiscoveryStatus, Finding, RemediationKind, ScanMode,
-    ScanResult, Scope, Severity, Source,
+    AdapterStatus, Axis, DefensiveControlStatus, DockerDiscoveryStatus, Finding, HostRuntimeInfo,
+    RemediationKind, ScanMode, ScanResult, Scope, Severity, Source,
 };
 use crate::i18n;
 
@@ -556,6 +556,12 @@ fn render_scan_results_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_re
         }
     }
 
+    let adapter_lines = adapter_summary_lines(scan_result, inner.width);
+    if !adapter_lines.is_empty() {
+        lines.push(Line::raw(String::new()));
+        lines.extend(adapter_lines);
+    }
+
     if !scan_result.metadata.warnings.is_empty() {
         lines.push(Line::raw(String::new()));
         lines.push(Line::styled(
@@ -1082,9 +1088,7 @@ fn remediation_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line
 fn server_service_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
-    if let Some(summary) = defensive_controls_summary(scan_result, available_width) {
-        lines.push(Line::raw(summary));
-    }
+    lines.extend(defensive_controls_lines(scan_result, available_width));
 
     lines.push(Line::styled(
         t!("app.server.services_heading").into_owned(),
@@ -1124,21 +1128,49 @@ fn server_service_lines(scan_result: &ScanResult, available_width: u16) -> Vec<L
     lines
 }
 
-fn defensive_controls_summary(scan_result: &ScanResult, available_width: u16) -> Option<String> {
-    let runtime = scan_result.metadata.host_runtime.as_ref()?;
-    let summary = format!(
-        "{}: {} {} | {} {}",
-        t!("app.server.controls").into_owned(),
+fn defensive_controls_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line<'static>> {
+    let Some(runtime) = scan_result.metadata.host_runtime.as_ref() else {
+        return Vec::new();
+    };
+    let text_width = available_width.saturating_sub(4).max(20) as usize;
+    let fail2ban = defensive_control_summary(
         t!("app.server.fail2ban").into_owned(),
-        defensive_control_status_label(runtime.fail2ban),
-        t!("app.server.crowdsec").into_owned(),
-        defensive_control_status_label(runtime.crowdsec),
+        runtime.fail2ban,
+        fail2ban_detail(runtime),
     );
+    vec![Line::raw(truncate_text(
+        &format!("{}: {}", t!("app.server.controls").into_owned(), fail2ban),
+        text_width,
+    ))]
+}
 
-    Some(truncate_text(
-        &summary,
-        available_width.saturating_sub(4).max(20) as usize,
-    ))
+fn defensive_control_summary(
+    label: String,
+    status: DefensiveControlStatus,
+    detail: Option<String>,
+) -> String {
+    match detail {
+        Some(detail) => format!(
+            "{} {} ({})",
+            label,
+            defensive_control_status_label(status),
+            detail
+        ),
+        None => format!("{} {}", label, defensive_control_status_label(status)),
+    }
+}
+
+fn fail2ban_detail(runtime: &HostRuntimeInfo) -> Option<String> {
+    let mut parts = Vec::new();
+
+    if let Some(count) = runtime.fail2ban_jails {
+        parts.push(t!("app.server.control_jails", count = count).into_owned());
+    }
+    if let Some(count) = runtime.fail2ban_banned_ips {
+        parts.push(t!("app.server.control_banned_ips", count = count).into_owned());
+    }
+
+    (!parts.is_empty()).then(|| parts.join(", "))
 }
 
 fn score_rows(scan_result: &ScanResult) -> Vec<(String, u8, bool)> {
@@ -1438,6 +1470,55 @@ fn docker_status_label(status: &DockerDiscoveryStatus) -> String {
         }
         DockerDiscoveryStatus::Failed(detail) => {
             t!("app.result.docker_failed", detail = detail.as_str()).into_owned()
+        }
+    }
+}
+
+fn adapter_summary_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line<'static>> {
+    if scan_result.metadata.adapters.is_empty() {
+        return Vec::new();
+    }
+
+    let text_width = available_width.saturating_sub(4).max(20) as usize;
+    let mut lines = vec![Line::styled(
+        t!("app.result.adapters_heading").into_owned(),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )];
+
+    for (name, status) in &scan_result.metadata.adapters {
+        lines.push(Line::raw(truncate_text(
+            &format!(
+                "* {}: {}",
+                adapter_name_label(name),
+                adapter_status_label(status)
+            ),
+            text_width,
+        )));
+    }
+
+    lines
+}
+
+fn adapter_name_label(name: &str) -> String {
+    match name {
+        "lynis" => source_label(Source::Lynis),
+        "trivy" => source_label(Source::Trivy),
+        "dockle" => source_label(Source::Dockle),
+        _ => name.to_owned(),
+    }
+}
+
+fn adapter_status_label(status: &AdapterStatus) -> String {
+    match status {
+        AdapterStatus::Available => t!("adapter.available").into_owned(),
+        AdapterStatus::Missing => t!("adapter.missing").into_owned(),
+        AdapterStatus::Skipped(detail) => {
+            t!("adapter.skipped", detail = detail.as_str()).into_owned()
+        }
+        AdapterStatus::Failed(detail) => {
+            t!("adapter.failed", detail = detail.as_str()).into_owned()
         }
     }
 }
@@ -1746,7 +1827,8 @@ mod tests {
                     uptime: Some(String::from("14d 3h 22m")),
                     load_average: Some(String::from("0.42 0.31 0.27")),
                     fail2ban: DefensiveControlStatus::Enabled,
-                    crowdsec: DefensiveControlStatus::Installed,
+                    fail2ban_jails: Some(2),
+                    fail2ban_banned_ips: Some(5),
                 }),
                 loaded_files: vec![
                     PathBuf::from("/srv/demo/docker-compose.yml"),
@@ -1870,8 +1952,10 @@ mod tests {
         assert!(content.contains("24.0.7"));
         assert!(content.contains("14d 3h 22m"));
         assert!(content.contains("0.42 0.31 0.27"));
-        assert!(content.contains("Fail2ban enabled"));
-        assert!(content.contains("CrowdSec installed"));
+        assert!(content.contains("Fail2ban enabled (2 jails, 5 banned)"));
+        assert!(content.contains("Adapters"));
+        assert!(content.contains("Lynis: available"));
+        assert!(content.contains("Trivy: missing"));
     }
 
     #[test]

--- a/src/tests/fixtures/adapters/lynis-report.dat
+++ b/src/tests/fixtures/adapters/lynis-report.dat
@@ -1,0 +1,15 @@
+report_version_major=1
+report_version_minor=0
+report_datetime_start=2026-04-12 10:15:20
+report_datetime_end=2026-04-12 10:16:03
+lynis_version=3.1.6
+hostname=demo-host
+os=Linux
+os_fullname=Fedora Linux 43
+hardening_index=67
+lynis_tests_done=214
+warning[]=AUTH-9286|Root account has no password set|Check /etc/shadow for passwordless root access|text:Set a strong root password or lock the account|
+warning[]=SSH-7408|PermitRootLogin is enabled|PermitRootLogin yes|text:Set PermitRootLogin no and reload sshd|
+suggestion[]=PKGS-7390|Install a package auditing tool|dnf updateinfo is not configured for unattended review|text:Install and configure a package auditing or auto-update workflow|
+details[]=SSH-7408|sshd|desc:sshd option PermitRootLogin;field:PermitRootLogin;prefval:NO;value:YES;|
+finish=true


### PR DESCRIPTION
## Summary
- add live external tooling integration for host scans, including a new Lynis adapter, clearer adapter status reporting, and richer Fail2Ban telemetry
- add a distro-aware `hostveil setup` flow plus installer handoff so recommended tools can be installed and baseline-configured during or after bootstrap
- update docs and automated coverage, then validate the setup flow on Fedora locally and on the Ubuntu-based `pavilion` host

## Validation
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- ./scripts/test-install-script.sh target/debug/hostveil
- local Fedora: `cargo run -- setup --yes`
- pavilion (Ubuntu 24.04): `hostveil setup --yes --tools lynis,trivy`

## Issues
- Refs #88
- Closes #96
- Closes #97
- Closes #98