### PR TITLE
feat(src): expand hardening, remediation, and adapter coverage

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -194,6 +194,7 @@ jobs:
             ## Optional dependencies
             - Docker improves live Compose discovery when it is available.
             - Trivy is supported as an optional image vulnerability adapter.
+            - Dockle is supported as an optional image hardening adapter.
             - Lynis is supported as an optional host-audit adapter.
             - Fail2Ban remains optional; host scans continue without it, but host hardening coverage is reduced.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ hostveil/
 ├── docs/
 │   └── adr/          # Architecture Decision Records — read before changing architecture
 ├── .github/
-│   └── workflows/    # CI/CD (not yet set up)
+│   └── workflows/    # Rust CI and release workflows
 ├── AGENTS.md         # This file
 ├── CONTRIBUTING.md   # Git conventions, branch strategy, commit format
 ├── LICENSE           # GPLv3
@@ -76,15 +76,14 @@ hostveil/
 
 ## GitHub Issues & Milestones
 
-All planned work is tracked as GitHub Issues organized into 3 Milestones. **AI agents are expected to participate in this workflow without being told to do so.**
+All planned work is tracked as GitHub Issues organized into Milestones. **AI agents are expected to participate in this workflow without being told to do so.**
 
-**Milestones** (see `github.com/seolcu/hostveil/milestones`):
+**Current milestone state** (see `github.com/seolcu/hostveil/milestones`):
 
-| # | Title | Due |
-|---|---|---|
-| 1 | Python CLI Prototype | 2026-03-30 |
-| 2 | Service Research & Rule Validation | 2026-04-19 |
-| 3 | Rust TUI Implementation | 2026-05-31 |
+- Closed: `#1 Python CLI Prototype`
+- Closed: `#2 Service Research & Rule Validation`
+- Closed: `#3 Rust TUI Implementation`
+- Active: `#5 v0.2 Hardening and UX`
 
 **How AI agents should use Issues:**
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ Current Rust implementation status:
 - `ratatui` + `crossterm` TUI wired and localized through `rust-i18n`
 - Generalized Rust scan result model and minimal JSON export path working
 - Compose parser ported with override merging and normalization parity tests
-- Native Compose rule engine and scoring model partially ported with Rust fixture tests
-- Native Linux host checks started for SSH posture and Docker host exposure via `--host-root`
+- Native Compose rule engine and scoring model ported with Rust fixture tests
+- Native Linux host checks added for SSH posture, Docker host exposure, and defensive-control telemetry via `--host-root`
+- Optional Trivy image and Lynis host adapters integrated into the shared findings pipeline
 - Initial Rust Compose remediation flow added for previewable `--quick-fix` and `--fix` operations with backup-safe writes
 - No-arg live scan now defaults to host scanning plus Docker-based Compose auto-discovery, with current-directory Compose fallback
 
@@ -233,16 +234,17 @@ Current release priorities:
 
 Explicitly deferred from the current early-release scope:
 
-- Trivy integration as the first optional external adapter
+- Additional optional adapters beyond Trivy, Lynis, and Dockle
 - TUI-embedded guided diff review before writes
 - Package-manager distribution such as apt, dnf, Homebrew, or AUR
 - Final scoring ADR and stable weighting guarantees
 
 Optional dependency policy for current releases:
 
-- `hostveil` should install and run without Docker or Trivy being present
+- `hostveil` should install and run without Docker, Trivy, Dockle, or Lynis being present
 - Docker-based live discovery improves Compose coverage when available
-- Trivy remains an optional adapter; if it is missing, scans continue with reduced coverage instead of failing
+- Trivy and Dockle remain optional image adapters; if either is missing, scans continue with reduced coverage instead of failing
+- Lynis remains an optional host adapter; if it is missing, scans continue with reduced host-audit coverage instead of failing
 - Missing external tools should be shown as coverage or adapter status, not as fatal startup errors
 
 Planned install and update model for current releases:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,11 +10,11 @@ else
 fi
 
 if [[ -n ${HOSTVEIL_CHANNEL+x} ]]; then
-  CHANNEL="$HOSTVEIL_CHANNEL"
-  CHANNEL_SET=1
+  LEGACY_CHANNEL="$HOSTVEIL_CHANNEL"
+  LEGACY_CHANNEL_SET=1
 else
-  CHANNEL="preview"
-  CHANNEL_SET=0
+  LEGACY_CHANNEL=""
+  LEGACY_CHANNEL_SET=0
 fi
 
 if [[ -n ${HOSTVEIL_INSTALL_DIR+x} ]]; then
@@ -86,7 +86,7 @@ After first install, prefer the installed hostveil command:
 
 Options:
   --version TAG            install or upgrade to a specific release tag
-  --channel NAME           legacy compatibility option; current documented releases use a single track
+  --channel NAME           legacy compatibility option; ignored because releases now use a single track
   --to DIR                 install into a specific binary directory
   --with-tools LIST        comma-separated optional tools to install after hostveil is installed
   --upgrade                upgrade an existing install using saved metadata
