### PR TITLE
feat(host): broaden hardening signal coverage

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -393,6 +393,11 @@ finding:
       description: "%{path} enables PermitUserEnvironment yes."
       why: "Allowing SSH users to inject environment variables can weaken restricted command setups and create unexpected execution paths after login."
       fix: "Set PermitUserEnvironment no unless you have a narrow, reviewed need for user-managed SSH environment files."
+    ssh_x11_forwarding:
+      title: "SSH X11 forwarding is enabled"
+      description: "%{path} enables X11Forwarding yes."
+      why: "X11 forwarding widens SSH session attack surface and can leak display/session trust boundaries from client systems to remote hosts."
+      fix: "Set X11Forwarding no unless remote GUI forwarding is a reviewed requirement, and prefer safer alternatives when possible."
     docker_socket_world_writable:
       title: "Docker socket is world writable"
       description: "%{path} is writable by all local users with mode %{mode}."
@@ -433,11 +438,21 @@ finding:
       description: "%{path} shows UFW is present but ENABLED is set to no."
       why: "A host firewall helps narrow inbound exposure and makes it harder for accidentally published services to become reachable."
       fix: "Enable UFW, review the default policy, and allow only the ports you intentionally expose."
+    ufw_default_input_policy_accept:
+      title: "UFW default incoming policy is ACCEPT"
+      description: "%{path} sets DEFAULT_INPUT_POLICY to %{policy}."
+      why: "An ACCEPT default policy can leave newly exposed services reachable before explicit firewall rules are reviewed."
+      fix: "Set DEFAULT_INPUT_POLICY to DROP (or REJECT), then explicitly allow only the inbound ports you intend to expose."
     unattended_upgrades_disabled:
       title: "Automatic security updates are disabled"
       description: "%{path} disables unattended-upgrades."
       why: "Missing security updates can leave known vulnerabilities unpatched longer than intended."
       fix: "Enable unattended-upgrades (or an equivalent patching workflow) so security fixes are applied regularly."
+    package_lists_auto_update_disabled:
+      title: "Automatic package list refresh is disabled"
+      description: "%{path} disables APT::Periodic::Update-Package-Lists."
+      why: "Outdated package indexes can delay security patch visibility and weaken automated patching expectations."
+      fix: "Enable periodic package list refresh or run an equivalent scheduled update workflow before unattended upgrades run."
   vaultwarden:
     signups_enabled:
       title: "Vaultwarden signups are left enabled"

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -313,16 +313,31 @@ finding:
       why: "메이저 전용 태그도 마이너/패치 업데이트로 이동해 동작 변화를 유발할 수 있습니다."
       fix: "예측 가능한 롤아웃을 위해 최소 마이너 또는 패치 버전까지 고정하세요."
   host:
+    ssh_x11_forwarding:
+      title: "SSH X11 포워딩이 활성화되어 있습니다"
+      description: "%{path}에서 X11Forwarding yes가 설정되어 있습니다."
+      why: "X11 포워딩은 SSH 세션 공격 표면을 넓히고 클라이언트의 디스플레이/세션 신뢰 경계를 원격 호스트까지 확장시킬 수 있습니다."
+      fix: "원격 GUI 포워딩이 검토된 요구사항이 아니라면 X11Forwarding을 no로 설정하고, 가능한 경우 더 안전한 대안을 사용하세요."
     ufw_disabled:
       title: "UFW가 설치되어 있지만 비활성화되어 있습니다"
       description: "%{path}에서 UFW가 존재하지만 ENABLED가 no로 설정되어 있습니다."
       why: "호스트 방화벽은 인바운드 노출을 줄이고, 실수로 공개된 서비스가 외부에서 접근 가능해지는 위험을 낮춥니다."
       fix: "UFW를 활성화하고 기본 정책을 검토한 뒤, 의도적으로 노출하는 포트만 허용하세요."
