### PR TITLE
fix(tui): stop blocking launch on external adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "crossterm 0.29.0",
  "dialoguer",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -244,6 +244,7 @@ source:
   lynis: "Lynis"
   dockle: "Dockle"
 adapter:
+  pending: "pending"
   available: "available"
   missing: "missing"
   skipped: "skipped: %{detail}"

--- a/src/src/adapters/trivy.rs
+++ b/src/src/adapters/trivy.rs
@@ -128,7 +128,7 @@ struct TrivyImageSummary {
 
 fn scan_image(image: &str) -> Result<Option<TrivyImageSummary>, String> {
     let output = Command::new("trivy")
-        .args(["image", "--format", "json", image])
+        .args(trivy_image_args(image))
         .env("NO_COLOR", "1")
         .output()
         .map_err(|error| error.to_string())?;
@@ -149,6 +149,18 @@ fn scan_image(image: &str) -> Result<Option<TrivyImageSummary>, String> {
         .map_err(|error| format!("failed to parse Trivy JSON: {error}"))?;
 
     Ok(summarize_report(image, report))
+}
+
+fn trivy_image_args(image: &str) -> [&str; 7] {
+    [
+        "image",
+        "--quiet",
+        "--format",
+        "json",
+        "--scanners",
+        "vuln",
+        image,
+    ]
 }
 
 fn summarize_report(image: &str, report: TrivyReport) -> Option<TrivyImageSummary> {
@@ -457,5 +469,21 @@ mod tests {
             AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned())
         );
         assert!(output.findings.is_empty());
+    }
+
+    #[test]
+    fn uses_vulnerability_only_scan_args() {
+        assert_eq!(
+            trivy_image_args("demo:1.0"),
+            [
+                "image",
+                "--quiet",
+                "--format",
+                "json",
+                "--scanners",
+                "vuln",
+                "demo:1.0",
+            ]
+        );
     }
 }

--- a/src/src/app/mod.rs
+++ b/src/src/app/mod.rs
@@ -144,16 +144,28 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
         return Ok(());
     }
 
-    let scan_result = scan::run(&config)?;
-
     match config.output_mode {
         OutputMode::Tui => {
             if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
                 return Err(AppError::TuiRequiresTerminal);
             }
-            tui::run(&scan_result)?;
+
+            let mut scan_result = scan::run_native(&config)?;
+            let adapter_updates = scan::prepare_background_adapter_scan(&mut scan_result);
+
+            tui::run(&mut scan_result, move |scan_result| {
+                let mut updated = false;
+
+                while let Ok(update) = adapter_updates.try_recv() {
+                    scan::apply_external_adapter_update(scan_result, update);
+                    updated = true;
+                }
+
+                updated
+            })?;
         }
         OutputMode::Json => {
+            let scan_result = scan::run(&config)?;
             print!("{}", export::scan_result_json(&scan_result));
         }
     }

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -1,5 +1,7 @@
 use std::env;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
 
 use crate::adapters;
 use crate::compose::{ComposeParseError, ComposeParser, ComposeProject};
@@ -7,14 +9,28 @@ use crate::discovery::{
     DiscoveredComposeProject, DockerDiscoveryResult, discover_running_compose_projects,
     project_summary,
 };
-use crate::domain::{DiscoveredProjectSummary, ScanMode, ScanResult, ServiceSummary};
+use crate::domain::{
+    AdapterStatus, DiscoveredProjectSummary, ScanMode, ScanResult, ServiceSummary,
+};
 use crate::host::{HostContext, HostScanner, collect_host_runtime_info};
 use crate::rules::RuleEngine;
 use crate::scoring;
 
 use super::{AppConfig, AppError};
 
+#[derive(Debug)]
+pub struct AdapterScanUpdate {
+    trivy: adapters::trivy::TrivyScanOutput,
+    lynis: adapters::lynis::LynisScanOutput,
+}
+
 pub fn run(config: &AppConfig) -> Result<ScanResult, AppError> {
+    let mut result = run_native(config)?;
+    apply_external_adapters(&mut result);
+    Ok(result)
+}
+
+pub fn run_native(config: &AppConfig) -> Result<ScanResult, AppError> {
     let mut result = ScanResult::default();
     let mut coverage = scoring::Coverage::default();
 
@@ -35,28 +51,124 @@ pub fn run(config: &AppConfig) -> Result<ScanResult, AppError> {
         }
     }
 
-    apply_external_adapters(&mut result);
-
     result.score_report = scoring::build_score_report_with_coverage(&result.findings, coverage);
     Ok(result)
 }
 
 fn apply_external_adapters(result: &mut ScanResult) {
-    let trivy_output = adapters::trivy::scan(&result.metadata.services);
-    result
-        .metadata
-        .adapters
-        .insert(String::from("trivy"), trivy_output.status);
-    result.metadata.warnings.extend(trivy_output.warnings);
-    result.findings.extend(trivy_output.findings);
+    let update = scan_external_adapters(
+        result.metadata.services.clone(),
+        result.metadata.host_root.clone(),
+    );
+    apply_external_adapter_update(result, update);
+}
 
