### PR TITLE
feat(rules): add Nextcloud service-aware checks

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -493,3 +493,19 @@ finding:
       description: "%{service} is part of an Immich deployment that still uses the default DB_PASSWORD value."
       why: "Leaving the default database password in place makes the storage backend easier to compromise if the stack or env file is exposed."
       fix: "Replace the default DB password with a unique random value before deploying or exposing the stack."
+  nextcloud:
+    insecure_overwriteprotocol:
+      title: "Nextcloud overwrite protocol is configured as HTTP"
+      description: "%{service} sets OVERWRITEPROTOCOL=%{protocol} while the service is publicly reachable."
+      why: "A public Nextcloud deployment with HTTP overwrite protocol weakens transport guarantees and can expose login or session traffic through insecure paths."
+      fix: "Set OVERWRITEPROTOCOL to https and terminate TLS at the reverse proxy or edge before exposing the service."
+    wildcard_trusted_domains:
+      title: "Nextcloud trusted domains allow wildcard-style host matching"
+      description: "%{service} sets NEXTCLOUD_TRUSTED_DOMAINS to %{trusted_domains}, which includes wildcard-style entries."
+      why: "Overly broad trusted domain matching makes host-header abuse easier and increases the chance of serving requests for unintended hostnames."
+      fix: "List only exact hostnames you control in NEXTCLOUD_TRUSTED_DOMAINS and remove wildcard-style values such as * or *.example.com."
+    default_admin_credentials:
+      title: "Nextcloud uses default admin bootstrap credentials"
+      description: "%{service} keeps NEXTCLOUD_ADMIN_USER and NEXTCLOUD_ADMIN_PASSWORD at default-like values."
+      why: "Default bootstrap credentials are widely known and can be abused quickly if setup endpoints are reachable before hardening is complete."
+      fix: "Use a unique admin username and strong random admin password during bootstrap, then rotate secrets through a safer external secret path."

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -319,5 +319,21 @@ finding:
       description: "%{path}에서 unattended-upgrades가 비활성화되어 있습니다."
       why: "보안 업데이트가 적용되지 않으면 알려진 취약점이 의도보다 오래 방치될 수 있습니다."
       fix: "unattended-upgrades(또는 동등한 패치 워크플로)를 활성화해 보안 수정이 정기적으로 적용되도록 하세요."
+  nextcloud:
+    insecure_overwriteprotocol:
+      title: "Nextcloud overwrite protocol이 HTTP로 설정되어 있습니다"
+      description: "%{service}가 공개 노출된 상태에서 OVERWRITEPROTOCOL=%{protocol}을 사용합니다."
+      why: "공개된 Nextcloud에서 HTTP overwrite protocol을 사용하면 전송 보안이 약해지고 로그인 또는 세션 트래픽이 비보안 경로로 노출될 수 있습니다."
+      fix: "서비스를 외부에 노출하기 전에 OVERWRITEPROTOCOL을 https로 설정하고, 리버스 프록시 또는 엣지에서 TLS를 종료하세요."
+    wildcard_trusted_domains:
+      title: "Nextcloud trusted domains에 와일드카드형 호스트가 포함되어 있습니다"
+      description: "%{service}가 NEXTCLOUD_TRUSTED_DOMAINS=%{trusted_domains}를 사용하며, 와일드카드형 항목이 포함되어 있습니다."
+      why: "과도하게 넓은 trusted domain 매칭은 Host 헤더 악용 가능성을 높이고 의도하지 않은 호스트명 요청을 허용할 위험이 있습니다."
+      fix: "NEXTCLOUD_TRUSTED_DOMAINS에는 관리하는 정확한 호스트명만 명시하고, * 또는 *.example.com 같은 값은 제거하세요."
+    default_admin_credentials:
+      title: "Nextcloud가 기본 관리자 초기 자격 증명을 사용하고 있습니다"
+      description: "%{service}가 NEXTCLOUD_ADMIN_USER와 NEXTCLOUD_ADMIN_PASSWORD를 기본값에 가까운 값으로 유지하고 있습니다."
+      why: "기본 초기 자격 증명은 널리 알려져 있어, 초기 하드닝 전에 설정 엔드포인트가 노출되면 빠르게 악용될 수 있습니다."
+      fix: "초기 설정 시 고유한 관리자 계정과 강력한 랜덤 비밀번호를 사용하고, 이후에는 더 안전한 외부 시크릿 경로로 자격 증명을 교체하세요."
 test:
   fallback_probe: "English fallback probe"