+    ufw_default_input_policy_accept:
+      title: "UFW 기본 인바운드 정책이 ACCEPT입니다"
+      description: "%{path}에서 DEFAULT_INPUT_POLICY가 %{policy}로 설정되어 있습니다."
+      why: "기본 정책이 ACCEPT이면 명시적 방화벽 규칙을 검토하기 전에 새로 노출된 서비스가 외부에서 접근 가능해질 수 있습니다."
+      fix: "DEFAULT_INPUT_POLICY를 DROP(또는 REJECT)으로 설정하고, 의도적으로 노출할 인바운드 포트만 명시적으로 허용하세요."
     unattended_upgrades_disabled:
       title: "자동 보안 업데이트가 비활성화되어 있습니다"
       description: "%{path}에서 unattended-upgrades가 비활성화되어 있습니다."
       why: "보안 업데이트가 적용되지 않으면 알려진 취약점이 의도보다 오래 방치될 수 있습니다."
       fix: "unattended-upgrades(또는 동등한 패치 워크플로)를 활성화해 보안 수정이 정기적으로 적용되도록 하세요."
+    package_lists_auto_update_disabled:
+      title: "패키지 목록 자동 갱신이 비활성화되어 있습니다"
+      description: "%{path}에서 APT::Periodic::Update-Package-Lists가 비활성화되어 있습니다."
+      why: "패키지 인덱스가 오래되면 보안 패치 가시성이 늦어지고 자동 패치 워크플로의 신뢰성이 떨어질 수 있습니다."
+      fix: "unattended-upgrades 실행 전에 정기 패키지 목록 갱신을 활성화하거나 동등한 스케줄 업데이트 절차를 사용하세요."
   nextcloud:
     insecure_overwriteprotocol:
       title: "Nextcloud overwrite protocol이 HTTP로 설정되어 있습니다"

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -16,8 +16,11 @@ const SSH_CONFIG_PATH: &str = "etc/ssh/sshd_config";
 const DOCKER_DAEMON_CONFIG_PATH: &str = "etc/docker/daemon.json";
 const DOCKER_SOCKET_PATH: &str = "var/run/docker.sock";
 const UFW_CONFIG_PATH: &str = "etc/ufw/ufw.conf";
+const UFW_DEFAULT_POLICY_PATH: &str = "etc/default/ufw";
 const UFW_INSTALL_MARKERS: [&str; 3] = ["etc/ufw/ufw.conf", "usr/sbin/ufw", "usr/bin/ufw"];
 const APT_AUTO_UPGRADES_CONFIG_PATH: &str = "etc/apt/apt.conf.d/20auto-upgrades";
+const APT_PERIODIC_UNATTENDED_UPGRADE_KEY: &str = "APT::Periodic::Unattended-Upgrade";
+const APT_PERIODIC_UPDATE_PACKAGE_LISTS_KEY: &str = "APT::Periodic::Update-Package-Lists";
 const FAIL2BAN_INSTALL_MARKERS: [&str; 6] = [
     "etc/fail2ban",
     "usr/bin/fail2ban-client",
@@ -252,6 +255,28 @@ fn scan_ssh_hardening(context: &HostContext) -> Vec<Finding> {
         ));
     }
 
