### PR TITLE
test(regression): harden export and adapter path coverage

### DIFF
--- a/src/src/adapters/dockle.rs
+++ b/src/src/adapters/dockle.rs
@@ -461,4 +461,10 @@ mod tests {
         let status = detect_dockle_with_command("false");
         assert!(matches!(status, DockleAvailability::Failed(_)));
     }
+
+    #[test]
+    fn detect_dockle_reports_available_for_true_command() {
+        let status = detect_dockle_with_command("true");
+        assert_eq!(status, DockleAvailability::Available);
+    }
 }

--- a/src/src/adapters/lynis.rs
+++ b/src/src/adapters/lynis.rs
@@ -128,7 +128,11 @@ enum LynisAvailability {
 }
 
 fn detect_lynis() -> LynisAvailability {
-    let output = Command::new("lynis")
+    detect_lynis_with_command("lynis")
+}
+
+fn detect_lynis_with_command(command: &str) -> LynisAvailability {
+    let output = Command::new(command)
         .arg("--version")
         .env("NO_COLOR", "1")
         .output();
@@ -470,5 +474,23 @@ mod tests {
             findings[1].evidence.get("mode").map(String::as_str),
             Some("pentest")
         );
+    }
+
+    #[test]
+    fn detect_lynis_reports_missing_for_unknown_binary() {
+        let status = detect_lynis_with_command("hostveil-nonexistent-lynis");
+        assert_eq!(status, LynisAvailability::Missing);
+    }
+
+    #[test]
+    fn detect_lynis_reports_failed_for_non_zero_command() {
+        let status = detect_lynis_with_command("false");
+        assert!(matches!(status, LynisAvailability::Failed(_)));
+    }
+
+    #[test]
+    fn detect_lynis_reports_available_for_true_command() {
+        let status = detect_lynis_with_command("true");
+        assert_eq!(status, LynisAvailability::Available);
     }
 }

--- a/src/src/adapters/trivy.rs
+++ b/src/src/adapters/trivy.rs
@@ -86,7 +86,11 @@ enum TrivyAvailability {
 }
 
 fn detect_trivy() -> TrivyAvailability {
-    let output = Command::new("trivy")
+    detect_trivy_with_command("trivy")
+}
+
+fn detect_trivy_with_command(command: &str) -> TrivyAvailability {
+    let output = Command::new(command)
         .arg("--version")
         .env("NO_COLOR", "1")
         .output();
@@ -485,5 +489,23 @@ mod tests {
                 "demo:1.0",
             ]
         );
+    }
+
+    #[test]
+    fn detect_trivy_reports_missing_for_unknown_binary() {
+        let status = detect_trivy_with_command("hostveil-nonexistent-trivy");
+        assert_eq!(status, TrivyAvailability::Missing);
+    }
+
+    #[test]
+    fn detect_trivy_reports_failed_for_non_zero_command() {
+        let status = detect_trivy_with_command("false");
+        assert!(matches!(status, TrivyAvailability::Failed(_)));
+    }
+
+    #[test]
+    fn detect_trivy_reports_available_for_true_command() {
+        let status = detect_trivy_with_command("true");
+        assert_eq!(status, TrivyAvailability::Available);
     }
 }

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -889,6 +889,72 @@ mod tests {
     }
 
     #[test]
