### PR TITLE
test(installer): pin locale for deterministic install validation

### DIFF
--- a/scripts/test-install-script.sh
+++ b/scripts/test-install-script.sh
@@ -5,6 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BINARY_PATH="${1:-$ROOT_DIR/target/debug/hostveil}"
 INSTALLER_PATH="$ROOT_DIR/scripts/install.sh"
 REAL_BASH="$(command -v bash)"
+# Keep test output deterministic across developer locales; allow explicit override.
+HOSTVEIL_TEST_LOCALE="${HOSTVEIL_TEST_LOCALE:-en}"
+export HOSTVEIL_LOCALE="$HOSTVEIL_TEST_LOCALE"
 
 [[ -x "$BINARY_PATH" ]] || {
   printf 'error: binary is not executable: %s\n' "$BINARY_PATH" >&2


### PR DESCRIPTION
## Summary
- pin installer test locale to English by default for deterministic CLI text behavior
- keep override support via HOSTVEIL_TEST_LOCALE for explicit locale runs
- preserve existing non-interactive install/setup/upgrade/uninstall validation coverage

## Validation
- ./scripts/test-install-script.sh target/debug/hostveil

Closes #139