+    if let Some(setting) = settings.get("x11forwarding")
+        && setting.value == "yes"
+    {
+        let subject_path = &setting.source;
+        findings.push(host_finding(
+            "host.ssh_x11_forwarding_enabled",
+            Severity::Medium,
+            subject_path,
+            HostFindingText {
+                title: t!("finding.host.ssh_x11_forwarding.title").into_owned(),
+                description: t!(
+                    "finding.host.ssh_x11_forwarding.description",
+                    path = subject_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.ssh_x11_forwarding.why").into_owned(),
+                how_to_fix: t!("finding.host.ssh_x11_forwarding.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("path"), subject_path.display().to_string())]),
+        ));
+    }
+
     findings
 }
 
@@ -388,41 +413,62 @@ fn scan_firewall_hardening(context: &HostContext) -> Vec<Finding> {
         return Vec::new();
     }
 
-    let Some(config_path) = resolve_existing_path(&context.root, UFW_CONFIG_PATH) else {
-        return Vec::new();
-    };
+    let mut findings = Vec::new();
 
-    let Ok(config_text) = fs::read_to_string(&config_path) else {
-        return Vec::new();
-    };
-
-    let Some(enabled) = parse_ufw_enabled(&config_text) else {
-        return Vec::new();
-    };
-
-    if enabled {
-        return Vec::new();
+    if let Some(config_path) = resolve_existing_path(&context.root, UFW_CONFIG_PATH)
+        && let Ok(config_text) = fs::read_to_string(&config_path)
+        && let Some(enabled) = parse_ufw_enabled(&config_text)
+        && !enabled
+    {
+        findings.push(host_finding(
+            "host.ufw_installed_but_disabled",
+            Severity::Medium,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.ufw_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.ufw_disabled.description",
+                    path = config_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.ufw_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.ufw_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), config_path.display().to_string()),
+                (String::from("enabled"), String::from("no")),
+            ]),
+        ));
     }
 
-    vec![host_finding(
-        "host.ufw_installed_but_disabled",
-        Severity::Medium,
-        &config_path,
-        HostFindingText {
-            title: t!("finding.host.ufw_disabled.title").into_owned(),
-            description: t!(
-                "finding.host.ufw_disabled.description",
-                path = config_path.display().to_string()
-            )
-            .into_owned(),
-            why_risky: t!("finding.host.ufw_disabled.why").into_owned(),
-            how_to_fix: t!("finding.host.ufw_disabled.fix").into_owned(),
-        },
-        BTreeMap::from([
-            (String::from("path"), config_path.display().to_string()),
-            (String::from("enabled"), String::from("no")),
-        ]),
-    )]
+    if let Some(defaults_path) = resolve_existing_path(&context.root, UFW_DEFAULT_POLICY_PATH)
+        && let Ok(defaults_text) = fs::read_to_string(&defaults_path)
+        && let Some(policy) = parse_ufw_default_input_policy(&defaults_text)
+        && policy.eq_ignore_ascii_case("accept")
+    {
+        findings.push(host_finding(
+            "host.ufw_default_input_policy_accept",
+            Severity::Medium,
+            &defaults_path,
+            HostFindingText {
+                title: t!("finding.host.ufw_default_input_policy_accept.title").into_owned(),
+                description: t!(
+                    "finding.host.ufw_default_input_policy_accept.description",
+                    path = defaults_path.display().to_string(),
+                    policy = policy.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.ufw_default_input_policy_accept.why").into_owned(),
+                how_to_fix: t!("finding.host.ufw_default_input_policy_accept.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), defaults_path.display().to_string()),
+                (String::from("policy"), policy),
+            ]),
+        ));
+    }
+
+    findings
 }
 
 fn scan_package_update_hardening(context: &HostContext) -> Vec<Finding> {
@@ -435,33 +481,60 @@ fn scan_package_update_hardening(context: &HostContext) -> Vec<Finding> {
         return Vec::new();
     };
 
-    let Some(enabled) = parse_unattended_upgrades_enabled(&config_text) else {
-        return Vec::new();
-    };
+    let mut findings = Vec::new();
 
-    if enabled {
-        return Vec::new();
+    if let Some(enabled) = parse_unattended_upgrades_enabled(&config_text)
+        && !enabled
+    {
+        findings.push(host_finding(
+            "host.apt_unattended_upgrades_disabled",
+            Severity::Medium,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.unattended_upgrades_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.unattended_upgrades_disabled.description",
+                    path = config_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.unattended_upgrades_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.unattended_upgrades_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), config_path.display().to_string()),
+                (String::from("unattended_upgrade"), String::from("disabled")),
+            ]),
+        ));
     }
 
