### PR TITLE
feat(i18n): add Korean locale and regression coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ cargo run -- --json --compose proto/tests/fixtures/parser/docker-compose.yml
 cargo run -- --json --host-root /
 cargo run -- --quick-fix proto/tests/fixtures/parser/docker-compose.yml --preview-changes
 cargo run -- --fix proto/tests/fixtures/parser/docker-compose.yml --preview-changes
+
+# Locale overrides (currently: en, ko)
+HOSTVEIL_LOCALE=ko cargo run -- --help
+LANG=ko_KR.UTF-8 cargo run -- --quick-fix proto/tests/fixtures/parser/docker-compose.yml --preview-changes
 ```
 
 Container-based development and installer validation:

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -30,10 +30,12 @@ printf '%s\n' "$VERSION_OUTPUT" | grep -q '^hostveil '
 $BINARY_PATH --help | grep -q -- '--version'
 $BINARY_PATH --help | grep -q -- 'hostveil upgrade'
 $BINARY_PATH --help | grep -q -- 'hostveil auto-upgrade enable'
+HOSTVEIL_LOCALE=ko $BINARY_PATH --help | grep -q '사용법'
 $BINARY_PATH --json | grep -q '"scan_mode": "live"'
 $BINARY_PATH --json --compose "$COMPOSE_FIXTURE" | grep -q '"findings"'
 $BINARY_PATH --json --host-root "$TMP_HOST_ROOT" | grep -q '"host_runtime"'
 $BINARY_PATH --quick-fix "$COMPOSE_FIXTURE" --preview-changes | grep -q 'Preview only: no files were modified.'
+HOSTVEIL_LOCALE=ko $BINARY_PATH --quick-fix "$COMPOSE_FIXTURE" --preview-changes | grep -q '미리보기 전용'
 $BINARY_PATH --fix "$COMPOSE_FIXTURE" --preview-changes | grep -q 'Preview only: no files were modified.'
 
 set +e

--- a/scripts/test-install-script.sh
+++ b/scripts/test-install-script.sh
@@ -387,6 +387,7 @@ run_custom_state_dir_case() {
     printf 'error: lifecycle manager was not saved in the custom state dir\n' >&2
     exit 1
   }
+  assert_file_contains "$install_dir/hostveil" "$custom_state_dir"
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_STATE_DIR='
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.1.0-test'
   assert_file_not_contains "$metadata_path" 'HOSTVEIL_META_CHANNEL='

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -1,0 +1,312 @@
+app:
+  name: "hostveil"
+  header:
+    subtitle: "리눅스 셀프호스팅 보안 대시보드"
+  status:
+    bootstrap: "Rust 스캔, TUI, JSON 내보내기를 사용할 수 있습니다."
+    no_target: "명시적인 대상이 없습니다. 인자 없이 실행하면 라이브 탐색을 수행하고, 특정 대상은 --compose PATH 또는 --host-root PATH를 사용하세요."
+    compose_loaded: "%{path}에서 서비스 %{count}개를 로드했습니다"
+    host_loaded: "%{path}에서 호스트 점검을 로드했습니다"
+    compose_and_host_loaded: "%{path}에서 서비스 %{count}개를 로드했고 호스트 점검을 함께 활성화했습니다"
+    live_discovery: "라이브 스캔: 프로젝트 %{project_count}개를 발견했고 호스트 점검을 활성화했습니다"
+    live_host_only: "라이브 스캔: 호스트 전용 모드"
+    live_docker_missing: "라이브 스캔: Docker를 찾지 못해 호스트 전용 모드로 전환합니다"
+    live_docker_denied: "라이브 스캔: Docker 권한이 없어 호스트 전용 모드로 전환합니다"
+    live_docker_failed: "라이브 스캔: Docker 탐색에 실패해 호스트 전용 모드로 전환합니다"
+  help:
+    usage: "사용법"
+    options: "옵션"
+    lifecycle: "수명주기"
+    text: |
+      hostveil
+
+      사용법:
+        hostveil
+        hostveil --json
+        hostveil [--compose PATH] [--host-root PATH] [--json]
+        hostveil setup [--tool NAME]... [--tools LIST] [--yes]
+        hostveil --quick-fix PATH [--preview-changes] [--yes]
+        hostveil --fix PATH [--preview-changes] [--yes]
+        hostveil upgrade [--version TAG]
+        hostveil uninstall
+        hostveil auto-upgrade enable
+        hostveil auto-upgrade disable
+        hostveil --version
+        hostveil --help
+
+      수명주기:
+        첫 설치:
+          curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
+        설치 후:
+          hostveil setup
+          hostveil upgrade
+          hostveil uninstall
+          hostveil auto-upgrade enable|disable
+
+      옵션:
+        --compose PATH    라이브 탐색 대신 특정 Compose 파일 또는 디렉터리를 사용합니다
+        --host-root PATH  기본 호스트 루트(/) 대신 특정 Linux 루트 또는 스냅샷을 사용합니다
+        --tool NAME       hostveil setup에서 설치 도구를 명시적으로 선택합니다(반복 가능)
+        --tools LIST      무인 setup 실행용 쉼표 구분 도구 목록입니다
+        --quick-fix PATH  특정 파일 또는 디렉터리에 안전한 Compose 전용 수정을 미리보기 또는 적용합니다
+        --fix PATH        특정 파일 또는 디렉터리에 안전/가이드 Compose 변경을 미리보기 또는 적용합니다
+        --preview-changes 파일을 쓰지 않고 예정된 diff를 표시합니다
+        --yes             대화형 확인 없이 검토한 변경을 적용합니다
+        --json            TUI 대신 스캔 결과 JSON을 출력합니다
+        -V, --version     버전 정보를 표시합니다
+        -h, --help        이 도움말을 표시합니다
+  version:
+    text: "%{name} %{version}"
+  hint:
+    quit: "q 또는 Esc를 눌러 종료"
+    json: "현재 스캔 결과 구조를 확인하려면 --json을 사용하세요"
+    open_findings: "Enter 또는 Right로 발견 항목을 엽니다"
+    switch_focus: "Tab, Left, Right로 포커스를 전환합니다"
+    switch_focus_compact: "Tab 또는 Left/Right로 포커스 전환"
+    list_move: "Arrow 키 또는 j/k로 발견 항목을 이동합니다"
+    list_move_compact: "Up/Down 또는 j/k 이동"
+    detail_scroll: "Arrow 키, j/k, PageUp/PageDown으로 상세 내용을 스크롤합니다"
+    detail_scroll_compact: "Up/Down, j/k, PgUp/PgDn 스크롤"
+    back_overview: "q 또는 Esc를 눌러 개요로 돌아갑니다"
+    back_overview_compact: "q 또는 Esc로 뒤로"
+    finding_controls: "Tab 또는 Left/Right 포커스 전환 | s 심각도 | x 소스 | o 정렬 | 1-4 점프 | q 또는 Esc 뒤로"
+    finding_controls_compact: "Tab/LR 포커스 | s 심각도 | x 소스 | o 정렬 | 1-4 점프 | q 뒤로"
+    fix_review_scroll: "Up/Down 또는 PgUp/PgDn으로 diff를 스크롤합니다"
+    fix_review_apply: "y 또는 Enter를 눌러 검토한 변경을 적용합니다"
+    fix_review_cancel: "q 또는 Esc를 눌러 취소합니다"
+  footer:
+    quit: "종료"
+    findings: "발견 항목 열기"
+    json: "JSON 내보내기"
+  panel:
+    status: "상태"
+    hints: "힌트"
+    server_status: "서버 상태"
+    scan_results: "스캔 결과"
+    security_scores: "보안 점수"
+    fix_paths: "수정 경로"
+    fix_review: "수정 검토"
+    fix_diff: "Diff"
+    overview_score: "전체 점수"
+    overview_axes: "축별 점수"
+    overview_activity: "발견 사항과 어댑터"
+    overview_findings: "주요 발견 사항"
+    next_steps: "다음 단계"
+    next_step_one: "심각도가 높은 발견 사항부터 검토하세요"
+    next_step_two: "자동화와 회귀 스냅샷에는 --json을 사용하세요"
+    next_step_three: "대상 스캔에는 --compose PATH 또는 --host-root PATH를 사용하세요"
+    findings_list: "발견 항목"
+    findings_list_active: "발견 항목 [리스트 포커스]"
+    finding_detail: "상세"
+    finding_detail_active: "상세 [상세 포커스]"
+  overview:
+    score_caption: "전체 보안 상태"
+    findings_available: "발견 항목 %{count}개가 있습니다. 상세 보기를 열어 확인하세요."
+    no_findings: "현재 발견 항목이 없습니다."
+    adapters_none: "아직 보고된 선택형 어댑터 상태가 없습니다."
+  server:
+    host_name: "호스트"
+    root_path: "루트"
+    docker_version: "Docker"
+    uptime: "업타임"
+    load: "부하"
+    controls: "방어 제어"
+    fail2ban: "Fail2ban"
+    control_enabled: "활성"
+    control_installed: "설치됨"
+    control_not_detected: "감지되지 않음"
+    control_jails: "jail %{count}개"
+    control_banned_ips: "차단 IP %{count}개"
+    services_heading: "서비스"
+    no_services: "로드된 Compose 서비스가 없습니다."
+    no_image: "이미지 정보 없음"
+    more_services: "... 외 %{count}개 서비스"
+    not_scanned: "스캔 안 됨"
+    not_loaded: "로드 안 됨"
+    not_available: "해당 없음"
+  summary:
+    title: "현재 스캔 컨텍스트"
+    none: "이번 스캔에서 로드된 Compose 프로젝트가 없습니다"
+    compose_file: "Compose 파일: %{path}"
+    compose_root: "작업 디렉터리: %{path}"
+    host_root: "호스트 루트: %{path}"
+    loaded_files: "로드된 파일 수: %{count}"
+    service_count: "서비스 수: %{count}"
+    overall_score: "전체 점수: %{score}"
+    finding_count: "발견 항목 수: %{count}"
+  adapter:
+    lynis_pentest_mode: "Lynis가 비권한 pentest 모드로 실행되어 root 권한이 필요한 일부 점검이 생략될 수 있습니다."
+    lynis_non_zero_exit: "Lynis가 비정상 종료 코드로 종료했습니다: %{detail}. 사용 가능한 보고서는 계속 파싱했습니다."
+    lynis_report_missing: "Lynis가 보고서 파일을 생성하지 않았습니다."
+  setup:
+    heading: "hostveil setup"
+    detected_os: "감지된 OS: %{name}"
+    selected_tools: "선택된 도구: %{tools}"
+    planned_changes: "예정된 변경"
+    prompt_tools: "설치하고 구성할 선택형 도구를 고르세요"
+    prompt_confirm: "이 setup 계획을 적용할까요?"
+    skipped: "Setup을 건너뛰었습니다. 나중에 `hostveil setup`으로 다시 구성하세요."
+    requesting_sudo: "패키지 설치와 시스템 구성을 위해 sudo 권한을 요청합니다..."
+    running_step: "실행 중: %{step}"
+    verification_heading: "검증"
+    complete: "Setup이 완료되었습니다. 설치 도구를 조정하려면 언제든지 `hostveil setup`을 다시 실행하세요."
+    check_failed: "%{command} 검증에 실패했습니다: %{detail}"
+    error:
+      unsupported_os: "hostveil setup은 아직 자동 의존성 설치를 지원하지 않습니다:"
+    step:
+      dnf_install: "dnf로 패키지 설치: %{packages}"
+      apt_install: "apt로 패키지 설치: %{packages}"
+      trivy_repo: "Trivy APT 저장소 추가"
+      fail2ban_baseline: "관리형 Fail2Ban sshd 기본 설정을 작성하고 서비스를 활성화"
+    tool:
+      lynis:
+        name: "Lynis"
+        prompt: "Lynis: 호스트 감사 및 하드닝 점검"
+      trivy:
+        name: "Trivy"
+        prompt: "Trivy: 이미지/컨테이너 취약점 스캔"
+      fail2ban:
+        name: "Fail2Ban"
+        prompt: "Fail2Ban: SSH 기본 침입 방지"
+  error:
+    unknown_argument: "알 수 없는 인자: %{argument}"
+    missing_argument_value: "인자 값이 없습니다: %{flag}"
+    invalid_argument_combination: "잘못된 인자 조합: %{message}"
+    lifecycle_requires_installed_wrapper: "%{command} 명령은 설치된 hostveil 래퍼에서만 사용할 수 있습니다. 먼저 설치 스크립트로 hostveil을 설치하세요"
+    compose_path_missing: "compose 경로가 존재하지 않습니다: %{path}"
+    compose_file_not_found: "디렉터리에서 compose 파일을 찾지 못했습니다: %{path}"
+    compose_malformed_yaml: "%{path}의 YAML 파싱에 실패했습니다: %{message}"
+    compose_missing_services: "%{path}에서 서비스를 찾지 못했습니다"
+    compose_io: "%{path} 읽기에 실패했습니다: %{message}"
+    io: "애플리케이션 오류: %{message}"
+    fix_serialize: "업데이트된 compose 파일 직렬화에 실패했습니다: %{message}"
+    json_export_failed: "현재 스캔 결과 직렬화에 실패했습니다"
+    tui_requires_terminal: "대화형 TUI는 터미널이 필요합니다. 비대화형 실행에는 --json을 사용하세요"
+    fix_requires_terminal: "guided Compose 수정은 터미널 검토가 필요합니다. 비대화형에서는 --preview-changes로 diff를 확인하세요"
+    missing_translation: "번역 키를 찾지 못했습니다: %{key}"
+  finding:
+    header: "발견 항목 상세"
+    status: "%{count}개 중 %{index} 선택 | 포커스: %{focus}"
+    empty_status: "아직 발견 항목이 없습니다"
+    empty_title: "발견 항목 없음"
+    empty_description: "대상을 스캔하거나 발견 항목이 생길 때까지 기다리세요."
+    focus_list: "리스트"
+    focus_detail: "상세"
+    subject_label: "대상"
+    related_service_label: "연관 서비스"
+    description_label: "설명"
+    why_label: "위험한 이유"
+    fix_label: "해결 방법"
+    evidence_label: "증거"
+    no_evidence: "이 발견 항목에는 구조화된 증거가 없습니다."
+    severity_filter_short: "심각도"
+    source_filter_short: "소스"
+    sort_short: "정렬"
+    filter_all: "전체"
+    sort_severity: "심각도"
+    sort_source: "소스"
+    sort_subject: "대상"
+  result:
+    host_group: "호스트"
+    ok: "정상"
+    none: "그룹화된 스캔 결과가 없습니다."
+    single_finding: "발견 항목 1개"
+    multi_findings: "발견 항목 %{count}개"
+    discovery_heading: "탐색"
+    adapters_heading: "어댑터"
+    warnings_heading: "경고"
+    docker_available: "사용 가능"
+    docker_missing: "없음"
+    docker_permission_denied: "권한 없음"
+    docker_failed: "실패: %{detail}"
+  fix:
+    none: "현재 대상에 적용 가능한 Compose 수정이 없습니다."
+    file: "Compose 파일: %{path}"
+    safe_plan: "안전한 변경 %{count}개를 검토할 수 있습니다."
+    guided_plan: "가이드 변경 %{count}개를 검토할 수 있습니다."
+    preview_only: "미리보기 전용: 파일은 수정되지 않았습니다."
+    cancelled: "파일을 쓰지 않고 취소했습니다."
+    backup: "백업 생성: %{path}"
+    applied: "적용됨: %{summary}"
+    confirm_quick: "%{path}에 안전한 Compose 변경을 적용할까요? [y/N]: "
+    confirm_all: "%{path}에 검토한 Compose 변경을 적용할까요? [y/N]: "
+    safe_bind_localhost: "%{service}: 공개 포트 %{port}를 127.0.0.1에 바인딩"
+    safe_nginx_stable: "%{service}: nginx를 nginx:stable로 고정"
+    guided_privileged_cap_add: "%{service}: privileged 모드를 최소 NET_BIND_SERVICE capability 검토 방식으로 대체"
+    guided_vaultwarden_signups: "%{service}: SIGNUPS_ALLOWED를 false로 설정"
+    guided_gitea_externalize_secrets: "%{service}: Gitea 보안 시크릿의 inline 값을 환경 변수 플레이스홀더로 교체"
+    guided_nginx_stable: "%{service}: nginx를 nginx:stable로 고정하도록 검토"
+axis:
+  sensitive_data: "민감 데이터"
+  permissions: "권한"
+  exposure: "노출"
+  updates: "공급망"
+  host_hardening: "호스트 하드닝"
+severity:
+  critical: "치명적"
+  high: "높음"
+  medium: "보통"
+  low: "낮음"
+scope:
+  service: "서비스"
+  image: "이미지"
+  host: "호스트"
+  project: "프로젝트"
+source:
+  native_compose: "네이티브 Compose"
+  native_host: "네이티브 호스트"
+  trivy: "Trivy"
+  lynis: "Lynis"
+  dockle: "Dockle"
+adapter:
+  pending: "대기 중"
+  available: "사용 가능"
+  missing: "없음"
+  skipped: "건너뜀: %{detail}"
+  failed: "실패: %{detail}"
+  reason:
+    no_image_targets: "발견된 이미지 대상이 없습니다"
+    host_not_scanned: "호스트 스캔이 요청되지 않았습니다"
+    live_host_only: "루트(/) 기반 라이브 호스트 스캔이 필요합니다"
+finding:
+  lynis:
+    host_warnings:
+      title: "Lynis가 호스트 하드닝 경고를 보고했습니다"
+      description: "Lynis가 %{subject}에 대해 하드닝 지수 %{index}와 함께 경고 %{count}개를 보고했습니다."
+      why: "Lynis 경고는 공격 표면을 넓히거나 침해 후 복구를 약화시키는 호스트 하드닝 공백을 가리키는 경우가 많습니다."
+      fix: "Lynis 경고를 우선순위대로 검토하고 영향이 큰 하드닝부터 적용한 뒤 감사 결과를 다시 확인하세요."
+    host_suggestions:
+      title: "Lynis가 추가 하드닝 제안을 보고했습니다"
+      description: "Lynis가 %{subject}에 대해 하드닝 지수 %{index}와 함께 제안 %{count}개를 보고했습니다."
+      why: "즉시 조치 항목이 아니더라도 하드닝 제안이 누적되면 기본 호스트 보안 상태가 기대보다 약하다는 신호일 수 있습니다."
+      fix: "호스트 역할에 맞는 Lynis 제안을 순차적으로 적용하고 각 단계 후 다시 감사를 수행하세요."
+  trivy:
+    image_vulnerabilities:
+      title: "이미지에 알려진 취약점이 있습니다"
+      description: "%{image}에서 Trivy가 보고한 취약점 기록 %{count}개가 발견되었습니다."
+      why: "기반 이미지나 패키지의 알려진 취약점은 노출된 서비스가 있을 때 악용될 수 있습니다."
+      fix: "이미지를 패치된 버전으로 업데이트하고 필요한 경우 재빌드한 뒤, 다음 배포 전 안정적인 태그나 digest로 고정하세요."
+  dockle:
+    image_best_practice:
+      title: "이미지가 Dockle 모범 사례 점검을 통과하지 못했습니다"
+      description: "%{image}에서 Dockle 모범 사례/하드닝 점검 %{count}개가 감지되었습니다."
+      why: "Dockle 발견 사항은 이미지 레이어 하드닝 부족을 나타내며, 셀프호스팅 환경에서 악용 가능성을 높이거나 런타임 격리를 약화시킬 수 있습니다."
+      fix: "Dockle 체크포인트 ID를 기준으로 Dockerfile 또는 기반 이미지를 개선하고, 영향이 큰 항목이 해소될 때까지 재스캔하세요."
+  updates:
+    latest:
+      title: "이미지가 latest 태그를 사용합니다"
+      description: "%{service}가 %{image}를 사용하고 있어 고정 버전 대신 가변 대상을 추적합니다."
+      why: "가변 태그는 배포 재현성을 떨어뜨리고 예고 없는 변경을 끌어올 수 있습니다."
+      fix: "다음 배포 전 특정 버전 또는 digest로 이미지를 고정하세요."
+    no_tag:
+      title: "이미지에 명시적인 태그가 없습니다"
+      description: "%{service}가 명시적 태그 없이 %{image}를 사용합니다."
+      why: "태그 없는 이미지는 latest와 유사하게 해석되어 업데이트가 예측 불가능해집니다."
+      fix: "고정 릴리스 버전 같은 안정적인 명시 태그를 추가하세요."
+    major_only:
+      title: "이미지가 메이저 버전만 고정되어 있습니다"
+      description: "%{service}가 메이저 버전만 고정된 %{image}를 사용합니다."
+      why: "메이저 전용 태그도 마이너/패치 업데이트로 이동해 동작 변화를 유발할 수 있습니다."
+      fix: "예측 가능한 롤아웃을 위해 최소 마이너 또는 패치 버전까지 고정하세요."
+test:
+  fallback_probe: "English fallback probe"

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -65,6 +65,16 @@ fn apply_external_adapters(result: &mut ScanResult) {
 }
 
 pub fn prepare_background_adapter_scan(result: &mut ScanResult) -> Receiver<AdapterScanUpdate> {
+    spawn_background_adapter_scan(result, scan_external_adapters)
+}
+
+fn spawn_background_adapter_scan<F>(
+    result: &mut ScanResult,
+    scan_fn: F,
+) -> Receiver<AdapterScanUpdate>
+where
+    F: FnOnce(Vec<ServiceSummary>, Option<PathBuf>) -> AdapterScanUpdate + Send + 'static,
+{
     seed_adapter_statuses(result);
 
     let services = result.metadata.services.clone();
@@ -72,7 +82,7 @@ pub fn prepare_background_adapter_scan(result: &mut ScanResult) -> Receiver<Adap
     let (sender, receiver) = mpsc::channel();
 
     thread::spawn(move || {
-        let update = scan_external_adapters(services, host_root);
+        let update = scan_fn(services, host_root);
         let _ = sender.send(update);
     });
 
@@ -223,17 +233,26 @@ fn run_live_scan(
     coverage.host_hardening = true;
 
     let discovery = discover_running_compose_projects();
+    apply_live_discovery_result(&discovery, &env::current_dir()?, result, coverage)
+}
+
+fn apply_live_discovery_result(
+    discovery: &DockerDiscoveryResult,
+    fallback_dir: &Path,
+    result: &mut ScanResult,
+    coverage: &mut scoring::Coverage,
+) -> Result<(), AppError> {
     result.metadata.docker_status = Some(discovery.status.clone());
     result.metadata.warnings.extend(discovery.warnings.clone());
 
     if !discovery.projects.is_empty() {
-        apply_discovered_projects(&discovery, result, coverage)?;
+        apply_discovered_projects(discovery, result, coverage)?;
         if coverage.compose {
             return Ok(());
         }
     }
 
-    apply_current_dir_fallback(result, coverage)
+    apply_current_dir_fallback_from(fallback_dir, result, coverage)
 }
 
 fn apply_discovered_projects(
@@ -339,13 +358,21 @@ fn load_discovered_project(
     ))
 }
 
+#[cfg(test)]
 fn apply_current_dir_fallback(
     result: &mut ScanResult,
     coverage: &mut scoring::Coverage,
 ) -> Result<(), AppError> {
     let current_dir = env::current_dir()?;
+    apply_current_dir_fallback_from(&current_dir, result, coverage)
+}
 
-    match ComposeParser::parse_path(&current_dir) {
+fn apply_current_dir_fallback_from(
+    current_dir: &Path,
+    result: &mut ScanResult,
+    coverage: &mut scoring::Coverage,
+) -> Result<(), AppError> {
+    match ComposeParser::parse_path(current_dir) {
         Ok(project) => {
             let summary = DiscoveredProjectSummary {
                 name: project
@@ -425,6 +452,9 @@ mod tests {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
+    use std::sync::mpsc::TryRecvError;
+    use std::thread;
+    use std::time::Duration;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::discovery::{DiscoveredComposeProject, DiscoveredContainerService};
@@ -435,7 +465,8 @@ mod tests {
 
     use super::{
         AdapterScanUpdate, apply_current_dir_fallback, apply_discovered_projects,
-        apply_external_adapter_update, run, scan_compose_project, seed_adapter_statuses,
+        apply_external_adapter_update, apply_live_discovery_result, run, scan_compose_project,
+        seed_adapter_statuses, spawn_background_adapter_scan,
     };
     use crate::app::{AppConfig, OutputMode};
     use crate::compose::ComposeParser;
@@ -1038,6 +1069,121 @@ mod tests {
             warning.contains("Docker metadata")
                 && warning.contains("refresh the saved Compose labels")
         }));
+    }
+
+    #[test]
+    fn live_scan_falls_back_to_current_dir_after_stale_discovery_paths_fail() {
+        let missing_root = temp_host_root("live-stale-compose-fallback");
+        let current_dir = temp_host_root("live-current-dir-compose");
+        let compose_path = missing_root.join("docker-compose.yml");
+        let working_dir = missing_root.join("gone-working-dir");
+        fs::remove_dir_all(&missing_root).expect("temp dir should be removed before scan");
+        write_file(
+            &current_dir.join("docker-compose.yml"),
+            concat!(
+                "services:\n",
+                "  demo:\n",
+                "    image: nginx:1.27.5\n",
+                "    ports:\n",
+                "      - \"8080:80\"\n"
+            ),
+        );
+
+        let discovery = crate::discovery::DockerDiscoveryResult {
+            status: DockerDiscoveryStatus::Available,
+            projects: vec![DiscoveredComposeProject {
+                name: String::from("demo"),
+                compose_path: Some(compose_path),
+                working_dir: Some(working_dir),
+                services: vec![DiscoveredContainerService {
+                    name: String::from("demo"),
+                    image: Some(String::from("nginx:1.27.5")),
+                }],
+                source: "docker",
+            }],
+            warnings: vec![String::from("Docker returned stale Compose labels")],
+        };
+
+        let mut result = crate::domain::ScanResult::default();
+        let mut coverage = crate::scoring::Coverage {
+            host_hardening: true,
+            ..Default::default()
+        };
+
+        apply_live_discovery_result(&discovery, &current_dir, &mut result, &mut coverage)
+            .expect("live scan fallback should succeed");
+
+        assert!(coverage.compose);
+        assert_eq!(result.metadata.service_count, 1);
+        assert!(
+            result
+                .metadata
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("stale Compose labels"))
+        );
+        assert!(
+            result
+                .metadata
+                .warnings
+                .iter()
+                .any(|warning| { warning.contains("current directory as a Compose fallback") })
+        );
+        assert_eq!(result.metadata.discovered_projects.len(), 2);
+        assert_eq!(result.metadata.discovered_projects[1].source, "current_dir");
+
+        fs::remove_dir_all(current_dir).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn background_adapter_scan_does_not_block_tui_startup() {
+        let mut result = crate::domain::ScanResult::default();
+        result.metadata.host_root = Some(PathBuf::from("/"));
+        result.metadata.services.push(ServiceSummary {
+            name: String::from("demo"),
+            image: Some(String::from("nginx:1.27.5")),
+        });
+
+        let receiver = spawn_background_adapter_scan(&mut result, |_, _| {
+            thread::sleep(Duration::from_millis(150));
+            AdapterScanUpdate {
+                trivy: crate::adapters::trivy::TrivyScanOutput {
+                    status: AdapterStatus::Missing,
+                    findings: Vec::new(),
+                    warnings: Vec::new(),
+                },
+                lynis: crate::adapters::lynis::LynisScanOutput {
+                    status: AdapterStatus::Skipped(String::from("not requested")),
+                    findings: Vec::new(),
+                    warnings: Vec::new(),
+                },
+                dockle: crate::adapters::dockle::DockleScanOutput {
+                    status: AdapterStatus::Missing,
+                    findings: Vec::new(),
+                    warnings: Vec::new(),
+                },
+            }
+        });
+
+        assert_eq!(
+            result.metadata.adapters.get("trivy"),
+            Some(&AdapterStatus::Pending)
+        );
+        assert_eq!(
+            result.metadata.adapters.get("dockle"),
+            Some(&AdapterStatus::Pending)
+        );
+        assert_eq!(
+            result.metadata.adapters.get("lynis"),
+            Some(&AdapterStatus::Pending)
+        );
+        assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
+
+        let update = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("background scan should eventually finish");
+        assert_eq!(update.trivy.status, AdapterStatus::Missing);
+        assert_eq!(update.dockle.status, AdapterStatus::Missing);
     }
 
     #[test]

--- a/src/src/i18n/mod.rs
+++ b/src/src/i18n/mod.rs
@@ -1,4 +1,55 @@
+use std::env;
+
 use crate::compose::ComposeParseError;
+
+pub fn initialize_locale_from_env() {
+    let hostveil_locale = env::var("HOSTVEIL_LOCALE").ok();
+    let lc_all = env::var("LC_ALL").ok();
+    let lang = env::var("LANG").ok();
+
+    rust_i18n::set_locale(resolve_preferred_locale(
+        hostveil_locale.as_deref(),
+        lc_all.as_deref(),
+        lang.as_deref(),
+    ));
+}
+
+fn resolve_preferred_locale(
+    hostveil_locale: Option<&str>,
+    lc_all: Option<&str>,
+    lang: Option<&str>,
+) -> &'static str {
+    [hostveil_locale, lc_all, lang]
+        .into_iter()
+        .flatten()
+        .find_map(normalize_locale_tag)
+        .unwrap_or("en")
+}
+
+fn normalize_locale_tag(raw: &str) -> Option<&'static str> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let without_codeset = trimmed.split_once('.').map_or(trimmed, |(head, _)| head);
+    let without_modifier = without_codeset
+        .split_once('@')
+        .map_or(without_codeset, |(head, _)| head);
+    let language = without_modifier.replace('_', "-").to_ascii_lowercase();
+
+    if language == "c" || language == "posix" {
+        return Some("en");
+    }
+
+    if language.starts_with("ko") {
+        Some("ko")
+    } else if language.starts_with("en") {
+        Some("en")
+    } else {
+        None
+    }
+}
 
 pub fn tr(key: &str) -> String {
     match key {
@@ -136,8 +187,9 @@ pub fn tr_summary_finding_count(count: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        tr, tr_compose_parse_error, tr_fix_requires_terminal, tr_invalid_argument_combination,
-        tr_io_error, tr_lifecycle_command_requires_installed_wrapper, tr_missing_argument_value,
+        normalize_locale_tag, resolve_preferred_locale, tr, tr_compose_parse_error,
+        tr_fix_requires_terminal, tr_invalid_argument_combination, tr_io_error,
+        tr_lifecycle_command_requires_installed_wrapper, tr_missing_argument_value,
         tr_status_compose_and_host_loaded, tr_status_compose_loaded, tr_status_host_loaded,
         tr_summary_finding_count, tr_summary_host_root, tr_summary_overall_score,
         tr_summary_service_count, tr_tui_requires_terminal, tr_unknown_argument, tr_version,
@@ -275,5 +327,55 @@ mod tests {
     #[test]
     fn formats_finding_count_summary() {
         assert_eq!(tr_summary_finding_count(4), "Finding count: 4");
+    }
+
+    #[test]
+    fn locale_resolver_prefers_explicit_hostveil_locale() {
+        assert_eq!(
+            resolve_preferred_locale(Some("ko_KR.UTF-8"), Some("en_US.UTF-8"), Some("en_US")),
+            "ko"
+        );
+    }
+
+    #[test]
+    fn locale_resolver_uses_system_locale_when_explicit_locale_is_missing() {
+        assert_eq!(
+            resolve_preferred_locale(None, Some("ko-KR"), Some("en_US.UTF-8")),
+            "ko"
+        );
+    }
+
+    #[test]
+    fn locale_resolver_falls_back_to_english_for_unknown_values() {
+        assert_eq!(
+            resolve_preferred_locale(Some("fr_FR.UTF-8"), Some("de_DE"), Some("es_ES")),
+            "en"
+        );
+        assert_eq!(resolve_preferred_locale(Some("C.UTF-8"), None, None), "en");
+    }
+
+    #[test]
+    fn locale_tag_parser_handles_common_variants() {
+        assert_eq!(normalize_locale_tag("ko_KR.UTF-8"), Some("ko"));
+        assert_eq!(normalize_locale_tag("en-US"), Some("en"));
+        assert_eq!(normalize_locale_tag("POSIX"), Some("en"));
+        assert_eq!(normalize_locale_tag(""), None);
+    }
+
+    #[test]
+    fn korean_locale_translates_cli_and_tui_strings() {
+        assert_eq!(t!("app.help.usage", locale = "ko").into_owned(), "사용법");
+        assert_eq!(
+            t!("app.hint.quit", locale = "ko").into_owned(),
+            "q 또는 Esc를 눌러 종료"
+        );
+    }
+
+    #[test]
+    fn korean_locale_falls_back_to_english_for_missing_keys() {
+        assert_eq!(
+            t!("test.fallback_probe", locale = "ko").into_owned(),
+            "English fallback probe"
+        );
     }
 }

--- a/src/src/main.rs
+++ b/src/src/main.rs
@@ -1,6 +1,8 @@
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    hostveil::i18n::initialize_locale_from_env();
+
     match hostveil::app::run(std::env::args().skip(1)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {


### PR DESCRIPTION
## Summary
- add regression coverage for stale Docker metadata fallback in live scans, non-blocking background adapter startup, and installed-wrapper state directory lifecycle behavior
- add Korean Rust locale coverage for shipped CLI/TUI/setup/fix strings and keep English fallback behavior for missing keys
- initialize locale selection from `HOSTVEIL_LOCALE`, `LC_ALL`, and `LANG`, then document locale override usage in README

## Validation
- `cargo fmt`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace`
- `./scripts/smoke-test.sh target/debug/hostveil`
- `./scripts/test-install-script.sh target/debug/hostveil`

## Linked issues
- Closes #113
- Closes #115
- Closes #123