### PR TITLE
fix(src): recover from stale Docker discovery metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crossterm 0.29.0",
  "dialoguer",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -3,7 +3,10 @@ use std::path::{Path, PathBuf};
 
 use crate::adapters;
 use crate::compose::{ComposeParseError, ComposeParser, ComposeProject};
-use crate::discovery::{DockerDiscoveryResult, discover_running_compose_projects, project_summary};
+use crate::discovery::{
+    DiscoveredComposeProject, DockerDiscoveryResult, discover_running_compose_projects,
+    project_summary,
+};
 use crate::domain::{DiscoveredProjectSummary, ScanMode, ScanResult, ServiceSummary};
 use crate::host::{HostContext, HostScanner, collect_host_runtime_info};
 use crate::rules::RuleEngine;
@@ -95,28 +98,96 @@ fn apply_discovered_projects(
             .discovered_projects
             .push(project_summary(project));
 
-        if let Some(path) = &project.compose_path {
-            match ComposeParser::parse_path(path) {
-                Ok(parsed) => {
-                    scan_compose_project(&parsed, result);
-                    coverage.compose = true;
+        match load_discovered_project(project) {
+            Ok((parsed, warning)) => {
+                if let Some(warning) = warning {
+                    result.metadata.warnings.push(warning);
                 }
-                Err(error) => {
-                    result.metadata.warnings.push(format!(
-                        "Failed to parse discovered project {}: {}",
-                        project.name, error
-                    ));
-                }
+                scan_compose_project(&parsed, result);
+                coverage.compose = true;
             }
-        } else {
-            result.metadata.warnings.push(format!(
-                "Discovered project {} has no usable compose path.",
-                project.name
-            ));
+            Err(warning) => {
+                result.metadata.warnings.push(warning);
+            }
         }
     }
 
     Ok(())
+}
+
+fn load_discovered_project(
+    project: &DiscoveredComposeProject,
+) -> Result<(ComposeProject, Option<String>), String> {
+    if let Some(path) = &project.compose_path {
+        match ComposeParser::parse_path(path) {
+            Ok(parsed) => return Ok((parsed, None)),
+            Err(ComposeParseError::ComposePathMissing { .. })
+            | Err(ComposeParseError::ComposeFileNotFound { .. }) => {
+                if let Some(working_dir) = project.working_dir.as_ref().filter(|dir| *dir != path) {
+                    match ComposeParser::parse_path(working_dir) {
+                        Ok(parsed) => {
+                            return Ok((
+                                parsed,
+                                Some(format!(
+                                    "Docker metadata for discovered project {} still points to missing compose path {}; recovered by scanning {} instead.",
+                                    project.name,
+                                    path.display(),
+                                    working_dir.display()
+                                )),
+                            ));
+                        }
+                        Err(ComposeParseError::ComposePathMissing { .. })
+                        | Err(ComposeParseError::ComposeFileNotFound { .. }) => {}
+                        Err(error) => {
+                            return Err(format!(
+                                "Discovered project {} points to missing compose path {} and fallback scan of {} failed: {}",
+                                project.name,
+                                path.display(),
+                                working_dir.display(),
+                                error
+                            ));
+                        }
+                    }
+                }
+
+                return Err(format!(
+                    "Discovered project {} points to missing compose path {} from Docker metadata. Recreate or remove the containers to refresh the saved Compose labels.",
+                    project.name,
+                    path.display()
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Failed to parse discovered project {}: {}",
+                    project.name, error
+                ));
+            }
+        }
+    }
+
+    if let Some(working_dir) = &project.working_dir {
+        return ComposeParser::parse_path(working_dir)
+            .map(|parsed| (parsed, None))
+            .map_err(|error| match error {
+                ComposeParseError::ComposePathMissing { .. }
+                | ComposeParseError::ComposeFileNotFound { .. } => format!(
+                    "Discovered project {} did not expose a compose file path, and no compose file was found in {}.",
+                    project.name,
+                    working_dir.display()
+                ),
+                _ => format!(
+                    "Failed to parse discovered project {} from working directory {}: {}",
+                    project.name,
+                    working_dir.display(),
+                    error
+                ),
+            });
+    }
+
+    Err(format!(
+        "Discovered project {} has no usable compose path.",
+        project.name
+    ))
 }
 
 fn apply_current_dir_fallback(
@@ -206,9 +277,10 @@ mod tests {
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use crate::discovery::{DiscoveredComposeProject, DiscoveredContainerService};
     use crate::domain::{AdapterStatus, DockerDiscoveryStatus, ScanMode};
 
-    use super::{apply_current_dir_fallback, run, scan_compose_project};
+    use super::{apply_current_dir_fallback, apply_discovered_projects, run, scan_compose_project};
     use crate::app::{AppConfig, OutputMode};
     use crate::compose::ComposeParser;
 
@@ -584,5 +656,82 @@ mod tests {
         );
 
         fs::remove_dir_all(second_dir).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn discovered_project_uses_working_dir_when_compose_label_is_stale() {
+        let temp_dir = temp_host_root("stale-compose-label");
+        write_file(
+            &temp_dir.join("docker-compose.yml"),
+            concat!("services:\n", "  demo:\n", "    image: nginx:1.27.5\n"),
+        );
+
+        let discovery = crate::discovery::DockerDiscoveryResult {
+            status: DockerDiscoveryStatus::Available,
+            projects: vec![DiscoveredComposeProject {
+                name: String::from("demo"),
+                compose_path: Some(temp_dir.join("deleted-compose.yml")),
+                working_dir: Some(temp_dir.clone()),
+                services: vec![DiscoveredContainerService {
+                    name: String::from("demo"),
+                    image: Some(String::from("nginx:1.27.5")),
+                }],
+                source: "docker",
+            }],
+            warnings: Vec::new(),
+        };
+
+        let mut result = crate::domain::ScanResult::default();
+        let mut coverage = crate::scoring::Coverage::default();
+
+        apply_discovered_projects(&discovery, &mut result, &mut coverage)
+            .expect("discovered project should recover from stale label");
+
+        assert!(coverage.compose);
+        assert_eq!(result.metadata.service_count, 1);
+        assert!(
+            result
+                .metadata
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("recovered by scanning"))
+        );
+
+        fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn discovered_project_reports_stale_docker_metadata_when_paths_are_gone() {
+        let missing_root = temp_host_root("missing-compose-label");
+        let compose_path = missing_root.join("docker-compose.yml");
+        let working_dir = missing_root.join("gone-working-dir");
+        fs::remove_dir_all(&missing_root).expect("temp dir should be removed before scan");
+
+        let discovery = crate::discovery::DockerDiscoveryResult {
+            status: DockerDiscoveryStatus::Available,
+            projects: vec![DiscoveredComposeProject {
+                name: String::from("demo"),
+                compose_path: Some(compose_path.clone()),
+                working_dir: Some(working_dir.clone()),
+                services: vec![DiscoveredContainerService {
+                    name: String::from("demo"),
+                    image: Some(String::from("nginx:1.27.5")),
+                }],
+                source: "docker",
+            }],
+            warnings: Vec::new(),
+        };
+
+        let mut result = crate::domain::ScanResult::default();
+        let mut coverage = crate::scoring::Coverage::default();
+
+        apply_discovered_projects(&discovery, &mut result, &mut coverage)
+            .expect("stale discovery warning should not fail the scan");
+
+        assert!(!coverage.compose);
+        assert!(result.metadata.warnings.iter().any(|warning| {
+            warning.contains("Docker metadata")
+                && warning.contains("refresh the saved Compose labels")
+        }));
     }
 }

--- a/src/src/app/setup.rs
+++ b/src/src/app/setup.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
@@ -32,24 +32,53 @@ struct SetupPlan {
     steps: Vec<SetupStep>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SetupState {
+    installed_tools: BTreeSet<SetupTool>,
+    fail2ban_baseline_ready: bool,
+}
+
 impl SetupPlan {
     fn new(distro: DistroInfo, tools: Vec<SetupTool>) -> Result<Self, AppError> {
+        let state = SetupState::detect(&tools);
+        Self::new_with_state(distro, tools, &state)
+    }
+
+    fn new_with_state(
+        distro: DistroInfo,
+        tools: Vec<SetupTool>,
+        state: &SetupState,
+    ) -> Result<Self, AppError> {
         let mut package_set = Vec::new();
         let mut steps = Vec::new();
 
         for tool in &tools {
-            if *tool == SetupTool::Trivy && distro.family == DistroFamily::Debian {
+            if *tool == SetupTool::Trivy
+                && distro.family == DistroFamily::Debian
+                && !state.tool_is_installed(SetupTool::Trivy)
+            {
                 steps.push(SetupStep::ConfigureTrivyAptRepo);
             }
-            package_set.push(tool.package_name().to_owned());
+
+            if !state.tool_is_installed(*tool) {
+                package_set.push(tool.package_name().to_owned());
+            }
         }
 
         package_set.sort();
         package_set.dedup();
 
         match distro.family {
-            DistroFamily::Fedora => steps.push(SetupStep::DnfInstall(package_set)),
-            DistroFamily::Debian => steps.push(SetupStep::AptInstall(package_set)),
+            DistroFamily::Fedora => {
+                if !package_set.is_empty() {
+                    steps.push(SetupStep::DnfInstall(package_set));
+                }
+            }
+            DistroFamily::Debian => {
+                if !package_set.is_empty() {
+                    steps.push(SetupStep::AptInstall(package_set));
+                }
+            }
             DistroFamily::Unsupported => {
                 return Err(AppError::Io(io::Error::other(format!(
                     "{} {}",
@@ -59,7 +88,7 @@ impl SetupPlan {
             }
         }
 
-        if tools.contains(&SetupTool::Fail2Ban) {
+        if tools.contains(&SetupTool::Fail2Ban) && !state.fail2ban_baseline_ready {
             steps.push(SetupStep::ConfigureFail2BanBaseline);
         }
 
@@ -72,6 +101,26 @@ impl SetupPlan {
 
     fn requires_privileges(&self) -> bool {
         !self.steps.is_empty()
+    }
+}
+
+impl SetupState {
+    fn detect(tools: &[SetupTool]) -> Self {
+        let installed_tools = tools
+            .iter()
+            .copied()
+            .filter(|tool| command_exists(tool.detection_command()))
+            .collect();
+
+        Self {
+            installed_tools,
+            fail2ban_baseline_ready: tools.contains(&SetupTool::Fail2Ban)
+                && fail2ban_baseline_is_ready(),
+        }
+    }
+
+    fn tool_is_installed(&self, tool: SetupTool) -> bool {
+        self.installed_tools.contains(&tool)
     }
 }
 
@@ -428,6 +477,25 @@ fn command_exists(program: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn fail2ban_baseline_is_ready() -> bool {
+    if !command_exists("systemctl") {
+        return false;
+    }
+
+    let baseline = match fs::read_to_string(FAIL2BAN_BASELINE_PATH) {
+        Ok(baseline) => baseline,
+        Err(_) => return false,
+    };
+
+    normalize_file_content(&baseline) == normalize_file_content(FAIL2BAN_BASELINE_CONTENT)
+        && run_command("systemctl", &["is-enabled", "fail2ban"]).is_ok()
+        && run_command("systemctl", &["is-active", "fail2ban"]).is_ok()
+}
+
+fn normalize_file_content(content: &str) -> &str {
+    content.trim_end_matches(['\r', '\n'])
+}
+
 fn shell_escape(value: &str) -> String {
     value.replace('"', "\\\"")
 }
@@ -612,6 +680,14 @@ impl SetupTool {
         self.cli_name()
     }
 
+    fn detection_command(self) -> &'static str {
+        match self {
+            Self::Lynis => "lynis",
+            Self::Trivy => "trivy",
+            Self::Fail2Ban => "fail2ban-client",
+        }
+    }
+
     fn display_name(self) -> String {
         match self {
             Self::Lynis => t!("app.setup.tool.lynis.name").into_owned(),
@@ -708,12 +784,16 @@ ID_LIKE="rhel centos fedora"
 
     #[test]
     fn builds_fedora_plan_without_extra_repo_step() {
-        let plan = SetupPlan::new(
+        let plan = SetupPlan::new_with_state(
             DistroInfo {
                 family: DistroFamily::Fedora,
                 pretty_name: String::from("Fedora Linux 43"),
             },
             vec![SetupTool::Lynis, SetupTool::Trivy, SetupTool::Fail2Ban],
+            &SetupState {
+                installed_tools: BTreeSet::new(),
+                fail2ban_baseline_ready: false,
+            },
         )
         .expect("fedora plan should build");
 
@@ -732,12 +812,16 @@ ID_LIKE="rhel centos fedora"
 
     #[test]
     fn builds_debian_plan_with_trivy_repo_step() {
-        let plan = SetupPlan::new(
+        let plan = SetupPlan::new_with_state(
             DistroInfo {
                 family: DistroFamily::Debian,
                 pretty_name: String::from("Ubuntu 24.04.4 LTS"),
             },
             vec![SetupTool::Trivy, SetupTool::Fail2Ban],
+            &SetupState {
+                installed_tools: BTreeSet::new(),
+                fail2ban_baseline_ready: false,
+            },
         )
         .expect("debian plan should build");
 
@@ -757,5 +841,35 @@ ID_LIKE="rhel centos fedora"
         let path_text = path.display().to_string();
 
         assert!(path_text.contains("hostveil-trivy-"));
+    }
+
+    #[test]
+    fn skips_steps_when_requested_tools_are_already_ready() {
+        let plan = SetupPlan::new_with_state(
+            DistroInfo {
+                family: DistroFamily::Fedora,
+                pretty_name: String::from("Fedora Linux 43"),
+            },
+            vec![SetupTool::Lynis, SetupTool::Trivy, SetupTool::Fail2Ban],
+            &SetupState {
+                installed_tools: [SetupTool::Lynis, SetupTool::Trivy, SetupTool::Fail2Ban]
+                    .into_iter()
+                    .collect(),
+                fail2ban_baseline_ready: true,
+            },
+        )
+        .expect("ready fedora plan should build");
+
+        assert!(plan.steps.is_empty());
+    }
+
+    #[test]
+    fn normalizes_trailing_newlines_when_comparing_managed_files() {
+        assert_eq!(
+            normalize_file_content(FAIL2BAN_BASELINE_CONTENT),
+            normalize_file_content(
+                "[sshd]\nenabled = true\nbackend = systemd\nbantime = 1h\nfindtime = 10m\nmaxretry = 5"
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary
- recover live discovery from stale Docker Compose labels when the original compose path is gone, and emit a targeted warning when Docker metadata must be refreshed
- make `hostveil setup --yes` skip package installs and Fail2Ban baseline work when the requested tools are already installed and ready
- bump the Rust crate version to `0.1.1` for the patch release that ships these fixes

## Validation
- `cargo fmt`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- local live scan verification after removing stale `erpsystem` containers
- local `hostveil setup --yes` verification on Fedora with Lynis, Trivy, and Fail2Ban already installed

Closes #107