-    vec![host_finding(
-        "host.apt_unattended_upgrades_disabled",
-        Severity::Medium,
-        &config_path,
-        HostFindingText {
-            title: t!("finding.host.unattended_upgrades_disabled.title").into_owned(),
-            description: t!(
-                "finding.host.unattended_upgrades_disabled.description",
-                path = config_path.display().to_string()
-            )
-            .into_owned(),
-            why_risky: t!("finding.host.unattended_upgrades_disabled.why").into_owned(),
-            how_to_fix: t!("finding.host.unattended_upgrades_disabled.fix").into_owned(),
-        },
-        BTreeMap::from([
-            (String::from("path"), config_path.display().to_string()),
-            (String::from("unattended_upgrade"), String::from("disabled")),
-        ]),
-    )]
+    if let Some(enabled) = parse_package_lists_auto_update_enabled(&config_text)
+        && !enabled
+    {
+        findings.push(host_finding(
+            "host.apt_package_lists_auto_update_disabled",
+            Severity::Low,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.package_lists_auto_update_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.package_lists_auto_update_disabled.description",
+                    path = config_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.package_lists_auto_update_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.package_lists_auto_update_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), config_path.display().to_string()),
+                (
+                    String::from("update_package_lists"),
+                    String::from("disabled"),
+                ),
+            ]),
+        ));
+    }
+
+    findings
 }
 
 fn detect_ufw_installed(root: &Path) -> bool {
@@ -493,16 +566,47 @@ fn parse_ufw_enabled(text: &str) -> Option<bool> {
     None
 }
 
-fn parse_unattended_upgrades_enabled(text: &str) -> Option<bool> {
-    const UNATTENDED_UPGRADE_KEY: &str = "APT::Periodic::Unattended-Upgrade";
-
+fn parse_ufw_default_input_policy(text: &str) -> Option<String> {
     for raw_line in text.lines() {
-        let line = strip_apt_comments(raw_line);
-        if line.is_empty() || !line.contains(UNATTENDED_UPGRADE_KEY) {
+        let line = strip_ini_comments(raw_line);
+        if line.is_empty() {
             continue;
         }
 
-        let (_, value) = line.split_once(UNATTENDED_UPGRADE_KEY)?;
+        let Some((key, value)) = parse_ini_key_value(line) else {
+            continue;
+        };
+        if !key.eq_ignore_ascii_case("DEFAULT_INPUT_POLICY") {
+            continue;
+        }
+
+        let policy = value.trim_matches('"').trim_matches('\'').trim();
+        if policy.is_empty() {
+            continue;
+        }
+
+        return Some(policy.to_ascii_uppercase());
+    }
+
+    None
+}
+
+fn parse_unattended_upgrades_enabled(text: &str) -> Option<bool> {
+    parse_apt_periodic_bool(text, APT_PERIODIC_UNATTENDED_UPGRADE_KEY)
+}
+
+fn parse_package_lists_auto_update_enabled(text: &str) -> Option<bool> {
+    parse_apt_periodic_bool(text, APT_PERIODIC_UPDATE_PACKAGE_LISTS_KEY)
+}
+
+fn parse_apt_periodic_bool(text: &str, key: &str) -> Option<bool> {
+    for raw_line in text.lines() {
+        let line = strip_apt_comments(raw_line);
+        if line.is_empty() || !line.contains(key) {
+            continue;
+        }
+
+        let (_, value) = line.split_once(key)?;
         let value = value
             .trim()
             .trim_start_matches('=')
@@ -1359,6 +1463,22 @@ mod tests {
     }
 
     #[test]
+    fn reports_ssh_x11_forwarding_when_enabled() {
+        let root = temp_host_root("ssh-x11-forwarding");
+        write_file(&root.join(SSH_CONFIG_PATH), "X11Forwarding yes\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.ssh_x11_forwarding_enabled")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
     fn parse_sshd_config_honors_include_globs_and_tracks_effective_source() {
         let root = temp_host_root("sshd-include-abs");
         let config_path = root.join(SSH_CONFIG_PATH);
@@ -1503,6 +1623,48 @@ mod tests {
     }
 
     #[test]
+    fn reports_ufw_default_input_policy_accept() {
+        let root = temp_host_root("ufw-default-accept");
+        write_file(&root.join("usr/sbin/ufw"), "");
+        write_file(&root.join(UFW_CONFIG_PATH), "ENABLED=yes\n");
+        write_file(
+            &root.join(UFW_DEFAULT_POLICY_PATH),
+            "DEFAULT_INPUT_POLICY=\"ACCEPT\"\n",
+        );
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.ufw_default_input_policy_accept")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn does_not_report_ufw_default_policy_when_drop() {
+        let root = temp_host_root("ufw-default-drop");
+        write_file(&root.join("usr/sbin/ufw"), "");
+        write_file(&root.join(UFW_CONFIG_PATH), "ENABLED=yes\n");
+        write_file(
+            &root.join(UFW_DEFAULT_POLICY_PATH),
+            "DEFAULT_INPUT_POLICY=\"DROP\"\n",
+        );
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .all(|finding| finding.id != "host.ufw_default_input_policy_accept")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
     fn does_not_report_ufw_when_enabled() {
         let root = temp_host_root("ufw-enabled");
         write_file(&root.join(UFW_CONFIG_PATH), "ENABLED=yes\n");
@@ -1541,6 +1703,33 @@ mod tests {
     }
 
     #[test]
+    fn reports_package_list_auto_updates_when_disabled() {
+        let root = temp_host_root("apt-package-lists-disabled");
+        write_file(
+            &root.join(APT_AUTO_UPGRADES_CONFIG_PATH),
+            concat!(
+                "APT::Periodic::Update-Package-Lists \"0\";\n",
+                "APT::Periodic::Unattended-Upgrade \"1\";\n"
+            ),
+        );
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.apt_package_lists_auto_update_disabled")
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|finding| finding.id != "host.apt_unattended_upgrades_disabled")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
     fn unattended_upgrades_parser_handles_common_formats() {
         assert_eq!(
             parse_unattended_upgrades_enabled("APT::Periodic::Unattended-Upgrade \"1\";"),
@@ -1556,6 +1745,30 @@ mod tests {
         );
         assert_eq!(
             parse_unattended_upgrades_enabled("APT::Periodic::Update-Package-Lists \"1\";"),
+            None
+        );
+        assert_eq!(
+            parse_package_lists_auto_update_enabled("APT::Periodic::Update-Package-Lists \"1\";"),
+            Some(true)
+        );
+        assert_eq!(
+            parse_package_lists_auto_update_enabled("APT::Periodic::Update-Package-Lists 0;"),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn ufw_default_input_policy_parser_handles_common_formats() {
+        assert_eq!(
+            parse_ufw_default_input_policy("DEFAULT_INPUT_POLICY=\"ACCEPT\""),
+            Some(String::from("ACCEPT"))
+        );
+        assert_eq!(
+            parse_ufw_default_input_policy("DEFAULT_INPUT_POLICY='DROP'"),
+            Some(String::from("DROP"))
+        );
+        assert_eq!(
+            parse_ufw_default_input_policy("DEFAULT_INPUT_POLICY="),
             None
         );
     }


### PR DESCRIPTION
## Summary
- add three practical host-hardening detections across SSH, firewall, and update hygiene
- SSH: detect X11 forwarding enabled (host.ssh_x11_forwarding_enabled)
- Firewall: detect UFW default incoming policy set to ACCEPT (host.ufw_default_input_policy_accept)
- Updates: detect disabled periodic package list refresh (host.apt_package_lists_auto_update_disabled)
- keep host remediation guidance-only behavior (no host auto-write)
- add host parser/scanner regression tests for new checks and parser edge cases
- add en/ko i18n text for new host findings

## Validation
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace host::tests:: -- --nocapture
- cargo test --workspace i18n::tests::korean_locale_translates_cli_and_tui_strings -- --nocapture
- cargo test --workspace --quiet

Closes #136