--- a/src/src/rules/mod.rs
+++ b/src/src/rules/mod.rs
@@ -336,6 +336,62 @@ mod realistic_fixture_tests {
             ]
         );
     }
+
+    #[test]
+    fn nextcloud_baseline_stays_clear_under_generic_rules() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("nextcloud", "baseline.yml"))
+                .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn nextcloud_vulnerable_fixture_produces_expected_findings() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("nextcloud", "vulnerable.yml"))
+                .expect("project should parse");
+
+        let findings = RuleEngine.scan(&project);
+
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| (
+                    finding.id.as_str(),
+                    finding.related_service.as_deref().unwrap_or_default(),
+                    finding.severity,
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("exposure.public_binding", "nextcloud", Severity::Medium),
+                ("permissions.implicit_root", "nextcloud", Severity::Medium),
+                (
+                    "sensitive.default_credential",
+                    "nextcloud",
+                    Severity::Critical,
+                ),
+                ("updates.latest_tag", "nextcloud", Severity::High),
+                (
+                    "service.nextcloud.insecure_overwriteprotocol",
+                    "nextcloud",
+                    Severity::High,
+                ),
+                (
+                    "service.nextcloud.wildcard_trusted_domains",
+                    "nextcloud",
+                    Severity::High,
+                ),
+                (
+                    "service.nextcloud.default_admin_credentials",
+                    "nextcloud",
+                    Severity::Critical,
+                ),
+            ]
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/src/rules/service_aware.rs
+++ b/src/src/rules/service_aware.rs
@@ -12,6 +12,7 @@ enum ServiceKind {
     Vaultwarden,
     Jellyfin,
     Gitea,
+    Nextcloud,
     Immich,
 }
 
@@ -27,6 +28,7 @@ pub fn scan_service_aware_risk(project: &ComposeProject) -> Vec<Finding> {
             ServiceKind::Vaultwarden => findings.extend(scan_vaultwarden_risk(service)),
             ServiceKind::Jellyfin => findings.extend(scan_jellyfin_risk(service)),
             ServiceKind::Gitea => findings.extend(scan_gitea_risk(service)),
+            ServiceKind::Nextcloud => findings.extend(scan_nextcloud_risk(service)),
             ServiceKind::Immich => findings.extend(scan_immich_risk(project, service)),
         }
     }