@@ -127,8 +127,8 @@ while (($# > 0)); do
       ;;
     --channel)
       (($# >= 2)) || fail "missing value for --channel"
-      CHANNEL="$2"
-      CHANNEL_SET=1
+      LEGACY_CHANNEL="$2"
+      LEGACY_CHANNEL_SET=1
       shift 2
       ;;
     --to)
@@ -176,6 +176,10 @@ while (($# > 0)); do
       ;;
   esac
 done
+
+if (( LEGACY_CHANNEL_SET == 1 )); then
+  log "Ignoring legacy channel selection '${LEGACY_CHANNEL}'; hostveil now uses a single SemVer release track."
+fi
 
 if command -v curl >/dev/null 2>&1; then
   fetch_to_file() {
@@ -273,20 +277,18 @@ resolve_version() {
     return
   fi
 
-  if [[ "$CHANNEL" == "stable" ]]; then
-    if tag_json="$(fetch_to_stdout "$(resolve_latest_stable_api_url)" 2>/dev/null)"; then
-      tag_name="$(printf '%s\n' "$tag_json" | extract_first_tag)"
-      [[ -n "$tag_name" ]] || fail "failed to resolve the latest stable release"
+  if tag_json="$(fetch_to_stdout "$(resolve_latest_stable_api_url)" 2>/dev/null)"; then
+    tag_name="$(printf '%s\n' "$tag_json" | extract_first_tag)"
+    if [[ -n "$tag_name" ]]; then
       printf '%s\n' "$tag_name"
       return
     fi
-
-    log "No stable release was found; falling back to the latest preview release."
   fi
 
+  log "Latest-release endpoint unavailable; falling back to the most recent release listing."
   tag_json="$(fetch_to_stdout "$(resolve_releases_api_url)")"
   tag_name="$(printf '%s\n' "$tag_json" | extract_first_tag)"
-  [[ -n "$tag_name" ]] || fail "failed to resolve the latest preview release"
+  [[ -n "$tag_name" ]] || fail "failed to resolve the latest release"
   printf '%s\n' "$tag_name"
 }
 
@@ -397,9 +399,6 @@ apply_metadata_defaults() {
   if (( REPO_SET == 0 )) && [[ -n "${HOSTVEIL_META_REPO:-}" ]]; then
     REPO="$HOSTVEIL_META_REPO"
   fi
-  if (( CHANNEL_SET == 0 )) && [[ -n "${HOSTVEIL_META_CHANNEL:-}" ]]; then
-    CHANNEL="$HOSTVEIL_META_CHANNEL"
-  fi
   if (( INSTALL_DIR_SET == 0 )) && [[ -n "${HOSTVEIL_META_INSTALL_DIR:-}" ]]; then
     INSTALL_DIR="$HOSTVEIL_META_INSTALL_DIR"
   fi
@@ -467,18 +466,6 @@ infer_installed_tag_from_binary() {
   fi
 }
 
-infer_channel_from_tag() {
-  local tag="$1"
-
-  if [[ -z "$tag" ]] || [[ "$tag" == "unknown" ]]; then
-    printf '%s\n' "$CHANNEL"
-  elif [[ "$tag" == *-* ]]; then
-    printf 'preview\n'
-  else
-    printf 'stable\n'
-  fi
-}
-
 resolve_current_installed_tag() {
   if (( metadata_loaded == 1 )) && [[ -n "${HOSTVEIL_META_INSTALLED_TAG:-}" ]]; then
     printf '%s\n' "$HOSTVEIL_META_INSTALLED_TAG"
@@ -495,7 +482,6 @@ write_metadata() {
   {
     printf 'HOSTVEIL_META_STATE_DIR=%q\n' "$STATE_DIR"
     printf 'HOSTVEIL_META_REPO=%q\n' "$REPO"
-    printf 'HOSTVEIL_META_CHANNEL=%q\n' "$CHANNEL"
     printf 'HOSTVEIL_META_INSTALL_DIR=%q\n' "$INSTALL_DIR"
     printf 'HOSTVEIL_META_WRAPPER_PATH=%q\n' "$(resolve_wrapper_path)"
     printf 'HOSTVEIL_META_BINARY_PATH=%q\n' "$(resolve_binary_path)"
@@ -617,9 +603,6 @@ resolve_existing_install_context() {
 
   if (( metadata_loaded == 0 )); then
     installed_tag="$(infer_installed_tag_from_binary "$entrypoint_path")"
-    if (( CHANNEL_SET == 0 )); then
-      CHANNEL="$(infer_channel_from_tag "$installed_tag")"
-    fi
     write_metadata "$installed_tag"
     metadata_loaded=0
     load_metadata_if_present
@@ -687,11 +670,6 @@ perform_install() {
   local checksums_url
   local tmpdir
   local installed_tag
-
-  case "$CHANNEL" in
-    preview|stable) ;;
-    *) fail "unsupported channel: $CHANNEL" ;;
-  esac
 
   INSTALL_DIR="$(resolve_install_dir)"
   tag="$(resolve_version)"

--- a/scripts/test-install-script.sh
+++ b/scripts/test-install-script.sh
@@ -39,6 +39,16 @@ assert_file_contains() {
   }
 }
 
+assert_file_not_contains() {
+  local path="$1"
+  local pattern="$2"
+
+  if grep -Fq -- "$pattern" "$path"; then
+    printf 'error: %s unexpectedly contained text: %s\n' "$path" "$pattern" >&2
+    exit 1
+  fi
+}
+
 create_release_fixture() {
   local release_dir="$1"
   local tag="$2"
@@ -116,6 +126,7 @@ run_install_case() {
 
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.0.0-test'
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_AUTO_UPGRADE=enabled'
+  assert_file_not_contains "$metadata_path" 'HOSTVEIL_META_CHANNEL='
 
   rm -rf "$case_dir"
 }
@@ -378,6 +389,7 @@ run_custom_state_dir_case() {
   }
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_STATE_DIR='
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.1.0-test'
+  assert_file_not_contains "$metadata_path" 'HOSTVEIL_META_CHANNEL='
   [[ ! -e "$default_state_home/hostveil/install.env" ]] || {
     printf 'error: install metadata leaked into the default state dir\n' >&2
     exit 1

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -66,6 +66,8 @@ app:
     detail_scroll_compact: "Up/Down, j/k, PgUp/PgDn scroll"
     back_overview: "Press q or Esc to return to the overview"
     back_overview_compact: "q or Esc back"
+    finding_controls: "Tab or Left/Right switch focus | s severity | x source | o sort | 1-4 jump | q or Esc back"
+    finding_controls_compact: "Tab/LR focus | s sev | x src | o sort | 1-4 jump | q back"
     fix_review_scroll: "Use Up/Down or PgUp/PgDn to scroll the diff"
     fix_review_apply: "Press y or Enter to apply the reviewed changes"
     fix_review_cancel: "Press q or Esc to cancel"
@@ -194,6 +196,13 @@ app:
     fix_label: "How to Fix"
     evidence_label: "Evidence"
     no_evidence: "No structured evidence for this finding."
+    severity_filter_short: "sev"
+    source_filter_short: "src"
+    sort_short: "sort"
+    filter_all: "all"
+    sort_severity: "severity"
+    sort_source: "source"
+    sort_subject: "subject"
   result:
     host_group: "Host"
     ok: "OK"
@@ -221,6 +230,9 @@ app:
     safe_bind_localhost: "%{service}: bind the published port %{port} to 127.0.0.1"
     safe_nginx_stable: "%{service}: pin nginx to nginx:stable"
     guided_privileged_cap_add: "%{service}: replace privileged mode with a minimal NET_BIND_SERVICE capability review"
+    guided_vaultwarden_signups: "%{service}: set SIGNUPS_ALLOWED to false"
+    guided_gitea_externalize_secrets: "%{service}: replace inline Gitea security secrets with environment placeholders"
+    guided_nginx_stable: "%{service}: review and pin nginx to nginx:stable"
 axis:
   sensitive_data: "Sensitive Data"
   permissions: "Permissions"
@@ -271,6 +283,12 @@ finding:
       description: "%{image} has %{count} vulnerability record(s) reported by Trivy."
       why: "Known vulnerabilities in base images or packages can be exploited when exposed services are reachable."
       fix: "Update the image to a patched version, rebuild if needed, and pin a stable tag or digest before the next deploy."
+  dockle:
+    image_best_practice:
+      title: "Image failed Dockle best-practice checks"
+      description: "%{image} triggered %{count} best-practice or hardening check(s) in Dockle."
+      why: "Dockle findings often indicate image-layer hardening gaps that increase exploitability or weaken runtime isolation in self-hosted deployments."
+      fix: "Review the Dockle checkpoint IDs, update the Dockerfile or base image accordingly, and rescan until high-impact findings are addressed."
   updates:
     latest:
       title: "Image uses the latest tag"
@@ -366,6 +384,11 @@ finding:
       description: "%{path} sets PubkeyAuthentication no."
       why: "Disabling public key authentication pushes administrators toward weaker password-based access or other less auditable workarounds."
       fix: "Set PubkeyAuthentication yes and enroll administrator keys before disabling password-based SSH login."
+    ssh_user_environment:
+      title: "SSH allows user-controlled environment files"
+      description: "%{path} enables PermitUserEnvironment yes."
+      why: "Allowing SSH users to inject environment variables can weaken restricted command setups and create unexpected execution paths after login."
+      fix: "Set PermitUserEnvironment no unless you have a narrow, reviewed need for user-managed SSH environment files."
     docker_socket_world_writable:
       title: "Docker socket is world writable"
       description: "%{path} is writable by all local users with mode %{mode}."
@@ -381,6 +404,16 @@ finding:
       description: "%{path} configures Docker to listen on a non-local TCP host."
       why: "A public or broadly reachable Docker API can allow remote container control and host compromise if not strongly protected."
       fix: "Remove the TCP listener or bind it to localhost with strong authentication and network restrictions."
+    docker_daemon_tcp_no_tlsverify:
+      title: "Docker TCP listener lacks TLS client verification"
+      description: "%{path} exposes a non-local TCP Docker host without tlsverify enabled."
+      why: "A remotely reachable Docker API without strong client authentication can allow full container control and often leads directly to host compromise."
+      fix: "Prefer the local Unix socket. If a TCP listener is unavoidable, require TLS with client certificate verification and restrict who can reach it."
+    docker_daemon_iptables_disabled:
+      title: "Docker disables iptables management"
+      description: "%{path} sets iptables to false in daemon.json."
+      why: "Disabling Docker's iptables integration can leave published ports and container networking exposed in ways the operator does not expect."
+      fix: "Keep iptables enabled unless you fully replace Docker's network policy with audited firewall rules."
     fail2ban_not_enabled:
       title: "Fail2ban is installed but not active"
       description: "%{path} shows local Fail2ban markers, but no enabled service marker was detected."

--- a/src/src/adapters/dockle.rs
+++ b/src/src/adapters/dockle.rs
@@ -1,0 +1,464 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::process::Command;
+
+use serde::Deserialize;
+
+use crate::domain::{
+    AdapterStatus, Axis, Finding, RemediationKind, Scope, ServiceSummary, Severity, Source,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DockleScanOutput {
+    pub status: AdapterStatus,
+    pub findings: Vec<Finding>,
+    pub warnings: Vec<String>,
+}
+
+pub fn scan(services: &[ServiceSummary]) -> DockleScanOutput {
+    let mut output = DockleScanOutput {
+        status: AdapterStatus::Missing,
+        findings: Vec::new(),
+        warnings: Vec::new(),
+    };
+    let mut successful_scans = 0_usize;
+    let mut first_scan_error: Option<String> = None;
+
+    let images = dedup_images(services);
+    if images.is_empty() {
+        output.status = AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned());
+        return output;
+    }
+
+    match detect_dockle() {
+        DockleAvailability::Missing => {
+            output.status = AdapterStatus::Missing;
+            return output;
+        }
+        DockleAvailability::Available => {
+            output.status = AdapterStatus::Available;
+        }
+        DockleAvailability::Failed(detail) => {
+            output.status = AdapterStatus::Failed(detail);
+            return output;
+        }
+    }
+
+    for image in images {
+        match scan_image(&image) {
+            Ok(Some(summary)) => {
+                successful_scans += 1;
+                output.findings.push(summary_to_finding(&summary, services));
+            }
+            Ok(None) => successful_scans += 1,
+            Err(error) => {
+                if first_scan_error.is_none() {
+                    first_scan_error = Some(error.clone());
+                }
+                output
+                    .warnings
+                    .push(format!("Dockle scan failed for {image}: {error}"));
+            }
+        }
+    }
+
+    finalize_status_after_image_scans(&mut output, successful_scans, first_scan_error);
+
+    output
+}
+
+fn finalize_status_after_image_scans(
+    output: &mut DockleScanOutput,
+    successful_scans: usize,
+    first_scan_error: Option<String>,
+) {
+    if successful_scans == 0
+        && let Some(error) = first_scan_error
+    {
+        output.status = AdapterStatus::Failed(error);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DockleAvailability {
+    Available,
+    Missing,
+    Failed(String),
+}
+
+fn detect_dockle() -> DockleAvailability {
+    detect_dockle_with_command("dockle")
+}
+
+fn detect_dockle_with_command(command: &str) -> DockleAvailability {
+    let output = Command::new(command)
+        .arg("--version")
+        .env("NO_COLOR", "1")
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => DockleAvailability::Available,
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            DockleAvailability::Failed(truncate(stderr.trim(), 200))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => DockleAvailability::Missing,
+        Err(error) => DockleAvailability::Failed(truncate(&error.to_string(), 200)),
+    }
+}
+
+fn dedup_images(services: &[ServiceSummary]) -> Vec<String> {
+    let mut images = BTreeSet::new();
+    for service in services {
+        if let Some(image) = &service.image {
+            let trimmed = image.trim();
+            if !trimmed.is_empty() {
+                images.insert(trimmed.to_owned());
+            }
+        }
+    }
+
+    images.into_iter().collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DockleImageSummary {
+    image: String,
+    total: usize,
+    counts: BTreeMap<DockleLevel, usize>,
+    max_level: DockleLevel,
+    sample_codes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum DockleLevel {
+    Fatal,
+    Warn,
+    Info,
+}
+
+fn scan_image(image: &str) -> Result<Option<DockleImageSummary>, String> {
+    let output = Command::new("dockle")
+        .args(dockle_image_args(image))
+        .env("NO_COLOR", "1")
+        .output()
+        .map_err(|error| error.to_string())?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let detail = if !stderr.trim().is_empty() {
+            stderr.trim().to_owned()
+        } else {
+            stdout.trim().to_owned()
+        };
+
+        return Err(truncate(&detail, 240));
+    }
+
+    let report: DockleReport = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("failed to parse Dockle JSON: {error}"))?;
+
+    Ok(summarize_report(image, report))
+}
+
+fn dockle_image_args(image: &str) -> [&str; 5] {
+    ["--format", "json", "--exit-code", "0", image]
+}
+
+fn summarize_report(image: &str, report: DockleReport) -> Option<DockleImageSummary> {
+    let mut counts = BTreeMap::from([
+        (DockleLevel::Fatal, 0_usize),
+        (DockleLevel::Warn, 0_usize),
+        (DockleLevel::Info, 0_usize),
+    ]);
+    let mut sample_codes = Vec::new();
+    let mut max_level: Option<DockleLevel> = None;
+
+    for detail in report.details.unwrap_or_default() {
+        let Some(level) = detail.level.as_deref().and_then(parse_dockle_level) else {
+            continue;
+        };
+
+        *counts.entry(level).or_insert(0) += 1;
+
+        if max_level.is_none_or(|current| level_rank(level) < level_rank(current)) {
+            max_level = Some(level);
+        }
+
+        if sample_codes.len() < 5
+            && let Some(code) = detail.code
+        {
+            sample_codes.push(code);
+        }
+    }
+
+    let total: usize = counts.values().sum();
+    let max_level = max_level?;
+
+    Some(DockleImageSummary {
+        image: image.to_owned(),
+        total,
+        counts,
+        max_level,
+        sample_codes,
+    })
+}
+
+fn parse_dockle_level(value: &str) -> Option<DockleLevel> {
+    match value.trim().to_ascii_uppercase().as_str() {
+        "FATAL" => Some(DockleLevel::Fatal),
+        "WARN" => Some(DockleLevel::Warn),
+        "INFO" => Some(DockleLevel::Info),
+        _ => None,
+    }
+}
+
+fn level_rank(level: DockleLevel) -> u8 {
+    match level {
+        DockleLevel::Fatal => 0,
+        DockleLevel::Warn => 1,
+        DockleLevel::Info => 2,
+    }
+}
+
+fn dockle_level_severity(level: DockleLevel) -> Severity {
+    match level {
+        DockleLevel::Fatal => Severity::High,
+        DockleLevel::Warn => Severity::Medium,
+        DockleLevel::Info => Severity::Low,
+    }
+}
+
+fn summary_to_finding(summary: &DockleImageSummary, services: &[ServiceSummary]) -> Finding {
+    let related_service = related_service_for_image(&summary.image, services);
+
+    let mut evidence = BTreeMap::new();
+    evidence.insert(String::from("image"), summary.image.clone());
+    evidence.insert(String::from("checks_total"), summary.total.to_string());
+    evidence.insert(
+        String::from("fatal"),
+        summary
+            .counts
+            .get(&DockleLevel::Fatal)
+            .copied()
+            .unwrap_or_default()
+            .to_string(),
+    );
+    evidence.insert(
+        String::from("warn"),
+        summary
+            .counts
+            .get(&DockleLevel::Warn)
+            .copied()
+            .unwrap_or_default()
+            .to_string(),
+    );
+    evidence.insert(
+        String::from("info"),
+        summary
+            .counts
+            .get(&DockleLevel::Info)
+            .copied()
+            .unwrap_or_default()
+            .to_string(),
+    );
+    if !summary.sample_codes.is_empty() {
+        evidence.insert(
+            String::from("sample_codes"),
+            summary.sample_codes.join(", "),
+        );
+    }
+
+    Finding {
+        id: format!("dockle.image_best_practice.{}", slug(&summary.image)),
+        axis: Axis::UpdateSupplyChainRisk,
+        severity: dockle_level_severity(summary.max_level),
+        scope: Scope::Image,
+        source: Source::Dockle,
+        subject: summary.image.clone(),
+        related_service,
+        title: t!("finding.dockle.image_best_practice.title").into_owned(),
+        description: t!(
+            "finding.dockle.image_best_practice.description",
+            image = summary.image,
+            count = summary.total
+        )
+        .into_owned(),
+        why_risky: t!("finding.dockle.image_best_practice.why").into_owned(),
+        how_to_fix: t!("finding.dockle.image_best_practice.fix").into_owned(),
+        evidence,
+        remediation: RemediationKind::None,
+    }
+}
+
+fn related_service_for_image(image: &str, services: &[ServiceSummary]) -> Option<String> {
+    services
+        .iter()
+        .find(|service| service.image.as_deref() == Some(image))
+        .map(|service| service.name.clone())
+}
+
+fn slug(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push('_');
+        }
+    }
+
+    let trimmed = out.trim_matches('_');
+    if trimmed.is_empty() {
+        String::from("image")
+    } else {
+        truncate(trimmed, 60)
+    }
+}
+
+fn truncate(value: &str, max_len: usize) -> String {
+    if value.len() <= max_len {
+        return value.to_owned();
+    }
+    value.chars().take(max_len).collect()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DockleReport {
+    #[serde(rename = "details")]
+    details: Option<Vec<DockleDetail>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DockleDetail {
+    #[serde(rename = "code")]
+    code: Option<String>,
+    #[serde(rename = "level")]
+    level: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_dockle_levels() {
+        assert_eq!(parse_dockle_level("FATAL"), Some(DockleLevel::Fatal));
+        assert_eq!(parse_dockle_level("warn"), Some(DockleLevel::Warn));
+        assert_eq!(parse_dockle_level("INFO"), Some(DockleLevel::Info));
+        assert_eq!(parse_dockle_level("PASS"), None);
+    }
+
+    #[test]
+    fn summarizes_dockle_report_into_single_finding_per_image() {
+        let report: DockleReport = serde_json::from_str(include_str!(
+            "../../tests/fixtures/adapters/dockle-image-report.json"
+        ))
+        .expect("fixture should parse");
+
+        let summary = summarize_report("demo:1.0", report).expect("should summarize");
+        assert_eq!(summary.image, "demo:1.0");
+        assert!(summary.total > 0);
+        assert_eq!(summary.max_level, DockleLevel::Fatal);
+
+        let services = vec![ServiceSummary {
+            name: String::from("demo"),
+            image: Some(String::from("demo:1.0")),
+        }];
+        let finding = summary_to_finding(&summary, &services);
+
+        assert_eq!(finding.source, Source::Dockle);
+        assert_eq!(finding.scope, Scope::Image);
+        assert_eq!(finding.axis, Axis::UpdateSupplyChainRisk);
+        assert_eq!(finding.related_service.as_deref(), Some("demo"));
+        assert!(finding.evidence.contains_key("checks_total"));
+        assert!(finding.evidence.contains_key("sample_codes"));
+    }
+
+    #[test]
+    fn ignores_unmapped_levels_without_dropping_known_findings() {
+        let report: DockleReport = serde_json::from_str(
+            r#"{
+                "details": [
+                    {"code": "CIS-DI-0001", "level": "PASS"},
+                    {"code": "DKL-DI-0005", "level": "WARN"}
+                ]
+            }"#,
+        )
+        .expect("fixture should parse");
+
+        let summary = summarize_report("demo:1.0", report).expect("known findings should remain");
+
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.max_level, DockleLevel::Warn);
+        assert_eq!(summary.sample_codes, vec![String::from("DKL-DI-0005")]);
+    }
+
+    #[test]
+    fn keeps_adapter_available_when_only_some_image_scans_fail() {
+        let mut output = DockleScanOutput {
+            status: AdapterStatus::Available,
+            findings: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        finalize_status_after_image_scans(
+            &mut output,
+            1,
+            Some(String::from("registry denied access")),
+        );
+
+        assert_eq!(output.status, AdapterStatus::Available);
+    }
+
+    #[test]
+    fn marks_adapter_failed_when_all_image_scans_fail() {
+        let mut output = DockleScanOutput {
+            status: AdapterStatus::Available,
+            findings: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        finalize_status_after_image_scans(
+            &mut output,
+            0,
+            Some(String::from("registry denied access")),
+        );
+
+        assert_eq!(
+            output.status,
+            AdapterStatus::Failed(String::from("registry denied access"))
+        );
+    }
+
+    #[test]
+    fn skips_when_no_image_targets_are_available() {
+        let output = scan(&[]);
+
+        assert_eq!(
+            output.status,
+            AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned())
+        );
+        assert!(output.findings.is_empty());
+    }
+
+    #[test]
+    fn uses_json_scan_args_with_non_failing_exit_code() {
+        assert_eq!(
+            dockle_image_args("demo:1.0"),
+            ["--format", "json", "--exit-code", "0", "demo:1.0",]
+        );
+    }
+
+    #[test]
+    fn detect_dockle_reports_missing_for_unknown_binary() {
+        let status = detect_dockle_with_command("hostveil-nonexistent-dockle");
+        assert_eq!(status, DockleAvailability::Missing);
+    }
+
+    #[test]
+    fn detect_dockle_reports_failed_for_non_zero_command() {
+        let status = detect_dockle_with_command("false");
+        assert!(matches!(status, DockleAvailability::Failed(_)));
+    }
+}

--- a/src/src/adapters/mod.rs
+++ b/src/src/adapters/mod.rs
@@ -1,5 +1,6 @@
 use crate::domain::Finding;
 
+pub mod dockle;
 pub mod lynis;
 pub mod trivy;
 

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -22,6 +22,7 @@ use super::{AppConfig, AppError};
 pub struct AdapterScanUpdate {
     trivy: adapters::trivy::TrivyScanOutput,
     lynis: adapters::lynis::LynisScanOutput,
+    dockle: adapters::dockle::DockleScanOutput,
 }
 
 pub fn run(config: &AppConfig) -> Result<ScanResult, AppError> {
@@ -79,7 +80,11 @@ pub fn prepare_background_adapter_scan(result: &mut ScanResult) -> Receiver<Adap
 }
 
 pub fn apply_external_adapter_update(result: &mut ScanResult, update: AdapterScanUpdate) {
-    let AdapterScanUpdate { trivy, lynis } = update;
+    let AdapterScanUpdate {
+        trivy,
+        lynis,
+        dockle,
+    } = update;
 
     result
         .metadata
@@ -94,6 +99,14 @@ pub fn apply_external_adapter_update(result: &mut ScanResult, update: AdapterSca
         .insert(String::from("lynis"), lynis.status);
     result.metadata.warnings.extend(lynis.warnings);
     result.findings.extend(lynis.findings);
+
+    result
+        .metadata
+        .adapters
+        .insert(String::from("dockle"), dockle.status);
+    result.metadata.warnings.extend(dockle.warnings);
+    result.findings.extend(dockle.findings);
+
     result.score_report =
         scoring::build_score_report_with_coverage(&result.findings, coverage_from_result(result));
 }
@@ -102,7 +115,10 @@ fn scan_external_adapters(
     services: Vec<ServiceSummary>,
     host_root: Option<PathBuf>,
 ) -> AdapterScanUpdate {
-    let trivy_handle = thread::spawn(move || adapters::trivy::scan(&services));
+    let trivy_services = services.clone();
+    let dockle_services = services;
+    let trivy_handle = thread::spawn(move || adapters::trivy::scan(&trivy_services));
+    let dockle_handle = thread::spawn(move || adapters::dockle::scan(&dockle_services));
     let lynis_handle = thread::spawn(move || adapters::lynis::scan(host_root.as_deref()));
 
     AdapterScanUpdate {
@@ -112,6 +128,9 @@ fn scan_external_adapters(
         lynis: lynis_handle
             .join()
             .unwrap_or_else(|_| failed_lynis_output()),
+        dockle: dockle_handle
+            .join()
+            .unwrap_or_else(|_| failed_dockle_output()),
     }
 }
 
@@ -125,6 +144,16 @@ fn seed_adapter_statuses(result: &mut ScanResult) {
         .metadata
         .adapters
         .insert(String::from("trivy"), trivy_status);
+
+    let dockle_status = if has_image_targets(&result.metadata.services) {
+        AdapterStatus::Pending
+    } else {
+        AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned())
+    };
+    result
+        .metadata
+        .adapters
+        .insert(String::from("dockle"), dockle_status);
 
     let lynis_status = match result.metadata.host_root.as_deref() {
         None => AdapterStatus::Skipped(t!("adapter.reason.host_not_scanned").into_owned()),
@@ -159,6 +188,14 @@ fn failed_trivy_output() -> adapters::trivy::TrivyScanOutput {
 fn failed_lynis_output() -> adapters::lynis::LynisScanOutput {
     adapters::lynis::LynisScanOutput {
         status: AdapterStatus::Failed(String::from("Lynis scan thread panicked")),
+        findings: Vec::new(),
+        warnings: Vec::new(),
+    }
+}
+
+fn failed_dockle_output() -> adapters::dockle::DockleScanOutput {
+    adapters::dockle::DockleScanOutput {
+        status: AdapterStatus::Failed(String::from("Dockle scan thread panicked")),
         findings: Vec::new(),
         warnings: Vec::new(),
     }
@@ -758,6 +795,19 @@ mod tests {
                     )],
                     warnings: Vec::new(),
                 },
+                dockle: crate::adapters::dockle::DockleScanOutput {
+                    status: AdapterStatus::Available,
+                    findings: vec![test_finding(
+                        "dockle.image_best_practice.nginx_1_27_5",
+                        Axis::UpdateSupplyChainRisk,
+                        Severity::Medium,
+                        Scope::Image,
+                        Source::Dockle,
+                        "nginx:1.27.5",
+                        Some("web"),
+                    )],
+                    warnings: Vec::new(),
+                },
             },
         );
 
@@ -787,12 +837,22 @@ mod tests {
                 .iter()
                 .any(|finding| finding.scope == Scope::Host && finding.source == Source::Lynis)
         );
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|finding| finding.scope == Scope::Image && finding.source == Source::Dockle)
+        );
         assert_eq!(
             result.metadata.adapters.get("trivy"),
             Some(&AdapterStatus::Available)
         );
         assert_eq!(
             result.metadata.adapters.get("lynis"),
+            Some(&AdapterStatus::Available)
+        );
+        assert_eq!(
+            result.metadata.adapters.get("dockle"),
             Some(&AdapterStatus::Available)
         );
     }
@@ -999,6 +1059,10 @@ mod tests {
             result.metadata.adapters.get("trivy"),
             Some(&AdapterStatus::Pending)
         );
+        assert_eq!(
+            result.metadata.adapters.get("dockle"),
+            Some(&AdapterStatus::Pending)
+        );
     }
 
     #[test]
@@ -1013,6 +1077,10 @@ mod tests {
         ));
         assert!(matches!(
             result.metadata.adapters.get("trivy"),
+            Some(AdapterStatus::Skipped(_))
+        ));
+        assert!(matches!(
+            result.metadata.adapters.get("dockle"),
             Some(AdapterStatus::Skipped(_))
         ));
     }

--- a/src/src/fix/mod.rs
+++ b/src/src/fix/mod.rs
@@ -175,11 +175,12 @@ fn apply_safe_fixes(
             continue;
         };
 
-        if finding_ids.contains("updates.no_tag")
+        if should_pin_nginx_image_to_stable(finding_ids)
             && let Some(image) = image_string(service)
-            && is_safe_nginx_image(&image)
+            && let Some(stable_image) = stable_nginx_image_for_findings(&image, finding_ids)
+            && image != stable_image
         {
-            service.insert(yaml_key("image"), Value::String(format!("{image}:stable")));
+            service.insert(yaml_key("image"), Value::String(stable_image));
             applied.push(FixProposal {
                 service: service_name.clone(),
                 summary: t!("app.fix.safe_nginx_stable", service = service_name.as_str())
@@ -228,53 +229,64 @@ fn apply_guided_fixes(
     let mut applied = Vec::new();
 
     for (service_name, finding_ids) in findings_by_service {
-        if !finding_ids.contains("permissions.privileged") {
-            continue;
-        }
-
-        let Some(service) = service_mapping_mut(services, service_name) else {
-            continue;
-        };
-        let Some(privileged) = service.get(yaml_key("privileged")) else {
-            continue;
-        };
-        if !yaml_truthy(privileged) {
-            continue;
-        }
-        if !service_uses_low_port(service) {
-            continue;
-        }
-
-        if matches!(service.get(yaml_key("cap_add")), Some(value) if !value.is_sequence()) {
-            continue;
-        }
-
-        service.remove(yaml_key("privileged"));
-        if service.get(yaml_key("cap_add")).is_none() {
-            service.insert(yaml_key("cap_add"), Value::Sequence(Sequence::new()));
-        }
-        let Some(cap_add) = service.get_mut(yaml_key("cap_add")) else {
-            continue;
-        };
-        let Some(capabilities) = cap_add.as_sequence_mut() else {
-            continue;
-        };
-
-        if !capabilities
-            .iter()
-            .any(|value| value.as_str() == Some("NET_BIND_SERVICE"))
+        if finding_ids.contains("permissions.privileged")
+            && let Some(service) = service_mapping_mut(services, service_name)
+            && apply_guided_privileged_low_port_fix(service)
         {
-            capabilities.push(Value::String(String::from("NET_BIND_SERVICE")));
+            applied.push(FixProposal {
+                service: service_name.clone(),
+                summary: t!(
+                    "app.fix.guided_privileged_cap_add",
+                    service = service_name.as_str()
+                )
+                .into_owned(),
+            });
         }
 
-        applied.push(FixProposal {
-            service: service_name.clone(),
-            summary: t!(
-                "app.fix.guided_privileged_cap_add",
-                service = service_name.as_str()
-            )
-            .into_owned(),
-        });
+        if finding_ids.contains("service.vaultwarden.signups_enabled")
+            && let Some(service) = service_mapping_mut(services, service_name)
+            && update_environment_value(service, "SIGNUPS_ALLOWED", "false", false)
+        {
+            applied.push(FixProposal {
+                service: service_name.clone(),
+                summary: t!(
+                    "app.fix.guided_vaultwarden_signups",
+                    service = service_name.as_str()
+                )
+                .into_owned(),
+            });
+        }
+
+        if finding_ids.contains("service.gitea.inline_security_secrets")
+            && let Some(service) = service_mapping_mut(services, service_name)
+            && externalize_gitea_security_env(service)
+        {
+            applied.push(FixProposal {
+                service: service_name.clone(),
+                summary: t!(
+                    "app.fix.guided_gitea_externalize_secrets",
+                    service = service_name.as_str()
+                )
+                .into_owned(),
+            });
+        }
+
+        if finding_ids.contains("updates.latest_tag")
+            && let Some(service) = service_mapping_mut(services, service_name)
+            && let Some(image) = image_string(service)
+            && let Some(stable_image) = stable_nginx_image_for_findings(&image, finding_ids)
+            && image != stable_image
+        {
+            service.insert(yaml_key("image"), Value::String(stable_image));
+            applied.push(FixProposal {
+                service: service_name.clone(),
+                summary: t!(
+                    "app.fix.guided_nginx_stable",
+                    service = service_name.as_str()
+                )
+                .into_owned(),
+            });
+        }
     }
 
     applied
@@ -300,6 +312,176 @@ fn yaml_key(key: &str) -> Value {
 
 fn image_string(service: &Mapping) -> Option<String> {
     service.get(yaml_key("image"))?.as_str().map(str::to_owned)
+}
+
+fn should_pin_nginx_image_to_stable(finding_ids: &BTreeSet<String>) -> bool {
+    finding_ids.contains("updates.no_tag")
+        || finding_ids.contains("updates.latest_tag")
+        || finding_ids.contains("updates.major_only_tag")
+}
+
+fn stable_nginx_image_for_findings(image: &str, finding_ids: &BTreeSet<String>) -> Option<String> {
+    if image.contains('@') {
+        return None;
+    }
+
+    let (repository, tag) = crate::rules::split_image_reference(image);
+    if !is_safe_nginx_image(&repository) {
+        return None;
+    }
+
+    let matches_no_tag = finding_ids.contains("updates.no_tag") && tag.is_none();
+    let matches_latest =
+        finding_ids.contains("updates.latest_tag") && tag.as_deref() == Some("latest");
+    let matches_major_only = finding_ids.contains("updates.major_only_tag")
+        && tag.as_deref().is_some_and(is_major_only_tag);
+
+    (matches_no_tag || matches_latest || matches_major_only)
+        .then_some(format!("{repository}:stable"))
+}
+
+fn is_major_only_tag(tag: &str) -> bool {
+    let candidate = tag.strip_prefix('v').unwrap_or(tag);
+    !candidate.is_empty()
+        && candidate
+            .chars()
+            .all(|character| character.is_ascii_digit())
+}
+
+fn apply_guided_privileged_low_port_fix(service: &mut Mapping) -> bool {
+    let Some(privileged) = service.get(yaml_key("privileged")) else {
+        return false;
+    };
+    if !yaml_truthy(privileged) {
+        return false;
+    }
+    if !service_uses_low_port(service) {
+        return false;
+    }
+
+    if matches!(service.get(yaml_key("cap_add")), Some(value) if !value.is_sequence()) {
+        return false;
+    }
+
+    service.remove(yaml_key("privileged"));
+    if service.get(yaml_key("cap_add")).is_none() {
+        service.insert(yaml_key("cap_add"), Value::Sequence(Sequence::new()));
+    }
+    let Some(cap_add) = service.get_mut(yaml_key("cap_add")) else {
+        return false;
+    };
+    let Some(capabilities) = cap_add.as_sequence_mut() else {
+        return false;
+    };
+
+    if !capabilities
+        .iter()
+        .any(|value| value.as_str() == Some("NET_BIND_SERVICE"))
+    {
+        capabilities.push(Value::String(String::from("NET_BIND_SERVICE")));
+    }
+
+    true
+}
+
+fn externalize_gitea_security_env(service: &mut Mapping) -> bool {
+    let mut changed = false;
+    for key in [
+        "GITEA__security__SECRET_KEY",
+        "GITEA__security__INTERNAL_TOKEN",
+    ] {
+        let placeholder = format!("${{{key}}}");
+        changed |= update_environment_value(service, key, &placeholder, false);
+    }
+
+    changed
+}
+
+fn update_environment_value(
+    service: &mut Mapping,
+    key: &str,
+    value: &str,
+    insert_if_missing: bool,
+) -> bool {
+    let Some(environment) = service.get_mut(yaml_key("environment")) else {
+        return false;
+    };
+
+    match environment {
+        Value::Mapping(mapping) => {
+            let environment_key = yaml_key(key);
+            match mapping.get(&environment_key) {
+                Some(current) if environment_value_matches(current, value) => false,
+                Some(_) => {
+                    mapping.insert(environment_key, environment_scalar_value(value));
+                    true
+                }
+                None if insert_if_missing => {
+                    mapping.insert(environment_key, environment_scalar_value(value));
+                    true
+                }
+                None => false,
+            }
+        }
+        Value::Sequence(sequence) => {
+            update_environment_sequence(sequence, key, value, insert_if_missing)
+        }
+        _ => false,
+    }
+}
+
+fn update_environment_sequence(
+    sequence: &mut Sequence,
+    key: &str,
+    value: &str,
+    insert_if_missing: bool,
+) -> bool {
+    for item in sequence.iter_mut() {
+        let Value::String(entry) = item else {
+            continue;
+        };
+
+        let trimmed = entry.trim();
+        if let Some((entry_key, entry_value)) = trimmed.split_once('=')
+            && entry_key.trim() == key
+        {
+            if entry_value.trim() == value {
+                return false;
+            }
+            *entry = format!("{key}={value}");
+            return true;
+        }
+
+        if trimmed == key {
+            *entry = format!("{key}={value}");
+            return true;
+        }
+    }
+
+    if insert_if_missing {
+        sequence.push(Value::String(format!("{key}={value}")));
+        true
+    } else {
+        false
+    }
+}
+
+fn environment_value_matches(current: &Value, expected: &str) -> bool {
+    match expected {
+        "false" => !yaml_truthy(current),
+        "true" => yaml_truthy(current),
+        _ => current
+            .as_str()
+            .is_some_and(|value| value.trim() == expected.trim()),
+    }
+}
+
+fn environment_scalar_value(value: &str) -> Value {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" => Value::Bool(true),
+        "false" => Value::Bool(false),
+        _ => Value::String(value.to_owned()),
+    }
 }
 
 fn rewrite_public_port(port: &mut Value) -> Option<String> {
@@ -787,6 +969,99 @@ mod tests {
         assert_eq!(plan.guided_applied.len(), 1);
         assert!(plan.diff_preview.contains("cap_add"));
         assert!(plan.diff_preview.contains("NET_BIND_SERVICE"));
+
+        fs::remove_dir_all(root).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn previews_quick_fix_pins_nginx_latest_to_stable() {
+        let root = temp_compose_dir("quick-nginx-latest");
+        let path = root.join("docker-compose.yml");
+        write_compose(
+            &path,
+            concat!(
+                "services:\n",
+                "  web:\n",
+                "    image: nginx:latest\n",
+                "    ports:\n",
+                "      - \"127.0.0.1:8080:80\"\n"
+            ),
+        );
+
+        let plan = preview(&path, FixMode::QuickFix).expect("quick-fix preview should succeed");
+
+        assert_eq!(plan.safe_applied.len(), 1);
+        assert!(plan.guided_applied.is_empty());
+        assert!(plan.diff_preview.contains("nginx:stable"));
+
+        fs::remove_dir_all(root).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn previews_guided_fix_for_vaultwarden_signups() {
+        let root = temp_compose_dir("guided-vaultwarden-signups");
+        let path = root.join("docker-compose.yml");
+        write_compose(
+            &path,
+            concat!(
+                "services:\n",
+                "  vaultwarden:\n",
+                "    image: vaultwarden/server:1.30.1\n",
+                "    ports:\n",
+                "      - \"8080:80\"\n",
+                "    environment:\n",
+                "      SIGNUPS_ALLOWED: true\n"
+            ),
+        );
+
+        let plan = preview(&path, FixMode::Fix).expect("fix preview should succeed");
+
+        assert_eq!(plan.guided_applied.len(), 1);
+        assert!(
+            plan.guided_applied
+                .iter()
+                .any(|proposal| proposal.summary.contains("SIGNUPS_ALLOWED"))
+        );
+        assert!(plan.diff_preview.contains("SIGNUPS_ALLOWED: false"));
+
+        fs::remove_dir_all(root).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn previews_guided_fix_for_gitea_inline_security_secrets() {
+        let root = temp_compose_dir("guided-gitea-secrets");
+        let path = root.join("docker-compose.yml");
+        write_compose(
+            &path,
+            concat!(
+                "services:\n",
+                "  server:\n",
+                "    image: gitea/gitea:1.21.11\n",
+                "    ports:\n",
+                "      - \"3000:3000\"\n",
+                "      - \"2222:22\"\n",
+                "    environment:\n",
+                "      - GITEA__security__SECRET_KEY=replace-me\n",
+                "      - GITEA__security__INTERNAL_TOKEN=replace-me-too\n"
+            ),
+        );
+
+        let plan = preview(&path, FixMode::Fix).expect("fix preview should succeed");
+
+        assert_eq!(plan.guided_applied.len(), 1);
+        assert!(
+            plan.guided_applied
+                .iter()
+                .any(|proposal| proposal.summary.contains("Gitea"))
+        );
+        assert!(
+            plan.diff_preview
+                .contains("GITEA__security__SECRET_KEY=${GITEA__security__SECRET_KEY}")
+        );
+        assert!(
+            plan.diff_preview
+                .contains("GITEA__security__INTERNAL_TOKEN=${GITEA__security__INTERNAL_TOKEN}")
+        );
 
         fs::remove_dir_all(root).expect("temp dir should be removed");
     }

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -227,6 +227,28 @@ fn scan_ssh_hardening(context: &HostContext) -> Vec<Finding> {
         ));
     }
 
+    if settings
+        .get("permituserenvironment")
+        .is_some_and(|value| value == "yes")
+    {
+        findings.push(host_finding(
+            "host.ssh_user_environment_enabled",
+            Severity::Medium,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.ssh_user_environment.title").into_owned(),
+                description: t!(
+                    "finding.host.ssh_user_environment.description",
+                    path = config_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.ssh_user_environment.why").into_owned(),
+                how_to_fix: t!("finding.host.ssh_user_environment.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("path"), config_path.display().to_string())]),
+        ));
+    }
+
     findings
 }
 
@@ -285,24 +307,74 @@ fn scan_docker_host_exposure(context: &HostContext) -> Vec<Finding> {
     if let Some(daemon_path) = resolve_existing_path(&context.root, DOCKER_DAEMON_CONFIG_PATH)
         && let Ok(text) = fs::read_to_string(&daemon_path)
         && let Ok(json) = serde_json::from_str::<JsonValue>(&text)
-        && daemon_hosts_include_public_tcp(&json)
     {
-        findings.push(host_finding(
-            "host.docker_daemon_tcp_public",
-            Severity::High,
-            &daemon_path,
-            HostFindingText {
-                title: t!("finding.host.docker_daemon_tcp_public.title").into_owned(),
-                description: t!(
-                    "finding.host.docker_daemon_tcp_public.description",
-                    path = daemon_path.display().to_string()
-                )
-                .into_owned(),
-                why_risky: t!("finding.host.docker_daemon_tcp_public.why").into_owned(),
-                how_to_fix: t!("finding.host.docker_daemon_tcp_public.fix").into_owned(),
-            },
-            BTreeMap::from([(String::from("path"), daemon_path.display().to_string())]),
-        ));
+        if daemon_hosts_include_public_tcp(&json) {
+            findings.push(host_finding(
+                "host.docker_daemon_tcp_public",
+                Severity::High,
+                &daemon_path,
+                HostFindingText {
+                    title: t!("finding.host.docker_daemon_tcp_public.title").into_owned(),
+                    description: t!(
+                        "finding.host.docker_daemon_tcp_public.description",
+                        path = daemon_path.display().to_string()
+                    )
+                    .into_owned(),
+                    why_risky: t!("finding.host.docker_daemon_tcp_public.why").into_owned(),
+                    how_to_fix: t!("finding.host.docker_daemon_tcp_public.fix").into_owned(),
+                },
+                BTreeMap::from([(String::from("path"), daemon_path.display().to_string())]),
+            ));
+
+            if !daemon_tlsverify_enabled(&json) {
+                findings.push(host_finding(
+                    "host.docker_daemon_tcp_no_tlsverify",
+                    Severity::Critical,
+                    &daemon_path,
+                    HostFindingText {
+                        title: t!("finding.host.docker_daemon_tcp_no_tlsverify.title").into_owned(),
+                        description: t!(
+                            "finding.host.docker_daemon_tcp_no_tlsverify.description",
+                            path = daemon_path.display().to_string()
+                        )
+                        .into_owned(),
+                        why_risky: t!("finding.host.docker_daemon_tcp_no_tlsverify.why")
+                            .into_owned(),
+                        how_to_fix: t!("finding.host.docker_daemon_tcp_no_tlsverify.fix")
+                            .into_owned(),
+                    },
+                    BTreeMap::from([
+                        (String::from("path"), daemon_path.display().to_string()),
+                        (
+                            String::from("tlsverify"),
+                            docker_daemon_setting_state(&json, "tlsverify"),
+                        ),
+                    ]),
+                ));
+            }
+        }
+
+        if docker_daemon_iptables_disabled(&json) {
+            findings.push(host_finding(
+                "host.docker_daemon_iptables_disabled",
+                Severity::High,
+                &daemon_path,
+                HostFindingText {
+                    title: t!("finding.host.docker_daemon_iptables_disabled.title").into_owned(),
+                    description: t!(
+                        "finding.host.docker_daemon_iptables_disabled.description",
+                        path = daemon_path.display().to_string()
+                    )
+                    .into_owned(),
+                    why_risky: t!("finding.host.docker_daemon_iptables_disabled.why").into_owned(),
+                    how_to_fix: t!("finding.host.docker_daemon_iptables_disabled.fix").into_owned(),
+                },
+                BTreeMap::from([
+                    (String::from("path"), daemon_path.display().to_string()),
+                    (String::from("iptables"), String::from("false")),
+                ]),
+            ));
+        }
     }
 
     findings
@@ -737,6 +809,25 @@ fn daemon_hosts_include_public_tcp(document: &JsonValue) -> bool {
     }
 }
 
+fn daemon_tlsverify_enabled(document: &JsonValue) -> bool {
+    document
+        .get("tlsverify")
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(false)
+}
+
+fn docker_daemon_iptables_disabled(document: &JsonValue) -> bool {
+    document.get("iptables").and_then(JsonValue::as_bool) == Some(false)
+}
+
+fn docker_daemon_setting_state(document: &JsonValue, key: &str) -> String {
+    match document.get(key).and_then(JsonValue::as_bool) {
+        Some(true) => String::from("true"),
+        Some(false) => String::from("false"),
+        None => String::from("missing"),
+    }
+}
+
 fn host_is_public_tcp(value: &JsonValue) -> bool {
     let Some(host) = value.as_str() else {
         return false;
@@ -791,12 +882,13 @@ mod tests {
                 "PermitRootLogin yes\n",
                 "PasswordAuthentication yes\n",
                 "PermitEmptyPasswords yes\n",
-                "PubkeyAuthentication no\n"
+                "PubkeyAuthentication no\n",
+                "PermitUserEnvironment yes\n"
             ),
         );
         write_file(
             &root.join(DOCKER_DAEMON_CONFIG_PATH),
-            r#"{"hosts": ["unix:///var/run/docker.sock", "tcp://0.0.0.0:2375"]}"#,
+            r#"{"hosts": ["unix:///var/run/docker.sock", "tcp://0.0.0.0:2375"], "tlsverify": false, "iptables": false}"#,
         );
         write_file(&root.join(DOCKER_SOCKET_PATH), "socket");
         fs::set_permissions(
@@ -817,8 +909,11 @@ mod tests {
                 "host.ssh_password_auth_enabled",
                 "host.ssh_empty_passwords_enabled",
                 "host.ssh_pubkey_auth_disabled",
+                "host.ssh_user_environment_enabled",
                 "host.docker_socket_world_writable",
                 "host.docker_daemon_tcp_public",
+                "host.docker_daemon_tcp_no_tlsverify",
+                "host.docker_daemon_iptables_disabled",
                 "host.defensive_controls_missing",
             ]
         );
@@ -841,7 +936,8 @@ mod tests {
                 "PermitRootLogin no\n",
                 "PasswordAuthentication no\n",
                 "PermitEmptyPasswords no\n",
-                "PubkeyAuthentication yes\n"
+                "PubkeyAuthentication yes\n",
+                "PermitUserEnvironment no\n"
             ),
         );
         write_file(
@@ -866,6 +962,30 @@ mod tests {
         let findings = HostScanner.scan(&HostContext { root: root.clone() });
 
         assert!(findings.is_empty());
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn public_docker_tcp_with_tlsverify_avoids_extra_tls_finding() {
+        let root = temp_host_root("docker-tlsverify");
+        write_file(
+            &root.join(DOCKER_DAEMON_CONFIG_PATH),
+            r#"{"hosts": ["unix:///var/run/docker.sock", "tcp://0.0.0.0:2376"], "tlsverify": true}"#,
+        );
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.docker_daemon_tcp_public")
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|finding| finding.id != "host.docker_daemon_tcp_no_tlsverify")
+        );
 
         fs::remove_dir_all(root).expect("temp root should be removed");
     }

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -41,6 +41,13 @@ enum FindingsFocus {
     Detail,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FindingSortMode {
+    Severity,
+    Source,
+    Subject,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AppState {
     screen: Screen,
@@ -48,16 +55,31 @@ struct AppState {
     selected_index: usize,
     detail_scroll: u16,
     sorted_indices: Vec<usize>,
+    severity_filter: Option<Severity>,
+    source_filter: Option<Source>,
+    sort_mode: FindingSortMode,
 }
 
 impl AppState {
     fn new(scan_result: &ScanResult) -> Self {
+        let severity_filter = None;
+        let source_filter = None;
+        let sort_mode = FindingSortMode::Severity;
+
         Self {
             screen: Screen::Overview,
             findings_focus: FindingsFocus::List,
             selected_index: 0,
             detail_scroll: 0,
-            sorted_indices: sorted_finding_indices(scan_result),
+            sorted_indices: visible_finding_indices(
+                scan_result,
+                severity_filter,
+                source_filter,
+                sort_mode,
+            ),
+            severity_filter,
+            source_filter,
+            sort_mode,
         }
     }
 
@@ -121,7 +143,12 @@ impl AppState {
     }
 
     fn clamp_selection(&mut self, scan_result: &ScanResult) {
-        self.sorted_indices = sorted_finding_indices(scan_result);
+        self.sorted_indices = visible_finding_indices(
+            scan_result,
+            self.severity_filter,
+            self.source_filter,
+            self.sort_mode,
+        );
 
         if self.sorted_indices.is_empty() {
             self.selected_index = 0;
@@ -136,6 +163,55 @@ impl AppState {
         self.detail_scroll = self
             .detail_scroll
             .min(max_scroll.min(u16::MAX as usize) as u16);
+    }
+
+    fn cycle_severity_filter(&mut self) {
+        self.severity_filter = match self.severity_filter {
+            None => Some(Severity::Critical),
+            Some(Severity::Critical) => Some(Severity::High),
+            Some(Severity::High) => Some(Severity::Medium),
+            Some(Severity::Medium) => Some(Severity::Low),
+            Some(Severity::Low) => None,
+        };
+        self.selected_index = 0;
+        self.detail_scroll = 0;
+    }
+
+    fn cycle_source_filter(&mut self) {
+        self.source_filter = match self.source_filter {
+            None => Some(Source::NativeCompose),
+            Some(Source::NativeCompose) => Some(Source::NativeHost),
+            Some(Source::NativeHost) => Some(Source::Trivy),
+            Some(Source::Trivy) => Some(Source::Lynis),
+            Some(Source::Lynis) => Some(Source::Dockle),
+            Some(Source::Dockle) => None,
+        };
+        self.selected_index = 0;
+        self.detail_scroll = 0;
+    }
+
+    fn cycle_sort_mode(&mut self) {
+        self.sort_mode = match self.sort_mode {
+            FindingSortMode::Severity => FindingSortMode::Source,
+            FindingSortMode::Source => FindingSortMode::Subject,
+            FindingSortMode::Subject => FindingSortMode::Severity,
+        };
+        self.selected_index = 0;
+        self.detail_scroll = 0;
+    }
+
+    fn jump_to_severity(&mut self, scan_result: &ScanResult, severity: Severity) {
+        self.clamp_selection(scan_result);
+
+        if let Some(position) = self.sorted_indices.iter().position(|index| {
+            scan_result
+                .findings
+                .get(*index)
+                .is_some_and(|finding| finding.severity == severity)
+        }) {
+            self.selected_index = position;
+            self.detail_scroll = 0;
+        }
     }
 }
 
@@ -199,7 +275,9 @@ where
 
         if event::poll(Duration::from_millis(100))? {
             match event::read()? {
-                Event::Key(key) if key.kind == KeyEventKind::Press && handle_key(state, key) => {
+                Event::Key(key)
+                    if key.kind == KeyEventKind::Press && handle_key(state, scan_result, key) =>
+                {
                     return Ok(());
                 }
                 Event::Resize(_, _) => {}
@@ -209,10 +287,10 @@ where
     }
 }
 
-fn handle_key(state: &mut AppState, key: KeyEvent) -> bool {
+fn handle_key(state: &mut AppState, scan_result: &ScanResult, key: KeyEvent) -> bool {
     match state.screen {
         Screen::Overview => handle_overview_key(state, key),
-        Screen::Findings => handle_findings_key(state, key),
+        Screen::Findings => handle_findings_key(state, scan_result, key),
     }
 }
 
@@ -227,10 +305,38 @@ fn handle_overview_key(state: &mut AppState, key: KeyEvent) -> bool {
     }
 }
 
-fn handle_findings_key(state: &mut AppState, key: KeyEvent) -> bool {
+fn handle_findings_key(state: &mut AppState, scan_result: &ScanResult, key: KeyEvent) -> bool {
     match key.code {
         KeyCode::Char('q') | KeyCode::Esc => {
             state.return_to_overview();
+            false
+        }
+        KeyCode::Char('s') => {
+            state.cycle_severity_filter();
+            false
+        }
+        KeyCode::Char('x') => {
+            state.cycle_source_filter();
+            false
+        }
+        KeyCode::Char('o') => {
+            state.cycle_sort_mode();
+            false
+        }
+        KeyCode::Char('1') => {
+            state.jump_to_severity(scan_result, Severity::Critical);
+            false
+        }
+        KeyCode::Char('2') => {
+            state.jump_to_severity(scan_result, Severity::High);
+            false
+        }
+        KeyCode::Char('3') => {
+            state.jump_to_severity(scan_result, Severity::Medium);
+            false
+        }
+        KeyCode::Char('4') => {
+            state.jump_to_severity(scan_result, Severity::Low);
             false
         }
         KeyCode::Tab => {
@@ -390,17 +496,22 @@ fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, sta
         list_state.select(Some(state.selected_index));
     }
 
-    let list = List::new(findings_list_items(scan_result, content[0].width, mode))
-        .block(
-            Block::default()
-                .title(findings_list_title(state.findings_focus))
-                .borders(Borders::ALL)
-                .border_style(focus_border_style(
-                    state.findings_focus == FindingsFocus::List,
-                )),
-        )
-        .highlight_symbol("> ")
-        .highlight_style(Style::default().bg(Color::DarkGray));
+    let list = List::new(findings_list_items(
+        scan_result,
+        state,
+        content[0].width,
+        mode,
+    ))
+    .block(
+        Block::default()
+            .title(findings_list_title(state.findings_focus))
+            .borders(Borders::ALL)
+            .border_style(focus_border_style(
+                state.findings_focus == FindingsFocus::List,
+            )),
+    )
+    .highlight_symbol("> ")
+    .highlight_style(Style::default().bg(Color::DarkGray));
 
     let detail_block = Block::default()
         .title(findings_detail_title(state.findings_focus))
@@ -672,8 +783,16 @@ fn findings_header(
     mode: FindingsLayoutMode,
 ) -> Paragraph<'static> {
     let inner_width = available_width.saturating_sub(2).max(16) as usize;
+    let filters = finding_filter_summary(state);
     let text = if state.finding_count() == 0 {
-        t!("app.finding.empty_status").into_owned()
+        truncate_text(
+            &format!(
+                "{} | {}",
+                t!("app.finding.empty_status").into_owned(),
+                filters
+            ),
+            inner_width,
+        )
     } else if mode == FindingsLayoutMode::SideBySide {
         let selection = t!(
             "app.finding.status",
@@ -683,14 +802,18 @@ fn findings_header(
         )
         .into_owned();
         let scan_status = compose_status(scan_result);
-        truncate_text(&format!("{} | {}", selection, scan_status), inner_width)
+        truncate_text(
+            &format!("{} | {} | {}", selection, filters, scan_status),
+            inner_width,
+        )
     } else {
         truncate_text(
             &format!(
-                "{}/{} | {}",
+                "{}/{} | {} | {}",
                 state.selected_index + 1,
                 state.finding_count(),
-                focus_label(state.findings_focus)
+                focus_label(state.findings_focus),
+                filters,
             ),
             inner_width,
         )
@@ -722,17 +845,9 @@ fn findings_footer(
         FindingsFocus::Detail => t!("app.hint.detail_scroll").into_owned(),
     };
     let controls = if mode == FindingsLayoutMode::Narrow {
-        format!(
-            "{} | {}",
-            t!("app.hint.switch_focus_compact").into_owned(),
-            t!("app.hint.back_overview_compact").into_owned()
-        )
+        t!("app.hint.finding_controls_compact").into_owned()
     } else {
-        format!(
-            "{} | {}",
-            t!("app.hint.switch_focus").into_owned(),
-            t!("app.hint.back_overview").into_owned()
-        )
+        t!("app.hint.finding_controls").into_owned()
     };
 
     Paragraph::new(Text::from(vec![
@@ -745,17 +860,20 @@ fn findings_footer(
 
 fn findings_list_items(
     scan_result: &ScanResult,
+    state: &AppState,
     available_width: u16,
     mode: FindingsLayoutMode,
 ) -> Vec<ListItem<'static>> {
-    if scan_result.findings.is_empty() {
+    if state.finding_count() == 0 {
         return vec![ListItem::new(t!("app.finding.empty_title").into_owned())];
     }
 
     let inner_width = available_width.saturating_sub(2).max(16) as usize;
 
-    sorted_finding_indices(scan_result)
-        .into_iter()
+    state
+        .sorted_indices
+        .iter()
+        .copied()
         .filter_map(|index| scan_result.findings.get(index))
         .map(|finding| {
             let compact_subject = finding_list_subject(finding);
@@ -899,6 +1017,13 @@ fn finding_list_subject(finding: &Finding) -> String {
         .related_service
         .clone()
         .unwrap_or_else(|| finding.subject.clone())
+}
+
+fn finding_sort_subject(finding: &Finding) -> &str {
+    finding
+        .related_service
+        .as_deref()
+        .unwrap_or(&finding.subject)
 }
 
 fn detail_section(label: String, value: &str) -> Vec<Line<'static>> {
@@ -1075,7 +1200,7 @@ fn severity_total_lines(scan_result: &ScanResult, available_width: u16) -> Vec<L
 fn remediation_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line<'static>> {
     let text_width = available_width.saturating_sub(12).max(16) as usize;
 
-    sorted_finding_indices(scan_result)
+    visible_finding_indices(scan_result, None, None, FindingSortMode::Severity)
         .into_iter()
         .take(4)
         .filter_map(|index| scan_result.findings.get(index))
@@ -1407,22 +1532,85 @@ fn result_group_label(finding: &Finding) -> String {
     }
 }
 
-fn sorted_finding_indices(scan_result: &ScanResult) -> Vec<usize> {
+fn visible_finding_indices(
+    scan_result: &ScanResult,
+    severity_filter: Option<Severity>,
+    source_filter: Option<Source>,
+    sort_mode: FindingSortMode,
+) -> Vec<usize> {
     let mut indices = (0..scan_result.findings.len()).collect::<Vec<_>>();
+    indices.retain(|index| {
+        scan_result.findings.get(*index).is_some_and(|finding| {
+            severity_filter.is_none_or(|severity| finding.severity == severity)
+                && source_filter.is_none_or(|source| finding.source == source)
+        })
+    });
     indices.sort_by(|left, right| {
-        compare_findings(&scan_result.findings[*left], &scan_result.findings[*right])
+        compare_findings(
+            &scan_result.findings[*left],
+            &scan_result.findings[*right],
+            sort_mode,
+        )
     });
     indices
 }
 
-fn compare_findings(left: &Finding, right: &Finding) -> Ordering {
-    severity_rank(left.severity)
-        .cmp(&severity_rank(right.severity))
-        .then_with(|| left.title.cmp(&right.title))
-        .then_with(|| source_label(left.source).cmp(&source_label(right.source)))
-        .then_with(|| scope_label(left.scope).cmp(&scope_label(right.scope)))
-        .then_with(|| left.subject.cmp(&right.subject))
-        .then_with(|| left.id.cmp(&right.id))
+fn compare_findings(left: &Finding, right: &Finding, sort_mode: FindingSortMode) -> Ordering {
+    match sort_mode {
+        FindingSortMode::Severity => severity_rank(left.severity)
+            .cmp(&severity_rank(right.severity))
+            .then_with(|| left.title.cmp(&right.title))
+            .then_with(|| left.source.cmp(&right.source))
+            .then_with(|| left.scope.cmp(&right.scope))
+            .then_with(|| left.subject.cmp(&right.subject))
+            .then_with(|| left.id.cmp(&right.id)),
+        FindingSortMode::Source => left
+            .source
+            .cmp(&right.source)
+            .then_with(|| severity_rank(left.severity).cmp(&severity_rank(right.severity)))
+            .then_with(|| left.title.cmp(&right.title))
+            .then_with(|| left.scope.cmp(&right.scope))
+            .then_with(|| left.subject.cmp(&right.subject))
+            .then_with(|| left.id.cmp(&right.id)),
+        FindingSortMode::Subject => finding_sort_subject(left)
+            .cmp(finding_sort_subject(right))
+            .then_with(|| severity_rank(left.severity).cmp(&severity_rank(right.severity)))
+            .then_with(|| left.title.cmp(&right.title))
+            .then_with(|| left.source.cmp(&right.source))
+            .then_with(|| left.id.cmp(&right.id)),
+    }
+}
+
+fn finding_filter_summary(state: &AppState) -> String {
+    format!(
+        "{}:{} {}:{} {}:{}",
+        t!("app.finding.severity_filter_short").into_owned(),
+        severity_filter_label(state.severity_filter),
+        t!("app.finding.source_filter_short").into_owned(),
+        source_filter_label(state.source_filter),
+        t!("app.finding.sort_short").into_owned(),
+        sort_mode_label(state.sort_mode),
+    )
+}
+
+fn severity_filter_label(filter: Option<Severity>) -> String {
+    filter
+        .map(severity_label)
+        .unwrap_or_else(|| t!("app.finding.filter_all").into_owned())
+}
+
+fn source_filter_label(filter: Option<Source>) -> String {
+    filter
+        .map(source_label)
+        .unwrap_or_else(|| t!("app.finding.filter_all").into_owned())
+}
+
+fn sort_mode_label(sort_mode: FindingSortMode) -> String {
+    match sort_mode {
+        FindingSortMode::Severity => t!("app.finding.sort_severity").into_owned(),
+        FindingSortMode::Source => t!("app.finding.sort_source").into_owned(),
+        FindingSortMode::Subject => t!("app.finding.sort_subject").into_owned(),
+    }
 }
 
 fn compose_status(scan_result: &ScanResult) -> String {
@@ -1923,10 +2111,12 @@ mod tests {
 
     #[test]
     fn overview_navigation_opens_findings() {
-        let mut state = AppState::new(&sample_result());
+        let result = sample_result();
+        let mut state = AppState::new(&result);
 
         let should_exit = handle_key(
             &mut state,
+            &result,
             KeyEvent::new(KeyCode::Enter, crossterm::event::KeyModifiers::NONE),
         );
 
@@ -1943,27 +2133,101 @@ mod tests {
 
         handle_key(
             &mut state,
+            &result,
             KeyEvent::new(KeyCode::Down, crossterm::event::KeyModifiers::NONE),
         );
         assert_eq!(state.selected_index, 1);
 
         handle_key(
             &mut state,
+            &result,
             KeyEvent::new(KeyCode::Tab, crossterm::event::KeyModifiers::NONE),
         );
         assert_eq!(state.findings_focus, FindingsFocus::Detail);
 
         handle_key(
             &mut state,
+            &result,
             KeyEvent::new(KeyCode::PageDown, crossterm::event::KeyModifiers::NONE),
         );
         assert!(state.detail_scroll > 0);
 
         handle_key(
             &mut state,
+            &result,
             KeyEvent::new(KeyCode::Esc, crossterm::event::KeyModifiers::NONE),
         );
         assert_eq!(state.screen, Screen::Overview);
+    }
+
+    #[test]
+    fn findings_controls_cycle_filters_and_sort_modes() {
+        let result = sample_result();
+        let mut state = AppState::new(&result);
+        state.open_findings();
+
+        handle_key(
+            &mut state,
+            &result,
+            KeyEvent::new(KeyCode::Char('s'), crossterm::event::KeyModifiers::NONE),
+        );
+        state.clamp_selection(&result);
+        assert_eq!(state.severity_filter, Some(Severity::Critical));
+        assert_eq!(state.finding_count(), 1);
+
+        handle_key(
+            &mut state,
+            &result,
+            KeyEvent::new(KeyCode::Char('x'), crossterm::event::KeyModifiers::NONE),
+        );
+        state.clamp_selection(&result);
+        assert_eq!(state.source_filter, Some(Source::NativeCompose));
+        assert_eq!(state.finding_count(), 1);
+
+        handle_key(
+            &mut state,
+            &result,
+            KeyEvent::new(KeyCode::Char('o'), crossterm::event::KeyModifiers::NONE),
+        );
+        assert_eq!(state.sort_mode, FindingSortMode::Source);
+
+        handle_key(
+            &mut state,
+            &result,
+            KeyEvent::new(KeyCode::Char('o'), crossterm::event::KeyModifiers::NONE),
+        );
+        assert_eq!(state.sort_mode, FindingSortMode::Subject);
+    }
+
+    #[test]
+    fn findings_controls_can_jump_to_requested_severity() {
+        let result = sample_result();
+        let mut state = AppState::new(&result);
+        state.open_findings();
+
+        handle_key(
+            &mut state,
+            &result,
+            KeyEvent::new(KeyCode::Char('4'), crossterm::event::KeyModifiers::NONE),
+        );
+        assert_eq!(
+            state
+                .selected_finding(&result)
+                .map(|finding| finding.severity),
+            Some(Severity::Low)
+        );
+
+        handle_key(
+            &mut state,
+            &result,
+            KeyEvent::new(KeyCode::Char('1'), crossterm::event::KeyModifiers::NONE),
+        );
+        assert_eq!(
+            state
+                .selected_finding(&result)
+                .map(|finding| finding.severity),
+            Some(Severity::Critical)
+        );
     }
 
     #[test]
@@ -2062,10 +2326,15 @@ mod tests {
         let result = mixed_scope_result();
         let mut state = AppState::new(&result);
         state.open_findings();
-        state.selected_index = result
-            .findings
+        state.selected_index = state
+            .sorted_indices
             .iter()
-            .position(|finding| finding.scope == Scope::Project)
+            .position(|index| {
+                result
+                    .findings
+                    .get(*index)
+                    .is_some_and(|finding| finding.scope == Scope::Project)
+            })
             .expect("project finding should exist");
         let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal should build");
 
@@ -2115,8 +2384,8 @@ mod tests {
 
         assert!(content.contains("[CRIT] Admin interface is exposed publicly - adminer"));
         assert!(content.contains("Critical | Native Compose | adminer"));
-        assert!(content.contains("Tab or Left/Right switch focus"));
-        assert!(content.contains("q or Esc back"));
+        assert!(content.contains("s sev | x src | o sort"));
+        assert!(content.contains("q back"));
         assert!(!content.contains("PageUp/PageDown"));
     }
 

--- a/src/tests/fixtures/adapters/dockle-image-report.json
+++ b/src/tests/fixtures/adapters/dockle-image-report.json
@@ -1,0 +1,42 @@
+{
+  "summary": {
+    "fatal": 2,
+    "warn": 1,
+    "info": 1,
+    "pass": 0
+  },
+  "details": [
+    {
+      "code": "CIS-DI-0001",
+      "title": "Create a user for the container",
+      "level": "WARN",
+      "alerts": [
+        "Last user should not be root"
+      ]
+    },
+    {
+      "code": "CIS-DI-0009",
+      "title": "Use COPY instead of ADD in Dockerfile",
+      "level": "FATAL",
+      "alerts": [
+        "Use COPY for added files"
+      ]
+    },
+    {
+      "code": "DKL-DI-0005",
+      "title": "Clear apt-get caches",
+      "level": "FATAL",
+      "alerts": [
+        "Run apt-get clean and remove lists"
+      ]
+    },
+    {
+      "code": "CIS-DI-0008",
+      "title": "Confirm safety of setuid/setgid files",
+      "level": "INFO",
+      "alerts": [
+        "setuid file found"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- retire legacy installer release-channel behavior so the installer and metadata follow the documented single-track SemVer flow
- broaden native Rust security coverage with additional host hardening checks, expanded Compose remediation paths, and findings-view filter/sort/jump controls
- add Dockle as an optional adapter and wire its status/findings into the shared scan pipeline, TUI adapter summary, and JSON-exported metadata
- sync AGENTS, README, and release-note optional dependency copy with the current roadmap and adapter surface

## Validation
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `./scripts/test-install-script.sh target/debug/hostveil`

## Linked issues
- Closes #118
- Closes #117
- Closes #116
- Closes #119
- Closes #120
- Refs #113
- Refs #121