### PR TITLE
ci(release): use Node 24 release action

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -155,7 +155,7 @@ jobs:
         run: cp scripts/install.sh dist/install.sh
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           body: |


### PR DESCRIPTION
## Summary
- Update the release publishing action from `softprops/action-gh-release@v2` to `@v3`.
- Confirmed upstream `@v3` action metadata uses `runs.using: node24`, while `@v2` uses `node20`.

## Why
The v0.4.0 release completed successfully, but GitHub Actions emitted a Node.js 20 deprecation annotation for the release publishing step. Moving to the Node 24 action line removes that deprecation source while keeping the existing release workflow behavior.

## Validation
- `git diff --check`
- `cargo fmt --check`
- Upstream action metadata check: `softprops/action-gh-release@v3` uses `node24`

Closes #155