-    let lynis_output = adapters::lynis::scan(result.metadata.host_root.as_deref());
+pub fn prepare_background_adapter_scan(result: &mut ScanResult) -> Receiver<AdapterScanUpdate> {
+    seed_adapter_statuses(result);
+
+    let services = result.metadata.services.clone();
+    let host_root = result.metadata.host_root.clone();
+    let (sender, receiver) = mpsc::channel();
+
+    thread::spawn(move || {
+        let update = scan_external_adapters(services, host_root);
+        let _ = sender.send(update);
+    });
+
+    receiver
+}
+
+pub fn apply_external_adapter_update(result: &mut ScanResult, update: AdapterScanUpdate) {
+    let AdapterScanUpdate { trivy, lynis } = update;
+
     result
         .metadata
         .adapters
-        .insert(String::from("lynis"), lynis_output.status);
-    result.metadata.warnings.extend(lynis_output.warnings);
-    result.findings.extend(lynis_output.findings);
+        .insert(String::from("trivy"), trivy.status);
+    result.metadata.warnings.extend(trivy.warnings);
+    result.findings.extend(trivy.findings);
+
+    result
+        .metadata
+        .adapters
+        .insert(String::from("lynis"), lynis.status);
+    result.metadata.warnings.extend(lynis.warnings);
+    result.findings.extend(lynis.findings);
+    result.score_report =
+        scoring::build_score_report_with_coverage(&result.findings, coverage_from_result(result));
+}
+
+fn scan_external_adapters(
+    services: Vec<ServiceSummary>,
+    host_root: Option<PathBuf>,
+) -> AdapterScanUpdate {
+    let trivy_handle = thread::spawn(move || adapters::trivy::scan(&services));
+    let lynis_handle = thread::spawn(move || adapters::lynis::scan(host_root.as_deref()));
+
+    AdapterScanUpdate {
+        trivy: trivy_handle
+            .join()
+            .unwrap_or_else(|_| failed_trivy_output()),
+        lynis: lynis_handle
+            .join()
+            .unwrap_or_else(|_| failed_lynis_output()),
+    }
+}
+
+fn seed_adapter_statuses(result: &mut ScanResult) {
+    let trivy_status = if has_image_targets(&result.metadata.services) {
+        AdapterStatus::Pending
+    } else {
+        AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned())
+    };
+    result
+        .metadata
+        .adapters
+        .insert(String::from("trivy"), trivy_status);
+
+    let lynis_status = match result.metadata.host_root.as_deref() {
+        None => AdapterStatus::Skipped(t!("adapter.reason.host_not_scanned").into_owned()),
+        Some(path) if path != Path::new("/") => {
+            AdapterStatus::Skipped(t!("adapter.reason.live_host_only").into_owned())
+        }
+        Some(_) => AdapterStatus::Pending,
+    };
+    result
+        .metadata
+        .adapters
+        .insert(String::from("lynis"), lynis_status);
+}
+
+fn has_image_targets(services: &[ServiceSummary]) -> bool {
+    services.iter().any(|service| {
+        service
+            .image
+            .as_deref()
+            .is_some_and(|image| !image.trim().is_empty())
+    })
+}
+
+fn failed_trivy_output() -> adapters::trivy::TrivyScanOutput {
+    adapters::trivy::TrivyScanOutput {
+        status: AdapterStatus::Failed(String::from("Trivy scan thread panicked")),
+        findings: Vec::new(),
+        warnings: Vec::new(),
+    }
+}
+
+fn failed_lynis_output() -> adapters::lynis::LynisScanOutput {
+    adapters::lynis::LynisScanOutput {
+        status: AdapterStatus::Failed(String::from("Lynis scan thread panicked")),
+        findings: Vec::new(),
+        warnings: Vec::new(),
+    }
+}
+
+fn coverage_from_result(result: &ScanResult) -> scoring::Coverage {
+    scoring::Coverage {
+        compose: result.metadata.compose_file.is_some() || !result.metadata.services.is_empty(),
+        host_hardening: result.metadata.host_root.is_some(),
+    }
 }
 
 fn uses_live_discovery(config: &AppConfig) -> bool {
@@ -274,13 +386,16 @@ fn apply_host_scan(host_root: PathBuf, result: &mut ScanResult) {
 mod tests {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::discovery::{DiscoveredComposeProject, DiscoveredContainerService};
-    use crate::domain::{AdapterStatus, DockerDiscoveryStatus, ScanMode};
+    use crate::domain::{AdapterStatus, DockerDiscoveryStatus, ScanMode, ServiceSummary};
 
-    use super::{apply_current_dir_fallback, apply_discovered_projects, run, scan_compose_project};
+    use super::{
+        apply_current_dir_fallback, apply_discovered_projects, run, scan_compose_project,
+        seed_adapter_statuses,
+    };
     use crate::app::{AppConfig, OutputMode};
     use crate::compose::ComposeParser;
 
@@ -733,5 +848,42 @@ mod tests {
             warning.contains("Docker metadata")
                 && warning.contains("refresh the saved Compose labels")
         }));
+    }
+
+    #[test]
+    fn seed_adapter_statuses_marks_pending_for_live_targets() {
+        let mut result = crate::domain::ScanResult::default();
+        result.metadata.host_root = Some(PathBuf::from("/"));
+        result.metadata.services.push(ServiceSummary {
+            name: String::from("demo"),
+            image: Some(String::from("nginx:1.27.5")),
+        });
+
+        seed_adapter_statuses(&mut result);
+
+        assert_eq!(
+            result.metadata.adapters.get("lynis"),
+            Some(&AdapterStatus::Pending)
+        );
+        assert_eq!(
+            result.metadata.adapters.get("trivy"),
+            Some(&AdapterStatus::Pending)
+        );
+    }
+
+    #[test]
+    fn seed_adapter_statuses_marks_skipped_when_targets_are_missing() {
+        let mut result = crate::domain::ScanResult::default();
+
+        seed_adapter_statuses(&mut result);
+
+        assert!(matches!(
+            result.metadata.adapters.get("lynis"),
+            Some(AdapterStatus::Skipped(_))
+        ));
+        assert!(matches!(
+            result.metadata.adapters.get("trivy"),
+            Some(AdapterStatus::Skipped(_))
+        ));
     }
 }

