### PR TITLE
ci(release): update artifact actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -107,7 +107,7 @@ jobs:
           tar -C dist/package -czf dist/hostveil-${{ github.ref_name }}-${{ matrix.target }}.tar.gz hostveil README.md LICENSE
 
       - name: Upload packaged archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hostveil-${{ matrix.target }}
           path: dist/hostveil-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: Download packaged archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -128,7 +128,7 @@ jobs:
         run: (cd dist && sha256sum *.tar.gz > SHA256SUMS)
 
       - name: Upload checksums
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hostveil-checksums
           path: dist/SHA256SUMS
@@ -143,7 +143,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download packaged archives and checksums
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
## Summary
- move the release workflow off the older artifact action majors that trigger GitHub's Node 20 deprecation warning
- keep the release flow otherwise unchanged while updating upload and download artifact steps to the current majors

## Validation
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- direct installer validation inside Fedora and Ubuntu lab containers after the workflow change

## Issues
- Closes #105