### PR TITLE
feat(ux): add explicit locale controls and clearer interactive guidance

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -168,6 +168,8 @@ jobs:
             hostveil setup
             ```
 
+            Locale defaults to English for terminal safety. Use `hostveil --locale ko ...`, `HOSTVEIL_LOCALE=ko hostveil ...`, or press `g` in the TUI for an explicit switch.
+
             ## Upgrade
             ```sh
             hostveil upgrade
@@ -200,7 +202,6 @@ jobs:
 
             ## Known limitations
             - Linux only
-            - TUI-embedded guided diff review is still deferred from the current release scope
           files: |
             dist/*.tar.gz
             dist/SHA256SUMS

--- a/README.ko.md
+++ b/README.ko.md
@@ -115,6 +115,10 @@ curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/instal
 hostveil setup
 ```
 
+터미널 호환성을 위해 기본 locale은 항상 영어입니다. 한국어로 명시적으로 바꾸려면 `hostveil --locale ko ...` 또는 `HOSTVEIL_LOCALE=ko hostveil ...`를 사용하고, TUI 안에서는 `g` 키로 영어/한국어를 전환할 수 있습니다.
+
+대화형 setup은 입력 전에 선택 조작 안내를 먼저 보여주며, 확인 프롬프트는 기본값이 `Y/n` 형식입니다.
+
 무인 설치에서는 bootstrap 단계에서 설치할 도구를 명시할 수 있습니다.
 
 ```sh
@@ -179,6 +183,7 @@ hostveil은 현재 초기 개발 단계입니다. 구현은 두 단계로 계획
 - `src/` 아래 활성 Rust crate 골격 생성 완료
 - `rust-toolchain.toml`로 stable toolchain 고정
 - `ratatui` + `crossterm` 기반 TUI 부트스트랩과 `rust-i18n` 연결 완료
+- 영어 기본값 + 명시적 locale override(`--locale`, `HOSTVEIL_LOCALE`) + TUI 내 `g` 전환 경로 추가
 - 일반화된 Rust scan result 모델과 최소 JSON export 경로 동작
 - override 병합과 정규화를 포함한 Compose parser 포팅 및 parity 테스트 추가
 - 기본 Compose 규칙 엔진과 점수화 모델을 Rust로 일부 포팅하고 fixture 테스트로 검증

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Run the setup flow again later:
 hostveil setup
 ```
 
+Locale defaults to English for terminal safety, even if the host locale is non-English. Use `hostveil --locale ko ...` or `HOSTVEIL_LOCALE=ko hostveil ...` for an explicit override, and press `g` inside the TUI to switch between English and Korean.
+
+Interactive setup explains the selector controls before input starts, and its confirmation prompts use a default-yes `Y/n` flow.
+
 For unattended installs, you can explicitly pick tools during bootstrap:
 
 ```sh
@@ -230,6 +234,7 @@ Current release priorities:
 - Linux-only scope with clear known limitations
 - Native Compose and host checks through one shared scan result
 - TUI overview plus finding detail navigation for real scan results
+- Explicit locale control with English-by-default terminal behavior and in-TUI language switching
 - Minimal headless JSON export for automation and regression snapshots
 - Previewable Compose `--quick-fix` and `--fix` flows with backup-safe writes
 - Release artifacts published through GitHub Releases with checksums
@@ -239,9 +244,8 @@ Current release priorities:
 Explicitly deferred from the current early-release scope:
 
 - Additional optional adapters beyond Trivy, Lynis, and Dockle
-- TUI-embedded guided diff review before writes
 - Package-manager distribution such as apt, dnf, Homebrew, or AUR
-- Final scoring ADR and stable weighting guarantees
+- Stable scoring-weight guarantees across future releases
 
 Optional dependency policy for current releases:
 

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -14,6 +14,9 @@ app:
     live_docker_denied: "Live scan: Docker permission denied, host-only mode"
     live_docker_failed: "Live scan: Docker discovery failed, host-only mode"
   help:
+    usage: "Usage"
+    lifecycle: "Lifecycle"
+    options: "Options"
     text: |
       hostveil
 
@@ -49,6 +52,7 @@ app:
         --fix PATH        preview or apply safe and guided Compose review changes for a specific file or directory
         --preview-changes show the planned diff without writing any files
         --yes             apply the reviewed changes without an interactive confirmation prompt
+        --locale LANG     use an explicit locale for this run (supported: en, ko)
         --json            emit scan result JSON instead of launching the TUI
         -V, --version     show version information
         -h, --help        show this help message
@@ -66,14 +70,15 @@ app:
     detail_scroll_compact: "Up/Down, j/k, PgUp/PgDn scroll"
     back_overview: "Press q or Esc to return to the overview"
     back_overview_compact: "q or Esc back"
-    finding_controls: "Tab or Left/Right switch focus | s severity | x source | o sort | r reset | 1-4 jump | q or Esc back"
-    finding_controls_compact: "Tab/LR focus | s sev | x src | o sort | r reset | 1-4 jump | q back"
+    finding_controls: "Tab or Left/Right switch focus | s severity | x source | o sort | r reset | 1-4 jump | g locale | q or Esc back"
+    finding_controls_compact: "Tab/LR focus | s sev | x src | o sort | r reset | 1-4 jump | g lang | q back"
     fix_review_scroll: "Use Up/Down or PgUp/PgDn to scroll the diff"
     fix_review_apply: "Press y or Enter to apply the reviewed changes"
     fix_review_cancel: "Press q or Esc to cancel"
   footer:
     quit: "quit"
     findings: "open findings"
+    locale: "switch locale"
     json: "export JSON"
   panel:
     status: "Status"
@@ -135,13 +140,48 @@ app:
     lynis_pentest_mode: "Lynis ran in unprivileged pentest mode; some root-only checks may be omitted."
     lynis_non_zero_exit: "Lynis exited with a non-zero status: %{detail}. Parsed the available report anyway."
     lynis_report_missing: "Lynis did not produce a report file."
+    scan_failed: "%{tool} scan failed for %{image}: %{error}"
+    json_parse_failed: "failed to parse %{tool} JSON: %{error}"
+    report_parse_failed: "failed to parse %{tool} report contents"
+    command_no_error_detail: "command returned no error detail"
+    scan_thread_panicked: "%{adapter} scan thread panicked"
+  discovery:
+    docker_cli_missing_fallback: "Docker CLI is not available; switching to fallback discovery."
+    docker_failed_fallback: "Docker discovery failed; switching to fallback discovery."
+    docker_failed_detail: "Docker discovery failed: %{detail}"
+    no_projects_current_dir: "No running Compose projects were discovered from Docker; checking the current directory."
+    recovered_missing_compose_path: "Docker metadata for discovered project %{project} still points to missing compose path %{compose_path}; recovered by scanning %{working_dir} instead."
+    missing_compose_path_and_fallback_failed: "Discovered project %{project} points to missing compose path %{compose_path} and fallback scan of %{working_dir} failed: %{error}"
+    missing_compose_path: "Discovered project %{project} points to missing compose path %{compose_path} from Docker metadata. Recreate or remove the containers to refresh the saved Compose labels."
+    parse_failed: "Failed to parse discovered project %{project}: %{error}"
+    no_compose_file_in_working_dir: "Discovered project %{project} did not expose a compose file path, and no compose file was found in %{working_dir}."
+    parse_failed_in_working_dir: "Failed to parse discovered project %{project} from working directory %{working_dir}: %{error}"
+    no_usable_compose_path: "Discovered project %{project} has no usable compose path."
+    current_dir_fallback_used: "Using the current directory as a Compose fallback because no running Compose project was discovered."
+    current_dir_fallback_failed: "Current-directory Compose fallback failed: %{error}"
+  score:
+    overall: "Overall"
+  validation:
+    auto_upgrade_mode_required: "choose one of enable or disable for auto-upgrade"
+    fix_requires_target: "a compose target is required for fix operations"
+    fix_host_root_not_supported: "--host-root is not supported with fix operations"
+    fix_compose_conflict: "use --quick-fix PATH or --fix PATH instead of combining them with --compose"
+    fix_json_not_supported: "--json is not supported with fix operations"
+    preview_yes_requires_fix_mode: "--preview-changes and --yes are only valid with --quick-fix or --fix"
+    fix_mode_conflict: "choose only one of --quick-fix or --fix"
+    unsupported_locale: "unsupported locale: %{value}"
+    duplicate_locale_override: "choose only one --locale override"
+    unsupported_setup_tool: "unsupported setup tool: %{value}"
+    setup_tools_required: "--tools requires at least one tool name"
   setup:
     heading: "hostveil setup"
     detected_os: "Detected OS: %{name}"
     selected_tools: "Selected tools: %{tools}"
     planned_changes: "Planned changes"
     prompt_tools: "Select the optional tools to install and configure"
-    prompt_confirm: "Apply this setup plan?"
+    prompt_tools_help: "Use Arrow keys to move, Space to toggle a tool, Enter to continue, and Esc to cancel."
+    prompt_confirm_default_yes: "Apply this setup plan? [Y/n]: "
+    prompt_invalid_yes_no: "Please answer Y or n."
     skipped: "Setup skipped. Run `hostveil setup` later to configure optional tools."
     requesting_sudo: "Requesting sudo access for package installation and system configuration..."
     running_step: "Running: %{step}"
@@ -150,6 +190,10 @@ app:
     check_failed: "%{command} could not be verified: %{detail}"
     error:
       unsupported_os: "hostveil setup does not yet support automatic dependency installation on"
+      requires_terminal_or_explicit_tools: "setup requires a terminal or explicit --tools/--tool selection; use --yes to accept the recommended defaults"
+      sudo_missing: "sudo is required for setup operations but was not found on PATH"
+      sudo_needs_terminal: "sudo needs a password but no interactive terminal is available"
+      sudo_credentials_failed: "failed to obtain sudo credentials: %{error}"
     step:
       dnf_install: "Install packages with dnf: %{packages}"
       apt_install: "Install packages with apt: %{packages}"
@@ -207,6 +251,7 @@ app:
     host_group: "Host"
     ok: "OK"
     none: "No grouped scan results yet."
+    total_findings: "Total: %{count} findings"
     single_finding: "1 finding"
     multi_findings: "%{count} findings"
     discovery_heading: "Discovery"
@@ -528,3 +573,5 @@ finding:
       description: "%{service} keeps NEXTCLOUD_ADMIN_USER and NEXTCLOUD_ADMIN_PASSWORD at default-like values."
       why: "Default bootstrap credentials are widely known and can be abused quickly if setup endpoints are reachable before hardening is complete."
       fix: "Use a unique admin username and strong random admin password during bootstrap, then rotate secrets through a safer external secret path."
+test:
+  fallback_probe: "English fallback probe"

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -52,6 +52,7 @@ app:
         --fix PATH        특정 파일 또는 디렉터리에 안전/가이드 Compose 변경을 미리보기 또는 적용합니다
         --preview-changes 파일을 쓰지 않고 예정된 diff를 표시합니다
         --yes             대화형 확인 없이 검토한 변경을 적용합니다
+        --locale LANG     이번 실행에 사용할 언어를 명시합니다 (지원: en, ko)
         --json            TUI 대신 스캔 결과 JSON을 출력합니다
         -V, --version     버전 정보를 표시합니다
         -h, --help        이 도움말을 표시합니다
@@ -69,14 +70,15 @@ app:
     detail_scroll_compact: "Up/Down, j/k, PgUp/PgDn 스크롤"
     back_overview: "q 또는 Esc를 눌러 개요로 돌아갑니다"
     back_overview_compact: "q 또는 Esc로 뒤로"
-    finding_controls: "Tab 또는 Left/Right 포커스 전환 | s 심각도 | x 소스 | o 정렬 | r 초기화 | 1-4 점프 | q 또는 Esc 뒤로"
-    finding_controls_compact: "Tab/LR 포커스 | s 심각도 | x 소스 | o 정렬 | r 초기화 | 1-4 점프 | q 뒤로"
+    finding_controls: "Tab 또는 Left/Right 포커스 전환 | s 심각도 | x 소스 | o 정렬 | r 초기화 | 1-4 점프 | g 언어 | q 또는 Esc 뒤로"
+    finding_controls_compact: "Tab/LR 포커스 | s 심각도 | x 소스 | o 정렬 | r 초기화 | 1-4 점프 | g 언어 | q 뒤로"
     fix_review_scroll: "Up/Down 또는 PgUp/PgDn으로 diff를 스크롤합니다"
     fix_review_apply: "y 또는 Enter를 눌러 검토한 변경을 적용합니다"
     fix_review_cancel: "q 또는 Esc를 눌러 취소합니다"
   footer:
     quit: "종료"
     findings: "발견 항목 열기"
+    locale: "언어 전환"
     json: "JSON 내보내기"
   panel:
     status: "상태"
@@ -138,13 +140,48 @@ app:
     lynis_pentest_mode: "Lynis가 비권한 pentest 모드로 실행되어 root 권한이 필요한 일부 점검이 생략될 수 있습니다."
     lynis_non_zero_exit: "Lynis가 비정상 종료 코드로 종료했습니다: %{detail}. 사용 가능한 보고서는 계속 파싱했습니다."
     lynis_report_missing: "Lynis가 보고서 파일을 생성하지 않았습니다."
+    scan_failed: "%{tool} 스캔이 %{image}에서 실패했습니다: %{error}"
+    json_parse_failed: "%{tool} JSON 파싱에 실패했습니다: %{error}"
+    report_parse_failed: "%{tool} 보고서 내용을 파싱하지 못했습니다"
+    command_no_error_detail: "명령에서 오류 상세를 반환하지 않았습니다"
+    scan_thread_panicked: "%{adapter} 스캔 스레드가 패닉으로 종료되었습니다"
+  discovery:
+    docker_cli_missing_fallback: "Docker CLI를 찾지 못해 fallback 탐색으로 전환합니다."
+    docker_failed_fallback: "Docker 탐색에 실패해 fallback 탐색으로 전환합니다."
+    docker_failed_detail: "Docker 탐색에 실패했습니다: %{detail}"
+    no_projects_current_dir: "Docker에서 실행 중인 Compose 프로젝트를 찾지 못해 현재 디렉터리를 확인합니다."
+    recovered_missing_compose_path: "발견된 프로젝트 %{project}의 Docker 메타데이터가 누락된 compose 경로 %{compose_path}를 가리키고 있어 %{working_dir}를 스캔해 복구했습니다."
+    missing_compose_path_and_fallback_failed: "발견된 프로젝트 %{project}가 누락된 compose 경로 %{compose_path}를 가리키고 있고, %{working_dir}에 대한 fallback 스캔도 실패했습니다: %{error}"
+    missing_compose_path: "발견된 프로젝트 %{project}가 Docker 메타데이터의 누락된 compose 경로 %{compose_path}를 가리킵니다. 저장된 Compose 라벨을 갱신하려면 컨테이너를 다시 만들거나 제거하세요."
+    parse_failed: "발견된 프로젝트 %{project}를 파싱하지 못했습니다: %{error}"
+    no_compose_file_in_working_dir: "발견된 프로젝트 %{project}가 compose 파일 경로를 노출하지 않았고, %{working_dir}에서도 compose 파일을 찾지 못했습니다."
+    parse_failed_in_working_dir: "작업 디렉터리 %{working_dir}에서 발견된 프로젝트 %{project}를 파싱하지 못했습니다: %{error}"
+    no_usable_compose_path: "발견된 프로젝트 %{project}에 사용할 수 있는 compose 경로가 없습니다."
+    current_dir_fallback_used: "실행 중인 Compose 프로젝트를 찾지 못해 현재 디렉터리를 Compose fallback으로 사용합니다."
+    current_dir_fallback_failed: "현재 디렉터리 Compose fallback에 실패했습니다: %{error}"
+  score:
+    overall: "전체"
+  validation:
+    auto_upgrade_mode_required: "auto-upgrade에는 enable 또는 disable 중 하나를 선택하세요"
+    fix_requires_target: "fix 작업에는 compose 대상이 필요합니다"
+    fix_host_root_not_supported: "fix 작업에서는 --host-root를 사용할 수 없습니다"
+    fix_compose_conflict: "--compose와 함께 쓰지 말고 --quick-fix PATH 또는 --fix PATH를 사용하세요"
+    fix_json_not_supported: "fix 작업에서는 --json을 사용할 수 없습니다"
+    preview_yes_requires_fix_mode: "--preview-changes와 --yes는 --quick-fix 또는 --fix와 함께 사용할 때만 유효합니다"
+    fix_mode_conflict: "--quick-fix와 --fix 중 하나만 선택하세요"
+    unsupported_locale: "지원하지 않는 언어입니다: %{value}"
+    duplicate_locale_override: "--locale override는 하나만 선택하세요"
+    unsupported_setup_tool: "지원하지 않는 setup 도구입니다: %{value}"
+    setup_tools_required: "--tools에는 최소 하나의 도구 이름이 필요합니다"
   setup:
     heading: "hostveil setup"
     detected_os: "감지된 OS: %{name}"
     selected_tools: "선택된 도구: %{tools}"
     planned_changes: "예정된 변경"
     prompt_tools: "설치하고 구성할 선택형 도구를 고르세요"
-    prompt_confirm: "이 setup 계획을 적용할까요?"
+    prompt_tools_help: "Arrow 키로 이동하고, Space로 도구를 선택 또는 해제하고, Enter로 진행하고, Esc로 취소하세요."
+    prompt_confirm_default_yes: "이 setup 계획을 적용할까요? [Y/n]: "
+    prompt_invalid_yes_no: "Y 또는 n으로 답해주세요."
     skipped: "Setup을 건너뛰었습니다. 나중에 `hostveil setup`으로 다시 구성하세요."
     requesting_sudo: "패키지 설치와 시스템 구성을 위해 sudo 권한을 요청합니다..."
     running_step: "실행 중: %{step}"
@@ -153,6 +190,10 @@ app:
     check_failed: "%{command} 검증에 실패했습니다: %{detail}"
     error:
       unsupported_os: "hostveil setup은 아직 자동 의존성 설치를 지원하지 않습니다:"
+      requires_terminal_or_explicit_tools: "setup에는 터미널이 필요합니다. 또는 --tools/--tool로 명시적으로 선택하고, 추천 기본값을 수락하려면 --yes를 사용하세요"
+      sudo_missing: "setup 작업에는 sudo가 필요하지만 PATH에서 찾지 못했습니다"
+      sudo_needs_terminal: "sudo에 비밀번호가 필요하지만 대화형 터미널을 사용할 수 없습니다"
+      sudo_credentials_failed: "sudo 자격 증명을 얻지 못했습니다: %{error}"
     step:
       dnf_install: "dnf로 패키지 설치: %{packages}"
       apt_install: "apt로 패키지 설치: %{packages}"
@@ -210,6 +251,7 @@ app:
     host_group: "호스트"
     ok: "정상"
     none: "그룹화된 스캔 결과가 없습니다."
+    total_findings: "총 발견 항목: %{count}개"
     single_finding: "발견 항목 1개"
     multi_findings: "발견 항목 %{count}개"
     discovery_heading: "탐색"
@@ -312,12 +354,130 @@ finding:
       description: "%{service}가 메이저 버전만 고정된 %{image}를 사용합니다."
       why: "메이저 전용 태그도 마이너/패치 업데이트로 이동해 동작 변화를 유발할 수 있습니다."
       fix: "예측 가능한 롤아웃을 위해 최소 마이너 또는 패치 버전까지 고정하세요."
+  exposure:
+    public_bind:
+      title: "서비스가 공개 인터페이스에 게시되어 있습니다"
+      description: "%{service}가 공개 접근 가능한 호스트 인터페이스에 %{port}를 게시합니다."
+      why: "공개 바인딩은 공격 표면을 넓히고, 더 안전한 localhost 전용 또는 리버스 프록시 구성을 우회할 수 있습니다."
+      fix: "서비스가 정말 직접 외부 접근이 필요하지 않다면 포트를 127.0.0.1에 바인딩하세요."
+    admin_public:
+      title: "관리 인터페이스가 공개 노출되어 있습니다"
+      description: "%{service}가 %{port}에서 관리 인터페이스를 노출합니다."
+      why: "공개된 관리 패널은 무차별 대입, 열거, 취약점 공격의 고가치 표적입니다."
+      fix: "관리 인터페이스를 사설 네트워크 뒤에 두거나 인증이 있는 리버스 프록시 뒤로 이동하세요."
+    reverse_proxy:
+      title: "서비스는 리버스 프록시 뒤에 두는 편이 안전합니다"
+      description: "%{service}는 보통 리버스 프록시 뒤에 둘 때 더 안전하지만, 현재 %{port}에 직접 게시되어 있습니다."
+      why: "사용자 대상 앱을 직접 공개하면 TLS, 인증 하드닝, 접근 제어를 놓치기 쉬워집니다."
+      fix: "가능한 경우 서비스를 리버스 프록시를 통해 노출하고 직접 공개 포트는 제거하세요."
+  permissions:
+    privileged:
+      title: "컨테이너가 privileged 모드로 실행됩니다"
+      description: "%{service}가 privileged 모드를 활성화합니다."
+      why: "privileged 컨테이너는 광범위한 커널/디바이스 접근 권한을 가져 탈출 시 영향이 크게 증가합니다."
+      fix: "privileged 모드를 제거하고 서비스에 실제로 필요한 최소 capability만 부여하세요."
+    root:
+      title: "컨테이너가 root로 실행됩니다"
+      description: "%{service}가 root로 실행되도록 구성되어 있습니다."
+      why: "root 컨테이너가 침해되면 영향 범위가 더 커지고 호스트 탈출도 더 위험해집니다."
+      fix: "지원되는 경우 non-root UID/GID로 서비스를 실행하도록 구성하세요."
+    implicit_root:
+      title: "컨테이너에 user 설정이 없습니다"
+      description: "%{service}가 user를 설정하지 않아 기본적으로 root로 실행될 가능성이 큽니다."
+      why: "많은 이미지는 기본값이 root이며, 이는 필요한 것보다 더 많은 파일시스템과 프로세스 접근 권한을 부여합니다."
+      fix: "이미지가 지원한다면 compose 파일에 명시적인 non-root user를 설정하세요."
+    host_network:
+      title: "컨테이너가 host 네트워킹을 사용합니다"
+      description: "%{service}가 network_mode: host를 사용합니다."
+      why: "host 네트워킹은 네트워크 격리를 제거하고 의도보다 더 많은 포트와 트래픽을 노출할 수 있습니다."
+      fix: "서비스에 강하고 문서화된 필요가 없는 한 bridge 네트워킹을 사용하세요."
+    sensitive_mount:
+      title: "컨테이너가 민감한 호스트 경로를 마운트합니다"
+      description: "%{service}가 민감한 호스트 경로 %{path}를 마운트합니다."
+      why: "민감한 호스트 경로를 마운트하면 시크릿, 호스트 제어 소켓, 광범위한 파일시스템 접근이 컨테이너에 노출될 수 있습니다."
+      fix: "마운트를 제거하거나 필요한 데이터만 노출하는 더 좁은 경로로 바꾸세요."
+  sensitive:
+    inline_secret:
+      title: "서비스가 환경 변수에 시크릿을 하드코딩합니다"
+      description: "%{service}가 민감한 변수 %{variable}를 environment에 직접 설정합니다."
+      why: "inline 시크릿은 버전 관리, 백업, 프로세스 조회를 통해 쉽게 유출될 수 있습니다."
+      fix: "시크릿을 Docker secrets, 외부 secret manager, 또는 버전 관리 밖의 보호된 env 파일로 옮기세요."
+    default_credential:
+      title: "서비스가 기본값 또는 빈 자격 증명을 사용합니다"
+      description: "%{service}가 %{variable}에 기본값 또는 빈 자격 증명을 설정합니다."
+      why: "기본 자격 증명은 널리 알려져 있으며 공격자가 가장 먼저 시도하는 경우가 많습니다."
+      fix: "고유한 시크릿 값을 설정하고 가능하면 compose 파일 밖에서 관리하세요."
+    env_file_secret:
+      title: "참조된 env 파일에 평문 시크릿이 들어 있습니다"
+      description: "%{service}가 평문 시크릿 값을 포함한 %{env_file}를 참조합니다."
+      why: "평문 env 파일은 적절한 보호 없이 백업, 셸, 저장소로 자주 복사됩니다."
+      fix: "시크릿을 Docker secrets로 옮기거나 env 파일을 보호하고 버전 관리에서 제외하세요."
   host:
+    ssh_root_login:
+      title: "SSH root 로그인이 활성화되어 있습니다"
+      description: "%{path}에서 PermitRootLogin %{value}로 root 로그인을 허용합니다."
+      why: "직접 root 로그인을 허용하면 공격자가 노릴 고가치 계정이 하나로 집중되고, 침해 후 추가 권한 경계도 사라집니다."
+      fix: "PermitRootLogin을 no로 설정하고, 관리 작업은 sudo가 가능한 non-root 계정으로 수행하세요."
+    ssh_password_auth:
+      title: "SSH 비밀번호 인증이 활성화되어 있습니다"
+      description: "%{path}에서 PasswordAuthentication yes를 활성화합니다."
+      why: "비밀번호 기반 SSH 로그인은 키 기반 인증보다 무차별 대입, 피싱, 재사용 공격에 더 취약합니다."
+      fix: "관리자가 SSH 키로 로그인할 수 있음을 확인한 뒤 PasswordAuthentication을 비활성화하세요."
+    ssh_empty_passwords:
+      title: "SSH가 빈 비밀번호를 허용합니다"
+      description: "%{path}에서 PermitEmptyPasswords yes를 활성화합니다."
+      why: "빈 비밀번호를 허용하면 로그인 가능한 계정 하나만 잘못 구성되어도 호스트가 매우 쉽게 침해될 수 있습니다."
+      fix: "PermitEmptyPasswords를 no로 설정하고 로컬 사용자 계정의 약하거나 누락된 자격 증명을 점검하세요."
+    ssh_pubkey_auth:
+      title: "SSH 공개키 인증이 비활성화되어 있습니다"
+      description: "%{path}에서 PubkeyAuthentication no를 설정합니다."
+      why: "공개키 인증을 끄면 관리자가 더 약한 비밀번호 기반 접근이나 감사하기 어려운 우회 수단에 의존하게 될 수 있습니다."
+      fix: "비밀번호 기반 SSH 로그인을 끄기 전에 PubkeyAuthentication을 yes로 설정하고 관리자 키를 등록하세요."
+    ssh_user_environment:
+      title: "SSH가 사용자 제어 환경 파일을 허용합니다"
+      description: "%{path}에서 PermitUserEnvironment yes를 활성화합니다."
+      why: "SSH 사용자가 환경 변수를 주입할 수 있으면 제한된 명령 구성이 약해지고 로그인 후 예기치 않은 실행 경로가 생길 수 있습니다."
+      fix: "좁고 검토된 필요가 없다면 PermitUserEnvironment를 no로 설정하세요."
     ssh_x11_forwarding:
       title: "SSH X11 포워딩이 활성화되어 있습니다"
       description: "%{path}에서 X11Forwarding yes가 설정되어 있습니다."
       why: "X11 포워딩은 SSH 세션 공격 표면을 넓히고 클라이언트의 디스플레이/세션 신뢰 경계를 원격 호스트까지 확장시킬 수 있습니다."
       fix: "원격 GUI 포워딩이 검토된 요구사항이 아니라면 X11Forwarding을 no로 설정하고, 가능한 경우 더 안전한 대안을 사용하세요."
+    docker_socket_world_writable:
+      title: "Docker 소켓이 world writable 상태입니다"
+      description: "%{path}가 mode %{mode}로 모든 로컬 사용자에게 쓰기 가능하게 열려 있습니다."
+      why: "Docker 소켓에 쓰기 가능한 사용자는 컨테이너를 제어할 수 있고, 종종 호스트에서 root에 준하는 접근을 얻게 됩니다."
+      fix: "소켓 접근을 root와 의도된 관리자 그룹으로 제한하고, 해당 그룹에 포함된 사용자를 점검하세요."
+    docker_socket_world_readable:
+      title: "Docker 소켓이 world readable 상태입니다"
+      description: "%{path}가 mode %{mode}로 모든 로컬 사용자에게 읽기 가능하게 열려 있습니다."
+      why: "광범위한 읽기 권한은 민감한 런타임/이미지 메타데이터를 유출할 수 있으며, Docker 소켓 접근 제어가 약하다는 신호일 수 있습니다."
+      fix: "소켓 권한을 root와 의도된 관리자 그룹으로 제한하세요."
+    docker_daemon_tcp_public:
+      title: "Docker 데몬이 TCP 리스너를 노출합니다"
+      description: "%{path}가 Docker가 non-local TCP host에 바인딩되도록 구성합니다."
+      why: "공개되거나 넓게 도달 가능한 Docker API는 강하게 보호되지 않으면 원격 컨테이너 제어와 호스트 침해로 이어질 수 있습니다."
+      fix: "TCP 리스너를 제거하거나 localhost에만 바인딩하고, 강한 인증과 네트워크 제한을 적용하세요."
+    docker_daemon_tcp_no_tlsverify:
+      title: "Docker TCP 리스너에 TLS 클라이언트 검증이 없습니다"
+      description: "%{path}가 tlsverify 없이 non-local TCP Docker host를 노출합니다."
+      why: "강한 클라이언트 인증이 없는 원격 Docker API는 전체 컨테이너 제어를 허용할 수 있고, 종종 바로 호스트 침해로 이어집니다."
+      fix: "가능하면 로컬 Unix 소켓을 사용하세요. TCP 리스너가 꼭 필요하다면 클라이언트 인증서를 검증하는 TLS를 강제하고 접근 대상을 제한하세요."
+    docker_daemon_iptables_disabled:
+      title: "Docker가 iptables 관리를 비활성화합니다"
+      description: "%{path}가 daemon.json에서 iptables를 false로 설정합니다."
+      why: "Docker의 iptables 통합을 끄면 게시된 포트와 컨테이너 네트워킹이 운영자 예상과 다른 방식으로 노출될 수 있습니다."
+      fix: "감사된 방화벽 규칙으로 Docker 네트워크 정책을 완전히 대체하지 않는 한 iptables를 활성화 상태로 유지하세요."
+    fail2ban_not_enabled:
+      title: "Fail2ban이 설치되어 있지만 활성 상태가 아닙니다"
+      description: "%{path}에서 로컬 Fail2ban 흔적이 보이지만, 활성화된 서비스 표시는 감지되지 않았습니다."
+      why: "Fail2ban을 설치만 하고 서비스나 실제 jail을 활성화하지 않으면 반복 로그인 시도나 노이즈 스캔을 막지 못합니다."
+      fix: "Fail2ban 서비스를 활성화하고, sshd 같은 실제 jail을 최소 하나 구성한 뒤 클라이언트에서 활성 상태를 확인하세요."
+    defensive_controls_missing:
+      title: "침입 방지 제어가 감지되지 않았습니다"
+      description: "%{path}에서 Fail2ban의 로컬 흔적을 찾지 못했습니다."
+      why: "기본적인 차단/ban 자동화는 반복 비밀번호 공격, 스캔, 기타 노이즈성 남용을 늦추는 데 도움이 됩니다."
+      fix: "Fail2ban을 설치하고 활성화한 뒤, 노출한 서비스가 실제로 보호되고 있는지 확인하세요."
     ufw_disabled:
       title: "UFW가 설치되어 있지만 비활성화되어 있습니다"
       description: "%{path}에서 UFW가 존재하지만 ENABLED가 no로 설정되어 있습니다."
@@ -338,6 +498,65 @@ finding:
       description: "%{path}에서 APT::Periodic::Update-Package-Lists가 비활성화되어 있습니다."
       why: "패키지 인덱스가 오래되면 보안 패치 가시성이 늦어지고 자동 패치 워크플로의 신뢰성이 떨어질 수 있습니다."
       fix: "unattended-upgrades 실행 전에 정기 패키지 목록 갱신을 활성화하거나 동등한 스케줄 업데이트 절차를 사용하세요."
+  vaultwarden:
+    signups_enabled:
+      title: "Vaultwarden 가입이 계속 활성화되어 있습니다"
+      description: "%{service}가 SIGNUPS_ALLOWED=true를 설정합니다."
+      why: "초기 설정 이후에도 공개 가입을 열어두면 원치 않는 계정이 생성되기 쉬워지고, 비밀번호 관리자 서비스의 공개 공격 표면이 넓어집니다."
+      fix: "초기 온보딩이 끝나면 가입을 비활성화하거나, 초대 기반 계정 생성 절차로 제한하세요."
+    admin_surface_public:
+      title: "Vaultwarden 관리자 화면이 공개 바인딩에서 접근 가능합니다"
+      description: "%{service}가 공개 인터페이스에 게시된 상태에서 admin token을 활성화합니다."
+      why: "공개 접근 가능한 Vaultwarden 배포에서 관리자 페이지가 열려 있으면, 고가치 관리 표면이 탐지, 무차별 대입, 자격 증명 유출 위험에 노출됩니다."
+      fix: "Vaultwarden을 리버스 프록시 뒤나 localhost 전용 바인딩 뒤에 두고, 관리자 페이지를 공용 인터넷에 노출하지 마세요."
+    insecure_domain:
+      title: "Vaultwarden DOMAIN이 공개 HTTP로 설정되어 있습니다"
+      description: "%{service}가 DOMAIN=%{domain}을 설정하지만, 이는 HTTPS 기반 URL이 아닙니다."
+      why: "Vaultwarden은 중요한 웹 기능에 안전한 컨텍스트를 기대하며, 공개 HTTP base URL은 비밀번호 관리자 배포의 전송 보안을 약화시킵니다."
+      fix: "리버스 프록시에서 TLS를 종료하고 DOMAIN을 외부 HTTPS base URL로 설정하세요."
+  jellyfin:
+    insecure_published_url:
+      title: "Jellyfin Published URL이 공개 HTTP를 사용합니다"
+      description: "%{service}가 JELLYFIN_PublishedServerUrl=%{url}을 설정하지만, HTTPS URL이 아닙니다."
+      why: "외부 URL이 HTTP인 미디어 서비스는 전송 보안이 약해지고, 클라이언트가 비보안 또는 혼합 콘텐츠 경로로 접근하기 쉬워집니다."
+      fix: "Jellyfin을 HTTPS로 노출하고, JELLYFIN_PublishedServerUrl을 클라이언트가 보는 외부 HTTPS URL로 설정하세요."
+    discovery_public:
+      title: "Jellyfin autodiscovery 포트가 공개 접근 가능합니다"
+      description: "%{service}가 autodiscovery 포트 %{port}를 게시합니다."
+      why: "공개된 autodiscovery 포트는 미디어 서버의 존재를 더 쉽게 드러내며, 신뢰된 로컬 네트워크 밖에서는 대개 필요하지 않습니다."
+      fix: "autodiscovery 포트를 로컬 네트워크로 제한하거나, 좁게 바인딩하거나, 필요하지 않다면 공개 게시를 비활성화하세요."
+    media_mount_writable:
+      title: "Jellyfin 미디어 라이브러리가 쓰기 가능하게 마운트됩니다"
+      description: "%{service}가 %{path}를 read-only 보호 없이 마운트합니다."
+      why: "미디어 라이브러리에 쓰기 권한을 주면 침해 시 영향이 커지고, 실수 또는 악의적 파일 변경도 쉬워집니다."
+      fix: "Jellyfin이 해당 경로에 실제로 쓰기 권한이 필요하지 않다면 read-only로 마운트하세요."
+  gitea:
+    web_and_ssh_public:
+      title: "Gitea가 웹과 SSH 표면을 모두 공개합니다"
+      description: "%{service}가 웹 UI와 Git-over-SSH 엔드포인트를 모두 공개 인터페이스에 직접 노출합니다."
+      why: "사용자 대상 표면을 둘 다 직접 게시하면 공격 표면이 넓어지고, 프록시/인증/속도 제한 보호를 놓치기 쉬워집니다."
+      fix: "웹 UI는 리버스 프록시 또는 좁은 바인딩을 우선하고, SSH는 의도적으로 필요한 경우에만 노출하세요."
+    ssh_published_public:
+      title: "Gitea SSH 엔드포인트가 공개 접근 가능합니다"
+      description: "%{service}가 Git-over-SSH 포트 %{port}를 게시합니다."
+      why: "공개 SSH 엔드포인트는 웹 UI가 하드닝되어 있어도 별도의 공격 표면이 되며, 무차별 대입과 열거를 유발할 수 있습니다."
+      fix: "SSH 노출을 의도한 네트워크로 제한하고, 키 기반 인증을 사용하며, HTTPS clone/push로 충분하다면 공개 게시를 피하세요."
+    inline_security_secrets:
+      title: "Gitea 앱 시크릿이 Compose에 하드코딩되어 있습니다"
+      description: "%{service}가 %{variables}를 environment에 직접 설정합니다."
+      why: "Gitea 보안 토큰을 Compose에 inline으로 두면 저장소, 백업, 프로세스 조회를 통해 유출되기 쉬우며, 문서화된 __FILE 기반 시크릿 경로도 활용하지 못합니다."
+      fix: "Gitea 보안 시크릿을 파일 또는 secrets backend로 옮기고, 민감한 값에는 문서화된 __FILE 설정 경로를 우선 사용하세요."
+  immich:
+    shared_secret_env_file:
+      title: "Immich가 하나의 secret env 파일을 여러 서비스와 공유합니다"
+      description: "%{service}가 속한 Immich 스택에서 %{env_file}이 여러 서비스에 재사용되고 있으며, secret 값을 포함합니다."
+      why: "서버와 머신러닝 서비스가 하나의 평문 env 파일을 공유하면, 그 파일이 복사되거나 유출되거나 과도하게 마운트될 때 영향 범위가 커집니다."
+      fix: "가능하면 민감 값을 서비스별로 분리하고, DB 자격 증명 같은 고가치 시크릿은 더 안전한 전달 경로로 옮기세요."
+    default_db_password:
+      title: "Immich 스택이 기본 DB 비밀번호를 유지합니다"
+      description: "%{service}가 속한 Immich 배포가 여전히 기본 DB_PASSWORD 값을 사용합니다."
+      why: "기본 DB 비밀번호를 그대로 두면 스택이나 env 파일이 노출되었을 때 저장소 백엔드가 더 쉽게 침해될 수 있습니다."
+      fix: "배포하거나 외부에 노출하기 전에 DB 비밀번호를 고유한 랜덤 값으로 바꾸세요."
   nextcloud:
     insecure_overwriteprotocol:
       title: "Nextcloud overwrite protocol이 HTTP로 설정되어 있습니다"

--- a/src/src/adapters/dockle.rs
+++ b/src/src/adapters/dockle.rs
@@ -54,9 +54,9 @@ pub fn scan(services: &[ServiceSummary]) -> DockleScanOutput {
                 if first_scan_error.is_none() {
                     first_scan_error = Some(error.clone());
                 }
-                output
-                    .warnings
-                    .push(format!("Dockle scan failed for {image}: {error}"));
+                output.warnings.push(crate::i18n::tr_adapter_scan_failed(
+                    "Dockle", &image, &error,
+                ));
             }
         }
     }
@@ -156,7 +156,7 @@ fn scan_image(image: &str) -> Result<Option<DockleImageSummary>, String> {
     }
 
     let report: DockleReport = serde_json::from_slice(&output.stdout)
-        .map_err(|error| format!("failed to parse Dockle JSON: {error}"))?;
+        .map_err(|error| crate::i18n::tr_adapter_json_parse_failed("Dockle", &error.to_string()))?;
 
     Ok(summarize_report(image, report))
 }
@@ -437,7 +437,9 @@ mod tests {
 
         assert_eq!(
             output.status,
-            AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned())
+            AdapterStatus::Skipped(
+                t!("adapter.reason.no_image_targets", locale = "en").into_owned()
+            )
         );
         assert!(output.findings.is_empty());
     }

--- a/src/src/adapters/lynis.rs
+++ b/src/src/adapters/lynis.rs
@@ -216,7 +216,7 @@ fn command_detail(stderr: &[u8], stdout: &[u8]) -> String {
         return stdout.trim().to_owned();
     }
 
-    String::from("command returned no error detail")
+    crate::i18n::tr_adapter_command_no_error_detail()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -272,7 +272,7 @@ fn parse_report(text: &str) -> Result<LynisReport, String> {
         && report.warnings.is_empty()
         && report.suggestions.is_empty()
     {
-        return Err(String::from("failed to parse Lynis report contents"));
+        return Err(crate::i18n::tr_adapter_report_parse_failed("Lynis"));
     }
 
     Ok(report)
@@ -430,7 +430,9 @@ mod tests {
 
         assert_eq!(
             output.status,
-            AdapterStatus::Skipped(t!("adapter.reason.host_not_scanned").into_owned())
+            AdapterStatus::Skipped(
+                t!("adapter.reason.host_not_scanned", locale = "en").into_owned()
+            )
         );
     }
 
@@ -440,7 +442,7 @@ mod tests {
 
         assert_eq!(
             output.status,
-            AdapterStatus::Skipped(t!("adapter.reason.live_host_only").into_owned())
+            AdapterStatus::Skipped(t!("adapter.reason.live_host_only", locale = "en").into_owned())
         );
     }
 

--- a/src/src/adapters/trivy.rs
+++ b/src/src/adapters/trivy.rs
@@ -56,7 +56,7 @@ pub fn scan(services: &[ServiceSummary]) -> TrivyScanOutput {
                 }
                 output
                     .warnings
-                    .push(format!("Trivy scan failed for {image}: {error}"));
+                    .push(crate::i18n::tr_adapter_scan_failed("Trivy", &image, &error));
             }
         }
     }
@@ -150,7 +150,7 @@ fn scan_image(image: &str) -> Result<Option<TrivyImageSummary>, String> {
     }
 
     let report: TrivyReport = serde_json::from_slice(&output.stdout)
-        .map_err(|error| format!("failed to parse Trivy JSON: {error}"))?;
+        .map_err(|error| crate::i18n::tr_adapter_json_parse_failed("Trivy", &error.to_string()))?;
 
     Ok(summarize_report(image, report))
 }
@@ -470,7 +470,9 @@ mod tests {
 
         assert_eq!(
             output.status,
-            AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned())
+            AdapterStatus::Skipped(
+                t!("adapter.reason.no_image_targets", locale = "en").into_owned()
+            )
         );
         assert!(output.findings.is_empty());
     }

--- a/src/src/app/config.rs
+++ b/src/src/app/config.rs
@@ -63,6 +63,7 @@ pub struct SetupConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppConfig {
+    pub locale_override: Option<String>,
     pub output_mode: OutputMode,
     pub show_help: bool,
     pub show_version: bool,
@@ -79,6 +80,7 @@ pub struct AppConfig {
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
+            locale_override: None,
             output_mode: OutputMode::Tui,
             show_help: false,
             show_version: false,
@@ -97,18 +99,38 @@ impl Default for AppConfig {
 impl AppConfig {
     pub fn parse(args: impl IntoIterator<Item = String>) -> Result<Self, AppError> {
         let args: Vec<String> = args.into_iter().collect();
+        let (locale_override, args) = strip_locale_override(args)?;
 
         if let Some(command) = args.first() {
             match command.as_str() {
-                "setup" => return Self::parse_setup(args.into_iter().skip(1)),
-                "upgrade" => return Self::parse_upgrade(args.into_iter().skip(1)),
-                "uninstall" => return Self::parse_uninstall(args.into_iter().skip(1)),
-                "auto-upgrade" => return Self::parse_auto_upgrade(args.into_iter().skip(1)),
+                "setup" => {
+                    let mut config = Self::parse_setup(args.into_iter().skip(1))?;
+                    config.locale_override = locale_override;
+                    return Ok(config);
+                }
+                "upgrade" => {
+                    let mut config = Self::parse_upgrade(args.into_iter().skip(1))?;
+                    config.locale_override = locale_override;
+                    return Ok(config);
+                }
+                "uninstall" => {
+                    let mut config = Self::parse_uninstall(args.into_iter().skip(1))?;
+                    config.locale_override = locale_override;
+                    return Ok(config);
+                }
+                "auto-upgrade" => {
+                    let mut config = Self::parse_auto_upgrade(args.into_iter().skip(1))?;
+                    config.locale_override = locale_override;
+                    return Ok(config);
+                }
                 _ => {}
             }
         }
 
-        let mut config = Self::default();
+        let mut config = Self {
+            locale_override,
+            ..Self::default()
+        };
         let mut args = args.into_iter();
 
         while let Some(argument) = args.next() {
@@ -280,9 +302,9 @@ impl AppConfig {
         let mut args = args.into_iter();
 
         let Some(mode) = args.next() else {
-            return Err(AppError::InvalidArgumentCombination(String::from(
-                "choose one of enable or disable for auto-upgrade",
-            )));
+            return Err(AppError::InvalidArgumentCombination(
+                crate::i18n::tr_auto_upgrade_mode_required(),
+            ));
         };
 
         let lifecycle_command = match mode.as_str() {
@@ -294,9 +316,9 @@ impl AppConfig {
                 return Ok(config);
             }
             _ => {
-                return Err(AppError::InvalidArgumentCombination(String::from(
-                    "choose one of enable or disable for auto-upgrade",
-                )));
+                return Err(AppError::InvalidArgumentCombination(
+                    crate::i18n::tr_auto_upgrade_mode_required(),
+                ));
             }
         };
 
@@ -323,29 +345,29 @@ impl AppConfig {
 
         if self.fix_mode.is_some() {
             if self.fix_target_path.is_none() {
-                return Err(AppError::InvalidArgumentCombination(String::from(
-                    "a compose target is required for fix operations",
-                )));
+                return Err(AppError::InvalidArgumentCombination(
+                    crate::i18n::tr_fix_requires_target(),
+                ));
             }
             if self.host_root.is_some() {
-                return Err(AppError::InvalidArgumentCombination(String::from(
-                    "--host-root is not supported with fix operations",
-                )));
+                return Err(AppError::InvalidArgumentCombination(
+                    crate::i18n::tr_fix_host_root_not_supported(),
+                ));
             }
             if self.compose_path.is_some() {
-                return Err(AppError::InvalidArgumentCombination(String::from(
-                    "use --quick-fix PATH or --fix PATH instead of combining them with --compose",
-                )));
+                return Err(AppError::InvalidArgumentCombination(
+                    crate::i18n::tr_fix_compose_conflict(),
+                ));
             }
             if self.output_mode == OutputMode::Json {
-                return Err(AppError::InvalidArgumentCombination(String::from(
-                    "--json is not supported with fix operations",
-                )));
+                return Err(AppError::InvalidArgumentCombination(
+                    crate::i18n::tr_fix_json_not_supported(),
+                ));
             }
         } else if self.preview_changes || self.assume_yes {
-            return Err(AppError::InvalidArgumentCombination(String::from(
-                "--preview-changes and --yes are only valid with --quick-fix or --fix",
-            )));
+            return Err(AppError::InvalidArgumentCombination(
+                crate::i18n::tr_preview_yes_requires_fix_mode(),
+            ));
         }
 
         Ok(())
@@ -353,9 +375,9 @@ impl AppConfig {
 
     fn set_fix_target(&mut self, mode: FixMode, path: PathBuf) -> Result<(), AppError> {
         if self.fix_mode.is_some() {
-            return Err(AppError::InvalidArgumentCombination(String::from(
-                "choose only one of --quick-fix or --fix",
-            )));
+            return Err(AppError::InvalidArgumentCombination(
+                crate::i18n::tr_fix_mode_conflict(),
+            ));
         }
 
         self.fix_mode = Some(mode);
@@ -364,9 +386,48 @@ impl AppConfig {
     }
 }
 
+fn strip_locale_override(args: Vec<String>) -> Result<(Option<String>, Vec<String>), AppError> {
+    let mut locale_override = None;
+    let mut stripped = Vec::new();
+    let mut args = args.into_iter();
+
+    while let Some(argument) = args.next() {
+        let locale_value = match argument.as_str() {
+            "--locale" => Some(
+                args.next()
+                    .ok_or(AppError::MissingArgumentValue("--locale"))?,
+            ),
+            _ if argument.starts_with("--locale=") => {
+                let value = argument.trim_start_matches("--locale=");
+                if value.is_empty() {
+                    return Err(AppError::MissingArgumentValue("--locale"));
+                }
+                Some(String::from(value))
+            }
+            _ => None,
+        };
+
+        if let Some(value) = locale_value {
+            let normalized = crate::i18n::parse_supported_locale(&value).ok_or_else(|| {
+                AppError::InvalidArgumentCombination(crate::i18n::tr_unsupported_locale(&value))
+            })?;
+
+            if locale_override.replace(String::from(normalized)).is_some() {
+                return Err(AppError::InvalidArgumentCombination(
+                    crate::i18n::tr_duplicate_locale_override(),
+                ));
+            }
+        } else {
+            stripped.push(argument);
+        }
+    }
+
+    Ok((locale_override, stripped))
+}
+
 fn push_setup_tool(tools: &mut Vec<SetupTool>, value: &str) -> Result<(), AppError> {
     let tool = SetupTool::from_arg(value).ok_or_else(|| {
-        AppError::InvalidArgumentCombination(format!("unsupported setup tool: {value}"))
+        AppError::InvalidArgumentCombination(crate::i18n::tr_unsupported_setup_tool(value))
     })?;
     if !tools.contains(&tool) {
         tools.push(tool);
@@ -389,9 +450,9 @@ fn parse_setup_tool_list(tools: &mut Vec<SetupTool>, value: &str) -> Result<(), 
     if parsed_any {
         Ok(())
     } else {
-        Err(AppError::InvalidArgumentCombination(String::from(
-            "--tools requires at least one tool name",
-        )))
+        Err(AppError::InvalidArgumentCombination(
+            crate::i18n::tr_setup_tools_required(),
+        ))
     }
 }
 
@@ -417,6 +478,31 @@ mod tests {
         let config = AppConfig::parse([String::from("--json")]).expect("config should parse");
 
         assert_eq!(config.output_mode, OutputMode::Json);
+    }
+
+    #[test]
+    fn parses_global_locale_override() {
+        let config = AppConfig::parse([
+            String::from("--locale"),
+            String::from("ko_KR.UTF-8"),
+            String::from("--json"),
+        ])
+        .expect("config should parse");
+
+        assert_eq!(config.locale_override.as_deref(), Some("ko"));
+    }
+
+    #[test]
+    fn parses_locale_override_before_subcommand() {
+        let config = AppConfig::parse([
+            String::from("--locale=en"),
+            String::from("setup"),
+            String::from("--yes"),
+        ])
+        .expect("config should parse");
+
+        assert_eq!(config.locale_override.as_deref(), Some("en"));
+        assert!(config.setup_command.is_some());
     }
 
     #[test]
@@ -616,6 +702,37 @@ mod tests {
         assert!(matches!(
             error,
             super::AppError::InvalidArgumentCombination(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_locale_override() {
+        let error = AppConfig::parse([
+            String::from("--locale=en"),
+            String::from("--locale"),
+            String::from("ko"),
+        ])
+        .expect_err("duplicate locale overrides should be rejected");
+
+        assert!(matches!(
+            error,
+            super::AppError::InvalidArgumentCombination(_)
+        ));
+    }
+
+    #[test]
+    fn duplicate_locale_override_uses_translation_helper_detail() {
+        let error = AppConfig::parse([
+            String::from("--locale=en"),
+            String::from("--locale"),
+            String::from("ko"),
+        ])
+        .expect_err("duplicate locale overrides should be rejected");
+
+        assert!(matches!(
+            error,
+            super::AppError::InvalidArgumentCombination(message)
+                if message == crate::i18n::tr_duplicate_locale_override()
         ));
     }
 }

--- a/src/src/app/mod.rs
+++ b/src/src/app/mod.rs
@@ -75,6 +75,7 @@ impl From<FixError> for AppError {
 
 pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
     let config = AppConfig::parse(args)?;
+    crate::i18n::initialize_locale(config.locale_override.as_deref());
 
     if config.show_help {
         print!("{}", i18n::tr("app.help.text"));
@@ -101,9 +102,7 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
 
     if let Some(mode) = config.fix_mode {
         let compose_path = config.fix_target_path.as_ref().ok_or_else(|| {
-            AppError::InvalidArgumentCombination(String::from(
-                "a compose target is required for fix operations",
-            ))
+            AppError::InvalidArgumentCombination(crate::i18n::tr_fix_requires_target())
         })?;
 
         let preview_plan = fix::preview(compose_path, mode)?;

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -189,7 +189,7 @@ fn has_image_targets(services: &[ServiceSummary]) -> bool {
 
 fn failed_trivy_output() -> adapters::trivy::TrivyScanOutput {
     adapters::trivy::TrivyScanOutput {
-        status: AdapterStatus::Failed(String::from("Trivy scan thread panicked")),
+        status: AdapterStatus::Failed(crate::i18n::tr_adapter_scan_thread_panicked("Trivy")),
         findings: Vec::new(),
         warnings: Vec::new(),
     }
@@ -197,7 +197,7 @@ fn failed_trivy_output() -> adapters::trivy::TrivyScanOutput {
 
 fn failed_lynis_output() -> adapters::lynis::LynisScanOutput {
     adapters::lynis::LynisScanOutput {
-        status: AdapterStatus::Failed(String::from("Lynis scan thread panicked")),
+        status: AdapterStatus::Failed(crate::i18n::tr_adapter_scan_thread_panicked("Lynis")),
         findings: Vec::new(),
         warnings: Vec::new(),
     }
@@ -205,7 +205,7 @@ fn failed_lynis_output() -> adapters::lynis::LynisScanOutput {
 
 fn failed_dockle_output() -> adapters::dockle::DockleScanOutput {
     adapters::dockle::DockleScanOutput {
-        status: AdapterStatus::Failed(String::from("Dockle scan thread panicked")),
+        status: AdapterStatus::Failed(crate::i18n::tr_adapter_scan_thread_panicked("Dockle")),
         findings: Vec::new(),
         warnings: Vec::new(),
     }
@@ -296,38 +296,37 @@ fn load_discovered_project(
                         Ok(parsed) => {
                             return Ok((
                                 parsed,
-                                Some(format!(
-                                    "Docker metadata for discovered project {} still points to missing compose path {}; recovered by scanning {} instead.",
-                                    project.name,
-                                    path.display(),
-                                    working_dir.display()
+                                Some(crate::i18n::tr_discovery_recovered_missing_compose_path(
+                                    &project.name,
+                                    &path.display().to_string(),
+                                    &working_dir.display().to_string(),
                                 )),
                             ));
                         }
                         Err(ComposeParseError::ComposePathMissing { .. })
                         | Err(ComposeParseError::ComposeFileNotFound { .. }) => {}
                         Err(error) => {
-                            return Err(format!(
-                                "Discovered project {} points to missing compose path {} and fallback scan of {} failed: {}",
-                                project.name,
-                                path.display(),
-                                working_dir.display(),
-                                error
-                            ));
+                            return Err(
+                                crate::i18n::tr_discovery_missing_compose_path_and_fallback_failed(
+                                    &project.name,
+                                    &path.display().to_string(),
+                                    &working_dir.display().to_string(),
+                                    &error.to_string(),
+                                ),
+                            );
                         }
                     }
                 }
 
-                return Err(format!(
-                    "Discovered project {} points to missing compose path {} from Docker metadata. Recreate or remove the containers to refresh the saved Compose labels.",
-                    project.name,
-                    path.display()
+                return Err(crate::i18n::tr_discovery_missing_compose_path(
+                    &project.name,
+                    &path.display().to_string(),
                 ));
             }
             Err(error) => {
-                return Err(format!(
-                    "Failed to parse discovered project {}: {}",
-                    project.name, error
+                return Err(crate::i18n::tr_discovery_parse_failed(
+                    &project.name,
+                    &error.to_string(),
                 ));
             }
         }
@@ -338,23 +337,22 @@ fn load_discovered_project(
             .map(|parsed| (parsed, None))
             .map_err(|error| match error {
                 ComposeParseError::ComposePathMissing { .. }
-                | ComposeParseError::ComposeFileNotFound { .. } => format!(
-                    "Discovered project {} did not expose a compose file path, and no compose file was found in {}.",
-                    project.name,
-                    working_dir.display()
-                ),
-                _ => format!(
-                    "Failed to parse discovered project {} from working directory {}: {}",
-                    project.name,
-                    working_dir.display(),
-                    error
+                | ComposeParseError::ComposeFileNotFound { .. } => {
+                    crate::i18n::tr_discovery_no_compose_file_in_working_dir(
+                        &project.name,
+                        &working_dir.display().to_string(),
+                    )
+                }
+                _ => crate::i18n::tr_discovery_parse_failed_in_working_dir(
+                    &project.name,
+                    &working_dir.display().to_string(),
+                    &error.to_string(),
                 ),
             });
     }
 
-    Err(format!(
-        "Discovered project {} has no usable compose path.",
-        project.name
+    Err(crate::i18n::tr_discovery_no_usable_compose_path(
+        &project.name,
     ))
 }
 
@@ -388,9 +386,10 @@ fn apply_current_dir_fallback_from(
                 service_count: project.services.len(),
             };
             result.metadata.discovered_projects.push(summary);
-            result.metadata.warnings.push(String::from(
-                "Using the current directory as a Compose fallback because no running Compose project was discovered.",
-            ));
+            result
+                .metadata
+                .warnings
+                .push(crate::i18n::tr_discovery_current_dir_fallback_used());
             scan_compose_project(&project, result);
             coverage.compose = true;
             Ok(())
@@ -398,9 +397,12 @@ fn apply_current_dir_fallback_from(
         Err(ComposeParseError::ComposeFileNotFound { .. }) => Ok(()),
         Err(ComposeParseError::ComposePathMissing { .. }) => Ok(()),
         Err(error) => {
-            result.metadata.warnings.push(format!(
-                "Current-directory Compose fallback failed: {error}"
-            ));
+            result
+                .metadata
+                .warnings
+                .push(crate::i18n::tr_discovery_current_dir_fallback_failed(
+                    &error.to_string(),
+                ));
             Ok(())
         }
     }
@@ -464,9 +466,9 @@ mod tests {
     };
 
     use super::{
-        AdapterScanUpdate, apply_current_dir_fallback, apply_discovered_projects,
-        apply_external_adapter_update, apply_live_discovery_result, run, scan_compose_project,
-        seed_adapter_statuses, spawn_background_adapter_scan,
+        AdapterScanUpdate, apply_current_dir_fallback, apply_current_dir_fallback_from,
+        apply_discovered_projects, apply_external_adapter_update, apply_live_discovery_result, run,
+        scan_compose_project, seed_adapter_statuses, spawn_background_adapter_scan,
     };
     use crate::app::{AppConfig, OutputMode};
     use crate::compose::ComposeParser;
@@ -527,6 +529,7 @@ mod tests {
     #[test]
     fn records_trivy_adapter_status_in_scan_metadata() {
         let config = AppConfig {
+            locale_override: None,
             output_mode: OutputMode::Json,
             show_help: false,
             show_version: false,
@@ -560,6 +563,7 @@ mod tests {
     #[test]
     fn records_lynis_as_skipped_for_compose_only_scans() {
         let config = AppConfig {
+            locale_override: None,
             output_mode: OutputMode::Json,
             show_help: false,
             show_version: false,
@@ -595,6 +599,7 @@ mod tests {
         );
 
         let config = AppConfig {
+            locale_override: None,
             output_mode: OutputMode::Json,
             show_help: false,
             show_version: false,
@@ -618,12 +623,13 @@ mod tests {
 
         assert!(matches!(status, AdapterStatus::Skipped(_)));
 
-        fs::remove_dir_all(host_root).expect("temp root should be removed");
+        let _ = fs::remove_dir_all(host_root);
     }
 
     #[test]
     fn populates_scan_metadata_from_compose_project() {
         let config = AppConfig {
+            locale_override: None,
             output_mode: OutputMode::Json,
             show_help: false,
             show_version: false,
@@ -699,6 +705,7 @@ mod tests {
         .expect("permissions should be set");
 
         let config = AppConfig {
+            locale_override: None,
             output_mode: OutputMode::Json,
             show_help: false,
             show_version: false,
@@ -1091,13 +1098,14 @@ mod tests {
 
         assert!(coverage.compose);
         assert_eq!(result.metadata.service_count, 1);
-        assert!(
-            result
-                .metadata
-                .warnings
-                .iter()
-                .any(|warning| warning.contains("recovered by scanning"))
-        );
+        assert!(result.metadata.warnings.iter().any(|warning| {
+            warning
+                == &crate::i18n::tr_discovery_recovered_missing_compose_path(
+                    "demo",
+                    &temp_dir.join("deleted-compose.yml").display().to_string(),
+                    &temp_dir.display().to_string(),
+                )
+        }));
 
         fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
     }
@@ -1132,8 +1140,11 @@ mod tests {
 
         assert!(!coverage.compose);
         assert!(result.metadata.warnings.iter().any(|warning| {
-            warning.contains("Docker metadata")
-                && warning.contains("refresh the saved Compose labels")
+            warning
+                == &crate::i18n::tr_discovery_missing_compose_path(
+                    "demo",
+                    &compose_path.display().to_string(),
+                )
         }));
     }
 
@@ -1189,11 +1200,9 @@ mod tests {
                 .any(|warning| warning.contains("stale Compose labels"))
         );
         assert!(
-            result
-                .metadata
-                .warnings
-                .iter()
-                .any(|warning| { warning.contains("current directory as a Compose fallback") })
+            result.metadata.warnings.iter().any(|warning| {
+                warning == &crate::i18n::tr_discovery_current_dir_fallback_used()
+            })
         );
         assert_eq!(result.metadata.discovered_projects.len(), 2);
         assert_eq!(result.metadata.discovered_projects[1].source, "current_dir");
@@ -1250,6 +1259,34 @@ mod tests {
             .expect("background scan should eventually finish");
         assert_eq!(update.trivy.status, AdapterStatus::Missing);
         assert_eq!(update.dockle.status, AdapterStatus::Missing);
+    }
+
+    #[test]
+    fn current_dir_fallback_warning_is_localized() {
+        let temp_dir = temp_host_root("cwd-fallback-warning");
+        write_file(
+            &temp_dir.join("docker-compose.yml"),
+            concat!(
+                "services:\n",
+                "  demo:\n",
+                "    image: nginx:1.27.5\n",
+                "    ports:\n",
+                "      - \"8080:80\"\n"
+            ),
+        );
+
+        let mut result = crate::domain::ScanResult::default();
+        let mut coverage = crate::scoring::Coverage::default();
+        apply_current_dir_fallback_from(&temp_dir, &mut result, &mut coverage)
+            .expect("fallback should succeed");
+
+        assert!(
+            result.metadata.warnings.iter().any(|warning| {
+                warning == &crate::i18n::tr_discovery_current_dir_fallback_used()
+            })
+        );
+
+        fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
     }
 
     #[test]

--- a/src/src/app/setup.rs
+++ b/src/src/app/setup.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use dialoguer::{Confirm, MultiSelect, theme::ColorfulTheme};
+use dialoguer::{MultiSelect, theme::ColorfulTheme};
 
 use super::{AppError, SetupConfig, SetupTool};
 
@@ -158,11 +158,8 @@ pub fn run(config: &SetupConfig) -> Result<(), AppError> {
     print_plan(&plan);
 
     if !config.assume_yes && io::stdin().is_terminal() && io::stdout().is_terminal() {
-        let confirmed = Confirm::with_theme(&ColorfulTheme::default())
-            .with_prompt(t!("app.setup.prompt_confirm").into_owned())
-            .default(true)
-            .interact()
-            .map_err(|error| AppError::Io(io::Error::other(error.to_string())))?;
+        let prompt = t!("app.setup.prompt_confirm_default_yes").into_owned();
+        let confirmed = prompt_yes_no_default_yes(&prompt)?;
         if !confirmed {
             println!("{}", t!("app.setup.skipped").into_owned());
             return Ok(());
@@ -189,10 +186,12 @@ fn resolve_requested_tools(config: &SetupConfig) -> Result<Vec<SetupTool>, AppEr
     }
 
     if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
-        return Err(AppError::InvalidArgumentCombination(String::from(
-            "setup requires a terminal or explicit --tools/--tool selection; use --yes to accept the recommended defaults",
-        )));
+        return Err(AppError::InvalidArgumentCombination(
+            crate::i18n::tr_setup_requires_terminal_or_explicit_tools(),
+        ));
     }
+
+    println!("{}", t!("app.setup.prompt_tools_help").into_owned());
 
     let labels = SetupTool::ALL
         .into_iter()
@@ -219,6 +218,23 @@ fn resolve_requested_tools(config: &SetupConfig) -> Result<Vec<SetupTool>, AppEr
         .into_iter()
         .map(|index| SetupTool::ALL[index])
         .collect())
+}
+
+fn prompt_yes_no_default_yes(prompt: &str) -> Result<bool, AppError> {
+    loop {
+        print!("{prompt}");
+        io::stdout().flush()?;
+
+        let mut answer = String::new();
+        io::stdin().read_line(&mut answer)?;
+        match answer.trim().to_ascii_lowercase().as_str() {
+            "" | "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => {
+                println!("{}", t!("app.setup.prompt_invalid_yes_no").into_owned());
+            }
+        }
+    }
 }
 
 fn recommended_tools() -> Vec<SetupTool> {
@@ -442,9 +458,9 @@ fn ensure_sudo_session() -> Result<(), AppError> {
     }
 
     if !command_exists("sudo") {
-        return Err(AppError::Io(io::Error::other(String::from(
-            "sudo is required for setup operations but was not found on PATH",
-        ))));
+        return Err(AppError::Io(io::Error::other(
+            crate::i18n::tr_setup_sudo_missing(),
+        )));
     }
 
     if run_command("sudo", &["-n", "true"]).is_ok() {
@@ -452,16 +468,16 @@ fn ensure_sudo_session() -> Result<(), AppError> {
     }
 
     if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
-        return Err(AppError::Io(io::Error::other(String::from(
-            "sudo needs a password but no interactive terminal is available",
-        ))));
+        return Err(AppError::Io(io::Error::other(
+            crate::i18n::tr_setup_sudo_needs_terminal(),
+        )));
     }
 
     println!("{}", t!("app.setup.requesting_sudo").into_owned());
     run_command("sudo", &["-v"]).map(|_| ()).map_err(|error| {
-        AppError::Io(io::Error::other(format!(
-            "failed to obtain sudo credentials: {error}"
-        )))
+        AppError::Io(io::Error::other(
+            crate::i18n::tr_setup_sudo_credentials_failed(&error),
+        ))
     })
 }
 
@@ -871,5 +887,17 @@ ID_LIKE="rhel centos fedora"
                 "[sshd]\nenabled = true\nbackend = systemd\nbantime = 1h\nfindtime = 10m\nmaxretry = 5"
             )
         );
+    }
+
+    #[test]
+    fn setup_terminal_requirement_uses_translation_helper_detail() {
+        let error = resolve_requested_tools(&SetupConfig::default())
+            .expect_err("non-interactive setup should require explicit tools");
+
+        assert!(matches!(
+            error,
+            AppError::InvalidArgumentCombination(message)
+                if message == crate::i18n::tr_setup_requires_terminal_or_explicit_tools()
+        ));
     }
 }

--- a/src/src/discovery/docker.rs
+++ b/src/src/discovery/docker.rs
@@ -38,9 +38,7 @@ pub fn discover_running_compose_projects() -> DockerDiscoveryResult {
             return DockerDiscoveryResult {
                 status: DockerDiscoveryStatus::Missing,
                 projects: Vec::new(),
-                warnings: vec![String::from(
-                    "Docker CLI is not available; switching to fallback discovery.",
-                )],
+                warnings: vec![crate::i18n::tr_discovery_docker_cli_missing_fallback()],
             };
         }
     };
@@ -56,9 +54,9 @@ pub fn discover_running_compose_projects() -> DockerDiscoveryResult {
             status,
             projects: Vec::new(),
             warnings: vec![if stderr.is_empty() {
-                String::from("Docker discovery failed; switching to fallback discovery.")
+                crate::i18n::tr_discovery_docker_failed_fallback()
             } else {
-                format!("Docker discovery failed: {stderr}")
+                crate::i18n::tr_discovery_docker_failed_detail(&stderr)
             }],
         };
     }
@@ -66,9 +64,7 @@ pub fn discover_running_compose_projects() -> DockerDiscoveryResult {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let projects = parse_docker_ps_output(&stdout);
     let warnings = if projects.is_empty() {
-        vec![String::from(
-            "No running Compose projects were discovered from Docker; checking the current directory.",
-        )]
+        vec![crate::i18n::tr_discovery_no_projects_current_dir()]
     } else {
         Vec::new()
     };

--- a/src/src/i18n/mod.rs
+++ b/src/src/i18n/mod.rs
@@ -1,29 +1,76 @@
 use std::env;
+use std::io;
 
 use crate::compose::ComposeParseError;
+use crate::settings;
 
-pub fn initialize_locale_from_env() {
+pub const DEFAULT_LOCALE: &str = "en";
+
+pub fn initialize_locale_from_args(args: &[String]) {
+    let cli_locale = locale_override_from_args(args);
+    initialize_locale(cli_locale.as_deref());
+}
+
+pub fn initialize_locale(cli_locale: Option<&str>) {
+    let configured_locale = settings::load().locale;
     let hostveil_locale = env::var("HOSTVEIL_LOCALE").ok();
-    let lc_all = env::var("LC_ALL").ok();
-    let lang = env::var("LANG").ok();
 
     rust_i18n::set_locale(resolve_preferred_locale(
+        cli_locale,
+        configured_locale.as_deref(),
         hostveil_locale.as_deref(),
-        lc_all.as_deref(),
-        lang.as_deref(),
     ));
 }
 
+pub fn locale_override_from_args(args: &[String]) -> Option<String> {
+    let mut args = args.iter();
+
+    while let Some(argument) = args.next() {
+        match argument.as_str() {
+            "--locale" => {
+                let value = args.next()?;
+                return parse_supported_locale(value).map(str::to_owned);
+            }
+            _ if argument.starts_with("--locale=") => {
+                let value = argument.trim_start_matches("--locale=");
+                return parse_supported_locale(value).map(str::to_owned);
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+pub fn parse_supported_locale(raw: &str) -> Option<&'static str> {
+    normalize_locale_tag(raw)
+}
+
+pub fn current_locale() -> String {
+    rust_i18n::locale().to_string()
+}
+
+pub fn cycle_persisted_locale() -> io::Result<&'static str> {
+    let next = match &*rust_i18n::locale() {
+        "ko" => "en",
+        _ => "ko",
+    };
+
+    rust_i18n::set_locale(next);
+    settings::persist_locale(next)?;
+    Ok(next)
+}
+
 fn resolve_preferred_locale(
+    cli_locale: Option<&str>,
+    configured_locale: Option<&str>,
     hostveil_locale: Option<&str>,
-    lc_all: Option<&str>,
-    lang: Option<&str>,
 ) -> &'static str {
-    [hostveil_locale, lc_all, lang]
+    [cli_locale, hostveil_locale, configured_locale]
         .into_iter()
         .flatten()
-        .find_map(normalize_locale_tag)
-        .unwrap_or("en")
+        .find_map(parse_supported_locale)
+        .unwrap_or(DEFAULT_LOCALE)
 }
 
 fn normalize_locale_tag(raw: &str) -> Option<&'static str> {
@@ -39,13 +86,13 @@ fn normalize_locale_tag(raw: &str) -> Option<&'static str> {
     let language = without_modifier.replace('_', "-").to_ascii_lowercase();
 
     if language == "c" || language == "posix" {
-        return Some("en");
+        return Some(DEFAULT_LOCALE);
     }
 
     if language.starts_with("ko") {
         Some("ko")
     } else if language.starts_with("en") {
-        Some("en")
+        Some(DEFAULT_LOCALE)
     } else {
         None
     }
@@ -85,6 +132,50 @@ pub fn tr_missing_argument_value(flag: &str) -> String {
 
 pub fn tr_invalid_argument_combination(message: &str) -> String {
     t!("app.error.invalid_argument_combination", message = message).into_owned()
+}
+
+pub fn tr_auto_upgrade_mode_required() -> String {
+    t!("app.validation.auto_upgrade_mode_required").into_owned()
+}
+
+pub fn tr_fix_requires_target() -> String {
+    t!("app.validation.fix_requires_target").into_owned()
+}
+
+pub fn tr_fix_host_root_not_supported() -> String {
+    t!("app.validation.fix_host_root_not_supported").into_owned()
+}
+
+pub fn tr_fix_compose_conflict() -> String {
+    t!("app.validation.fix_compose_conflict").into_owned()
+}
+
+pub fn tr_fix_json_not_supported() -> String {
+    t!("app.validation.fix_json_not_supported").into_owned()
+}
+
+pub fn tr_preview_yes_requires_fix_mode() -> String {
+    t!("app.validation.preview_yes_requires_fix_mode").into_owned()
+}
+
+pub fn tr_fix_mode_conflict() -> String {
+    t!("app.validation.fix_mode_conflict").into_owned()
+}
+
+pub fn tr_unsupported_locale(value: &str) -> String {
+    t!("app.validation.unsupported_locale", value = value).into_owned()
+}
+
+pub fn tr_duplicate_locale_override() -> String {
+    t!("app.validation.duplicate_locale_override").into_owned()
+}
+
+pub fn tr_unsupported_setup_tool(value: &str) -> String {
+    t!("app.validation.unsupported_setup_tool", value = value).into_owned()
+}
+
+pub fn tr_setup_tools_required() -> String {
+    t!("app.validation.setup_tools_required").into_owned()
 }
 
 pub fn tr_lifecycle_command_requires_installed_wrapper(command: &str) -> String {
@@ -184,17 +275,180 @@ pub fn tr_summary_finding_count(count: usize) -> String {
     t!("app.summary.finding_count", count = count).into_owned()
 }
 
+pub fn tr_setup_requires_terminal_or_explicit_tools() -> String {
+    t!("app.setup.error.requires_terminal_or_explicit_tools").into_owned()
+}
+
+pub fn tr_setup_sudo_missing() -> String {
+    t!("app.setup.error.sudo_missing").into_owned()
+}
+
+pub fn tr_setup_sudo_needs_terminal() -> String {
+    t!("app.setup.error.sudo_needs_terminal").into_owned()
+}
+
+pub fn tr_setup_sudo_credentials_failed(error: &str) -> String {
+    t!("app.setup.error.sudo_credentials_failed", error = error).into_owned()
+}
+
+pub fn tr_adapter_scan_failed(tool: &str, image: &str, error: &str) -> String {
+    t!(
+        "app.adapter.scan_failed",
+        tool = tool,
+        image = image,
+        error = error
+    )
+    .into_owned()
+}
+
+pub fn tr_adapter_json_parse_failed(tool: &str, error: &str) -> String {
+    t!("app.adapter.json_parse_failed", tool = tool, error = error).into_owned()
+}
+
+pub fn tr_adapter_command_no_error_detail() -> String {
+    t!("app.adapter.command_no_error_detail").into_owned()
+}
+
+pub fn tr_adapter_report_parse_failed(tool: &str) -> String {
+    t!("app.adapter.report_parse_failed", tool = tool).into_owned()
+}
+
+pub fn tr_adapter_scan_thread_panicked(adapter: &str) -> String {
+    t!("app.adapter.scan_thread_panicked", adapter = adapter).into_owned()
+}
+
+pub fn tr_discovery_docker_cli_missing_fallback() -> String {
+    t!("app.discovery.docker_cli_missing_fallback").into_owned()
+}
+
+pub fn tr_discovery_docker_failed_fallback() -> String {
+    t!("app.discovery.docker_failed_fallback").into_owned()
+}
+
+pub fn tr_discovery_docker_failed_detail(detail: &str) -> String {
+    t!("app.discovery.docker_failed_detail", detail = detail).into_owned()
+}
+
+pub fn tr_discovery_no_projects_current_dir() -> String {
+    t!("app.discovery.no_projects_current_dir").into_owned()
+}
+
+pub fn tr_discovery_recovered_missing_compose_path(
+    project: &str,
+    compose_path: &str,
+    working_dir: &str,
+) -> String {
+    t!(
+        "app.discovery.recovered_missing_compose_path",
+        project = project,
+        compose_path = compose_path,
+        working_dir = working_dir
+    )
+    .into_owned()
+}
+
+pub fn tr_discovery_missing_compose_path_and_fallback_failed(
+    project: &str,
+    compose_path: &str,
+    working_dir: &str,
+    error: &str,
+) -> String {
+    t!(
+        "app.discovery.missing_compose_path_and_fallback_failed",
+        project = project,
+        compose_path = compose_path,
+        working_dir = working_dir,
+        error = error
+    )
+    .into_owned()
+}
+
+pub fn tr_discovery_missing_compose_path(project: &str, compose_path: &str) -> String {
+    t!(
+        "app.discovery.missing_compose_path",
+        project = project,
+        compose_path = compose_path
+    )
+    .into_owned()
+}
+
+pub fn tr_discovery_parse_failed(project: &str, error: &str) -> String {
+    t!(
+        "app.discovery.parse_failed",
+        project = project,
+        error = error
+    )
+    .into_owned()
+}
+
+pub fn tr_discovery_no_compose_file_in_working_dir(project: &str, working_dir: &str) -> String {
+    t!(
+        "app.discovery.no_compose_file_in_working_dir",
+        project = project,
+        working_dir = working_dir
+    )
+    .into_owned()
+}
+
+pub fn tr_discovery_parse_failed_in_working_dir(
+    project: &str,
+    working_dir: &str,
+    error: &str,
+) -> String {
+    t!(
+        "app.discovery.parse_failed_in_working_dir",
+        project = project,
+        working_dir = working_dir,
+        error = error
+    )
+    .into_owned()
+}
+
+pub fn tr_discovery_no_usable_compose_path(project: &str) -> String {
+    t!("app.discovery.no_usable_compose_path", project = project).into_owned()
+}
+
+pub fn tr_discovery_current_dir_fallback_used() -> String {
+    t!("app.discovery.current_dir_fallback_used").into_owned()
+}
+
+pub fn tr_discovery_current_dir_fallback_failed(error: &str) -> String {
+    t!("app.discovery.current_dir_fallback_failed", error = error).into_owned()
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
+    use serde_yaml::Value;
+
     use super::{
-        normalize_locale_tag, resolve_preferred_locale, tr, tr_compose_parse_error,
-        tr_fix_requires_terminal, tr_invalid_argument_combination, tr_io_error,
-        tr_lifecycle_command_requires_installed_wrapper, tr_missing_argument_value,
+        locale_override_from_args, normalize_locale_tag, resolve_preferred_locale, tr,
+        tr_compose_parse_error, tr_fix_requires_terminal, tr_invalid_argument_combination,
+        tr_io_error, tr_lifecycle_command_requires_installed_wrapper, tr_missing_argument_value,
         tr_status_compose_and_host_loaded, tr_status_compose_loaded, tr_status_host_loaded,
         tr_summary_finding_count, tr_summary_host_root, tr_summary_overall_score,
         tr_summary_service_count, tr_tui_requires_terminal, tr_unknown_argument, tr_version,
     };
     use crate::compose::ComposeParseError;
+
+    fn flatten_yaml_keys(value: &Value, prefix: &str, keys: &mut BTreeSet<String>) {
+        if let Value::Mapping(mapping) = value {
+            for (key, value) in mapping {
+                let Value::String(key) = key else {
+                    continue;
+                };
+
+                let next = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                keys.insert(next.clone());
+                flatten_yaml_keys(value, &next, keys);
+            }
+        }
+    }
 
     #[test]
     fn returns_known_translation() {
@@ -330,7 +584,7 @@ mod tests {
     }
 
     #[test]
-    fn locale_resolver_prefers_explicit_hostveil_locale() {
+    fn locale_resolver_prefers_cli_override() {
         assert_eq!(
             resolve_preferred_locale(Some("ko_KR.UTF-8"), Some("en_US.UTF-8"), Some("en_US")),
             "ko"
@@ -338,11 +592,16 @@ mod tests {
     }
 
     #[test]
-    fn locale_resolver_uses_system_locale_when_explicit_locale_is_missing() {
+    fn locale_resolver_prefers_hostveil_env_over_saved_locale() {
         assert_eq!(
             resolve_preferred_locale(None, Some("ko-KR"), Some("en_US.UTF-8")),
-            "ko"
+            "en"
         );
+    }
+
+    #[test]
+    fn locale_resolver_uses_saved_locale_when_no_explicit_override_is_present() {
+        assert_eq!(resolve_preferred_locale(None, Some("ko-KR"), None), "ko");
     }
 
     #[test]
@@ -363,6 +622,22 @@ mod tests {
     }
 
     #[test]
+    fn locale_override_parser_detects_flag_forms() {
+        assert_eq!(
+            locale_override_from_args(&[
+                String::from("--locale"),
+                String::from("ko_KR.UTF-8"),
+                String::from("--json"),
+            ]),
+            Some(String::from("ko"))
+        );
+        assert_eq!(
+            locale_override_from_args(&[String::from("--locale=en")]),
+            Some(String::from("en"))
+        );
+    }
+
+    #[test]
     fn korean_locale_translates_cli_and_tui_strings() {
         assert_eq!(t!("app.help.usage", locale = "ko").into_owned(), "사용법");
         assert_eq!(
@@ -377,5 +652,20 @@ mod tests {
             t!("test.fallback_probe", locale = "ko").into_owned(),
             "English fallback probe"
         );
+    }
+
+    #[test]
+    fn locale_files_keep_en_and_ko_keys_in_sync() {
+        let en: Value =
+            serde_yaml::from_str(include_str!("../../locales/en.yml")).expect("en locale parses");
+        let ko: Value =
+            serde_yaml::from_str(include_str!("../../locales/ko.yml")).expect("ko locale parses");
+
+        let mut en_keys = BTreeSet::new();
+        let mut ko_keys = BTreeSet::new();
+        flatten_yaml_keys(&en, "", &mut en_keys);
+        flatten_yaml_keys(&ko, "", &mut ko_keys);
+
+        assert_eq!(en_keys, ko_keys, "locale keys must stay in sync");
     }
 }

--- a/src/src/lib.rs
+++ b/src/src/lib.rs
@@ -14,4 +14,5 @@ pub mod host;
 pub mod i18n;
 pub mod rules;
 pub mod scoring;
+pub mod settings;
 pub mod tui;

--- a/src/src/main.rs
+++ b/src/src/main.rs
@@ -1,9 +1,10 @@
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
-    hostveil::i18n::initialize_locale_from_env();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    hostveil::i18n::initialize_locale_from_args(&args);
 
-    match hostveil::app::run(std::env::args().skip(1)) {
+    match hostveil::app::run(args) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("{error}");

--- a/src/src/settings.rs
+++ b/src/src/settings.rs
@@ -1,0 +1,146 @@
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const HOSTVEIL_CONFIG_DIR_ENV: &str = "HOSTVEIL_CONFIG_DIR";
+const XDG_CONFIG_HOME_ENV: &str = "XDG_CONFIG_HOME";
+const HOME_ENV: &str = "HOME";
+const CONFIG_FILE_NAME: &str = "config.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct AppSettings {
+    pub locale: Option<String>,
+}
+
+pub fn load() -> AppSettings {
+    config_file_path()
+        .ok()
+        .and_then(|path| load_from_path(&path).ok())
+        .unwrap_or_default()
+}
+
+pub fn persist_locale(locale: &str) -> io::Result<()> {
+    let mut settings = load();
+    settings.locale = Some(locale.to_owned());
+    save(&settings)
+}
+
+fn save(settings: &AppSettings) -> io::Result<()> {
+    let path = config_file_path()?;
+    save_to_path(&path, settings)
+}
+
+fn load_from_path(path: &Path) -> io::Result<AppSettings> {
+    let text = fs::read_to_string(path)?;
+    serde_json::from_str(&text).map_err(|error| io::Error::other(error.to_string()))
+}
+
+fn save_to_path(path: &Path, settings: &AppSettings) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let text = serde_json::to_string_pretty(settings)
+        .map_err(|error| io::Error::other(error.to_string()))?;
+    fs::write(path, text + "\n")
+}
+
+fn config_file_path() -> io::Result<PathBuf> {
+    resolve_config_dir(
+        env::var(HOSTVEIL_CONFIG_DIR_ENV).ok().as_deref(),
+        env::var(XDG_CONFIG_HOME_ENV).ok().as_deref(),
+        env::var(HOME_ENV).ok().as_deref(),
+    )
+    .map(|dir| dir.join(CONFIG_FILE_NAME))
+    .ok_or_else(|| io::Error::other("failed to resolve a hostveil config directory"))
+}
+
+fn resolve_config_dir(
+    explicit_dir: Option<&str>,
+    xdg_config_home: Option<&str>,
+    home: Option<&str>,
+) -> Option<PathBuf> {
+    explicit_dir
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            xdg_config_home
+                .filter(|value| !value.trim().is_empty())
+                .map(PathBuf::from)
+                .map(|path| path.join("hostveil"))
+        })
+        .or_else(|| {
+            home.filter(|value| !value.trim().is_empty())
+                .map(PathBuf::from)
+                .map(|path| path.join(".config").join("hostveil"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{AppSettings, resolve_config_dir, save_to_path};
+
+    fn temp_settings_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!(
+                "hostveil-settings-{name}-{}-{nanos}",
+                std::process::id()
+            ))
+            .join("config.json")
+    }
+
+    #[test]
+    fn prefers_explicit_config_dir() {
+        let dir = resolve_config_dir(Some("/tmp/hostveil"), Some("/xdg"), Some("/home/user"))
+            .expect("dir should resolve");
+
+        assert_eq!(dir, PathBuf::from("/tmp/hostveil"));
+    }
+
+    #[test]
+    fn falls_back_to_xdg_config_home() {
+        let dir =
+            resolve_config_dir(None, Some("/xdg"), Some("/home/user")).expect("dir should resolve");
+
+        assert_eq!(dir, PathBuf::from("/xdg/hostveil"));
+    }
+
+    #[test]
+    fn falls_back_to_home_config_dir() {
+        let dir = resolve_config_dir(None, None, Some("/home/user")).expect("dir should resolve");
+
+        assert_eq!(dir, PathBuf::from("/home/user/.config/hostveil"));
+    }
+
+    #[test]
+    fn returns_none_when_no_config_base_exists() {
+        assert!(resolve_config_dir(None, None, None).is_none());
+    }
+
+    #[test]
+    fn saves_settings_as_json() {
+        let path = temp_settings_path("save");
+        let settings = AppSettings {
+            locale: Some(String::from("ko")),
+        };
+
+        save_to_path(&path, &settings).expect("settings should save");
+
+        let written = fs::read_to_string(&path).expect("settings file should exist");
+        assert!(written.contains("\"locale\": \"ko\""));
+
+        fs::remove_dir_all(path.parent().expect("config dir should exist"))
+            .expect("temp dir should be removed");
+    }
+}

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -305,6 +305,10 @@ fn handle_key(state: &mut AppState, scan_result: &ScanResult, key: KeyEvent) -> 
 fn handle_overview_key(state: &mut AppState, key: KeyEvent) -> bool {
     match key.code {
         KeyCode::Char('q') | KeyCode::Esc => true,
+        KeyCode::Char('g') => {
+            let _ = i18n::cycle_persisted_locale();
+            false
+        }
         KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
             state.open_findings();
             false
@@ -333,6 +337,10 @@ fn handle_findings_key(state: &mut AppState, scan_result: &ScanResult, key: KeyE
         }
         KeyCode::Char('r') => {
             state.reset_filters_and_sort();
+            false
+        }
+        KeyCode::Char('g') => {
+            let _ = i18n::cycle_persisted_locale();
             false
         }
         KeyCode::Char('1') => {
@@ -590,6 +598,13 @@ fn header_banner() -> Paragraph<'static> {
             t!("app.header.subtitle").into_owned(),
             Style::default().fg(Color::White),
         ),
+        Span::raw(" | "),
+        Span::styled(
+            current_locale_badge(),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
     ])))
     .alignment(Alignment::Center)
     .block(Block::default().borders(Borders::TOP | Borders::BOTTOM))
@@ -781,6 +796,8 @@ fn overview_footer() -> Paragraph<'static> {
         hint_span("q", t!("app.footer.quit").into_owned()),
         Span::raw("  "),
         hint_span("Enter", t!("app.footer.findings").into_owned()),
+        Span::raw("  "),
+        hint_span("g", t!("app.footer.locale").into_owned()),
         Span::raw("  "),
         hint_span("--json", t!("app.footer.json").into_owned()),
     ])))
@@ -1177,13 +1194,25 @@ fn severity_total_lines(scan_result: &ScanResult, available_width: u16) -> Vec<L
 
     if available_width < 42 {
         vec![
-            Line::raw(format!("Total: {} findings", scan_result.findings.len())),
+            Line::raw(
+                t!(
+                    "app.result.total_findings",
+                    count = scan_result.findings.len()
+                )
+                .into_owned(),
+            ),
             first_pair,
             second_pair,
         ]
     } else {
         vec![
-            Line::raw(format!("Total: {} findings", scan_result.findings.len())),
+            Line::raw(
+                t!(
+                    "app.result.total_findings",
+                    count = scan_result.findings.len()
+                )
+                .into_owned(),
+            ),
             Line::from(vec![
                 Span::styled(
                     format!("{critical} {}", t!("severity.critical").into_owned()),
@@ -1832,6 +1861,10 @@ fn focus_label(focus: FindingsFocus) -> String {
         FindingsFocus::List => t!("app.finding.focus_list").into_owned(),
         FindingsFocus::Detail => t!("app.finding.focus_detail").into_owned(),
     }
+}
+
+fn current_locale_badge() -> String {
+    format!("LANG {}", i18n::current_locale().to_ascii_uppercase())
 }
 
 fn panel_border_style() -> Style {


### PR DESCRIPTION
## Summary
- default locale resolution to English unless the user explicitly overrides it
- add explicit locale controls through `--locale`, `HOSTVEIL_LOCALE`, persisted settings, and the TUI `g` toggle
- improve `hostveil setup` with selector guidance and default-yes `Y/n` confirmation flow
- finish the remaining #149 i18n cleanup across setup, scan, discovery, and adapter status messaging

## Why
Some terminals do not render CJK output reliably, so locale should not silently follow the host environment. The setup and TUI flows also needed clearer, more explicit interaction guidance.

## User Impact
- English stays the safe default even on non-English hosts
- Korean can be enabled explicitly from the CLI, env, or inside the TUI
- setup interactions are easier to understand before input starts
- Korean TUI/help flows no longer show mixed fallback copy for the shipped surfaces covered by this batch

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `./scripts/smoke-test.sh target/debug/hostveil`
- `./scripts/test-install-script.sh target/debug/hostveil`
- `LANG=ko_KR.UTF-8 target/debug/hostveil --help`
- `HOSTVEIL_LOCALE=ko target/debug/hostveil --help`
- `target/debug/hostveil --locale ko --help`
- manual PTY/TUI check in Korean for overview and findings flows

Closes #149