@@ -35,12 +37,9 @@ pub fn scan_service_aware_risk(project: &ComposeProject) -> Vec<Finding> {
 }
 
 fn detect_service_kind(service: &ComposeService) -> Option<ServiceKind> {
-    let haystack = format!(
-        "{} {}",
-        service.name,
-        service.image.as_deref().unwrap_or_default()
-    )
-    .to_lowercase();
+    let service_name = service.name.to_lowercase();
+    let image = service.image.as_deref().unwrap_or_default().to_lowercase();
+    let haystack = format!("{service_name} {image}");
 
     if haystack.contains("vaultwarden") {
         Some(ServiceKind::Vaultwarden)
@@ -48,7 +47,9 @@ fn detect_service_kind(service: &ComposeService) -> Option<ServiceKind> {
         Some(ServiceKind::Jellyfin)
     } else if haystack.contains("gitea") {
         Some(ServiceKind::Gitea)
-    } else if service.name.contains("immich-server") || haystack.contains("immich-server") {
+    } else if image.contains("nextcloud") || service_name == "nextcloud" {
+        Some(ServiceKind::Nextcloud)
+    } else if service_name.contains("immich-server") || haystack.contains("immich-server") {
         Some(ServiceKind::Immich)
     } else {
         None
@@ -292,6 +293,92 @@ fn scan_gitea_risk(service: &ComposeService) -> Vec<Finding> {
     findings
 }
 
+fn scan_nextcloud_risk(service: &ComposeService) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let publicly_exposed = service.ports.iter().any(is_public_port);
+
+    if publicly_exposed
+        && let Some(overwrite_protocol) = env_value(service, "OVERWRITEPROTOCOL")
+        && overwrite_protocol.eq_ignore_ascii_case("http")
+    {
+        findings.push(service_finding(
+            "service.nextcloud.insecure_overwriteprotocol",
+            Axis::UnnecessaryExposure,
+            Severity::High,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.nextcloud.insecure_overwriteprotocol.title").into_owned(),
+                description: t!(
+                    "finding.nextcloud.insecure_overwriteprotocol.description",
+                    service = service.name.as_str(),
+                    protocol = overwrite_protocol
+                )
+                .into_owned(),
+                why_risky: t!("finding.nextcloud.insecure_overwriteprotocol.why").into_owned(),
+                how_to_fix: t!("finding.nextcloud.insecure_overwriteprotocol.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("variable"), String::from("OVERWRITEPROTOCOL")),
+                (String::from("value"), overwrite_protocol.to_owned()),
+            ]),
+        ));
+    }
+
+    if let Some(trusted_domains) = env_value(service, "NEXTCLOUD_TRUSTED_DOMAINS")
+        && contains_wildcard_trusted_domain(trusted_domains)
+    {
+        findings.push(service_finding(
+            "service.nextcloud.wildcard_trusted_domains",
+            Axis::UnnecessaryExposure,
+            Severity::High,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.nextcloud.wildcard_trusted_domains.title").into_owned(),
+                description: t!(
+                    "finding.nextcloud.wildcard_trusted_domains.description",
+                    service = service.name.as_str(),
+                    trusted_domains = trusted_domains
+                )
+                .into_owned(),
+                why_risky: t!("finding.nextcloud.wildcard_trusted_domains.why").into_owned(),
+                how_to_fix: t!("finding.nextcloud.wildcard_trusted_domains.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("trusted_domains"), trusted_domains.to_owned())]),
+        ));
+    }
+
+    if has_default_nextcloud_admin_credentials(service) {
+        findings.push(service_finding(
+            "service.nextcloud.default_admin_credentials",
+            Axis::SensitiveData,
+            Severity::Critical,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.nextcloud.default_admin_credentials.title").into_owned(),
+                description: t!(
+                    "finding.nextcloud.default_admin_credentials.description",
+                    service = service.name.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.nextcloud.default_admin_credentials.why").into_owned(),
+                how_to_fix: t!("finding.nextcloud.default_admin_credentials.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (
+                    String::from("user_variable"),
+                    String::from("NEXTCLOUD_ADMIN_USER"),
+                ),
+                (
+                    String::from("password_variable"),
+                    String::from("NEXTCLOUD_ADMIN_PASSWORD"),
+                ),
+            ]),
+        ));
+    }
+
+    findings
+}
+
 fn scan_immich_risk(project: &ComposeProject, service: &ComposeService) -> Vec<Finding> {
     let mut findings = Vec::new();
     let shared_secret_env_files = shared_secret_env_files(project, "immich");
@@ -380,6 +467,32 @@ fn inline_env_keys(service: &ComposeService, keys: &[&str]) -> Vec<String> {
     keys.iter()
         .filter_map(|key| env_value(service, key).map(|_| (*key).to_owned()))
         .collect()
+}
+
+fn contains_wildcard_trusted_domain(value: &str) -> bool {
+    value
+        .split(|ch: char| ch == ',' || ch.is_whitespace())
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .any(|token| token == "*" || token == "0.0.0.0" || token == "::" || token.starts_with("*."))
+}
+
+fn has_default_nextcloud_admin_credentials(service: &ComposeService) -> bool {
+    let Some(admin_user) = env_value(service, "NEXTCLOUD_ADMIN_USER") else {
+        return false;
+    };
+    let Some(admin_password) = env_value(service, "NEXTCLOUD_ADMIN_PASSWORD") else {
+        return false;
+    };
+
+    if !admin_user.eq_ignore_ascii_case("admin") {
+        return false;
+    }
+
+    matches!(
+        admin_password.to_ascii_lowercase().as_str(),
+        "admin" | "password" | "nextcloud" | "changeme" | "123456" | "12345678"
+    )
 }
 
 fn shared_secret_env_files(project: &ComposeProject, service_prefix: &str) -> Vec<String> {
@@ -592,6 +705,38 @@ mod tests {
             vec![
                 "service.immich.shared_secret_env_file",
                 "service.immich.default_db_password",
+            ]
+        );
+    }
+
+    #[test]
+    fn nextcloud_baseline_avoids_service_specific_findings() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("nextcloud", "baseline.yml"))
+                .expect("project should parse");
+
+        let findings = scan_service_aware_risk(&project);
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn nextcloud_vulnerable_fixture_triggers_service_specific_findings() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("nextcloud", "vulnerable.yml"))
+                .expect("project should parse");
+
+        let findings = scan_service_aware_risk(&project);
+
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| finding.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "service.nextcloud.insecure_overwriteprotocol",
+                "service.nextcloud.wildcard_trusted_domains",
+                "service.nextcloud.default_admin_credentials",
             ]
         );
     }

