### PR TITLE
chore(release): bump version to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "crossterm 0.29.0",
  "dialoguer",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"


### PR DESCRIPTION
Closes #132

- Bumps `src/Cargo.toml` to `0.2.0`
- Regenerates and commits `Cargo.lock`

Tag push (`v0.2.0`) will be done after this lands on `main`.