### PR TITLE
feat(dev): add multi-distro container labs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+.github/
+proto/.venv/
+src/target/
+target/

--- a/README.ko.md
+++ b/README.ko.md
@@ -59,6 +59,34 @@ cargo run -- --json --compose proto/tests/fixtures/parser/docker-compose.yml
 cargo run -- --json --host-root /
 ```
 
+컨테이너 기반 개발 및 installer 검증:
+
+```sh
+# 일반 Rust 개발용 컨테이너 시작
+./scripts/dev-env.sh up dev
+./scripts/dev-env.sh shell dev
+
+# 배포판별 setup 검증용 lab 시작
+./scripts/dev-env.sh up fedora-lab ubuntu-lab debian-lab rocky-lab
+
+# 호스트 대신 lab 안에서 optional tool setup 실행
+./scripts/dev-env.sh setup fedora-lab lynis,trivy,fail2ban
+./scripts/dev-env.sh setup ubuntu-lab lynis,trivy
+
+# lab 컨테이너 자체를 host-root 대상으로 스캔
+./scripts/dev-env.sh scan rocky-lab
+```
+
+lab 스택은 `compose.dev.yml`에 있으며 현재 다음 환경을 제공합니다.
+
+- `dev`: 일반 Rust 개발 쉘
+- `fedora-lab`: Fedora + systemd + dnf 검증
+- `rocky-lab`: Rocky Linux + systemd + RHEL 계열 검증
+- `ubuntu-lab`: Ubuntu + systemd + apt 검증
+- `debian-lab`: Debian + systemd + apt 검증
+
+lab 이미지는 공통 `docker/labs/systemd-lab.Dockerfile`을 공유하므로, 이후 다른 배포판을 추가할 때도 전체 구조를 다시 만들 필요 없이 compose 서비스만 늘리면 됩니다.
+
 현재 릴리스 전달 경로:
 
 - `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`용 GitHub Releases tarball

--- a/README.md
+++ b/README.md
@@ -62,6 +62,34 @@ cargo run -- --quick-fix proto/tests/fixtures/parser/docker-compose.yml --previe
 cargo run -- --fix proto/tests/fixtures/parser/docker-compose.yml --preview-changes
 ```
 
