### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "crossterm 0.29.0",
  "dialoguer",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary
- bump crate/binary version in src/Cargo.toml from 0.2.0 to 0.3.0
- align Cargo.lock package version for hostveil to 0.3.0

## Validation
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --quiet
- HOSTVEIL_LOCALE=en ./scripts/smoke-test.sh target/debug/hostveil
- HOSTVEIL_LOCALE=en ./scripts/test-install-script.sh target/debug/hostveil
