### PR TITLE
feat(host): add ufw + unattended-upgrades checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,10 @@ hostveil/
 - Do **not** bundle unrelated changes into one commit — split them
 - Do **not** commit a broken or half-finished state; if a task spans multiple commits, ensure each intermediate commit at least compiles/runs
 - Prefer small, reviewable commits over large, hard-to-review ones
-- Always run the relevant checks before committing: `cargo clippy && cargo fmt` (Rust), or verify the prototype runs (Python)
+- Always run the relevant checks before committing:
+	- Rust baseline: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`
+	- Rust install/release/entrypoint-impacting changes: also run `./scripts/smoke-test.sh target/debug/hostveil` and `./scripts/test-install-script.sh target/debug/hostveil`
+	- Python prototype work: verify the prototype still runs (and tests where relevant)
 
 **i18n:**
 - All user-visible strings must go through the i18n layer — no hardcoded display text
@@ -61,7 +64,7 @@ hostveil/
 
 **Rust (when src/ exists):**
 - `Cargo.lock` must be committed — hostveil is a binary crate
-- Run `cargo clippy` and `cargo fmt` before committing
+- Run `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace` before committing
 
 **Versioning and releases:**
 - Use SemVer `X.Y.Z` for the crate and binary version

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -424,6 +424,16 @@ finding:
       description: "%{path} does not show local markers for Fail2ban."
       why: "Basic blocking or ban automation can slow down repeated password attacks, scanning, and other noisy abuse against exposed services."
       fix: "Install and enable Fail2ban, then verify it is protecting the services you expose."
+    ufw_disabled:
+      title: "UFW is installed but disabled"
+      description: "%{path} shows UFW is present but ENABLED is set to no."
+      why: "A host firewall helps narrow inbound exposure and makes it harder for accidentally published services to become reachable."
+      fix: "Enable UFW, review the default policy, and allow only the ports you intentionally expose."
+    unattended_upgrades_disabled:
+      title: "Automatic security updates are disabled"
+      description: "%{path} disables unattended-upgrades."
+      why: "Missing security updates can leave known vulnerabilities unpatched longer than intended."
+      fix: "Enable unattended-upgrades (or an equivalent patching workflow) so security fixes are applied regularly."
   vaultwarden:
     signups_enabled:
       title: "Vaultwarden signups are left enabled"

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -308,5 +308,16 @@ finding:
       description: "%{service}가 메이저 버전만 고정된 %{image}를 사용합니다."
       why: "메이저 전용 태그도 마이너/패치 업데이트로 이동해 동작 변화를 유발할 수 있습니다."
       fix: "예측 가능한 롤아웃을 위해 최소 마이너 또는 패치 버전까지 고정하세요."
+  host:
+    ufw_disabled:
+      title: "UFW가 설치되어 있지만 비활성화되어 있습니다"
+      description: "%{path}에서 UFW가 존재하지만 ENABLED가 no로 설정되어 있습니다."
+      why: "호스트 방화벽은 인바운드 노출을 줄이고, 실수로 공개된 서비스가 외부에서 접근 가능해지는 위험을 낮춥니다."
+      fix: "UFW를 활성화하고 기본 정책을 검토한 뒤, 의도적으로 노출하는 포트만 허용하세요."
+    unattended_upgrades_disabled:
+      title: "자동 보안 업데이트가 비활성화되어 있습니다"
+      description: "%{path}에서 unattended-upgrades가 비활성화되어 있습니다."
+      why: "보안 업데이트가 적용되지 않으면 알려진 취약점이 의도보다 오래 방치될 수 있습니다."
+      fix: "unattended-upgrades(또는 동등한 패치 워크플로)를 활성화해 보안 수정이 정기적으로 적용되도록 하세요."
 test:
   fallback_probe: "English fallback probe"

--- a/src/src/app/mod.rs
+++ b/src/src/app/mod.rs
@@ -5,7 +5,10 @@ mod setup;
 pub use config::{AppConfig, OutputMode, SetupConfig, SetupTool};
 
 use std::fmt;
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, Write};
+
+#[cfg(not(test))]
+use std::io::IsTerminal;
 
 use crate::compose::ComposeParseError;
 use crate::export;
@@ -120,7 +123,7 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
             if config.assume_yes {
                 print_fix_review(&preview_plan);
             } else {
-                if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+                if !is_interactive_terminal() {
                     return Err(AppError::FixRequiresTerminal);
                 }
 
@@ -146,7 +149,7 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
 
     match config.output_mode {
         OutputMode::Tui => {
-            if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+            if !is_interactive_terminal() {
                 return Err(AppError::TuiRequiresTerminal);
             }
 
@@ -171,6 +174,18 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
     }
 
     Ok(())
+}
+
+fn is_interactive_terminal() -> bool {
+    #[cfg(test)]
+    {
+        false
+    }
+
+    #[cfg(not(test))]
+    {
+        io::stdin().is_terminal() && io::stdout().is_terminal()
+    }
 }
 
 fn confirm_fix(

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -14,6 +14,9 @@ use crate::domain::{
 const SSH_CONFIG_PATH: &str = "etc/ssh/sshd_config";
 const DOCKER_DAEMON_CONFIG_PATH: &str = "etc/docker/daemon.json";
 const DOCKER_SOCKET_PATH: &str = "var/run/docker.sock";
+const UFW_CONFIG_PATH: &str = "etc/ufw/ufw.conf";
+const UFW_INSTALL_MARKERS: [&str; 3] = ["etc/ufw/ufw.conf", "usr/sbin/ufw", "usr/bin/ufw"];
+const APT_AUTO_UPGRADES_CONFIG_PATH: &str = "etc/apt/apt.conf.d/20auto-upgrades";
 const FAIL2BAN_INSTALL_MARKERS: [&str; 6] = [
     "etc/fail2ban",
     "usr/bin/fail2ban-client",
@@ -57,6 +60,8 @@ impl HostScanner {
         let mut findings = Vec::new();
         findings.extend(scan_ssh_hardening(context));
         findings.extend(scan_docker_host_exposure(context));
+        findings.extend(scan_firewall_hardening(context));
+        findings.extend(scan_package_update_hardening(context));
         findings.extend(scan_defensive_controls(context, runtime));
         findings
     }
@@ -378,6 +383,162 @@ fn scan_docker_host_exposure(context: &HostContext) -> Vec<Finding> {
     }
 
     findings
+}
+
+fn scan_firewall_hardening(context: &HostContext) -> Vec<Finding> {
+    if !detect_ufw_installed(&context.root) {
+        return Vec::new();
+    }
+
+    let Some(config_path) = resolve_existing_path(&context.root, UFW_CONFIG_PATH) else {
+        return Vec::new();
+    };
+
+    let Ok(config_text) = fs::read_to_string(&config_path) else {
+        return Vec::new();
+    };
+
+    let Some(enabled) = parse_ufw_enabled(&config_text) else {
+        return Vec::new();
+    };
+
+    if enabled {
+        return Vec::new();
+    }
+
+    vec![host_finding(
+        "host.ufw_installed_but_disabled",
+        Severity::Medium,
+        &config_path,
+        HostFindingText {
+            title: t!("finding.host.ufw_disabled.title").into_owned(),
+            description: t!(
+                "finding.host.ufw_disabled.description",
+                path = config_path.display().to_string()
+            )
+            .into_owned(),
+            why_risky: t!("finding.host.ufw_disabled.why").into_owned(),
+            how_to_fix: t!("finding.host.ufw_disabled.fix").into_owned(),
+        },
+        BTreeMap::from([
+            (String::from("path"), config_path.display().to_string()),
+            (String::from("enabled"), String::from("no")),
+        ]),
+    )]
+}
+
+fn scan_package_update_hardening(context: &HostContext) -> Vec<Finding> {
+    let Some(config_path) = resolve_existing_path(&context.root, APT_AUTO_UPGRADES_CONFIG_PATH)
+    else {
+        return Vec::new();
+    };
+
+    let Ok(config_text) = fs::read_to_string(&config_path) else {
+        return Vec::new();
+    };
+
+    let Some(enabled) = parse_unattended_upgrades_enabled(&config_text) else {
+        return Vec::new();
+    };
+
+    if enabled {
+        return Vec::new();
+    }
+
+    vec![host_finding(
+        "host.apt_unattended_upgrades_disabled",
+        Severity::Medium,
+        &config_path,
+        HostFindingText {
+            title: t!("finding.host.unattended_upgrades_disabled.title").into_owned(),
+            description: t!(
+                "finding.host.unattended_upgrades_disabled.description",
+                path = config_path.display().to_string()
+            )
+            .into_owned(),
+            why_risky: t!("finding.host.unattended_upgrades_disabled.why").into_owned(),
+            how_to_fix: t!("finding.host.unattended_upgrades_disabled.fix").into_owned(),
+        },
+        BTreeMap::from([
+            (String::from("path"), config_path.display().to_string()),
+            (String::from("unattended_upgrade"), String::from("disabled")),
+        ]),
+    )]
+}
+
+fn detect_ufw_installed(root: &Path) -> bool {
+    UFW_INSTALL_MARKERS
+        .iter()
+        .any(|marker| resolve_existing_path(root, marker).is_some())
+}
+
+fn parse_ufw_enabled(text: &str) -> Option<bool> {
+    for raw_line in text.lines() {
+        let line = strip_ini_comments(raw_line);
+        if line.is_empty() {
+            continue;
+        }
+
+        let Some((key, value)) = parse_ini_key_value(line) else {
+            continue;
+        };
+        if !key.eq_ignore_ascii_case("ENABLED") {
+            continue;
+        }
+
+        let value = value.trim_matches('"').trim_matches('\'').trim();
+        if let Some(enabled) = parse_ini_bool(value) {
+            return Some(enabled);
+        }
+    }
+
+    None
+}
+
+fn parse_unattended_upgrades_enabled(text: &str) -> Option<bool> {
+    const UNATTENDED_UPGRADE_KEY: &str = "APT::Periodic::Unattended-Upgrade";
+
+    for raw_line in text.lines() {
+        let line = strip_apt_comments(raw_line);
+        if line.is_empty() || !line.contains(UNATTENDED_UPGRADE_KEY) {
+            continue;
+        }
+
+        let (_, value) = line.split_once(UNATTENDED_UPGRADE_KEY)?;
+        let value = value
+            .trim()
+            .trim_start_matches('=')
+            .trim()
+            .trim_end_matches(';')
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .trim();
+
+        if let Some(enabled) = parse_ini_bool(value) {
+            return Some(enabled);
+        }
+    }
+
+    None
+}
+
+fn strip_apt_comments(line: &str) -> &str {
+    let trimmed = line.trim();
+    if trimmed.starts_with('#') || trimmed.starts_with("//") {
+        return "";
+    }
+
+    let hash_index = line.find('#');
+    let slash_index = line.find("//");
+    let comment_index = match (hash_index, slash_index) {
+        (Some(hash), Some(slash)) => Some(hash.min(slash)),
+        (Some(hash), None) => Some(hash),
+        (None, Some(slash)) => Some(slash),
+        (None, None) => None,
+    };
+
+    line[..comment_index.unwrap_or(line.len())].trim()
 }
 
 fn scan_defensive_controls(context: &HostContext, runtime: &HostRuntimeInfo) -> Vec<Finding> {
@@ -1147,6 +1308,81 @@ mod tests {
                 "   |- Currently banned: 3\n"
             )),
             Some(3)
+        );
+    }
+
+    #[test]
+    fn reports_ufw_when_installed_but_disabled() {
+        let root = temp_host_root("ufw-disabled");
+        write_file(&root.join("usr/sbin/ufw"), "");
+        write_file(&root.join(UFW_CONFIG_PATH), "ENABLED=no\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.ufw_installed_but_disabled")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn does_not_report_ufw_when_enabled() {
+        let root = temp_host_root("ufw-enabled");
+        write_file(&root.join(UFW_CONFIG_PATH), "ENABLED=yes\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .all(|finding| finding.id != "host.ufw_installed_but_disabled")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn reports_unattended_upgrades_when_explicitly_disabled() {
+        let root = temp_host_root("apt-auto-upgrades-disabled");
+        write_file(
+            &root.join(APT_AUTO_UPGRADES_CONFIG_PATH),
+            concat!(
+                "APT::Periodic::Update-Package-Lists \"1\";\n",
+                "APT::Periodic::Unattended-Upgrade \"0\";\n"
+            ),
+        );
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.apt_unattended_upgrades_disabled")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn unattended_upgrades_parser_handles_common_formats() {
+        assert_eq!(
+            parse_unattended_upgrades_enabled("APT::Periodic::Unattended-Upgrade \"1\";"),
+            Some(true)
+        );
+        assert_eq!(
+            parse_unattended_upgrades_enabled("APT::Periodic::Unattended-Upgrade \"0\";"),
+            Some(false)
+        );
+        assert_eq!(
+            parse_unattended_upgrades_enabled("APT::Periodic::Unattended-Upgrade 1;"),
+            Some(true)
+        );
+        assert_eq!(
+            parse_unattended_upgrades_enabled("APT::Periodic::Update-Package-Lists \"1\";"),
+            None
         );
     }
 }


### PR DESCRIPTION
## Summary

- Align AGENTS.md checks with CI gates.
- Add host hardening findings for UFW disabled + unattended-upgrades disabled (snapshot-friendly).
- Prevent unit tests from entering interactive TUI when running in a TTY (avoids alt-screen capture issues).

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

Closes #121
Closes #125
Closes #126