+Container-based development and installer validation:
+
+```sh
+# Start the normal Rust dev container
+./scripts/dev-env.sh up dev
+./scripts/dev-env.sh shell dev
+
+# Bring up distro-specific labs for setup validation
+./scripts/dev-env.sh up fedora-lab ubuntu-lab debian-lab rocky-lab
+
+# Exercise optional-tool setup inside a lab instead of on the host
+./scripts/dev-env.sh setup fedora-lab lynis,trivy,fail2ban
+./scripts/dev-env.sh setup ubuntu-lab lynis,trivy
+
+# Run a host-root scan against the lab container itself
+./scripts/dev-env.sh scan rocky-lab
+```
+
+The lab stack lives in `compose.dev.yml` and currently covers:
+
+- `dev`: normal Rust development shell
+- `fedora-lab`: Fedora + systemd + dnf validation
+- `rocky-lab`: Rocky Linux + systemd + RHEL-like validation
+- `ubuntu-lab`: Ubuntu + systemd + apt validation
+- `debian-lab`: Debian + systemd + apt validation
+
+The lab images share a generic `docker/labs/systemd-lab.Dockerfile`, so adding more distro services later should be a compose-level change instead of a full redesign.
+
 Current reference prototype setup:
 
 ```sh

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,0 +1,148 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: docker/dev/Dockerfile
+      args:
+        USER_ID: ${HOSTVEIL_UID:-1000}
+        GROUP_ID: ${HOSTVEIL_GID:-1000}
+        USER_NAME: ${HOSTVEIL_USER:-hostveil}
+    working_dir: /workspace
+    command: ["sleep", "infinity"]
+    init: true
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/workspace
+
+  fedora-lab:
+    build:
+      context: .
+      dockerfile: docker/labs/systemd-lab.Dockerfile
+      args:
+        BASE_IMAGE: fedora:43
+        DISTRO_FAMILY: dnf
+        LAB_LABEL: Fedora 43
+    privileged: true
+    cgroup: host
+    stop_signal: SIGRTMIN+3
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    environment:
+      container: docker
+      CARGO_HOME: /cargo
+      RUSTUP_HOME: /rustup
+    working_dir: /workspace
+    command: ["/sbin/init"]
+    volumes:
+      - .:/workspace:ro
+      - fedora-cargo:/cargo
+      - fedora-rustup:/rustup
+      - fedora-target:/workspace/target
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    profiles: ["labs", "fedora", "rpm"]
+
+  rocky-lab:
+    build:
+      context: .
+      dockerfile: docker/labs/systemd-lab.Dockerfile
+      args:
+        BASE_IMAGE: rockylinux:9
+        DISTRO_FAMILY: dnf
+        LAB_LABEL: Rocky Linux 9
+    privileged: true
+    cgroup: host
+    stop_signal: SIGRTMIN+3
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    environment:
+      container: docker
+      CARGO_HOME: /cargo
+      RUSTUP_HOME: /rustup
+    working_dir: /workspace
+    command: ["/sbin/init"]
+    volumes:
+      - .:/workspace:ro
+      - rocky-cargo:/cargo
+      - rocky-rustup:/rustup
+      - rocky-target:/workspace/target
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    profiles: ["labs", "rocky", "rpm"]
+
+  ubuntu-lab:
+    build:
+      context: .
+      dockerfile: docker/labs/systemd-lab.Dockerfile
+      args:
+        BASE_IMAGE: ubuntu:24.04
+        DISTRO_FAMILY: apt
+        LAB_LABEL: Ubuntu 24.04
+    privileged: true
+    cgroup: host
+    stop_signal: SIGRTMIN+3
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    environment:
+      container: docker
+      CARGO_HOME: /cargo
+      RUSTUP_HOME: /rustup
+      DEBIAN_FRONTEND: noninteractive
+    working_dir: /workspace
+    command: ["/sbin/init"]
+    volumes:
+      - .:/workspace:ro
+      - ubuntu-cargo:/cargo
+      - ubuntu-rustup:/rustup
+      - ubuntu-target:/workspace/target
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    profiles: ["labs", "ubuntu", "deb"]
+
+  debian-lab:
+    build:
+      context: .
+      dockerfile: docker/labs/systemd-lab.Dockerfile
+      args:
+        BASE_IMAGE: debian:trixie
+        DISTRO_FAMILY: apt
+        LAB_LABEL: Debian trixie
+    privileged: true
+    cgroup: host
+    stop_signal: SIGRTMIN+3
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    environment:
+      container: docker
+      CARGO_HOME: /cargo
+      RUSTUP_HOME: /rustup
+      DEBIAN_FRONTEND: noninteractive
+    working_dir: /workspace
+    command: ["/sbin/init"]
+    volumes:
+      - .:/workspace:ro
+      - debian-cargo:/cargo
+      - debian-rustup:/rustup
+      - debian-target:/workspace/target
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    profiles: ["labs", "debian", "deb"]
+
+volumes:
+  fedora-cargo:
+  fedora-rustup:
+  fedora-target:
+  rocky-cargo:
+  rocky-rustup:
+  rocky-target:
+  ubuntu-cargo:
+  ubuntu-rustup:
+  ubuntu-target:
+  debian-cargo:
+  debian-rustup:
+  debian-target:

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,31 @@
+FROM rust:1-bookworm
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+ARG USER_NAME=hostveil
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        less \
+        procps \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid "${GROUP_ID}" "${USER_NAME}" \
+    && useradd --uid "${USER_ID}" --gid "${GROUP_ID}" --create-home --shell /bin/bash "${USER_NAME}" \
+    && printf '%s ALL=(ALL) NOPASSWD:ALL\n' "${USER_NAME}" > "/etc/sudoers.d/${USER_NAME}" \
+    && chmod 0440 "/etc/sudoers.d/${USER_NAME}"
+
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+USER ${USER_NAME}
+WORKDIR /workspace

--- a/docker/labs/systemd-lab.Dockerfile
+++ b/docker/labs/systemd-lab.Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1.7
+
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE}
+
+ARG DISTRO_FAMILY=apt
+ARG LAB_LABEL=Linux lab
+
+ENV container=docker \
+    CARGO_HOME=/cargo \
+    RUSTUP_HOME=/rustup \
+    PATH=/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN case "${DISTRO_FAMILY}" in \
+      apt) \
+        apt-get update \
+        && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          bash \
+          build-essential \
+          ca-certificates \
+          curl \
+          git \
+          gnupg \
+          iproute2 \
+          less \
+          pkg-config \
+          procps \
+          sudo \
+          systemd \
+          systemd-sysv \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* \
+        ;; \
+      dnf) \
+        dnf install -y \
+          bash \
+          ca-certificates \
+          curl-minimal \
+          findutils \
+          gcc \
+          gcc-c++ \
+          git \
+          gnupg2 \
+          hostname \
+          iproute \
+          less \
+          make \
+          pkgconf-pkg-config \
+          procps-ng \
+          sudo \
+          systemd \
+          which \
+        && dnf clean all \
+        ;; \
+      *) \
+        printf 'unsupported lab distro family: %s\n' "${DISTRO_FAMILY}" >&2 \
+        && exit 1 \
+        ;; \
+    esac
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal --component clippy,rustfmt
+
+RUN mkdir -p /cargo /rustup /workspace /etc/hostveil-lab \
+    && printf '%s\n' "${LAB_LABEL}" > /etc/hostveil-lab/name \
+    && printf '%s\n' "${DISTRO_FAMILY}" > /etc/hostveil-lab/family
+
+RUN systemctl mask \
+      dev-hugepages.mount \
+      sys-fs-fuse-connections.mount \
+      systemd-remount-fs.service \
+      getty.target \
+      console-getty.service \
+      systemd-logind.service \
+      systemd-vconsole-setup.service || true
+
+VOLUME ["/sys/fs/cgroup", "/run", "/tmp"]
+STOPSIGNAL SIGRTMIN+3

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/compose.dev.yml"
+
+usage() {
+  cat <<'EOF'
+Manage the hostveil development and multi-distro lab containers.
+
+Usage:
+  scripts/dev-env.sh up [service...]
+  scripts/dev-env.sh down
+  scripts/dev-env.sh ps
+  scripts/dev-env.sh logs SERVICE
+  scripts/dev-env.sh shell [service]
+  scripts/dev-env.sh exec SERVICE -- COMMAND [ARG...]
+  scripts/dev-env.sh setup SERVICE [tool-list]
+  scripts/dev-env.sh scan SERVICE
+
+Services:
+  dev
+  fedora-lab
+  rocky-lab
+  ubuntu-lab
+  debian-lab
+
+Examples:
+  scripts/dev-env.sh up dev
+  scripts/dev-env.sh shell dev
+  scripts/dev-env.sh up fedora-lab
+  scripts/dev-env.sh setup fedora-lab lynis,trivy,fail2ban
+  scripts/dev-env.sh setup ubuntu-lab lynis,trivy
+  scripts/dev-env.sh scan rocky-lab
+EOF
+}
+
+compose() {
+  docker compose -f "$COMPOSE_FILE" "$@"
+}
+
+ensure_docker() {
+  command -v docker >/dev/null 2>&1 || {
+    printf 'error: docker is required\n' >&2
+    exit 1
+  }
+  docker compose version >/dev/null 2>&1 || {
+    printf 'error: docker compose is required\n' >&2
+    exit 1
+  }
+}
+
+require_service() {
+  [[ $# -ge 1 ]] || {
+    printf 'error: missing service name\n' >&2
+    exit 1
+  }
+}
+
+ensure_service_up() {
+  local service="$1"
+  compose up -d "$service"
+}
+
+run_setup() {
+  local service="$1"
+  local tools="${2:-}"
+
+  ensure_service_up "$service"
+
+  if [[ -n "$tools" ]]; then
+    compose exec "$service" bash -c "cd /workspace && cargo run -- setup --yes --tools '$tools'"
+  else
+    compose exec "$service" bash -c 'cd /workspace && cargo run -- setup --yes'
+  fi
+}
+
+run_scan() {
+  local service="$1"
+
+  ensure_service_up "$service"
+  compose exec "$service" bash -c 'cd /workspace && cargo run -- --json --host-root /'
+}
+
+main() {
+  local command="${1:-}"
+  shift || true
+
+  ensure_docker
+
+  case "$command" in
+    up)
+      if [[ $# -eq 0 ]]; then
+        compose up -d --build dev
+      else
+        compose up -d --build "$@"
+      fi
+      ;;
+    down)
+      compose down --remove-orphans
+      ;;
+    ps)
+      compose ps
+      ;;
+    logs)
+      require_service "$@"
+      compose logs -f "$1"
+      ;;
+    shell)
+      local service="${1:-dev}"
+      ensure_service_up "$service"
+      compose exec "$service" bash
+      ;;
+    exec)
+      require_service "$@"
+      local service="$1"
+      shift
+      [[ "${1:-}" == "--" ]] && shift
+      [[ $# -ge 1 ]] || {
+        printf 'error: missing command for exec\n' >&2
+        exit 1
+      }
+      ensure_service_up "$service"
+      compose exec "$service" "$@"
+      ;;
+    setup)
+      require_service "$@"
+      run_setup "$1" "${2:-}"
+      ;;
+    scan)
+      require_service "$@"
+      run_scan "$1"
+      ;;
+    -h|--help|help)
+      usage
+      ;;
+    *)
+      printf 'error: unknown command: %s\n\n' "$command" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/src/src/app/setup.rs
+++ b/src/src/app/setup.rs
@@ -3,7 +3,8 @@ use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use dialoguer::{Confirm, MultiSelect, theme::ColorfulTheme};
 
@@ -331,8 +332,24 @@ fn configure_fail2ban_baseline() -> Result<(), AppError> {
     )?;
     run_privileged_command("fail2ban-client", &["-t"])?;
     run_privileged_command("systemctl", &["enable", "--now", "fail2ban"])?;
-    run_privileged_command("fail2ban-client", &["status"])?;
-    run_privileged_command("fail2ban-client", &["status", "sshd"])?;
+    wait_for_privileged_command(
+        "systemctl",
+        &["is-active", "--quiet", "fail2ban"],
+        10,
+        Duration::from_millis(500),
+    )?;
+    wait_for_privileged_command(
+        "fail2ban-client",
+        &["status"],
+        10,
+        Duration::from_millis(500),
+    )?;
+    wait_for_privileged_command(
+        "fail2ban-client",
+        &["status", "sshd"],
+        10,
+        Duration::from_millis(500),
+    )?;
     Ok(())
 }
 
@@ -449,6 +466,35 @@ fn run_privileged_command(program: &str, args: &[&str]) -> Result<String, AppErr
         .map_err(|error| AppError::Io(io::Error::other(error.to_string())))?;
     command_output_to_result(program, args, output)
         .map_err(|error| AppError::Io(io::Error::other(error)))
+}
+
+fn wait_for_privileged_command(
+    program: &str,
+    args: &[&str],
+    retries: usize,
+    delay: Duration,
+) -> Result<String, AppError> {
+    let mut last_error = None;
+
+    for attempt in 0..retries {
+        match run_privileged_command(program, args) {
+            Ok(output) => return Ok(output),
+            Err(error) => {
+                last_error = Some(error);
+                if attempt + 1 < retries {
+                    thread::sleep(delay);
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        AppError::Io(io::Error::other(format!(
+            "{} did not succeed after {} attempt(s)",
+            format_command(program, args),
+            retries
+        )))
+    }))
 }
 
 fn run_privileged_command_with_stdin(
@@ -633,6 +679,31 @@ ID_LIKE=debian
         );
 
         assert_eq!(distro.family, DistroFamily::Debian);
+    }
+
+    #[test]
+    fn parses_debian_as_debian_family() {
+        let distro = parse_os_release(
+            r#"
+PRETTY_NAME="Debian GNU/Linux trixie/sid"
+ID=debian
+"#,
+        );
+
+        assert_eq!(distro.family, DistroFamily::Debian);
+    }
+
+    #[test]
+    fn parses_rocky_as_fedora_family() {
+        let distro = parse_os_release(
+            r#"
+PRETTY_NAME="Rocky Linux 9.5"
+ID=rocky
+ID_LIKE="rhel centos fedora"
+"#,
+        );
+
+        assert_eq!(distro.family, DistroFamily::Fedora);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a compose-based dev environment plus reusable systemd-backed distro labs for Fedora, Rocky, Ubuntu, and Debian
- add a `scripts/dev-env.sh` helper so setup and host-root scan validation can run inside lab containers instead of repeatedly changing the host system
- harden setup validation by retrying Fail2Ban readiness checks and document the container workflow in both READMEs

## Validation
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- docker compose --profile labs -f compose.dev.yml config
- docker compose -f compose.dev.yml build dev fedora-lab ubuntu-lab debian-lab rocky-lab
- ./scripts/dev-env.sh setup ubuntu-lab lynis,trivy
- ./scripts/dev-env.sh setup fedora-lab lynis,trivy,fail2ban
- ./scripts/dev-env.sh scan fedora-lab

## Issues
- Closes #100