--- a/src/src/domain/mod.rs
+++ b/src/src/domain/mod.rs
@@ -177,6 +177,7 @@ impl Default for ScoreReport {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "state", content = "detail", rename_all = "snake_case")]
 pub enum AdapterStatus {
+    Pending,
     Available,
     Missing,
     Skipped(String),

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::io;
+use std::time::Duration;
 
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
 use crossterm::execute;
@@ -159,7 +160,10 @@ enum FindingsLayoutMode {
     Narrow,
 }
 
-pub fn run(scan_result: &ScanResult) -> io::Result<()> {
+pub fn run<F>(scan_result: &mut ScanResult, mut refresh: F) -> io::Result<()>
+where
+    F: FnMut(&mut ScanResult) -> bool,
+{
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -168,7 +172,7 @@ pub fn run(scan_result: &ScanResult) -> io::Result<()> {
     let mut terminal = Terminal::new(backend)?;
     let mut state = AppState::new(scan_result);
 
-    let result = run_event_loop(&mut terminal, scan_result, &mut state);
+    let result = run_event_loop(&mut terminal, scan_result, &mut state, &mut refresh);
 
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
@@ -177,20 +181,30 @@ pub fn run(scan_result: &ScanResult) -> io::Result<()> {
     result
 }
 
-fn run_event_loop(
+fn run_event_loop<F>(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    scan_result: &ScanResult,
+    scan_result: &mut ScanResult,
     state: &mut AppState,
-) -> io::Result<()> {
+    refresh: &mut F,
+) -> io::Result<()>
+where
+    F: FnMut(&mut ScanResult) -> bool,
+{
     loop {
+        if refresh(scan_result) {
+            state.clamp_selection(scan_result);
+        }
+
         terminal.draw(|frame| render(frame, scan_result, state))?;
 
-        match event::read()? {
-            Event::Key(key) if key.kind == KeyEventKind::Press && handle_key(state, key) => {
-                return Ok(());
+        if event::poll(Duration::from_millis(100))? {
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press && handle_key(state, key) => {
+                    return Ok(());
+                }
+                Event::Resize(_, _) => {}
+                _ => {}
             }
-            Event::Resize(_, _) => {}
-            _ => {}
         }
     }
 }
@@ -1512,6 +1526,7 @@ fn adapter_name_label(name: &str) -> String {
 
 fn adapter_status_label(status: &AdapterStatus) -> String {
     match status {
+        AdapterStatus::Pending => t!("adapter.pending").into_owned(),
         AdapterStatus::Available => t!("adapter.available").into_owned(),
         AdapterStatus::Missing => t!("adapter.missing").into_owned(),
         AdapterStatus::Skipped(detail) => {


### PR DESCRIPTION
## Summary
- show the TUI as soon as the native scan is ready and keep Lynis/Trivy adapter work in the background so interactive launch no longer appears hung
- run full adapter scans in parallel for non-interactive paths and trim Trivy image scans to vulnerability-only mode to reduce runtime overhead
- bump the Rust crate version to `0.1.2` for the patch release that ships the startup latency fix

## Validation
- `cargo fmt`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- pavilion timing before fix: current installed `hostveil` produced no TUI output within 3 seconds and `HOSTVEIL_SKIP_AUTO_UPGRADE=1 hostveil --json` took about 176 seconds
- pavilion timing after patch: `/tmp/hostveil-patched` produced TUI output in about 0.15 seconds and `--json` completed in about 43 seconds

Closes #110