### PR TITLE
feat(scan): control and bound optional adapters

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -54,10 +54,12 @@ cargo run -- --help
 cargo run -- --version
 cargo run
 cargo run -- --json
+cargo run -- --json --adapters none
 
 # 스냅샷/타깃 테스트용 고급 override
 cargo run -- --json --compose proto/tests/fixtures/parser/docker-compose.yml
 cargo run -- --json --host-root /
+HOSTVEIL_ADAPTERS=trivy,dockle cargo run -- --json
 cargo run -- --quick-fix proto/tests/fixtures/parser/docker-compose.yml --preview-changes
 cargo run -- --fix proto/tests/fixtures/parser/docker-compose.yml --preview-changes
 
@@ -158,7 +160,11 @@ hostveil
 hostveil --json
 hostveil --compose path/to/docker-compose.yml --json
 hostveil --host-root / --json
+hostveil --json --adapters none
+HOSTVEIL_ADAPTERS=trivy,dockle hostveil --json
 ```
+
+선택형 scanner adapter의 기본값은 `all`입니다. 기본 점검만 빠르게 실행하려면 `--adapters none`을 쓰고, 일부만 실행하려면 `--adapters trivy,dockle`처럼 지정합니다.
 
 파일을 쓰기 전에 Compose 수정 계획을 미리 볼 수 있습니다.
 
@@ -260,6 +266,7 @@ v0.4.0 릴리스 하이라이트:
 
 - `hostveil`은 Docker, Trivy, Dockle, Lynis가 없어도 설치/실행되어야 함
 - Docker가 있을 경우 live discovery의 Compose 커버리지를 확장
+- 선택형 scanner 실행은 `--adapters` 또는 `HOSTVEIL_ADAPTERS`로 제어 가능
 - Trivy와 Dockle은 optional image adapter이며, 미설치 시 실패 대신 커버리지 축소로 처리
 - Lynis는 optional host adapter이며, 미설치 시 실패 대신 host-audit 커버리지 축소로 처리
 - 외부 도구 누락은 시작 실패가 아니라 coverage/adapter 상태로 표시

--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ cargo run -- --help
 cargo run -- --version
 cargo run
 cargo run -- --json
+cargo run -- --json --adapters none
 
 # Advanced overrides for snapshots or targeted testing
 cargo run -- --json --compose proto/tests/fixtures/parser/docker-compose.yml
 cargo run -- --json --host-root /
+HOSTVEIL_ADAPTERS=trivy,dockle cargo run -- --json
 cargo run -- --quick-fix proto/tests/fixtures/parser/docker-compose.yml --preview-changes
 cargo run -- --fix proto/tests/fixtures/parser/docker-compose.yml --preview-changes
 
@@ -177,7 +179,11 @@ hostveil
 hostveil --json
 hostveil --compose path/to/docker-compose.yml --json
 hostveil --host-root / --json
+hostveil --json --adapters none
+HOSTVEIL_ADAPTERS=trivy,dockle hostveil --json
 ```
+
+Optional scanner adapters default to `all`. Use `--adapters none` for native-only scans, or choose a subset such as `--adapters trivy,dockle`.
 
 Preview Compose remediation before writing files:
 
@@ -281,6 +287,7 @@ Optional dependency policy for current releases:
 
 - `hostveil` should install and run without Docker, Trivy, Dockle, or Lynis being present
 - Docker-based live discovery improves Compose coverage when available
+- Optional scanner execution can be controlled with `--adapters` or `HOSTVEIL_ADAPTERS`
 - Trivy and Dockle remain optional image adapters; if either is missing, scans continue with reduced coverage instead of failing
 - Lynis remains an optional host adapter; if it is missing, scans continue with reduced host-audit coverage instead of failing
 - Missing external tools should be shown as coverage or adapter status, not as fatal startup errors

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6,6 +6,8 @@ BINARY_PATH="${1:-$ROOT_DIR/target/debug/hostveil}"
 # Keep smoke outputs deterministic across developer locales; allow explicit override.
 HOSTVEIL_TEST_LOCALE="${HOSTVEIL_TEST_LOCALE:-en}"
 export HOSTVEIL_LOCALE="$HOSTVEIL_TEST_LOCALE"
