### PR TITLE
fix(installer): preserve state dir and finalize remaining issue cleanup

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -199,7 +199,6 @@ jobs:
 
             ## Known limitations
             - Linux only
-            - Nextcloud-specific service-aware rules are not included yet
             - TUI-embedded guided diff review is still deferred from the current release scope
           files: |
             dist/*.tar.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ hostveil is a **lightweight TUI security dashboard for Linux self-hosted environ
 
 The Python prototype validated the Compose parser, rule engine, scoring model, and fix flows. The real product direction is broader: native Compose checks, Linux host hardening checks, and optional external scanner adapters should all feed one scored self-hosting security tool. The long-term target audit axes are sensitive data exposure, excessive permissions, unnecessary exposure, update/supply-chain risk, and host hardening.
 
-**Target users:** Self-hosters running services like Jellyfin, Nextcloud, Vaultwarden, Gitea, Immich on a single Linux server.
+**Target users:** Self-hosters running services like Jellyfin, Vaultwarden, Gitea, Immich on a single Linux server.
 
 ## Tech Stack
 
@@ -76,7 +76,7 @@ hostveil/
 
 ## GitHub Issues & Milestones
 
-All planned work is tracked as GitHub Issues organized into 4 Milestones. **AI agents are expected to participate in this workflow without being told to do so.**
+All planned work is tracked as GitHub Issues organized into 3 Milestones. **AI agents are expected to participate in this workflow without being told to do so.**
 
 **Milestones** (see `github.com/seolcu/hostveil/milestones`):
 
@@ -85,7 +85,6 @@ All planned work is tracked as GitHub Issues organized into 4 Milestones. **AI a
 | 1 | Python CLI Prototype | 2026-03-30 |
 | 2 | Service Research & Rule Validation | 2026-04-19 |
 | 3 | Rust TUI Implementation | 2026-05-31 |
-| 4 | Finalization & Submission | 2026-06-21 |
 
 **How AI agents should use Issues:**
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Status: Early Development](https://img.shields.io/badge/status-early%20development-orange)](https://github.com/seolcu/hostveil)
 
-Jellyfin, Nextcloud, Vaultwarden, Gitea, Immich 등을 운영하는 셀프호스터는 보안 상태를 확인하기 위해 Lynis, Trivy, Dockle, Docker Bench, Fail2ban 같은 도구를 각각 따로 설치하고 해석해야 합니다. hostveil은 이런 신호를 하나의 터미널 중심 워크플로로 통합하는 것을 목표로 합니다. 심각도 순으로 정렬된 점수화된 발견 사항, 셀프호스팅 맥락에 맞춘 설명, 그리고 구체적인 해결 가이드를 한 번에 제공합니다.
+Jellyfin, Vaultwarden, Gitea, Immich 등을 운영하는 셀프호스터는 보안 상태를 확인하기 위해 Lynis, Trivy, Dockle, Docker Bench, Fail2ban 같은 도구를 각각 따로 설치하고 해석해야 합니다. hostveil은 이런 신호를 하나의 터미널 중심 워크플로로 통합하는 것을 목표로 합니다. 심각도 순으로 정렬된 점수화된 발견 사항, 셀프호스팅 맥락에 맞춘 설명, 그리고 구체적인 해결 가이드를 한 번에 제공합니다.
 
 [Chrome Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) (실행 가능한 가이드를 포함한 점수화 감사)와 [btop](https://github.com/aristocratos/btop) (경량 TUI 디자인)에서 영감을 받았습니다.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Status: Early Development](https://img.shields.io/badge/status-early%20development-orange)](https://github.com/seolcu/hostveil)
 
-Self-hosters running Jellyfin, Nextcloud, Vaultwarden, Gitea, or Immich typically need to run and interpret several separate security tools — Lynis, Trivy, Dockle, Docker Bench, Fail2ban, and more — with results scattered across all of them. hostveil is intended to consolidate those signals into one terminal-first workflow: scored findings, prioritized by severity, explained in self-hosting terms, and paired with concrete fix guidance.
+Self-hosters running Jellyfin, Vaultwarden, Gitea, or Immich typically need to run and interpret several separate security tools — Lynis, Trivy, Dockle, Docker Bench, Fail2ban, and more — with results scattered across all of them. hostveil is intended to consolidate those signals into one terminal-first workflow: scored findings, prioritized by severity, explained in self-hosting terms, and paired with concrete fix guidance.
 
 Inspired by [Chrome Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) (scored audits with actionable guidance) and [btop](https://github.com/aristocratos/btop) (lightweight TUI design).
 
@@ -233,7 +233,6 @@ Current release priorities:
 
 Explicitly deferred from the current early-release scope:
 
-- Nextcloud-specific service-aware rules
 - Trivy integration as the first optional external adapter
 - TUI-embedded guided diff review before writes
 - Package-manager distribution such as apt, dnf, Homebrew, or AUR

--- a/proto/demo.py
+++ b/proto/demo.py
@@ -17,7 +17,7 @@ from rich.text import Text
 
 SERVICES = [
     ("Vaultwarden", "vaultwarden/server:1.30.1"),
-    ("Nextcloud",   "nextcloud:27.1.2"),
+    ("Immich",      "ghcr.io/immich-app/immich-server:v2.1.0"),
     ("Jellyfin",    "jellyfin/jellyfin:10.8.13"),
     ("Gitea",       "gitea:latest"),
     ("Nginx",       "nginx"),
@@ -34,7 +34,7 @@ SCAN_CHECKS = [
 
 SCAN_RESULTS = [
     ("Vaultwarden", "CRITICAL", 1),
-    ("Nextcloud",   "CRITICAL", 1),
+    ("Immich",      "CRITICAL", 1),
     ("Jellyfin",    "HIGH",     1),
     ("Gitea",       "MEDIUM",   1),
     ("Nginx",       "LOW",      1),
@@ -52,7 +52,7 @@ QUICKFIXES = [
     ("SAFE",   "Bind Jellyfin port 8096 → 127.0.0.1"),
     ("SAFE",   "Pin gitea:latest → gitea/gitea:1.21"),
     ("GUIDED", "Remove privileged:true (Vaultwarden)"),
-    ("GUIDED", "Move Nextcloud DB password to secret"),
+    ("GUIDED", "Move Immich DB password to secret"),
 ]
 
 # ── Helpers ────────────────────────────────────────────────────────────────────

--- a/proto/hostveil/rules/exposure.py
+++ b/proto/hostveil/rules/exposure.py
@@ -7,7 +7,7 @@ from ..models import Axis, ComposeProject, Finding, PortBinding, Severity
 
 
 ADMIN_SERVICE_HINTS = ("adminer", "pgadmin", "phpmyadmin", "portainer", "traefik")
-REVERSE_PROXY_HINTS = ("vaultwarden", "nextcloud", "gitea", "immich")
+REVERSE_PROXY_HINTS = ("vaultwarden", "gitea", "immich")
 LOCAL_ONLY_HOSTS = {"127.0.0.1", "::1", "localhost"}
 PUBLIC_HOSTS = {None, "0.0.0.0", "::", "[::]"}
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,7 +34,23 @@ else
 fi
 
 DOWNLOAD_BASE_URL="${HOSTVEIL_DOWNLOAD_BASE_URL:-}"
-STATE_DIR="${HOSTVEIL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/hostveil}"
+
+resolve_state_dir() {
+  local default_state_dir script_path script_name script_dir
+
+  default_state_dir="${HOSTVEIL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/hostveil}"
+  script_path="${BASH_SOURCE[0]}"
+  script_name="$(basename "$script_path")"
+  script_dir="$(cd "$(dirname "$script_path")" && pwd)"
+
+  if [[ "$script_name" == "manage.sh" ]] && [[ -f "$script_dir/install.env" ]]; then
+    printf '%s\n' "$script_dir"
+  else
+    printf '%s\n' "$default_state_dir"
+  fi
+}
+
+STATE_DIR="$(resolve_state_dir)"
 
 WRAPPER_NAME="hostveil"
 BINARY_NAME="hostveil-bin"
@@ -477,6 +493,7 @@ write_metadata() {
   mkdir -p "$STATE_DIR"
 
   {
+    printf 'HOSTVEIL_META_STATE_DIR=%q\n' "$STATE_DIR"
     printf 'HOSTVEIL_META_REPO=%q\n' "$REPO"
     printf 'HOSTVEIL_META_CHANNEL=%q\n' "$CHANNEL"
     printf 'HOSTVEIL_META_INSTALL_DIR=%q\n' "$INSTALL_DIR"
@@ -509,24 +526,38 @@ write_wrapper_script() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-METADATA_PATH=$(printf '%q' "$METADATA_PATH")
-MANAGER_SCRIPT_PATH=$(printf '%q' "$MANAGER_SCRIPT_PATH")
+DEFAULT_STATE_DIR=$(printf '%q' "$STATE_DIR")
 DEFAULT_BINARY_PATH=$(printf '%q' "$binary_path")
 
-if [[ -f "\$METADATA_PATH" ]]; then
+state_dir="\$DEFAULT_STATE_DIR"
+metadata_path="\$state_dir/install.env"
+manager_script_path="\$state_dir/manage.sh"
+
+if [[ -f "\$metadata_path" ]]; then
   # shellcheck disable=SC1090
-  source "\$METADATA_PATH"
+  source "\$metadata_path"
+fi
+
+if [[ -n "\${HOSTVEIL_META_STATE_DIR:-}" ]] && [[ "\$HOSTVEIL_META_STATE_DIR" != "\$state_dir" ]]; then
+  state_dir="\$HOSTVEIL_META_STATE_DIR"
+  metadata_path="\$state_dir/install.env"
+  manager_script_path="\$state_dir/manage.sh"
+
+  if [[ -f "\$metadata_path" ]]; then
+    # shellcheck disable=SC1090
+    source "\$metadata_path"
+  fi
 fi
 
 binary_path="\${HOSTVEIL_META_BINARY_PATH:-\$DEFAULT_BINARY_PATH}"
 
 run_manager_command() {
-  if [[ ! -x "\$MANAGER_SCRIPT_PATH" ]]; then
+  if [[ ! -x "\$manager_script_path" ]]; then
     printf 'error: hostveil lifecycle manager is unavailable; reinstall hostveil with the installer\n' >&2
     exit 1
   fi
 
-  HOSTVEIL_SKIP_AUTO_UPGRADE=1 exec "\$MANAGER_SCRIPT_PATH" "\$@"
+  HOSTVEIL_STATE_DIR="\$state_dir" HOSTVEIL_SKIP_AUTO_UPGRADE=1 exec "\$manager_script_path" "\$@"
 }
 
 case "\${1:-}" in
@@ -560,11 +591,11 @@ case "\${1:-}" in
     ;;
 esac
 
-if [[ "\${HOSTVEIL_SKIP_AUTO_UPGRADE:-}" != "1" && "\${HOSTVEIL_AUTO_UPGRADE_RUNNING:-}" != "1" && "\${HOSTVEIL_META_AUTO_UPGRADE:-enabled}" != "disabled" && -x "\$MANAGER_SCRIPT_PATH" ]]; then
-  HOSTVEIL_AUTO_UPGRADE_RUNNING=1 HOSTVEIL_SKIP_AUTO_UPGRADE=1 "\$MANAGER_SCRIPT_PATH" --upgrade >/dev/null 2>&1 || true
-  if [[ -f "\$METADATA_PATH" ]]; then
+if [[ "\${HOSTVEIL_SKIP_AUTO_UPGRADE:-}" != "1" && "\${HOSTVEIL_AUTO_UPGRADE_RUNNING:-}" != "1" && "\${HOSTVEIL_META_AUTO_UPGRADE:-enabled}" != "disabled" && -x "\$manager_script_path" ]]; then
+  HOSTVEIL_STATE_DIR="\$state_dir" HOSTVEIL_AUTO_UPGRADE_RUNNING=1 HOSTVEIL_SKIP_AUTO_UPGRADE=1 "\$manager_script_path" --upgrade >/dev/null 2>&1 || true
+  if [[ -f "\$metadata_path" ]]; then
     # shellcheck disable=SC1090
-    source "\$METADATA_PATH"
+    source "\$metadata_path"
     binary_path="\${HOSTVEIL_META_BINARY_PATH:-\$DEFAULT_BINARY_PATH}"
   fi
 fi

--- a/scripts/test-install-script.sh
+++ b/scripts/test-install-script.sh
@@ -109,7 +109,7 @@ run_install_case() {
     printf 'error: local lifecycle manager was not saved for checksum prefix %s\n' "$checksum_prefix" >&2
     exit 1
   }
-  [[ "$($install_dir/hostveil --version)" == "$EXPECTED_VERSION" ]] || {
+  [[ "$(HOSTVEIL_SKIP_AUTO_UPGRADE=1 "$install_dir/hostveil" --version)" == "$EXPECTED_VERSION" ]] || {
     printf 'error: installed wrapper returned an unexpected version for checksum prefix %s\n' "$checksum_prefix" >&2
     exit 1
   }
@@ -141,7 +141,7 @@ run_latest_install_case() {
     HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
     bash "$INSTALLER_PATH" --channel preview --to "$install_dir"
 
-  [[ "$($install_dir/hostveil --version)" == "$EXPECTED_VERSION" ]] || {
+  [[ "$(HOSTVEIL_SKIP_AUTO_UPGRADE=1 "$install_dir/hostveil" --version)" == "$EXPECTED_VERSION" ]] || {
     printf 'error: latest install did not install the expected binary\n' >&2
     exit 1
   }
@@ -334,6 +334,118 @@ run_upgrade_auto_uninstall_case() {
   rm -rf "$case_dir"
 }
 
+run_custom_state_dir_case() {
+  local case_dir
+  local default_state_home
+  local custom_state_dir
+  local release_one
+  local release_two
+  local release_three
+  local api_three
+  local install_dir
+  local metadata_path
+  local manager_path
+
+  case_dir="$(mktemp -d)"
+  default_state_home="$case_dir/default-state"
+  custom_state_dir="$case_dir/custom-state/isolated-hostveil"
+  release_one="$case_dir/release-one"
+  release_two="$case_dir/release-two"
+  release_three="$case_dir/release-three"
+  api_three="$case_dir/api-three"
+  install_dir="$case_dir/install/bin"
+  metadata_path="$custom_state_dir/install.env"
+  manager_path="$custom_state_dir/manage.sh"
+
+  create_release_fixture "$release_one" "v0.1.0-test" ""
+  create_release_fixture "$release_two" "v0.2.0-test" ""
+  create_release_fixture "$release_three" "v0.3.0-test" ""
+  create_releases_api_fixture "$api_three" "v0.3.0-test"
+
+  XDG_STATE_HOME="$default_state_home" \
+    HOSTVEIL_STATE_DIR="$custom_state_dir" \
+    HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_one" \
+    HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
+    bash "$INSTALLER_PATH" --version v0.1.0-test --to "$install_dir"
+
+  [[ -x "$install_dir/hostveil" ]] || {
+    printf 'error: wrapper install is missing for custom state dir case\n' >&2
+    exit 1
+  }
+  [[ -x "$manager_path" ]] || {
+    printf 'error: lifecycle manager was not saved in the custom state dir\n' >&2
+    exit 1
+  }
+  assert_file_contains "$metadata_path" 'HOSTVEIL_META_STATE_DIR='
+  assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.1.0-test'
+  [[ ! -e "$default_state_home/hostveil/install.env" ]] || {
+    printf 'error: install metadata leaked into the default state dir\n' >&2
+    exit 1
+  }
+
+  PATH="$install_dir:$PATH" \
+    XDG_STATE_HOME="$default_state_home" \
+    HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_two" \
+    HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
+    hostveil upgrade --version v0.2.0-test
+
+  assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.2.0-test'
+  [[ ! -e "$default_state_home/hostveil/install.env" ]] || {
+    printf 'error: upgrade recreated metadata in the default state dir\n' >&2
+    exit 1
+  }
+
+  XDG_STATE_HOME="$default_state_home" \
+    HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_three" \
+    HOSTVEIL_RELEASES_API_URL="file://$api_three/releases.json" \
+    HOSTVEIL_LATEST_STABLE_API_URL="file://$api_three/latest.json" \
+    HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
+    "$install_dir/hostveil" --version >/dev/null
+
+  assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.3.0-test'
+  [[ ! -e "$default_state_home/hostveil/install.env" ]] || {
+    printf 'error: auto-upgrade recreated metadata in the default state dir\n' >&2
+    exit 1
+  }
+
+  XDG_STATE_HOME="$default_state_home" \
+    PATH="$install_dir:$PATH" \
+    hostveil auto-upgrade disable
+  assert_file_contains "$metadata_path" 'HOSTVEIL_META_AUTO_UPGRADE=disabled'
+
+  XDG_STATE_HOME="$default_state_home" \
+    PATH="$install_dir:$PATH" \
+    hostveil auto-upgrade enable
+  assert_file_contains "$metadata_path" 'HOSTVEIL_META_AUTO_UPGRADE=enabled'
+
+  XDG_STATE_HOME="$default_state_home" \
+    PATH="$install_dir:$PATH" \
+    hostveil uninstall
+
+  [[ ! -e "$install_dir/hostveil" ]] || {
+    printf 'error: wrapper still exists after custom state uninstall\n' >&2
+    exit 1
+  }
+  [[ ! -e "$install_dir/hostveil-bin" ]] || {
+    printf 'error: payload binary still exists after custom state uninstall\n' >&2
+    exit 1
+  }
+  [[ ! -e "$manager_path" ]] || {
+    printf 'error: custom state lifecycle manager still exists after uninstall\n' >&2
+    exit 1
+  }
+  [[ ! -e "$metadata_path" ]] || {
+    printf 'error: custom state install metadata still exists after uninstall\n' >&2
+    exit 1
+  }
+  [[ ! -e "$default_state_home/hostveil" ]] || {
+    printf 'error: uninstall touched the default state dir unexpectedly\n' >&2
+    exit 1
+  }
+
+  rm -rf "$case_dir"
+}
+
 run_post_install_setup_handoff_case() {
   local case_dir
   local release_dir
@@ -388,6 +500,7 @@ run_latest_install_case
 run_login_path_detection_case
 run_current_path_detection_case
 run_upgrade_auto_uninstall_case
+run_custom_state_dir_case
 run_post_install_setup_handoff_case
 
 printf 'Installer tests passed for %s\n' "$BINARY_PATH"

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -384,17 +384,21 @@ fn apply_host_scan(host_root: PathBuf, result: &mut ScanResult) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::discovery::{DiscoveredComposeProject, DiscoveredContainerService};
-    use crate::domain::{AdapterStatus, DockerDiscoveryStatus, ScanMode, ServiceSummary};
+    use crate::domain::{
+        AdapterStatus, Axis, DockerDiscoveryStatus, Finding, RemediationKind, ScanMode, Scope,
+        ServiceSummary, Severity, Source,
+    };
 
     use super::{
-        apply_current_dir_fallback, apply_discovered_projects, run, scan_compose_project,
-        seed_adapter_statuses,
+        AdapterScanUpdate, apply_current_dir_fallback, apply_discovered_projects,
+        apply_external_adapter_update, run, scan_compose_project, seed_adapter_statuses,
     };
     use crate::app::{AppConfig, OutputMode};
     use crate::compose::ComposeParser;
@@ -424,6 +428,32 @@ mod tests {
             fs::create_dir_all(parent).expect("parent should be created");
         }
         fs::write(path, content).expect("file should be written");
+    }
+
+    fn test_finding(
+        id: &str,
+        axis: Axis,
+        severity: Severity,
+        scope: Scope,
+        source: Source,
+        subject: &str,
+        related_service: Option<&str>,
+    ) -> Finding {
+        Finding {
+            id: id.to_owned(),
+            axis,
+            severity,
+            scope,
+            source,
+            subject: subject.to_owned(),
+            related_service: related_service.map(str::to_owned),
+            title: format!("Synthetic finding {id}"),
+            description: format!("Synthetic description for {id}"),
+            why_risky: String::from("Synthetic risk explanation"),
+            how_to_fix: String::from("Synthetic remediation guidance"),
+            evidence: BTreeMap::from([(String::from("id"), id.to_owned())]),
+            remediation: RemediationKind::None,
+        }
     }
 
     #[test]
@@ -665,6 +695,106 @@ mod tests {
         assert!(result.score_report.axis_scores[&crate::domain::Axis::HostHardening] < 100);
 
         fs::remove_dir_all(host_root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn native_and_adapter_findings_share_one_scan_result() {
+        let mut result = crate::domain::ScanResult {
+            findings: vec![
+                test_finding(
+                    "project.compose_bundle_loaded",
+                    Axis::SensitiveData,
+                    Severity::Low,
+                    Scope::Project,
+                    Source::NativeCompose,
+                    "/srv/demo/docker-compose.yml",
+                    None,
+                ),
+                test_finding(
+                    "service.public_binding",
+                    Axis::UnnecessaryExposure,
+                    Severity::Medium,
+                    Scope::Service,
+                    Source::NativeCompose,
+                    "web",
+                    Some("web"),
+                ),
+            ],
+            ..Default::default()
+        };
+        result.metadata.services.push(ServiceSummary {
+            name: String::from("web"),
+            image: Some(String::from("nginx:1.27.5")),
+        });
+        result.metadata.host_root = Some(PathBuf::from("/"));
+
+        seed_adapter_statuses(&mut result);
+        apply_external_adapter_update(
+            &mut result,
+            AdapterScanUpdate {
+                trivy: crate::adapters::trivy::TrivyScanOutput {
+                    status: AdapterStatus::Available,
+                    findings: vec![test_finding(
+                        "trivy.image_vulnerabilities.nginx_1_27_5",
+                        Axis::UpdateSupplyChainRisk,
+                        Severity::High,
+                        Scope::Image,
+                        Source::Trivy,
+                        "nginx:1.27.5",
+                        Some("web"),
+                    )],
+                    warnings: Vec::new(),
+                },
+                lynis: crate::adapters::lynis::LynisScanOutput {
+                    status: AdapterStatus::Available,
+                    findings: vec![test_finding(
+                        "lynis.ssh.password_authentication_enabled",
+                        Axis::HostHardening,
+                        Severity::High,
+                        Scope::Host,
+                        Source::Lynis,
+                        "/etc/ssh/sshd_config",
+                        None,
+                    )],
+                    warnings: Vec::new(),
+                },
+            },
+        );
+
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|finding| finding.scope == Scope::Project
+                    && finding.source == Source::NativeCompose)
+        );
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|finding| finding.scope == Scope::Service
+                    && finding.source == Source::NativeCompose)
+        );
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|finding| finding.scope == Scope::Image && finding.source == Source::Trivy)
+        );
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|finding| finding.scope == Scope::Host && finding.source == Source::Lynis)
+        );
+        assert_eq!(
+            result.metadata.adapters.get("trivy"),
+            Some(&AdapterStatus::Available)
+        );
+        assert_eq!(
+            result.metadata.adapters.get("lynis"),
+            Some(&AdapterStatus::Available)
+        );
     }
 
     #[test]

--- a/src/src/discovery/docker.rs
+++ b/src/src/discovery/docker.rs
@@ -201,19 +201,19 @@ mod tests {
     #[test]
     fn project_summary_captures_display_data() {
         let project = DiscoveredComposeProject {
-            name: String::from("nextcloud"),
-            compose_path: Some(PathBuf::from("/srv/nextcloud/docker-compose.yml")),
-            working_dir: Some(PathBuf::from("/srv/nextcloud")),
+            name: String::from("immich"),
+            compose_path: Some(PathBuf::from("/srv/immich/docker-compose.yml")),
+            working_dir: Some(PathBuf::from("/srv/immich")),
             services: vec![DiscoveredContainerService {
-                name: String::from("app"),
-                image: Some(String::from("nextcloud:27.1.2")),
+                name: String::from("server"),
+                image: Some(String::from("ghcr.io/immich-app/immich-server:v2.1.0")),
             }],
             source: "docker",
         };
 
         let summary = project_summary(&project);
 
-        assert_eq!(summary.name, "nextcloud");
+        assert_eq!(summary.name, "immich");
         assert_eq!(summary.source, "docker");
         assert_eq!(summary.service_count, 1);
     }

--- a/src/src/export/mod.rs
+++ b/src/src/export/mod.rs
@@ -26,8 +26,34 @@ fn escape_json(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::scan_result_json;
-    use crate::domain::ScanResult;
+    use crate::domain::{Axis, Finding, RemediationKind, ScanResult, Scope, Severity, Source};
+
+    fn test_finding(
+        id: &str,
+        scope: Scope,
+        source: Source,
+        subject: &str,
+        related_service: Option<&str>,
+    ) -> Finding {
+        Finding {
+            id: id.to_owned(),
+            axis: Axis::UpdateSupplyChainRisk,
+            severity: Severity::High,
+            scope,
+            source,
+            subject: subject.to_owned(),
+            related_service: related_service.map(str::to_owned),
+            title: format!("Synthetic finding {id}"),
+            description: format!("Synthetic description for {id}"),
+            why_risky: String::from("Synthetic risk explanation"),
+            how_to_fix: String::from("Synthetic remediation guidance"),
+            evidence: BTreeMap::from([(String::from("subject"), subject.to_owned())]),
+            remediation: RemediationKind::None,
+        }
+    }
 
     #[test]
     fn emits_valid_scan_result_shape() {
@@ -36,5 +62,52 @@ mod tests {
         assert!(json.contains("\"findings\": []"));
         assert!(json.contains("\"score_report\":"));
         assert!(json.contains("\"metadata\":"));
+    }
+
+    #[test]
+    fn serializes_mixed_scopes_and_sources() {
+        let result = ScanResult {
+            findings: vec![
+                test_finding(
+                    "service.public_binding",
+                    Scope::Service,
+                    Source::NativeCompose,
+                    "web",
+                    Some("web"),
+                ),
+                test_finding(
+                    "trivy.image_vulnerabilities.nginx",
+                    Scope::Image,
+                    Source::Trivy,
+                    "nginx:1.27.5",
+                    Some("web"),
+                ),
+                test_finding(
+                    "lynis.ssh.password_authentication_enabled",
+                    Scope::Host,
+                    Source::Lynis,
+                    "/etc/ssh/sshd_config",
+                    None,
+                ),
+                test_finding(
+                    "project.compose_bundle_loaded",
+                    Scope::Project,
+                    Source::NativeCompose,
+                    "/srv/demo/docker-compose.yml",
+                    None,
+                ),
+            ],
+            ..Default::default()
+        };
+
+        let json = scan_result_json(&result);
+
+        assert!(json.contains("\"scope\": \"service\""));
+        assert!(json.contains("\"scope\": \"image\""));
+        assert!(json.contains("\"scope\": \"host\""));
+        assert!(json.contains("\"scope\": \"project\""));
+        assert!(json.contains("\"source\": \"native_compose\""));
+        assert!(json.contains("\"source\": \"trivy\""));
+        assert!(json.contains("\"source\": \"lynis\""));
     }
 }

--- a/src/src/rules/exposure.rs
+++ b/src/src/rules/exposure.rs
@@ -6,7 +6,7 @@ use crate::domain::{Axis, Finding, RemediationKind, Severity};
 use super::{ServiceFindingText, service_finding, service_finding_with_remediation};
 
 const ADMIN_SERVICE_HINTS: [&str; 5] = ["adminer", "pgadmin", "phpmyadmin", "portainer", "traefik"];
-const REVERSE_PROXY_HINTS: [&str; 4] = ["vaultwarden", "nextcloud", "gitea", "immich"];
+const REVERSE_PROXY_HINTS: [&str; 3] = ["vaultwarden", "gitea", "immich"];
 const LOCAL_ONLY_HOSTS: [&str; 3] = ["127.0.0.1", "::1", "localhost"];
 
 pub fn scan_exposure_risk(project: &ComposeProject) -> Vec<Finding> {

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -1879,6 +1879,48 @@ mod tests {
         }
     }
 
+    fn mixed_scope_result() -> ScanResult {
+        let mut result = sample_result();
+        result.findings.push(Finding {
+            id: String::from("trivy.image_vulnerabilities.adminer_latest"),
+            axis: Axis::UpdateSupplyChainRisk,
+            severity: Severity::High,
+            scope: Scope::Image,
+            source: Source::Trivy,
+            subject: String::from("adminer:latest"),
+            related_service: Some(String::from("adminer")),
+            title: String::from("Image vulnerabilities found"),
+            description: String::from("adminer:latest has multiple high-risk vulnerabilities."),
+            why_risky: String::from("Known CVEs increase the chance of compromise."),
+            how_to_fix: String::from("Pin and rebuild with a patched image."),
+            evidence: BTreeMap::from([(String::from("image"), String::from("adminer:latest"))]),
+            remediation: RemediationKind::None,
+        });
+        result.findings.push(Finding {
+            id: String::from("project.compose_bundle_loaded"),
+            axis: Axis::SensitiveData,
+            severity: Severity::Low,
+            scope: Scope::Project,
+            source: Source::NativeCompose,
+            subject: String::from("/srv/demo/docker-compose.yml"),
+            related_service: None,
+            title: String::from("Project-level compose review"),
+            description: String::from(
+                "Project-wide settings should be reviewed alongside per-service findings.",
+            ),
+            why_risky: String::from(
+                "Shared Compose settings can affect every service in the stack.",
+            ),
+            how_to_fix: String::from("Review the Compose project configuration as a whole."),
+            evidence: BTreeMap::from([(
+                String::from("compose_file"),
+                String::from("/srv/demo/docker-compose.yml"),
+            )]),
+            remediation: RemediationKind::None,
+        });
+        result
+    }
+
     #[test]
     fn overview_navigation_opens_findings() {
         let mut state = AppState::new(&sample_result());
@@ -2013,6 +2055,29 @@ mod tests {
         assert!(content.contains("Native Compose"));
         assert!(content.contains("Service"));
         assert!(content.contains("adminer"));
+    }
+
+    #[test]
+    fn findings_view_renders_project_scope_from_shared_scan_result() {
+        let result = mixed_scope_result();
+        let mut state = AppState::new(&result);
+        state.open_findings();
+        state.selected_index = result
+            .findings
+            .iter()
+            .position(|finding| finding.scope == Scope::Project)
+            .expect("project finding should exist");
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal should build");
+
+        terminal
+            .draw(|frame| render(frame, &result, &mut state))
+            .expect("findings view should render mixed scopes");
+
+        let content = buffer_to_string(terminal.backend());
+
+        assert!(content.contains("Project"));
+        assert!(content.contains("Project-level compose review"));
+        assert!(content.contains("/srv/demo/docker-compose.yml"));
     }
 
     #[test]

--- a/src/tests/fixtures/rules/hardened-stack.yml
+++ b/src/tests/fixtures/rules/hardened-stack.yml
@@ -7,13 +7,13 @@ services:
     environment:
       DOMAIN: ${VAULTWARDEN_DOMAIN}
 
-  nextcloud:
-    image: nextcloud:29.0.7
-    user: "33:33"
+  immich-server:
+    image: ghcr.io/immich-app/immich-server:v2.1.0
+    user: "1000:1000"
     ports:
-      - "127.0.0.1:8081:80"
+      - "127.0.0.1:2283:2283"
     volumes:
-      - ./nextcloud:/var/www/html
+      - ./immich:/data
 
   gitea:
     image: gitea/gitea:1.21.11


### PR DESCRIPTION
## Summary
- preserve custom `HOSTVEIL_STATE_DIR` installs across upgrade, auto-upgrade, and uninstall, with installer regression coverage
- lock the shared Rust `ScanResult` pipeline with mixed scope/source tests for the app scan path, JSON export, and TUI findings view
- remove obsolete Finalization milestone and Nextcloud references from docs, fixtures, workflow copy, and prototype assets

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `scripts/test-install-script.sh target/debug/hostveil`
- `scripts/smoke-test.sh target/debug/hostveil`

## Issues
- Closes #109
- Closes #53
- Closes #17
- Closes #16
- Closes #86
- Closes #49