--- a/src/tests/fixtures/services/nextcloud/baseline.yml
+++ b/src/tests/fixtures/services/nextcloud/baseline.yml
@@ -1,0 +1,13 @@
+services:
+  nextcloud:
+    image: nextcloud:30.0.0-apache
+    user: "1000:1000"
+    environment:
+      OVERWRITEPROTOCOL: "https"
+      NEXTCLOUD_TRUSTED_DOMAINS: "cloud.example.com"
+      NEXTCLOUD_ADMIN_USER: "nc-admin"
+      NEXTCLOUD_ADMIN_PASSWORD: "${NEXTCLOUD_ADMIN_PASSWORD}"
+    volumes:
+      - ./nextcloud:/var/www/html
+    ports:
+      - "127.0.0.1:8080:80"

--- a/src/tests/fixtures/services/nextcloud/vulnerable.yml
+++ b/src/tests/fixtures/services/nextcloud/vulnerable.yml
@@ -1,0 +1,12 @@
+services:
+  nextcloud:
+    image: nextcloud:latest
+    environment:
+      OVERWRITEPROTOCOL: "http"
+      NEXTCLOUD_TRUSTED_DOMAINS: "cloud.example.com, *"
+      NEXTCLOUD_ADMIN_USER: "admin"
+      NEXTCLOUD_ADMIN_PASSWORD: "admin"
+    volumes:
+      - ./nextcloud:/var/www/html
+    ports:
+      - "8080:80"


### PR DESCRIPTION
## Summary
- add Nextcloud service-aware finding logic in service-aware rule scanning
- cover three Nextcloud-specific risks:
  - insecure OVERWRITEPROTOCOL=http on public exposure
  - wildcard-style NEXTCLOUD_TRUSTED_DOMAINS values
  - default-like admin bootstrap credentials
- add Nextcloud baseline/vulnerable fixtures
- add service-aware and integrated RuleEngine tests for Nextcloud
- add English and Korean locale messages for new finding keys

## Validation
- cargo test --workspace nextcloud -- --nocapture
- cargo fmt
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace

Refs #134