+    fn adapter_status_transitions_and_warnings_are_recorded() {
+        let mut result = crate::domain::ScanResult::default();
+        result.metadata.host_root = Some(PathBuf::from("/"));
+        result.metadata.services.push(ServiceSummary {
+            name: String::from("web"),
+            image: Some(String::from("nginx:1.27.5")),
+        });
+
+        seed_adapter_statuses(&mut result);
+        apply_external_adapter_update(
+            &mut result,
+            AdapterScanUpdate {
+                trivy: crate::adapters::trivy::TrivyScanOutput {
+                    status: AdapterStatus::Missing,
+                    findings: Vec::new(),
+                    warnings: vec![String::from("trivy binary missing")],
+                },
+                lynis: crate::adapters::lynis::LynisScanOutput {
+                    status: AdapterStatus::Failed(String::from("lynis crashed")),
+                    findings: Vec::new(),
+                    warnings: vec![String::from("lynis exited with non-zero status")],
+                },
+                dockle: crate::adapters::dockle::DockleScanOutput {
+                    status: AdapterStatus::Skipped(String::from("no image targets")),
+                    findings: Vec::new(),
+                    warnings: vec![String::from("dockle intentionally skipped")],
+                },
+            },
+        );
+
+        assert_eq!(
+            result.metadata.adapters.get("trivy"),
+            Some(&AdapterStatus::Missing)
+        );
+        assert_eq!(
+            result.metadata.adapters.get("lynis"),
+            Some(&AdapterStatus::Failed(String::from("lynis crashed")))
+        );
+        assert_eq!(
+            result.metadata.adapters.get("dockle"),
+            Some(&AdapterStatus::Skipped(String::from("no image targets")))
+        );
+        assert!(
+            result
+                .metadata
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("trivy binary missing"))
+        );
+        assert!(
+            result
+                .metadata
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("lynis exited with non-zero status"))
+        );
+        assert!(
+            result
+                .metadata
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("dockle intentionally skipped"))
+        );
+    }
+
+    #[test]
     fn current_dir_fallback_loads_compose_project_when_docker_finds_nothing() {
         let temp_dir = temp_host_root("cwd-fallback");
         write_file(

--- a/src/src/export/mod.rs
+++ b/src/src/export/mod.rs
@@ -27,9 +27,16 @@ fn escape_json(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use serde_json::Value;
 
     use super::scan_result_json;
-    use crate::domain::{Axis, Finding, RemediationKind, ScanResult, Scope, Severity, Source};
+    use crate::domain::{
+        AdapterStatus, Axis, DefensiveControlStatus, DiscoveredProjectSummary,
+        DockerDiscoveryStatus, Finding, HostRuntimeInfo, RemediationKind, ScanMetadata, ScanMode,
+        ScanResult, Scope, ServiceSummary, Severity, Source,
+    };
 
     fn test_finding(
         id: &str,
@@ -55,13 +62,26 @@ mod tests {
         }
     }
 
+    fn parse_json(scan_result: &ScanResult) -> Value {
+        serde_json::from_str(&scan_result_json(scan_result)).expect("exported JSON should parse")
+    }
+
     #[test]
     fn emits_valid_scan_result_shape() {
-        let json = scan_result_json(&ScanResult::default());
+        let json = parse_json(&ScanResult::default());
+        let root = json
+            .as_object()
+            .expect("scan_result_json should return a JSON object");
 
-        assert!(json.contains("\"findings\": []"));
-        assert!(json.contains("\"score_report\":"));
-        assert!(json.contains("\"metadata\":"));
+        assert!(root.contains_key("findings"));
+        assert!(root.contains_key("score_report"));
+        assert!(root.contains_key("metadata"));
+        assert!(json["findings"].is_array());
+        assert!(json["score_report"]["overall"].is_number());
+        assert!(json["score_report"]["axis_scores"].is_object());
+        assert!(json["score_report"]["severity_counts"].is_object());
+        assert!(json["metadata"]["adapters"].is_object());
+        assert!(json["metadata"]["warnings"].is_array());
     }
 
     #[test]
@@ -109,5 +129,98 @@ mod tests {
         assert!(json.contains("\"source\": \"native_compose\""));
         assert!(json.contains("\"source\": \"trivy\""));
         assert!(json.contains("\"source\": \"lynis\""));
+    }
+
+    #[test]
+    fn preserves_key_metadata_and_adapter_contract_fields() {
+        let mut adapters = BTreeMap::new();
+        adapters.insert(String::from("trivy"), AdapterStatus::Available);
+        adapters.insert(
+            String::from("lynis"),
+            AdapterStatus::Failed(String::from("command crashed")),
+        );
+        adapters.insert(
+            String::from("dockle"),
+            AdapterStatus::Skipped(String::from("no image targets")),
+        );
+
+        let result = ScanResult {
+            findings: vec![test_finding(
+                "service.public_binding",
+                Scope::Service,
+                Source::NativeCompose,
+                "web",
+                Some("web"),
+            )],
+            metadata: ScanMetadata {
+                scan_mode: ScanMode::Live,
+                compose_root: Some(PathBuf::from("/srv/demo")),
+                compose_file: Some(PathBuf::from("/srv/demo/compose.yaml")),
+                host_root: Some(PathBuf::from("/")),
+                host_runtime: Some(HostRuntimeInfo {
+                    hostname: Some(String::from("demo-host")),
+                    docker_version: Some(String::from("28.0.1")),
+                    uptime: Some(String::from("2d 1h 4m")),
+                    load_average: Some(String::from("0.21 0.19 0.17")),
+                    fail2ban: DefensiveControlStatus::Enabled,
+                    fail2ban_jails: Some(3),
+                    fail2ban_banned_ips: Some(0),
+                }),
+                loaded_files: vec![
+                    PathBuf::from("/srv/demo/compose.yaml"),
+                    PathBuf::from("/srv/demo/compose.override.yaml"),
+                ],
+                service_count: 1,
+                services: vec![ServiceSummary {
+                    name: String::from("web"),
+                    image: Some(String::from("nginx:1.27.5")),
+                }],
+                discovered_projects: vec![DiscoveredProjectSummary {
+                    name: String::from("demo"),
+                    source: String::from("docker"),
+                    compose_path: Some(PathBuf::from("/srv/demo/compose.yaml")),
+                    working_dir: Some(PathBuf::from("/srv/demo")),
+                    service_count: 1,
+                }],
+                docker_status: Some(DockerDiscoveryStatus::Failed(String::from(
+                    "permission denied",
+                ))),
+                warnings: vec![String::from("discovery fallback was used")],
+                adapters,
+            },
+            ..Default::default()
+        };
+
+        let json = parse_json(&result);
+
+        assert_eq!(json["metadata"]["scan_mode"], "live");
+        assert_eq!(json["metadata"]["compose_root"], "/srv/demo");
+        assert_eq!(json["metadata"]["compose_file"], "/srv/demo/compose.yaml");
+        assert_eq!(json["metadata"]["host_root"], "/");
+        assert_eq!(json["metadata"]["service_count"], 1);
+        assert_eq!(json["metadata"]["services"][0]["name"], "web");
+        assert_eq!(json["metadata"]["services"][0]["image"], "nginx:1.27.5");
+        assert_eq!(json["metadata"]["docker_status"]["state"], "failed");
+        assert_eq!(
+            json["metadata"]["docker_status"]["detail"],
+            "permission denied"
+        );
+        assert_eq!(json["metadata"]["adapters"]["trivy"]["state"], "available");
+        assert_eq!(json["metadata"]["adapters"]["lynis"]["state"], "failed");
+        assert_eq!(
+            json["metadata"]["adapters"]["lynis"]["detail"],
+            "command crashed"
+        );
+        assert_eq!(json["metadata"]["adapters"]["dockle"]["state"], "skipped");
+        assert_eq!(
+            json["metadata"]["adapters"]["dockle"]["detail"],
+            "no image targets"
+        );
+        assert_eq!(json["findings"][0]["id"], "service.public_binding");
+        assert_eq!(json["findings"][0]["scope"], "service");
+        assert_eq!(json["findings"][0]["source"], "native_compose");
+        assert_eq!(json["findings"][0]["evidence"]["subject"], "web");
+        assert!(json["score_report"]["axis_scores"]["sensitive_data"].is_number());
+        assert!(json["score_report"]["severity_counts"]["critical"].is_number());
     }
 }


### PR DESCRIPTION
## Summary
- strengthen JSON export regression checks by asserting parsed contract fields for top-level and critical nested metadata
- add adapter availability-path tests for Trivy and Lynis (missing, failed, available) and complete Dockle with an explicit available-path check
- add scan-metadata regression test for adapter status transitions and warning propagation (missing/failed/skipped)

## Validation
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace export::tests:: -- --nocapture
- cargo test --workspace adapters::trivy::tests:: -- --nocapture
- cargo test --workspace adapters::lynis::tests:: -- --nocapture
- cargo test --workspace adapters::dockle::tests:: -- --nocapture
- cargo test --workspace app::scan::tests::adapter_status_transitions_and_warnings_are_recorded -- --nocapture
- cargo test --workspace --quiet

Closes #138