+# Keep smoke scans deterministic and avoid optional external scanner execution.
+export HOSTVEIL_ADAPTERS="${HOSTVEIL_ADAPTERS:-none}"
 
 [[ -x "$BINARY_PATH" ]] || {
   printf 'error: binary is not executable: %s\n' "$BINARY_PATH" >&2
@@ -42,6 +44,7 @@ VERSION_OUTPUT="$($BINARY_PATH --version)"
 printf '%s\n' "$VERSION_OUTPUT" | grep -q '^hostveil '
 
 $BINARY_PATH --help | grep -q -- '--version'
+$BINARY_PATH --help | grep -q -- '--adapters'
 $BINARY_PATH --help | grep -q -- 'hostveil upgrade'
 $BINARY_PATH --help | grep -q -- 'hostveil auto-upgrade enable'
 HOSTVEIL_LOCALE=ko $BINARY_PATH --help | grep -q '사용법'

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -23,7 +23,7 @@ app:
       Usage:
         hostveil
         hostveil --json
-        hostveil [--compose PATH] [--host-root PATH] [--json]
+        hostveil [--compose PATH] [--host-root PATH] [--adapters LIST] [--json]
         hostveil setup [--tool NAME]... [--tools LIST] [--yes]
         hostveil --quick-fix PATH [--preview-changes] [--yes]
         hostveil --fix PATH [--preview-changes] [--yes]
@@ -46,6 +46,7 @@ app:
       Options:
         --compose PATH    override live discovery with a specific Compose file or directory
         --host-root PATH  override the default live host root (/) with a Linux root or snapshot
+        --adapters LIST   choose optional scanners: all, none, or comma-separated trivy,dockle,lynis
         --tool NAME       select a setup tool explicitly for hostveil setup (repeatable)
         --tools LIST      comma-separated setup tool list for unattended setup runs
         --quick-fix PATH  preview or apply safe Compose-only fixes for a specific file or directory
@@ -56,6 +57,9 @@ app:
         --json            emit scan result JSON instead of launching the TUI
         -V, --version     show version information
         -h, --help        show this help message
+
+      Environment:
+        HOSTVEIL_ADAPTERS provides the same adapter selection when --adapters is not set.
   version:
     text: "%{name} %{version}"
   hint:
@@ -145,6 +149,7 @@ app:
     json_parse_failed: "failed to parse %{tool} JSON: %{error}"
     report_parse_failed: "failed to parse %{tool} report contents"
     command_no_error_detail: "command returned no error detail"
+    command_timed_out: "timed out after %{seconds}s"
     scan_thread_panicked: "%{adapter} scan thread panicked"
   discovery:
     docker_cli_missing_fallback: "Docker CLI is not available; switching to fallback discovery."
@@ -174,6 +179,10 @@ app:
     duplicate_locale_override: "choose only one --locale override"
     unsupported_setup_tool: "unsupported setup tool: %{value}"
     setup_tools_required: "--tools requires at least one tool name"
+    unsupported_adapter: "unsupported adapter: %{value}"
+    adapter_selection_required: "--adapters requires all, none, or one or more adapter names"
+    adapter_selection_keyword_conflict: "all and none cannot be combined with adapter names"
+    adapters_require_scan_mode: "--adapters is only valid for scan operations"
   setup:
     heading: "hostveil setup"
     detected_os: "Detected OS: %{name}"
@@ -320,6 +329,7 @@ adapter:
     no_image_targets: "no image targets were discovered"
     host_not_scanned: "host scanning was not requested"
     live_host_only: "a live host scan rooted at / is required"
+    disabled_by_selection: "disabled by adapter selection"
 finding:
   lynis:
     host_warnings:

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -23,7 +23,7 @@ app:
       사용법:
         hostveil
         hostveil --json
-        hostveil [--compose PATH] [--host-root PATH] [--json]
+        hostveil [--compose PATH] [--host-root PATH] [--adapters LIST] [--json]
         hostveil setup [--tool NAME]... [--tools LIST] [--yes]
         hostveil --quick-fix PATH [--preview-changes] [--yes]
         hostveil --fix PATH [--preview-changes] [--yes]
@@ -46,6 +46,7 @@ app:
       옵션:
         --compose PATH    라이브 탐색 대신 특정 Compose 파일 또는 디렉터리를 사용합니다
         --host-root PATH  기본 호스트 루트(/) 대신 특정 Linux 루트 또는 스냅샷을 사용합니다
+        --adapters LIST   선택형 스캐너를 고릅니다: all, none 또는 쉼표 구분 trivy,dockle,lynis
         --tool NAME       hostveil setup에서 설치 도구를 명시적으로 선택합니다(반복 가능)
         --tools LIST      무인 setup 실행용 쉼표 구분 도구 목록입니다
         --quick-fix PATH  특정 파일 또는 디렉터리에 안전한 Compose 전용 수정을 미리보기 또는 적용합니다
@@ -56,6 +57,9 @@ app:
         --json            TUI 대신 스캔 결과 JSON을 출력합니다
         -V, --version     버전 정보를 표시합니다
         -h, --help        이 도움말을 표시합니다
+
+      환경 변수:
+        --adapters가 없으면 HOSTVEIL_ADAPTERS로 같은 adapter 선택을 지정할 수 있습니다.
   version:
     text: "%{name} %{version}"
   hint:
@@ -145,6 +149,7 @@ app:
     json_parse_failed: "%{tool} JSON 파싱에 실패했습니다: %{error}"
     report_parse_failed: "%{tool} 보고서 내용을 파싱하지 못했습니다"
     command_no_error_detail: "명령에서 오류 상세를 반환하지 않았습니다"
+    command_timed_out: "%{seconds}초 후 시간 초과"
     scan_thread_panicked: "%{adapter} 스캔 스레드가 패닉으로 종료되었습니다"
   discovery:
     docker_cli_missing_fallback: "Docker CLI를 찾지 못해 fallback 탐색으로 전환합니다."
@@ -174,6 +179,10 @@ app:
     duplicate_locale_override: "--locale override는 하나만 선택하세요"
     unsupported_setup_tool: "지원하지 않는 setup 도구입니다: %{value}"
     setup_tools_required: "--tools에는 최소 하나의 도구 이름이 필요합니다"
+    unsupported_adapter: "지원하지 않는 adapter입니다: %{value}"
+    adapter_selection_required: "--adapters에는 all, none 또는 하나 이상의 adapter 이름이 필요합니다"
+    adapter_selection_keyword_conflict: "all과 none은 adapter 이름과 함께 사용할 수 없습니다"
+    adapters_require_scan_mode: "--adapters는 scan 작업에서만 사용할 수 있습니다"
   setup:
     heading: "hostveil setup"
     detected_os: "감지된 OS: %{name}"
@@ -320,6 +329,7 @@ adapter:
     no_image_targets: "발견된 이미지 대상이 없습니다"
     host_not_scanned: "호스트 스캔이 요청되지 않았습니다"
     live_host_only: "루트(/) 기반 라이브 호스트 스캔이 필요합니다"
+    disabled_by_selection: "adapter 선택에 의해 비활성화됨"
 finding:
   lynis:
     host_warnings:

--- a/src/src/adapters/command.rs
+++ b/src/src/adapters/command.rs
@@ -1,0 +1,158 @@
+use std::io::{self, Read};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub const DEFAULT_ADAPTER_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[derive(Debug)]
+pub struct CommandOutput {
+    pub status: ExitStatus,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub enum CommandError {
+    Io(io::Error),
+    TimedOut(Duration),
+}
+
+impl CommandError {
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, Self::Io(error) if error.kind() == io::ErrorKind::NotFound)
+    }
+
+    pub fn detail(&self) -> String {
+        match self {
+            Self::Io(error) => error.to_string(),
+            Self::TimedOut(timeout) => crate::i18n::tr_adapter_command_timed_out(timeout.as_secs()),
+        }
+    }
+}
+
+pub fn run_with_default_timeout(command: Command) -> Result<CommandOutput, CommandError> {
+    run_with_timeout(command, DEFAULT_ADAPTER_TIMEOUT)
+}
+
+pub fn run_with_timeout(
+    mut command: Command,
+    timeout: Duration,
+) -> Result<CommandOutput, CommandError> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    configure_timeout_process_group(&mut command);
+
+    let mut child = command.spawn().map_err(CommandError::Io)?;
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+
+    let stdout_handle = thread::spawn(move || read_pipe(stdout));
+    let stderr_handle = thread::spawn(move || read_pipe(stderr));
+    let start = Instant::now();
+
+    loop {
+        match child.try_wait().map_err(CommandError::Io)? {
+            Some(status) => {
+                let stdout = stdout_handle.join().unwrap_or_default();
+                let stderr = stderr_handle.join().unwrap_or_default();
+                return Ok(CommandOutput {
+                    status,
+                    stdout,
+                    stderr,
+                });
+            }
+            None if start.elapsed() >= timeout => {
+                terminate_child(&mut child);
+                let _ = stdout_handle.join();
+                let _ = stderr_handle.join();
+                return Err(CommandError::TimedOut(timeout));
+            }
+            None => thread::sleep(Duration::from_millis(10)),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn configure_timeout_process_group(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    unsafe {
+        command.pre_exec(|| {
+            if setpgid(0, 0) == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn configure_timeout_process_group(_command: &mut Command) {}
+
+fn terminate_child(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        kill_process_group(child.id());
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+fn kill_process_group(child_id: u32) {
+    const SIGKILL: i32 = 9;
+
+    let Ok(pgid) = i32::try_from(child_id) else {
+        return;
+    };
+
+    unsafe {
+        let _ = kill(-pgid, SIGKILL);
+    }
+}
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn setpgid(pid: i32, pgid: i32) -> i32;
+    fn kill(pid: i32, sig: i32) -> i32;
+}
+
+fn read_pipe<R: Read>(pipe: Option<R>) -> Vec<u8> {
+    let Some(mut pipe) = pipe else {
+        return Vec::new();
+    };
+
+    let mut output = Vec::new();
+    let _ = pipe.read_to_end(&mut output);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    use super::{CommandError, run_with_timeout};
+
+    #[test]
+    fn command_timeout_kills_and_returns_detail() {
+        rust_i18n::set_locale("en");
+
+        let started = Instant::now();
+        let error = run_with_timeout(
+            {
+                let mut command = Command::new("sh");
+                command.args(["-c", "sleep 2"]);
+                command
+            },
+            Duration::from_millis(50),
+        )
+        .expect_err("sleep command should time out");
+
+        assert!(matches!(error, CommandError::TimedOut(_)));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(error.detail().contains("timed out after"));
+    }
+}

--- a/src/src/adapters/dockle.rs
+++ b/src/src/adapters/dockle.rs
@@ -1,8 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
+use std::time::Duration;
 
 use serde::Deserialize;
 
+use crate::adapters::command;
 use crate::domain::{
     AdapterStatus, Axis, Finding, RemediationKind, Scope, ServiceSummary, Severity, Source,
 };
@@ -15,6 +17,20 @@ pub struct DockleScanOutput {
 }
 
 pub fn scan(services: &[ServiceSummary]) -> DockleScanOutput {
+    scan_with_commands(
+        services,
+        "dockle",
+        "dockle",
+        command::DEFAULT_ADAPTER_TIMEOUT,
+    )
+}
+
+fn scan_with_commands(
+    services: &[ServiceSummary],
+    detect_command: &str,
+    scan_command: &str,
+    timeout: Duration,
+) -> DockleScanOutput {
     let mut output = DockleScanOutput {
         status: AdapterStatus::Missing,
         findings: Vec::new(),
@@ -29,7 +45,7 @@ pub fn scan(services: &[ServiceSummary]) -> DockleScanOutput {
         return output;
     }
 
-    match detect_dockle() {
+    match detect_dockle_with_command_and_timeout(detect_command, timeout) {
         DockleAvailability::Missing => {
             output.status = AdapterStatus::Missing;
             return output;
@@ -44,7 +60,7 @@ pub fn scan(services: &[ServiceSummary]) -> DockleScanOutput {
     }
 
     for image in images {
-        match scan_image(&image) {
+        match scan_image_with_command(scan_command, &image, timeout) {
             Ok(Some(summary)) => {
                 successful_scans += 1;
                 output.findings.push(summary_to_finding(&summary, services));
@@ -85,15 +101,18 @@ enum DockleAvailability {
     Failed(String),
 }
 
-fn detect_dockle() -> DockleAvailability {
-    detect_dockle_with_command("dockle")
+#[cfg(test)]
+fn detect_dockle_with_command(command_name: &str) -> DockleAvailability {
+    detect_dockle_with_command_and_timeout(command_name, command::DEFAULT_ADAPTER_TIMEOUT)
 }
 
-fn detect_dockle_with_command(command: &str) -> DockleAvailability {
-    let output = Command::new(command)
-        .arg("--version")
-        .env("NO_COLOR", "1")
-        .output();
+fn detect_dockle_with_command_and_timeout(
+    command_name: &str,
+    timeout: Duration,
+) -> DockleAvailability {
+    let mut command = Command::new(command_name);
+    command.arg("--version").env("NO_COLOR", "1");
+    let output = command::run_with_timeout(command, timeout);
 
     match output {
         Ok(output) if output.status.success() => DockleAvailability::Available,
@@ -101,8 +120,8 @@ fn detect_dockle_with_command(command: &str) -> DockleAvailability {
             let stderr = String::from_utf8_lossy(&output.stderr);
             DockleAvailability::Failed(truncate(stderr.trim(), 200))
         }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => DockleAvailability::Missing,
-        Err(error) => DockleAvailability::Failed(truncate(&error.to_string(), 200)),
+        Err(error) if error.is_not_found() => DockleAvailability::Missing,
+        Err(error) => DockleAvailability::Failed(truncate(&error.detail(), 200)),
     }
 }
 
@@ -136,12 +155,14 @@ enum DockleLevel {
     Info,
 }
 
-fn scan_image(image: &str) -> Result<Option<DockleImageSummary>, String> {
-    let output = Command::new("dockle")
-        .args(dockle_image_args(image))
-        .env("NO_COLOR", "1")
-        .output()
-        .map_err(|error| error.to_string())?;
+fn scan_image_with_command(
+    command_name: &str,
+    image: &str,
+    timeout: Duration,
+) -> Result<Option<DockleImageSummary>, String> {
+    let mut command = Command::new(command_name);
+    command.args(dockle_image_args(image)).env("NO_COLOR", "1");
+    let output = command::run_with_timeout(command, timeout).map_err(|error| error.detail())?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/src/adapters/lynis.rs
+++ b/src/src/adapters/lynis.rs
@@ -3,8 +3,9 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crate::adapters::command;
 use crate::domain::{AdapterStatus, Axis, Finding, RemediationKind, Scope, Severity, Source};
 
 const LIVE_HOST_ROOT: &str = "/";
@@ -130,17 +131,23 @@ fn detect_lynis() -> LynisAvailability {
     detect_lynis_with_command("lynis")
 }
 
-fn detect_lynis_with_command(command: &str) -> LynisAvailability {
-    let output = Command::new(command)
-        .arg("--version")
-        .env("NO_COLOR", "1")
-        .output();
+fn detect_lynis_with_command(command_name: &str) -> LynisAvailability {
+    detect_lynis_with_command_and_timeout(command_name, command::DEFAULT_ADAPTER_TIMEOUT)
+}
+
+fn detect_lynis_with_command_and_timeout(
+    command_name: &str,
+    timeout: Duration,
+) -> LynisAvailability {
+    let mut command = Command::new(command_name);
+    command.arg("--version").env("NO_COLOR", "1");
+    let output = command::run_with_timeout(command, timeout);
 
     match output {
         Ok(output) if output.status.success() => LynisAvailability::Available,
         Ok(output) => LynisAvailability::Failed(command_detail(&output.stderr, &output.stdout)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => LynisAvailability::Missing,
-        Err(error) => LynisAvailability::Failed(error.to_string()),
+        Err(error) if error.is_not_found() => LynisAvailability::Missing,
+        Err(error) => LynisAvailability::Failed(error.detail()),
     }
 }
 
@@ -175,7 +182,15 @@ struct LynisCommandResult {
 }
 
 fn run_lynis(files: &LynisTempFiles) -> Result<LynisCommandResult, String> {
-    let mut command = Command::new("lynis");
+    run_lynis_with_command("lynis", files, command::DEFAULT_ADAPTER_TIMEOUT)
+}
+
+fn run_lynis_with_command(
+    command_name: &str,
+    files: &LynisTempFiles,
+    timeout: Duration,
+) -> Result<LynisCommandResult, String> {
+    let mut command = Command::new(command_name);
     command
         .args(["audit", "system", "--cronjob", "--quiet", "--nocolors"])
         .arg("--report-file")
@@ -184,7 +199,7 @@ fn run_lynis(files: &LynisTempFiles) -> Result<LynisCommandResult, String> {
         .arg(&files.log_file)
         .env("NO_COLOR", "1");
 
-    let output = command.output().map_err(|error| error.to_string())?;
+    let output = command::run_with_timeout(command, timeout).map_err(|error| error.detail())?;
 
     Ok(LynisCommandResult {
         success: output.status.success(),

--- a/src/src/adapters/mod.rs
+++ b/src/src/adapters/mod.rs
@@ -1,5 +1,6 @@
 use crate::domain::Finding;
 
+pub mod command;
 pub mod dockle;
 pub mod lynis;
 pub mod trivy;

--- a/src/src/adapters/trivy.rs
+++ b/src/src/adapters/trivy.rs
@@ -1,8 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
+use std::time::Duration;
 
 use serde::Deserialize;
 
+use crate::adapters::command;
 use crate::domain::{
     AdapterStatus, Axis, Finding, RemediationKind, Scope, ServiceSummary, Severity, Source,
 };
@@ -15,6 +17,15 @@ pub struct TrivyScanOutput {
 }
 
 pub fn scan(services: &[ServiceSummary]) -> TrivyScanOutput {
+    scan_with_commands(services, "trivy", "trivy", command::DEFAULT_ADAPTER_TIMEOUT)
+}
+
+fn scan_with_commands(
+    services: &[ServiceSummary],
+    detect_command: &str,
+    scan_command: &str,
+    timeout: Duration,
+) -> TrivyScanOutput {
     let mut output = TrivyScanOutput {
         status: AdapterStatus::Missing,
         findings: Vec::new(),
@@ -29,7 +40,7 @@ pub fn scan(services: &[ServiceSummary]) -> TrivyScanOutput {
         return output;
     }
 
-    match detect_trivy() {
+    match detect_trivy_with_command_and_timeout(detect_command, timeout) {
         TrivyAvailability::Missing => {
             output.status = AdapterStatus::Missing;
             return output;
@@ -44,7 +55,7 @@ pub fn scan(services: &[ServiceSummary]) -> TrivyScanOutput {
     }
 
     for image in images {
-        match scan_image(&image) {
+        match scan_image_with_command(scan_command, &image, timeout) {
             Ok(Some(summary)) => {
                 successful_scans += 1;
                 output.findings.push(summary_to_finding(&summary, services));
@@ -85,15 +96,18 @@ enum TrivyAvailability {
     Failed(String),
 }
 
-fn detect_trivy() -> TrivyAvailability {
-    detect_trivy_with_command("trivy")
+#[cfg(test)]
+fn detect_trivy_with_command(command_name: &str) -> TrivyAvailability {
+    detect_trivy_with_command_and_timeout(command_name, command::DEFAULT_ADAPTER_TIMEOUT)
 }
 
-fn detect_trivy_with_command(command: &str) -> TrivyAvailability {
-    let output = Command::new(command)
-        .arg("--version")
-        .env("NO_COLOR", "1")
-        .output();
+fn detect_trivy_with_command_and_timeout(
+    command_name: &str,
+    timeout: Duration,
+) -> TrivyAvailability {
+    let mut command = Command::new(command_name);
+    command.arg("--version").env("NO_COLOR", "1");
+    let output = command::run_with_timeout(command, timeout);
 
     match output {
         Ok(output) if output.status.success() => TrivyAvailability::Available,
@@ -101,8 +115,8 @@ fn detect_trivy_with_command(command: &str) -> TrivyAvailability {
             let stderr = String::from_utf8_lossy(&output.stderr);
             TrivyAvailability::Failed(truncate(stderr.trim(), 200))
         }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => TrivyAvailability::Missing,
-        Err(error) => TrivyAvailability::Failed(truncate(&error.to_string(), 200)),
+        Err(error) if error.is_not_found() => TrivyAvailability::Missing,
+        Err(error) => TrivyAvailability::Failed(truncate(&error.detail(), 200)),
     }
 }
 
@@ -130,12 +144,14 @@ struct TrivyImageSummary {
     sample_ids: Vec<String>,
 }
 
-fn scan_image(image: &str) -> Result<Option<TrivyImageSummary>, String> {
-    let output = Command::new("trivy")
-        .args(trivy_image_args(image))
-        .env("NO_COLOR", "1")
-        .output()
-        .map_err(|error| error.to_string())?;
+fn scan_image_with_command(
+    command_name: &str,
+    image: &str,
+    timeout: Duration,
+) -> Result<Option<TrivyImageSummary>, String> {
+    let mut command = Command::new(command_name);
+    command.args(trivy_image_args(image)).env("NO_COLOR", "1");
+    let output = command::run_with_timeout(command, timeout).map_err(|error| error.detail())?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -360,7 +376,30 @@ struct TrivyVulnerability {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
     use super::*;
+
+    fn temp_command(content: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "hostveil-trivy-test-command-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::write(&path, content).expect("test command should be written");
+        let mut permissions = fs::metadata(&path)
+            .expect("test command metadata should be available")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).expect("test command should be executable");
+        path
+    }
 
     #[test]
     fn maps_trivy_severities() {
@@ -462,6 +501,53 @@ mod tests {
             output.status,
             AdapterStatus::Failed(String::from("registry denied access"))
         );
+    }
+
+    #[test]
+    fn partial_image_timeout_preserves_successful_trivy_findings() {
+        rust_i18n::set_locale("en");
+
+        let command = temp_command(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'trivy test\n'
+  exit 0
+fi
+image="${@: -1}"
+if [[ "$image" == "slow:1" ]]; then
+  sleep 2
+  exit 0
+fi
+cat <<'JSON'
+{"Results":[{"Target":"fast:1","Vulnerabilities":[{"VulnerabilityID":"CVE-2026-0001","Severity":"HIGH"}]}]}
+JSON
+"#,
+        );
+        let command = command.display().to_string();
+        let services = vec![
+            ServiceSummary {
+                name: String::from("fast"),
+                image: Some(String::from("fast:1")),
+            },
+            ServiceSummary {
+                name: String::from("slow"),
+                image: Some(String::from("slow:1")),
+            },
+        ];
+
+        let output = scan_with_commands(&services, &command, &command, Duration::from_millis(50));
+
+        assert_eq!(output.status, AdapterStatus::Available);
+        assert_eq!(output.findings.len(), 1);
+        assert!(
+            output
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("timed out after"))
+        );
+
+        let _ = fs::remove_file(command);
     }
 
     #[test]

--- a/src/src/app/config.rs
+++ b/src/src/app/config.rs
@@ -9,6 +9,81 @@ pub enum OutputMode {
     Json,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ScanAdapter {
+    Trivy,
+    Dockle,
+    Lynis,
+}
+
+impl ScanAdapter {
+    pub const ALL: [Self; 3] = [Self::Trivy, Self::Dockle, Self::Lynis];
+
+    pub fn from_arg(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "trivy" => Some(Self::Trivy),
+            "dockle" => Some(Self::Dockle),
+            "lynis" => Some(Self::Lynis),
+            _ => None,
+        }
+    }
+
+    pub fn cli_name(self) -> &'static str {
+        match self {
+            Self::Trivy => "trivy",
+            Self::Dockle => "dockle",
+            Self::Lynis => "lynis",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdapterSelection {
+    pub trivy: bool,
+    pub dockle: bool,
+    pub lynis: bool,
+}
+
+impl AdapterSelection {
+    pub const fn all() -> Self {
+        Self {
+            trivy: true,
+            dockle: true,
+            lynis: true,
+        }
+    }
+
+    pub const fn none() -> Self {
+        Self {
+            trivy: false,
+            dockle: false,
+            lynis: false,
+        }
+    }
+
+    pub const fn is_enabled(self, adapter: ScanAdapter) -> bool {
+        match adapter {
+            ScanAdapter::Trivy => self.trivy,
+            ScanAdapter::Dockle => self.dockle,
+            ScanAdapter::Lynis => self.lynis,
+        }
+    }
+
+    fn enable(&mut self, adapter: ScanAdapter) {
+        match adapter {
+            ScanAdapter::Trivy => self.trivy = true,
+            ScanAdapter::Dockle => self.dockle = true,
+            ScanAdapter::Lynis => self.lynis = true,
+        }
+    }
+}
+
+impl Default for AdapterSelection {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LifecycleCommand {
     Upgrade,
@@ -71,6 +146,7 @@ pub struct AppConfig {
     pub setup_command: Option<SetupConfig>,
     pub compose_path: Option<PathBuf>,
     pub host_root: Option<PathBuf>,
+    pub adapter_selection: AdapterSelection,
     pub fix_mode: Option<FixMode>,
     pub fix_target_path: Option<PathBuf>,
     pub preview_changes: bool,
@@ -88,6 +164,7 @@ impl Default for AppConfig {
             setup_command: None,
             compose_path: None,
             host_root: None,
+            adapter_selection: AdapterSelection::all(),
             fix_mode: None,
             fix_target_path: None,
             preview_changes: false,
@@ -98,6 +175,14 @@ impl Default for AppConfig {
 
 impl AppConfig {
     pub fn parse(args: impl IntoIterator<Item = String>) -> Result<Self, AppError> {
+        let adapter_env = std::env::var("HOSTVEIL_ADAPTERS").ok();
+        Self::parse_with_adapter_env(args, adapter_env.as_deref())
+    }
+
+    fn parse_with_adapter_env(
+        args: impl IntoIterator<Item = String>,
+        adapter_env: Option<&str>,
+    ) -> Result<Self, AppError> {
         let args: Vec<String> = args.into_iter().collect();
         let (locale_override, args) = strip_locale_override(args)?;
 
@@ -131,6 +216,7 @@ impl AppConfig {
             locale_override,
             ..Self::default()
         };
+        let mut adapter_selection_explicit = false;
         let mut args = args.into_iter();
 
         while let Some(argument) = args.next() {
@@ -166,6 +252,21 @@ impl AppConfig {
                     }
                     config.host_root = Some(PathBuf::from(value));
                 }
+                "--adapters" => {
+                    let value = args
+                        .next()
+                        .ok_or(AppError::MissingArgumentValue("--adapters"))?;
+                    config.adapter_selection = parse_adapter_selection(&value)?;
+                    adapter_selection_explicit = true;
+                }
+                _ if argument.starts_with("--adapters=") => {
+                    let value = argument.trim_start_matches("--adapters=");
+                    if value.is_empty() {
+                        return Err(AppError::MissingArgumentValue("--adapters"));
+                    }
+                    config.adapter_selection = parse_adapter_selection(value)?;
+                    adapter_selection_explicit = true;
+                }
                 "--quick-fix" => {
                     let value = args
                         .next()
@@ -192,6 +293,19 @@ impl AppConfig {
                 }
                 _ => return Err(AppError::UnknownArgument(argument)),
             }
+        }
+
+        if !adapter_selection_explicit
+            && config.fix_mode.is_none()
+            && let Some(adapter_env) = adapter_env
+        {
+            config.adapter_selection = parse_adapter_selection(adapter_env)?;
+        }
+
+        if config.fix_mode.is_some() && adapter_selection_explicit {
+            return Err(AppError::InvalidArgumentCombination(
+                crate::i18n::tr_adapters_require_scan_mode(),
+            ));
         }
 
         config.validate()?;
@@ -456,9 +570,51 @@ fn parse_setup_tool_list(tools: &mut Vec<SetupTool>, value: &str) -> Result<(), 
     }
 }
 
+fn parse_adapter_selection(value: &str) -> Result<AdapterSelection, AppError> {
+    let entries: Vec<String> = value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| entry.to_ascii_lowercase())
+        .collect();
+
+    if entries.is_empty() {
+        return Err(AppError::InvalidArgumentCombination(
+            crate::i18n::tr_adapter_selection_required(),
+        ));
+    }
+
+    let has_all = entries.iter().any(|entry| entry == "all");
+    let has_none = entries.iter().any(|entry| entry == "none");
+
+    if (has_all || has_none) && entries.len() > 1 {
+        return Err(AppError::InvalidArgumentCombination(
+            crate::i18n::tr_adapter_selection_keyword_conflict(),
+        ));
+    }
+
+    if has_all {
+        return Ok(AdapterSelection::all());
+    }
+
+    if has_none {
+        return Ok(AdapterSelection::none());
+    }
+
+    let mut selection = AdapterSelection::none();
+    for entry in entries {
+        let adapter = ScanAdapter::from_arg(&entry).ok_or_else(|| {
+            AppError::InvalidArgumentCombination(crate::i18n::tr_unsupported_adapter(&entry))
+        })?;
+        selection.enable(adapter);
+    }
+
+    Ok(selection)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{AppConfig, LifecycleCommand, OutputMode, SetupTool};
+    use super::{AdapterSelection, AppConfig, LifecycleCommand, OutputMode, SetupTool};
     use crate::fix::FixMode;
 
     #[test]
@@ -470,6 +626,7 @@ mod tests {
         assert!(!config.show_version);
         assert!(config.lifecycle_command.is_none());
         assert!(config.setup_command.is_none());
+        assert_eq!(config.adapter_selection, AdapterSelection::all());
         assert!(config.fix_mode.is_none());
     }
 
@@ -698,6 +855,96 @@ mod tests {
             String::from("dockle"),
         ])
         .expect_err("unknown setup tool should be rejected");
+
+        assert!(matches!(
+            error,
+            super::AppError::InvalidArgumentCombination(_)
+        ));
+    }
+
+    #[test]
+    fn parses_adapter_selection_all() {
+        let config =
+            AppConfig::parse([String::from("--adapters=all")]).expect("config should parse");
+
+        assert_eq!(config.adapter_selection, AdapterSelection::all());
+    }
+
+    #[test]
+    fn parses_adapter_selection_none() {
+        let config =
+            AppConfig::parse([String::from("--adapters=none")]).expect("config should parse");
+
+        assert_eq!(config.adapter_selection, AdapterSelection::none());
+    }
+
+    #[test]
+    fn parses_adapter_selection_list() {
+        let config = AppConfig::parse([
+            String::from("--adapters"),
+            String::from("trivy,dockle"),
+            String::from("--json"),
+        ])
+        .expect("config should parse");
+
+        assert!(config.adapter_selection.trivy);
+        assert!(config.adapter_selection.dockle);
+        assert!(!config.adapter_selection.lynis);
+    }
+
+    #[test]
+    fn adapter_selection_uses_env_fallback() {
+        let config = AppConfig::parse_with_adapter_env([String::from("--json")], Some("lynis"))
+            .expect("config should parse");
+
+        assert!(!config.adapter_selection.trivy);
+        assert!(!config.adapter_selection.dockle);
+        assert!(config.adapter_selection.lynis);
+    }
+
+    #[test]
+    fn adapter_selection_cli_overrides_env() {
+        let config = AppConfig::parse_with_adapter_env(
+            [String::from("--adapters=trivy"), String::from("--json")],
+            Some("none"),
+        )
+        .expect("config should parse");
+
+        assert!(config.adapter_selection.trivy);
+        assert!(!config.adapter_selection.dockle);
+        assert!(!config.adapter_selection.lynis);
+    }
+
+    #[test]
+    fn rejects_unknown_adapter_selection() {
+        let error = AppConfig::parse([String::from("--adapters=nmap")])
+            .expect_err("unknown adapter should be rejected");
+
+        assert!(matches!(
+            error,
+            super::AppError::InvalidArgumentCombination(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_none_combined_with_adapter_selection() {
+        let error = AppConfig::parse([String::from("--adapters=none,trivy")])
+            .expect_err("none should be exclusive");
+
+        assert!(matches!(
+            error,
+            super::AppError::InvalidArgumentCombination(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_adapters_with_fix_mode() {
+        let error = AppConfig::parse([
+            String::from("--quick-fix"),
+            String::from("docker-compose.yml"),
+            String::from("--adapters=none"),
+        ])
+        .expect_err("adapter selection should require scan mode");
 
         assert!(matches!(
             error,

--- a/src/src/app/mod.rs
+++ b/src/src/app/mod.rs
@@ -2,7 +2,7 @@ mod config;
 mod scan;
 mod setup;
 
-pub use config::{AppConfig, OutputMode, SetupConfig, SetupTool};
+pub use config::{AdapterSelection, AppConfig, OutputMode, ScanAdapter, SetupConfig, SetupTool};
 
 use std::fmt;
 use std::io::{self, Write};
@@ -153,7 +153,8 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
             }
 
             let mut scan_result = scan::run_native(&config)?;
-            let adapter_updates = scan::prepare_background_adapter_scan(&mut scan_result);
+            let adapter_updates =
+                scan::prepare_background_adapter_scan(&mut scan_result, config.adapter_selection);
 
             tui::run(&mut scan_result, move |scan_result| {
                 let mut updated = false;

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -16,7 +16,7 @@ use crate::host::{HostContext, HostScanner, collect_host_runtime_info};
 use crate::rules::RuleEngine;
 use crate::scoring;
 
-use super::{AppConfig, AppError};
+use super::{AdapterSelection, AppConfig, AppError, ScanAdapter};
 
 #[derive(Debug)]
 pub struct AdapterScanUpdate {
@@ -27,7 +27,7 @@ pub struct AdapterScanUpdate {
 
 pub fn run(config: &AppConfig) -> Result<ScanResult, AppError> {
     let mut result = run_native(config)?;
-    apply_external_adapters(&mut result);
+    apply_external_adapters(&mut result, config.adapter_selection);
     Ok(result)
 }
 
@@ -56,33 +56,40 @@ pub fn run_native(config: &AppConfig) -> Result<ScanResult, AppError> {
     Ok(result)
 }
 
-fn apply_external_adapters(result: &mut ScanResult) {
+fn apply_external_adapters(result: &mut ScanResult, selection: AdapterSelection) {
     let update = scan_external_adapters(
         result.metadata.services.clone(),
         result.metadata.host_root.clone(),
+        selection,
     );
     apply_external_adapter_update(result, update);
 }
 
-pub fn prepare_background_adapter_scan(result: &mut ScanResult) -> Receiver<AdapterScanUpdate> {
-    spawn_background_adapter_scan(result, scan_external_adapters)
+pub fn prepare_background_adapter_scan(
+    result: &mut ScanResult,
+    selection: AdapterSelection,
+) -> Receiver<AdapterScanUpdate> {
+    spawn_background_adapter_scan(result, selection, scan_external_adapters)
 }
 
 fn spawn_background_adapter_scan<F>(
     result: &mut ScanResult,
+    selection: AdapterSelection,
     scan_fn: F,
 ) -> Receiver<AdapterScanUpdate>
 where
-    F: FnOnce(Vec<ServiceSummary>, Option<PathBuf>) -> AdapterScanUpdate + Send + 'static,
+    F: FnOnce(Vec<ServiceSummary>, Option<PathBuf>, AdapterSelection) -> AdapterScanUpdate
+        + Send
+        + 'static,
 {
-    seed_adapter_statuses(result);
+    seed_adapter_statuses(result, selection);
 
     let services = result.metadata.services.clone();
     let host_root = result.metadata.host_root.clone();
     let (sender, receiver) = mpsc::channel();
 
     thread::spawn(move || {
-        let update = scan_fn(services, host_root);
+        let update = scan_fn(services, host_root, selection);
         let _ = sender.send(update);
     });
 
@@ -124,28 +131,37 @@ pub fn apply_external_adapter_update(result: &mut ScanResult, update: AdapterSca
 fn scan_external_adapters(
     services: Vec<ServiceSummary>,
     host_root: Option<PathBuf>,
+    selection: AdapterSelection,
 ) -> AdapterScanUpdate {
-    let trivy_services = services.clone();
-    let dockle_services = services;
-    let trivy_handle = thread::spawn(move || adapters::trivy::scan(&trivy_services));
-    let dockle_handle = thread::spawn(move || adapters::dockle::scan(&dockle_services));
-    let lynis_handle = thread::spawn(move || adapters::lynis::scan(host_root.as_deref()));
+    let trivy_handle = selection.is_enabled(ScanAdapter::Trivy).then(|| {
+        let trivy_services = services.clone();
+        thread::spawn(move || adapters::trivy::scan(&trivy_services))
+    });
+    let dockle_handle = selection.is_enabled(ScanAdapter::Dockle).then(|| {
+        let dockle_services = services;
+        thread::spawn(move || adapters::dockle::scan(&dockle_services))
+    });
+    let lynis_handle = selection
+        .is_enabled(ScanAdapter::Lynis)
+        .then(|| thread::spawn(move || adapters::lynis::scan(host_root.as_deref())));
 
     AdapterScanUpdate {
-        trivy: trivy_handle
-            .join()
-            .unwrap_or_else(|_| failed_trivy_output()),
-        lynis: lynis_handle
-            .join()
-            .unwrap_or_else(|_| failed_lynis_output()),
-        dockle: dockle_handle
-            .join()
-            .unwrap_or_else(|_| failed_dockle_output()),
+        trivy: trivy_handle.map_or_else(disabled_trivy_output, |handle| {
+            handle.join().unwrap_or_else(|_| failed_trivy_output())
+        }),
+        lynis: lynis_handle.map_or_else(disabled_lynis_output, |handle| {
+            handle.join().unwrap_or_else(|_| failed_lynis_output())
+        }),
+        dockle: dockle_handle.map_or_else(disabled_dockle_output, |handle| {
+            handle.join().unwrap_or_else(|_| failed_dockle_output())
+        }),
     }
 }
 
-fn seed_adapter_statuses(result: &mut ScanResult) {
-    let trivy_status = if has_image_targets(&result.metadata.services) {
+fn seed_adapter_statuses(result: &mut ScanResult, selection: AdapterSelection) {
+    let trivy_status = if !selection.is_enabled(ScanAdapter::Trivy) {
+        AdapterStatus::Skipped(t!("adapter.reason.disabled_by_selection").into_owned())
+    } else if has_image_targets(&result.metadata.services) {
         AdapterStatus::Pending
     } else {
         AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned())
@@ -155,7 +171,9 @@ fn seed_adapter_statuses(result: &mut ScanResult) {
         .adapters
         .insert(String::from("trivy"), trivy_status);
 
-    let dockle_status = if has_image_targets(&result.metadata.services) {
+    let dockle_status = if !selection.is_enabled(ScanAdapter::Dockle) {
+        AdapterStatus::Skipped(t!("adapter.reason.disabled_by_selection").into_owned())
+    } else if has_image_targets(&result.metadata.services) {
         AdapterStatus::Pending
     } else {
         AdapterStatus::Skipped(t!("adapter.reason.no_image_targets").into_owned())
@@ -165,12 +183,16 @@ fn seed_adapter_statuses(result: &mut ScanResult) {
         .adapters
         .insert(String::from("dockle"), dockle_status);
 
-    let lynis_status = match result.metadata.host_root.as_deref() {
-        None => AdapterStatus::Skipped(t!("adapter.reason.host_not_scanned").into_owned()),
-        Some(path) if path != Path::new("/") => {
-            AdapterStatus::Skipped(t!("adapter.reason.live_host_only").into_owned())
+    let lynis_status = if !selection.is_enabled(ScanAdapter::Lynis) {
+        AdapterStatus::Skipped(t!("adapter.reason.disabled_by_selection").into_owned())
+    } else {
+        match result.metadata.host_root.as_deref() {
+            None => AdapterStatus::Skipped(t!("adapter.reason.host_not_scanned").into_owned()),
+            Some(path) if path != Path::new("/") => {
+                AdapterStatus::Skipped(t!("adapter.reason.live_host_only").into_owned())
+            }
+            Some(_) => AdapterStatus::Pending,
         }
-        Some(_) => AdapterStatus::Pending,
     };
     result
         .metadata
@@ -195,6 +217,14 @@ fn failed_trivy_output() -> adapters::trivy::TrivyScanOutput {
     }
 }
 
+fn disabled_trivy_output() -> adapters::trivy::TrivyScanOutput {
+    adapters::trivy::TrivyScanOutput {
+        status: AdapterStatus::Skipped(t!("adapter.reason.disabled_by_selection").into_owned()),
+        findings: Vec::new(),
+        warnings: Vec::new(),
+    }
+}
+
 fn failed_lynis_output() -> adapters::lynis::LynisScanOutput {
     adapters::lynis::LynisScanOutput {
         status: AdapterStatus::Failed(crate::i18n::tr_adapter_scan_thread_panicked("Lynis")),
@@ -203,9 +233,25 @@ fn failed_lynis_output() -> adapters::lynis::LynisScanOutput {
     }
 }
 
+fn disabled_lynis_output() -> adapters::lynis::LynisScanOutput {
+    adapters::lynis::LynisScanOutput {
+        status: AdapterStatus::Skipped(t!("adapter.reason.disabled_by_selection").into_owned()),
+        findings: Vec::new(),
+        warnings: Vec::new(),
+    }
+}
+
 fn failed_dockle_output() -> adapters::dockle::DockleScanOutput {
     adapters::dockle::DockleScanOutput {
         status: AdapterStatus::Failed(crate::i18n::tr_adapter_scan_thread_panicked("Dockle")),
+        findings: Vec::new(),
+        warnings: Vec::new(),
+    }
+}
+
+fn disabled_dockle_output() -> adapters::dockle::DockleScanOutput {
+    adapters::dockle::DockleScanOutput {
+        status: AdapterStatus::Skipped(t!("adapter.reason.disabled_by_selection").into_owned()),
         findings: Vec::new(),
         warnings: Vec::new(),
     }
@@ -468,9 +514,10 @@ mod tests {
     use super::{
         AdapterScanUpdate, apply_current_dir_fallback, apply_current_dir_fallback_from,
         apply_discovered_projects, apply_external_adapter_update, apply_live_discovery_result, run,
-        run_native, scan_compose_project, seed_adapter_statuses, spawn_background_adapter_scan,
+        run_native, scan_compose_project, scan_external_adapters, seed_adapter_statuses,
+        spawn_background_adapter_scan,
     };
-    use crate::app::{AppConfig, OutputMode};
+    use crate::app::{AdapterSelection, AppConfig, OutputMode};
     use crate::compose::ComposeParser;
 
     fn parser_fixture() -> std::path::PathBuf {
@@ -555,6 +602,7 @@ mod tests {
             setup_command: None,
             compose_path: Some(compose_path.clone()),
             host_root: None,
+            adapter_selection: AdapterSelection::all(),
             fix_mode: None,
             fix_target_path: None,
             preview_changes: false,
@@ -587,6 +635,7 @@ mod tests {
             setup_command: None,
             compose_path: Some(compose_path.clone()),
             host_root: None,
+            adapter_selection: AdapterSelection::all(),
             fix_mode: None,
             fix_target_path: None,
             preview_changes: false,
@@ -626,6 +675,7 @@ mod tests {
             setup_command: None,
             compose_path: None,
             host_root: Some(host_root.clone()),
+            adapter_selection: AdapterSelection::all(),
             fix_mode: None,
             fix_target_path: None,
             preview_changes: false,
@@ -646,6 +696,66 @@ mod tests {
     }
 
     #[test]
+    fn adapters_none_skips_all_external_scanners_in_final_metadata() {
+        let compose_path = no_image_compose_fixture("adapters-none");
+        let config = AppConfig {
+            locale_override: None,
+            output_mode: OutputMode::Json,
+            show_help: false,
+            show_version: false,
+            lifecycle_command: None,
+            setup_command: None,
+            compose_path: Some(compose_path.clone()),
+            host_root: None,
+            adapter_selection: AdapterSelection::none(),
+            fix_mode: None,
+            fix_target_path: None,
+            preview_changes: false,
+            assume_yes: false,
+        };
+
+        let result = run(&config).expect("scan should succeed");
+        let disabled = t!("adapter.reason.disabled_by_selection", locale = "en").into_owned();
+
+        assert_eq!(
+            result.metadata.adapters.get("trivy"),
+            Some(&AdapterStatus::Skipped(disabled.clone()))
+        );
+        assert_eq!(
+            result.metadata.adapters.get("dockle"),
+            Some(&AdapterStatus::Skipped(disabled.clone()))
+        );
+        assert_eq!(
+            result.metadata.adapters.get("lynis"),
+            Some(&AdapterStatus::Skipped(disabled))
+        );
+
+        fs::remove_dir_all(compose_path.parent().expect("fixture dir should exist"))
+            .expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn selected_adapter_runs_while_others_are_disabled_in_final_metadata() {
+        let update = scan_external_adapters(
+            Vec::new(),
+            None,
+            AdapterSelection {
+                trivy: true,
+                dockle: false,
+                lynis: false,
+            },
+        );
+        let disabled = t!("adapter.reason.disabled_by_selection", locale = "en").into_owned();
+
+        assert!(matches!(update.trivy.status, AdapterStatus::Skipped(_)));
+        assert_eq!(
+            update.dockle.status,
+            AdapterStatus::Skipped(disabled.clone())
+        );
+        assert_eq!(update.lynis.status, AdapterStatus::Skipped(disabled));
+    }
+
+    #[test]
     fn populates_scan_metadata_from_compose_project() {
         let config = AppConfig {
             locale_override: None,
@@ -656,6 +766,7 @@ mod tests {
             setup_command: None,
             compose_path: Some(parser_fixture()),
             host_root: None,
+            adapter_selection: AdapterSelection::all(),
             fix_mode: None,
             fix_target_path: None,
             preview_changes: false,
@@ -733,6 +844,7 @@ mod tests {
             setup_command: None,
             compose_path: Some(parser_fixture()),
             host_root: Some(host_root.clone()),
+            adapter_selection: AdapterSelection::all(),
             fix_mode: None,
             fix_target_path: None,
             preview_changes: false,
@@ -823,7 +935,7 @@ mod tests {
         });
         result.metadata.host_root = Some(PathBuf::from("/"));
 
-        seed_adapter_statuses(&mut result);
+        seed_adapter_statuses(&mut result, AdapterSelection::all());
         apply_external_adapter_update(
             &mut result,
             AdapterScanUpdate {
@@ -924,7 +1036,7 @@ mod tests {
             image: Some(String::from("nginx:1.27.5")),
         });
 
-        seed_adapter_statuses(&mut result);
+        seed_adapter_statuses(&mut result, AdapterSelection::all());
         apply_external_adapter_update(
             &mut result,
             AdapterScanUpdate {
@@ -1239,26 +1351,27 @@ mod tests {
             image: Some(String::from("nginx:1.27.5")),
         });
 
-        let receiver = spawn_background_adapter_scan(&mut result, |_, _| {
-            thread::sleep(Duration::from_millis(150));
-            AdapterScanUpdate {
-                trivy: crate::adapters::trivy::TrivyScanOutput {
-                    status: AdapterStatus::Missing,
-                    findings: Vec::new(),
-                    warnings: Vec::new(),
-                },
-                lynis: crate::adapters::lynis::LynisScanOutput {
-                    status: AdapterStatus::Skipped(String::from("not requested")),
-                    findings: Vec::new(),
-                    warnings: Vec::new(),
-                },
-                dockle: crate::adapters::dockle::DockleScanOutput {
-                    status: AdapterStatus::Missing,
-                    findings: Vec::new(),
-                    warnings: Vec::new(),
-                },
-            }
-        });
+        let receiver =
+            spawn_background_adapter_scan(&mut result, AdapterSelection::all(), |_, _, _| {
+                thread::sleep(Duration::from_millis(150));
+                AdapterScanUpdate {
+                    trivy: crate::adapters::trivy::TrivyScanOutput {
+                        status: AdapterStatus::Missing,
+                        findings: Vec::new(),
+                        warnings: Vec::new(),
+                    },
+                    lynis: crate::adapters::lynis::LynisScanOutput {
+                        status: AdapterStatus::Skipped(String::from("not requested")),
+                        findings: Vec::new(),
+                        warnings: Vec::new(),
+                    },
+                    dockle: crate::adapters::dockle::DockleScanOutput {
+                        status: AdapterStatus::Missing,
+                        findings: Vec::new(),
+                        warnings: Vec::new(),
+                    },
+                }
+            });
 
         assert_eq!(
             result.metadata.adapters.get("trivy"),
@@ -1318,7 +1431,7 @@ mod tests {
             image: Some(String::from("nginx:1.27.5")),
         });
 
-        seed_adapter_statuses(&mut result);
+        seed_adapter_statuses(&mut result, AdapterSelection::all());
 
         assert_eq!(
             result.metadata.adapters.get("lynis"),
@@ -1335,10 +1448,44 @@ mod tests {
     }
 
     #[test]
+    fn seed_adapter_statuses_marks_disabled_adapters_as_skipped() {
+        let mut result = crate::domain::ScanResult::default();
+        result.metadata.host_root = Some(PathBuf::from("/"));
+        result.metadata.services.push(ServiceSummary {
+            name: String::from("demo"),
+            image: Some(String::from("nginx:1.27.5")),
+        });
+
+        seed_adapter_statuses(
+            &mut result,
+            AdapterSelection {
+                trivy: true,
+                dockle: false,
+                lynis: false,
+            },
+        );
+
+        assert_eq!(
+            result.metadata.adapters.get("trivy"),
+            Some(&AdapterStatus::Pending)
+        );
+        assert!(matches!(
+            result.metadata.adapters.get("dockle"),
+            Some(AdapterStatus::Skipped(detail))
+                if detail == &t!("adapter.reason.disabled_by_selection", locale = "en").into_owned()
+        ));
+        assert!(matches!(
+            result.metadata.adapters.get("lynis"),
+            Some(AdapterStatus::Skipped(detail))
+                if detail == &t!("adapter.reason.disabled_by_selection", locale = "en").into_owned()
+        ));
+    }
+
+    #[test]
     fn seed_adapter_statuses_marks_skipped_when_targets_are_missing() {
         let mut result = crate::domain::ScanResult::default();
 
-        seed_adapter_statuses(&mut result);
+        seed_adapter_statuses(&mut result, AdapterSelection::all());
 
         assert!(matches!(
             result.metadata.adapters.get("lynis"),

--- a/src/src/i18n/mod.rs
+++ b/src/src/i18n/mod.rs
@@ -178,6 +178,22 @@ pub fn tr_setup_tools_required() -> String {
     t!("app.validation.setup_tools_required").into_owned()
 }
 
+pub fn tr_unsupported_adapter(value: &str) -> String {
+    t!("app.validation.unsupported_adapter", value = value).into_owned()
+}
+
+pub fn tr_adapter_selection_required() -> String {
+    t!("app.validation.adapter_selection_required").into_owned()
+}
+
+pub fn tr_adapter_selection_keyword_conflict() -> String {
+    t!("app.validation.adapter_selection_keyword_conflict").into_owned()
+}
+
+pub fn tr_adapters_require_scan_mode() -> String {
+    t!("app.validation.adapters_require_scan_mode").into_owned()
+}
+
 pub fn tr_lifecycle_command_requires_installed_wrapper(command: &str) -> String {
     t!(
         "app.error.lifecycle_requires_installed_wrapper",
@@ -307,6 +323,10 @@ pub fn tr_adapter_json_parse_failed(tool: &str, error: &str) -> String {
 
 pub fn tr_adapter_command_no_error_detail() -> String {
     t!("app.adapter.command_no_error_detail").into_owned()
+}
+
+pub fn tr_adapter_command_timed_out(seconds: u64) -> String {
+    t!("app.adapter.command_timed_out", seconds = seconds).into_owned()
 }
 
 pub fn tr_adapter_report_parse_failed(tool: &str) -> String {


### PR DESCRIPTION
## Summary
- add explicit optional scanner selection with `--adapters` and `HOSTVEIL_ADAPTERS`
- skip disabled adapters without detection or execution while recording skipped metadata
- add bounded external adapter command runtime for Trivy, Dockle, and Lynis
- document the adapter controls and keep smoke tests deterministic with adapters disabled by default

## Impact
- Default scanner coverage stays compatible with existing behavior through `all`.
- Users can run native-only scans with `--adapters none` or choose subsets such as `--adapters trivy,dockle`.
- Long-running external scanner detect/scan commands now time out after 120 seconds and clean up child processes.

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace`
- `./scripts/smoke-test.sh target/debug/hostveil`
- `./scripts/test-install-script.sh target/debug/hostveil`
- manual `--help`, `--adapters none`, env fallback, and CLI-over-env checks

Closes #157
Closes #158
Closes #159