### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -163,6 +163,11 @@ jobs:
 
             After the first install, use the installed `hostveil` command for lifecycle actions.
 
+            Optional dependency setup after install:
+            ```sh
+            hostveil setup
+            ```
+
             ## Upgrade
             ```sh
             hostveil upgrade
@@ -188,7 +193,9 @@ jobs:
 
             ## Optional dependencies
             - Docker improves live Compose discovery when it is available.
-            - Trivy is planned as an optional adapter and is not required for this release.
+            - Trivy is supported as an optional image vulnerability adapter.
+            - Lynis is supported as an optional host-audit adapter.
+            - Fail2Ban remains optional; host scans continue without it, but host hardening coverage is reduced.
 
             ## Known limitations
             - Linux only


### PR DESCRIPTION
## Summary
- refresh the automated release body so the `v0.1.0` release notes reflect the current installer and optional-tool support
- keep the first SemVer release aligned with the current Rust product surface instead of the earlier alpha wording

## Validation
- reviewed the release workflow body against the current install, setup, and optional adapter behavior

## Issues
- Closes #90