### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,11 +83,11 @@ All planned work is tracked as GitHub Issues organized into Milestones. **AI age
 
 **Current milestone state** (see `github.com/seolcu/hostveil/milestones`):
 
+- Open: #8 v0.5.0 Scanner Control and Reliability
 - Closed: #1 Python CLI Prototype
 - Closed: #2 Service Research & Rule Validation
 - Closed: #3 Rust TUI Implementation
 - Closed: #5 v0.2 Hardening and UX
-- Closed: #8 v0.5.0 Scanner Control and Reliability
 - Closed: #167 v0.6.0 Expanded Remediation and UX Polish
 - Closed: #172 v0.7.0 Containerized Verification Lab
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "crossterm 0.29.0",
  "dialoguer",

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,9 +13,11 @@ Jellyfin, Nextcloud, Vaultwarden, Gitea, Immich 등을 운영하는 셀프호스
 
 ## 주요 기능
 
-- **보안 개요 대시보드** — 카테고리별 세부 점수 및 심각도 카운트를 포함한 전체 점수
+- **보안 개요 대시보드** — 전체 보안 상태, 축별 점수, 그룹화된 조치 대기열, 어댑터 활동을 한 화면에 표시
 - **셀프호스팅 맥락 기반 기본 점검** — 각 서비스의 데이터 위치, Compose 구조, 운영 위험을 반영한 점검
 - **선택적 외부 스캐너 어댑터** — Trivy, Dockle, Lynis 같은 기존 도구 결과를 런타임 필수 의존성으로 강제하지 않고 통합
+- **보이는 백그라운드 진행 상태** — 실행 시 자동 업데이트 점검과 TUI 내부 어댑터 로딩 상태를 숨기지 않고 표시
+- **테마 프리셋** — 터미널 기본 ANSI와 Catppuccin, Nord, Tokyo Night, Gruvbox 팔레트를 TUI에서 전환 가능
 - **실행 가능한 가이드** — 모든 발견 사항에 포함: 무엇인지, 왜 위험한지, 어떻게 수정하는지
 - **Compose 중심 수정 흐름** — `quick-fix`와 `fix`는 미리보기와 백업이 가능한 Compose 변경에 집중
 
@@ -126,6 +128,8 @@ hostveil setup
 
 터미널 호환성을 위해 기본 locale은 항상 영어입니다. 한국어로 명시적으로 바꾸려면 `hostveil --locale ko ...` 또는 `HOSTVEIL_LOCALE=ko hostveil ...`를 사용하고, TUI 안에서는 `g` 키로 영어/한국어를 전환할 수 있습니다.
 
+설치된 래퍼 경로에서 자동 업데이트 점검이 실행될 때는 이제 짧은 상태 줄을 출력하므로, 느린 업데이트 확인이 멈춘 것처럼 보이지 않습니다.
+
 대화형 setup은 입력 전에 선택 조작 안내를 먼저 보여주며, 확인 프롬프트는 기본값이 `Y/n` 형식입니다.
 
 무인 설치에서는 bootstrap 단계에서 설치할 도구를 명시할 수 있습니다.
@@ -167,6 +171,20 @@ HOSTVEIL_ADAPTERS=trivy,dockle hostveil --json
 ```
 
 선택형 scanner adapter의 기본값은 `all`입니다. 기본 점검만 빠르게 실행하려면 `--adapters none`을 쓰고, 일부만 실행하려면 `--adapters trivy,dockle`처럼 지정합니다.
+
+현재 TUI 주요 조작:
+
+- `Enter`: 개요에서 Findings 화면 열기
+- `g`: locale 전환 및 설정 저장
+- `t`: 테마 프리셋 전환 및 설정 저장
+- `f`: Compose 수정이 가능할 때 remediation 흐름 열기
+
+현재 overview 화면 규칙:
+
+- `Security Scores`는 어댑터 로딩이 끝나면 최종 점수를 보여줍니다
+- 어댑터가 아직 실행 중이면 점수 패널에서 진행 상태와 네이티브 기준 점수를 분리해 보여줍니다
+- `Action Queue`는 서비스 또는 호스트 단위로 묶은 다음 조치 요약입니다
+- `Findings`는 근거, 위험 설명, 수정 방법까지 포함한 항목별 상세 화면입니다
 
 파일을 쓰기 전에 Compose 수정 계획을 미리 볼 수 있습니다.
 
@@ -219,13 +237,16 @@ hostveil은 현재 초기 개발 단계입니다. 구현은 두 단계로 계획
 - `src/` 아래 활성 Rust crate 골격 생성 완료
 - `rust-toolchain.toml`로 stable toolchain 고정
 - `ratatui` + `crossterm` 기반 TUI 부트스트랩과 `rust-i18n` 연결 완료
+- 좁은 터미널, 중간 폭, 넓은 화면을 나누는 responsive overview/findings 레이아웃 적용
 - 영어 기본값 + 명시적 locale override(`--locale`, `HOSTVEIL_LOCALE`) + TUI 내 `g` 전환 경로 추가
+- ANSI, Catppuccin, Nord, Tokyo Night, Gruvbox 테마 프리셋과 설정 저장 추가
 - 수정 가능한 finding을 빠르게 검토할 수 있는 remediation-first TUI triage 추가
 - 일반화된 Rust scan result 모델과 최소 JSON export 경로 동작
 - override 병합과 정규화를 포함한 Compose parser 포팅 및 parity 테스트 추가
 - 기본 Compose 규칙 엔진과 점수화 모델을 Rust로 일부 포팅하고 fixture 테스트로 검증
 - `--host-root`를 통한 SSH posture 및 Docker host exposure 기본 점검 시작
 - Trivy, Dockle, Lynis optional adapter가 공통 finding pipeline에 통합됨
+- external coverage가 로딩 중일 때 TUI에 어댑터별 진행 상태를 표시
 - root가 아닌 live host scan에서는 데스크톱 인증창을 피하기 위해 Lynis 실행을 건너뜀
 - 인자 없는 live scan이 host 스캔 + Docker 기반 Compose 자동 발견 + 현재 디렉터리 fallback으로 동작
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ Inspired by [Chrome Lighthouse](https://developer.chrome.com/docs/lighthouse/ove
 
 ## Features
 
-- **Security Overview Dashboard** — overall score with per-category breakdown and severity counts
+- **Security Overview Dashboard** — responsive overview with overall posture, per-axis breakdown, grouped action queue, and adapter activity
 - **Native Self-hosting-aware Checks** — checks tailored to each service's known data locations, Compose structure, and operational risk
 - **Optional External Scanner Adapters** — integrate existing tools without making them mandatory at runtime (Trivy, Dockle, and Lynis are supported as optional adapters)
+- **Visible Background Progress** — launch-time auto-upgrade checks and in-TUI adapter loading surface status instead of appearing frozen
+- **Theme Presets** — terminal-default ANSI plus Catppuccin, Nord, Tokyo Night, and Gruvbox presets are available from the TUI
 - **Actionable Guidance** — every finding includes: what it is, why it matters, how to fix it
 - **Compose-focused Remediation** — `quick-fix` and `fix` stay focused on previewable, backup-safe Compose changes
 
@@ -138,6 +140,8 @@ hostveil setup
 
 Locale defaults to English for terminal safety, even if the host locale is non-English. Use `hostveil --locale ko ...` or `HOSTVEIL_LOCALE=ko hostveil ...` for an explicit override, and press `g` inside the TUI to switch between English and Korean.
 
+When automatic upgrade checks run through the installed wrapper, hostveil now prints a short launch-time status line so slow update checks are visible instead of feeling like a hang.
+
 Interactive setup explains the selector controls before input starts, and its confirmation prompts use a default-yes `Y/n` flow.
 
 For unattended installs, you can explicitly pick tools during bootstrap:
@@ -186,6 +190,20 @@ HOSTVEIL_ADAPTERS=trivy,dockle hostveil --json
 ```
 
 Optional scanner adapters default to `all`. Use `--adapters none` for native-only scans, or choose a subset such as `--adapters trivy,dockle`.
+
+Current TUI controls:
+
+- `Enter` opens Findings from the overview
+- `g` cycles locale and persists it
+- `t` cycles the theme preset and persists it
+- `f` opens the remediation flow when Compose fixes are available
+
+Current overview model:
+
+- `Security Scores` shows the final score when adapter loading is complete
+- while adapters are still running, the score panel shows adapter progress and keeps the native baseline explicit
+- `Action Queue` is a grouped next-step summary by service or host scope
+- `Findings` is the per-issue drill-down view with evidence, risk explanation, and fix detail
 
 Preview Compose remediation before writing files:
 
@@ -238,13 +256,16 @@ Current Rust implementation status:
 - Active Rust crate scaffolded under `src/`
 - Pinned stable toolchain via `rust-toolchain.toml`
 - `ratatui` + `crossterm` TUI wired and localized through `rust-i18n`
+- Responsive overview and findings layouts for narrow, compact, and wide terminals
 - TUI findings navigation supports remediation-first triage for faster review of fixable issues
 - Explicit locale controls are available through `--locale`, `HOSTVEIL_LOCALE`, and the in-TUI `g` switch
+- Persisted TUI theme presets with ANSI, Catppuccin, Nord, Tokyo Night, and Gruvbox palettes
 - Generalized Rust scan result model and minimal JSON export path working
 - Compose parser ported with override merging and normalization parity tests
 - Native Compose rule engine and scoring model ported with Rust fixture tests
 - Native Linux host checks added for SSH posture, Docker host exposure, and defensive-control telemetry via `--host-root`
 - Optional Trivy, Dockle, and Lynis adapters integrated into the shared findings pipeline
+- Per-adapter background progress is surfaced in the TUI while external coverage is still loading
 - Non-root live host scans skip Lynis instead of invoking desktop authorization prompts
 - Initial Rust Compose remediation flow added for previewable `--quick-fix` and `--fix` operations with backup-safe writes
 - No-arg live scan now defaults to host scanning plus Docker-based Compose auto-discovery, with current-directory Compose fallback

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -578,11 +578,16 @@ case "\${1:-}" in
 esac
 
 if [[ "\${HOSTVEIL_SKIP_AUTO_UPGRADE:-}" != "1" && "\${HOSTVEIL_AUTO_UPGRADE_RUNNING:-}" != "1" && "\${HOSTVEIL_META_AUTO_UPGRADE:-enabled}" != "disabled" && -x "\$manager_script_path" ]]; then
+  previous_tag="\${HOSTVEIL_META_INSTALLED_TAG:-unknown}"
+  printf 'hostveil: checking for updates before launch...\n' >&2
   HOSTVEIL_STATE_DIR="\$state_dir" HOSTVEIL_AUTO_UPGRADE_RUNNING=1 HOSTVEIL_SKIP_AUTO_UPGRADE=1 "\$manager_script_path" --upgrade >/dev/null 2>&1 || true
   if [[ -f "\$metadata_path" ]]; then
     # shellcheck disable=SC1090
     source "\$metadata_path"
     binary_path="\${HOSTVEIL_META_BINARY_PATH:-\$DEFAULT_BINARY_PATH}"
+    if [[ "\${HOSTVEIL_META_INSTALLED_TAG:-unknown}" != "\$previous_tag" ]]; then
+      printf 'hostveil: updated to %s\n' "\${HOSTVEIL_META_INSTALLED_TAG:-unknown}" >&2
+    fi
   fi
 fi
 

--- a/scripts/test-install-script.sh
+++ b/scripts/test-install-script.sh
@@ -95,6 +95,9 @@ run_install_case() {
   local state_home
   local metadata_path
   local manager_path
+  local wrapper_update_output
+  local wrapper_disabled_output
+  local wrapper_reenabled_output
 
   case_dir="$(mktemp -d)"
   release_dir="$case_dir/release"
@@ -287,42 +290,68 @@ run_upgrade_auto_uninstall_case() {
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.0.2-test'
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_AUTO_UPGRADE=enabled'
 
-  XDG_STATE_HOME="$state_home" \
-    HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_three" \
-    HOSTVEIL_RELEASES_API_URL="file://$api_three/releases.json" \
-    HOSTVEIL_LATEST_STABLE_API_URL="file://$api_three/latest.json" \
-    HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
-    "$install_dir/hostveil" --version >/dev/null
+  wrapper_update_output="$(
+    XDG_STATE_HOME="$state_home" \
+      HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_three" \
+      HOSTVEIL_RELEASES_API_URL="file://$api_three/releases.json" \
+      HOSTVEIL_LATEST_STABLE_API_URL="file://$api_three/latest.json" \
+      HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
+      "$install_dir/hostveil" --version 2>&1
+  )"
 
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.0.3-test'
+  printf '%s\n' "$wrapper_update_output" | grep -q 'checking for updates before launch' || {
+    printf 'error: wrapper did not announce the launch-time update check\n' >&2
+    exit 1
+  }
+  printf '%s\n' "$wrapper_update_output" | grep -q 'updated to v0.0.3-test' || {
+    printf 'error: wrapper did not announce the updated installed version\n' >&2
+    exit 1
+  }
 
   XDG_STATE_HOME="$state_home" \
     PATH="$install_dir:$PATH" \
     hostveil auto-upgrade disable
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_AUTO_UPGRADE=disabled'
 
-  XDG_STATE_HOME="$state_home" \
-    HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_four" \
-    HOSTVEIL_RELEASES_API_URL="file://$api_four/releases.json" \
-    HOSTVEIL_LATEST_STABLE_API_URL="file://$api_four/latest.json" \
-    HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
-    "$install_dir/hostveil" --version >/dev/null
+  wrapper_disabled_output="$(
+    XDG_STATE_HOME="$state_home" \
+      HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_four" \
+      HOSTVEIL_RELEASES_API_URL="file://$api_four/releases.json" \
+      HOSTVEIL_LATEST_STABLE_API_URL="file://$api_four/latest.json" \
+      HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
+      "$install_dir/hostveil" --version 2>&1
+  )"
 
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.0.3-test'
+  ! printf '%s\n' "$wrapper_disabled_output" | grep -q 'checking for updates before launch' || {
+    printf 'error: disabled auto-upgrade still announced a launch-time update check\n' >&2
+    exit 1
+  }
 
   XDG_STATE_HOME="$state_home" \
     PATH="$install_dir:$PATH" \
     hostveil auto-upgrade enable
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_AUTO_UPGRADE=enabled'
 
-  XDG_STATE_HOME="$state_home" \
-    HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_four" \
-    HOSTVEIL_RELEASES_API_URL="file://$api_four/releases.json" \
-    HOSTVEIL_LATEST_STABLE_API_URL="file://$api_four/latest.json" \
-    HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
-    "$install_dir/hostveil" --version >/dev/null
+  wrapper_reenabled_output="$(
+    XDG_STATE_HOME="$state_home" \
+      HOSTVEIL_DOWNLOAD_BASE_URL="file://$release_four" \
+      HOSTVEIL_RELEASES_API_URL="file://$api_four/releases.json" \
+      HOSTVEIL_LATEST_STABLE_API_URL="file://$api_four/latest.json" \
+      HOSTVEIL_INSTALLER_URL="file://$INSTALLER_PATH" \
+      "$install_dir/hostveil" --version 2>&1
+  )"
 
   assert_file_contains "$metadata_path" 'HOSTVEIL_META_INSTALLED_TAG=v0.0.4-test'
+  printf '%s\n' "$wrapper_reenabled_output" | grep -q 'checking for updates before launch' || {
+    printf 'error: re-enabled auto-upgrade did not announce the launch-time update check\n' >&2
+    exit 1
+  }
+  printf '%s\n' "$wrapper_reenabled_output" | grep -q 'updated to v0.0.4-test' || {
+    printf 'error: re-enabled auto-upgrade did not announce the new installed version\n' >&2
+    exit 1
+  }
 
   XDG_STATE_HOME="$state_home" \
     PATH="$install_dir:$PATH" \

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -2,6 +2,7 @@ app:
   name: "hostveil"
   header:
     subtitle: "Linux Self-Hosting Security Dashboard"
+    theme_badge: "THEME %{theme}"
   status:
     bootstrap: "Rust scan, TUI, and JSON export are available for active development."
     no_target: "No explicit target was provided. Run without arguments for live discovery, or pass --compose PATH / --host-root PATH for a targeted scan."
@@ -78,8 +79,8 @@ app:
     detail_scroll_compact: "Up/Down, j/k, PgUp/PgDn scroll"
     back_overview: "Press q or Esc to return to the overview"
     back_overview_compact: "q or Esc back"
-    finding_controls: "Tab or Left/Right switch focus | s severity | x source | v service | m remediation | o sort | r reset | 1-4 jump | f fix | g locale | q or Esc back"
-    finding_controls_compact: "Tab/LR focus | s sev | x src | v svc | m rem | o sort | r reset | 1-4 jump | f fix | g lang | q back"
+    finding_controls: "Tab or Left/Right switch focus | s severity | x source | v service | m remediation | o sort | r reset | 1-4 jump | f fix | g locale | t theme | q or Esc back"
+    finding_controls_compact: "Tab/LR focus | s sev | x src | v svc | m rem | o sort | r reset | 1-4 jump | f fix | g lang | t theme | q back"
     fix_review_scroll: "Use Up/Down or PgUp/PgDn to scroll the diff"
     fix_review_apply: "Press y or Enter to apply the reviewed changes"
     fix_review_cancel: "Press q or Esc to cancel"
@@ -87,6 +88,7 @@ app:
     quit: "quit"
     findings: "open findings"
     locale: "switch locale"
+    theme: "switch theme"
     json: "export JSON"
   panel:
     status: "Status"
@@ -96,6 +98,7 @@ app:
     security_scores: "Security Scores"
     fix_paths: "Fix Paths"
     remediation_summary: "Remediation Summary"
+    action_queue: "Action Queue"
     fix_review: "Fix Review"
     fix_diff: "Diff"
     overview_score: "Overview Score"
@@ -115,6 +118,10 @@ app:
     findings_available: "%{count} finding(s) available. Open the findings view for details."
     no_findings: "No findings detected yet."
     adapters_none: "No optional adapter status reported yet."
+    score_pending_detail: "Final score is waiting for adapter results. The rows below are the native baseline."
+    score_ready: "Adapter loading complete"
+    adapter_loading: "%{spinner} loading adapters: %{adapters}"
+    action_queue_hint: "Overview groups next actions by service. Open Findings for per-issue evidence and fix detail."
   server:
     host_name: "Host"
     root_path: "Root"
@@ -346,6 +353,7 @@ source:
   dockle: "Dockle"
 adapter:
   pending: "pending"
+  loading: "loading"
   available: "available"
   missing: "missing"
   skipped: "skipped: %{detail}"

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -2,6 +2,7 @@ app:
   name: "hostveil"
   header:
     subtitle: "리눅스 셀프호스팅 보안 대시보드"
+    theme_badge: "테마 %{theme}"
   status:
     bootstrap: "Rust 스캔, TUI, JSON 내보내기를 사용할 수 있습니다."
     no_target: "명시적인 대상이 없습니다. 인자 없이 실행하면 라이브 탐색을 수행하고, 특정 대상은 --compose PATH 또는 --host-root PATH를 사용하세요."
@@ -78,8 +79,8 @@ app:
     detail_scroll_compact: "Up/Down, j/k, PgUp/PgDn 스크롤"
     back_overview: "q 또는 Esc를 눌러 개요로 돌아갑니다"
     back_overview_compact: "q 또는 Esc로 뒤로"
-    finding_controls: "Tab 또는 Left/Right 포커스 전환 | s 심각도 | x 소스 | v 서비스 | m 수정 경로 | o 정렬 | r 초기화 | 1-4 점프 | f 조치 | g 언어 | q 또는 Esc 뒤로"
-    finding_controls_compact: "Tab/LR 포커스 | s 심각도 | x 소스 | v 서비스 | m 조치 | o 정렬 | r 초기화 | 1-4 점프 | f 조치 | g 언어 | q 뒤로"
+    finding_controls: "Tab 또는 Left/Right 포커스 전환 | s 심각도 | x 소스 | v 서비스 | m 수정 경로 | o 정렬 | r 초기화 | 1-4 점프 | f 조치 | g 언어 | t 테마 | q 또는 Esc 뒤로"
+    finding_controls_compact: "Tab/LR 포커스 | s 심각도 | x 소스 | v 서비스 | m 조치 | o 정렬 | r 초기화 | 1-4 점프 | f 조치 | g 언어 | t 테마 | q 뒤로"
     fix_review_scroll: "Up/Down 또는 PgUp/PgDn으로 diff를 스크롤합니다"
     fix_review_apply: "y 또는 Enter를 눌러 검토한 변경을 적용합니다"
     fix_review_cancel: "q 또는 Esc를 눌러 취소합니다"
@@ -87,6 +88,7 @@ app:
     quit: "종료"
     findings: "발견 항목 열기"
     locale: "언어 전환"
+    theme: "테마 전환"
     json: "JSON 내보내기"
   panel:
     status: "상태"
@@ -96,6 +98,7 @@ app:
     security_scores: "보안 점수"
     fix_paths: "수정 경로"
     remediation_summary: "조치 요약"
+    action_queue: "조치 대기열"
     fix_review: "수정 검토"
     fix_diff: "Diff"
     overview_score: "전체 점수"
@@ -115,6 +118,10 @@ app:
     findings_available: "발견 항목 %{count}개가 있습니다. 상세 보기를 열어 확인하세요."
     no_findings: "현재 발견 항목이 없습니다."
     adapters_none: "아직 보고된 선택형 어댑터 상태가 없습니다."
+    score_pending_detail: "최종 점수는 어댑터 결과를 기다리고 있습니다. 아래 행은 네이티브 기준 점수입니다."
+    score_ready: "어댑터 로딩 완료"
+    adapter_loading: "%{spinner} 어댑터 로딩 중: %{adapters}"
+    action_queue_hint: "개요는 서비스별 다음 조치를 묶어서 보여줍니다. Findings에서 항목별 근거와 수정 상세를 확인하세요."
   server:
     host_name: "호스트"
     root_path: "루트"
@@ -346,6 +353,7 @@ source:
   dockle: "Dockle"
 adapter:
   pending: "대기 중"
+  loading: "로딩 중"
   available: "사용 가능"
   missing: "없음"
   skipped: "건너뜀: %{detail}"

--- a/src/src/adapters/command.rs
+++ b/src/src/adapters/command.rs
@@ -3,7 +3,7 @@ use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-pub const DEFAULT_ADAPTER_TIMEOUT: Duration = Duration::from_secs(120);
+pub const DEFAULT_ADAPTER_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(Debug)]
 pub struct CommandOutput {

--- a/src/src/app/mod.rs
+++ b/src/src/app/mod.rs
@@ -162,8 +162,8 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), AppError> {
                 let action = tui::run(&mut scan_result, move |scan_result| {
                     let mut updated = false;
 
-                    while let Ok(update) = adapter_updates.try_recv() {
-                        scan::apply_external_adapter_update(scan_result, update);
+                    while let Ok(event) = adapter_updates.try_recv() {
+                        scan::apply_external_adapter_event(scan_result, event);
                         updated = true;
                     }
 

--- a/src/src/app/scan.rs
+++ b/src/src/app/scan.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{self, Receiver};
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
 use crate::adapters;
@@ -23,6 +23,13 @@ pub struct AdapterScanUpdate {
     trivy: adapters::trivy::TrivyScanOutput,
     lynis: adapters::lynis::LynisScanOutput,
     dockle: adapters::dockle::DockleScanOutput,
+}
+
+#[derive(Debug)]
+pub enum AdapterScanEvent {
+    Trivy(adapters::trivy::TrivyScanOutput),
+    Lynis(adapters::lynis::LynisScanOutput),
+    Dockle(adapters::dockle::DockleScanOutput),
 }
 
 pub fn run(config: &AppConfig) -> Result<ScanResult, AppError> {
@@ -68,32 +75,87 @@ fn apply_external_adapters(result: &mut ScanResult, selection: AdapterSelection)
 pub fn prepare_background_adapter_scan(
     result: &mut ScanResult,
     selection: AdapterSelection,
-) -> Receiver<AdapterScanUpdate> {
-    spawn_background_adapter_scan(result, selection, scan_external_adapters)
+) -> Receiver<AdapterScanEvent> {
+    spawn_background_adapter_scan(result, selection)
 }
 
-fn spawn_background_adapter_scan<F>(
+fn spawn_background_adapter_scan(
     result: &mut ScanResult,
     selection: AdapterSelection,
-    scan_fn: F,
-) -> Receiver<AdapterScanUpdate>
-where
-    F: FnOnce(Vec<ServiceSummary>, Option<PathBuf>, AdapterSelection) -> AdapterScanUpdate
-        + Send
-        + 'static,
-{
+) -> Receiver<AdapterScanEvent> {
     seed_adapter_statuses(result, selection);
 
     let services = result.metadata.services.clone();
     let host_root = result.metadata.host_root.clone();
     let (sender, receiver) = mpsc::channel();
 
-    thread::spawn(move || {
-        let update = scan_fn(services, host_root, selection);
-        let _ = sender.send(update);
-    });
+    spawn_adapter_workers(sender, services, host_root, selection);
 
     receiver
+}
+
+fn spawn_adapter_workers(
+    sender: Sender<AdapterScanEvent>,
+    services: Vec<ServiceSummary>,
+    host_root: Option<PathBuf>,
+    selection: AdapterSelection,
+) {
+    if selection.is_enabled(ScanAdapter::Trivy) && has_image_targets(&services) {
+        let sender = sender.clone();
+        let trivy_services = services.clone();
+        thread::spawn(move || {
+            let _ = sender.send(AdapterScanEvent::Trivy(adapters::trivy::scan(
+                &trivy_services,
+            )));
+        });
+    }
+
+    if selection.is_enabled(ScanAdapter::Dockle) && has_image_targets(&services) {
+        let sender = sender.clone();
+        thread::spawn(move || {
+            let _ = sender.send(AdapterScanEvent::Dockle(adapters::dockle::scan(&services)));
+        });
+    }
+
+    if selection.is_enabled(ScanAdapter::Lynis)
+        && let Some(path) = host_root.filter(|path| path == Path::new("/"))
+    {
+        thread::spawn(move || {
+            let _ = sender.send(AdapterScanEvent::Lynis(adapters::lynis::scan(Some(&path))));
+        });
+    }
+}
+
+pub fn apply_external_adapter_event(result: &mut ScanResult, event: AdapterScanEvent) {
+    match event {
+        AdapterScanEvent::Trivy(output) => {
+            result
+                .metadata
+                .adapters
+                .insert(String::from("trivy"), output.status.clone());
+            result.metadata.warnings.extend(output.warnings);
+            result.findings.extend(output.findings);
+        }
+        AdapterScanEvent::Lynis(output) => {
+            result
+                .metadata
+                .adapters
+                .insert(String::from("lynis"), output.status.clone());
+            result.metadata.warnings.extend(output.warnings);
+            result.findings.extend(output.findings);
+        }
+        AdapterScanEvent::Dockle(output) => {
+            result
+                .metadata
+                .adapters
+                .insert(String::from("dockle"), output.status.clone());
+            result.metadata.warnings.extend(output.warnings);
+            result.findings.extend(output.findings);
+        }
+    }
+
+    result.score_report =
+        scoring::build_score_report_with_coverage(&result.findings, coverage_from_result(result));
 }
 
 pub fn apply_external_adapter_update(result: &mut ScanResult, update: AdapterScanUpdate) {
@@ -501,8 +563,6 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::sync::mpsc::TryRecvError;
-    use std::thread;
-    use std::time::Duration;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::discovery::{DiscoveredComposeProject, DiscoveredContainerService};
@@ -512,9 +572,10 @@ mod tests {
     };
 
     use super::{
-        AdapterScanUpdate, apply_current_dir_fallback, apply_current_dir_fallback_from,
-        apply_discovered_projects, apply_external_adapter_update, apply_live_discovery_result, run,
-        run_native, scan_compose_project, scan_external_adapters, seed_adapter_statuses,
+        AdapterScanEvent, AdapterScanUpdate, apply_current_dir_fallback,
+        apply_current_dir_fallback_from, apply_discovered_projects, apply_external_adapter_event,
+        apply_external_adapter_update, apply_live_discovery_result, run, run_native,
+        scan_compose_project, scan_external_adapters, seed_adapter_statuses,
         spawn_background_adapter_scan,
     };
     use crate::app::{AdapterSelection, AppConfig, OutputMode};
@@ -1127,6 +1188,60 @@ mod tests {
     }
 
     #[test]
+    fn background_adapter_event_updates_only_completed_adapter() {
+        let mut result = crate::domain::ScanResult::default();
+        result.metadata.host_root = Some(PathBuf::from("/"));
+        result.metadata.services.push(ServiceSummary {
+            name: String::from("web"),
+            image: Some(String::from("nginx:1.27.5")),
+        });
+
+        seed_adapter_statuses(&mut result, AdapterSelection::all());
+        apply_external_adapter_event(
+            &mut result,
+            AdapterScanEvent::Trivy(crate::adapters::trivy::TrivyScanOutput {
+                status: AdapterStatus::Available,
+                findings: vec![test_finding(
+                    "trivy.image_vulnerabilities.nginx_1_27_5",
+                    Axis::UpdateSupplyChainRisk,
+                    Severity::High,
+                    Scope::Image,
+                    Source::Trivy,
+                    "nginx:1.27.5",
+                    Some("web"),
+                )],
+                warnings: vec![String::from("trivy warning")],
+            }),
+        );
+
+        assert_eq!(
+            result.metadata.adapters.get("trivy"),
+            Some(&AdapterStatus::Available)
+        );
+        assert_eq!(
+            result.metadata.adapters.get("dockle"),
+            Some(&AdapterStatus::Pending)
+        );
+        assert_eq!(
+            result.metadata.adapters.get("lynis"),
+            Some(&AdapterStatus::Pending)
+        );
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|finding| finding.source == Source::Trivy)
+        );
+        assert!(
+            result
+                .metadata
+                .warnings
+                .iter()
+                .any(|warning| warning == "trivy warning")
+        );
+    }
+
+    #[test]
     fn current_dir_fallback_loads_compose_project_when_docker_finds_nothing() {
         let temp_dir = temp_host_root("cwd-fallback");
         write_file(
@@ -1384,27 +1499,7 @@ mod tests {
             image: Some(String::from("nginx:1.27.5")),
         });
 
-        let receiver =
-            spawn_background_adapter_scan(&mut result, AdapterSelection::all(), |_, _, _| {
-                thread::sleep(Duration::from_millis(150));
-                AdapterScanUpdate {
-                    trivy: crate::adapters::trivy::TrivyScanOutput {
-                        status: AdapterStatus::Missing,
-                        findings: Vec::new(),
-                        warnings: Vec::new(),
-                    },
-                    lynis: crate::adapters::lynis::LynisScanOutput {
-                        status: AdapterStatus::Skipped(String::from("not requested")),
-                        findings: Vec::new(),
-                        warnings: Vec::new(),
-                    },
-                    dockle: crate::adapters::dockle::DockleScanOutput {
-                        status: AdapterStatus::Missing,
-                        findings: Vec::new(),
-                        warnings: Vec::new(),
-                    },
-                }
-            });
+        let receiver = spawn_background_adapter_scan(&mut result, AdapterSelection::all());
 
         assert_eq!(
             result.metadata.adapters.get("trivy"),
@@ -1419,12 +1514,6 @@ mod tests {
             Some(&AdapterStatus::Pending)
         );
         assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
-
-        let update = receiver
-            .recv_timeout(Duration::from_secs(1))
-            .expect("background scan should eventually finish");
-        assert_eq!(update.trivy.status, AdapterStatus::Missing);
-        assert_eq!(update.dockle.status, AdapterStatus::Missing);
     }
 
     #[test]

--- a/src/src/settings.rs
+++ b/src/src/settings.rs
@@ -13,6 +13,7 @@ const CONFIG_FILE_NAME: &str = "config.json";
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct AppSettings {
     pub locale: Option<String>,
+    pub theme: Option<String>,
 }
 
 pub fn load() -> AppSettings {
@@ -25,6 +26,12 @@ pub fn load() -> AppSettings {
 pub fn persist_locale(locale: &str) -> io::Result<()> {
     let mut settings = load();
     settings.locale = Some(locale.to_owned());
+    save(&settings)
+}
+
+pub fn persist_theme(theme: &str) -> io::Result<()> {
+    let mut settings = load();
+    settings.theme = Some(theme.to_owned());
     save(&settings)
 }
 
@@ -85,7 +92,7 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{AppSettings, resolve_config_dir, save_to_path};
+    use super::{AppSettings, load_from_path, resolve_config_dir, save_to_path};
 
     fn temp_settings_path(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -133,12 +140,31 @@ mod tests {
         let path = temp_settings_path("save");
         let settings = AppSettings {
             locale: Some(String::from("ko")),
+            theme: Some(String::from("nord")),
         };
 
         save_to_path(&path, &settings).expect("settings should save");
 
         let written = fs::read_to_string(&path).expect("settings file should exist");
         assert!(written.contains("\"locale\": \"ko\""));
+        assert!(written.contains("\"theme\": \"nord\""));
+
+        fs::remove_dir_all(path.parent().expect("config dir should exist"))
+            .expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn loads_saved_theme_and_locale_round_trip() {
+        let path = temp_settings_path("roundtrip");
+        let settings = AppSettings {
+            locale: Some(String::from("en")),
+            theme: Some(String::from("tokyo_night")),
+        };
+
+        save_to_path(&path, &settings).expect("settings should save");
+
+        let loaded = load_from_path(&path).expect("settings should load");
+        assert_eq!(loaded, settings);
 
         fs::remove_dir_all(path.parent().expect("config dir should exist"))
             .expect("temp dir should be removed");

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -11,7 +11,7 @@ use crossterm::terminal::{
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Margin, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::symbols;
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
@@ -24,10 +24,13 @@ use crate::domain::{
     RemediationKind, ScanMode, ScanResult, Scope, Severity, Source,
 };
 use crate::i18n;
+use crate::settings;
 
 mod fix_review;
+mod theme;
 
 pub use fix_review::run_fix_review;
+pub use theme::{Theme, ThemePreset};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Screen {
@@ -57,7 +60,7 @@ enum RemediationFilter {
     Manual,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 struct AppState {
     screen: Screen,
     findings_focus: FindingsFocus,
@@ -69,15 +72,29 @@ struct AppState {
     remediation_filter: RemediationFilter,
     service_filter: Option<String>,
     sort_mode: FindingSortMode,
+    theme: Theme,
+    theme_preset: ThemePreset,
+    tick: usize,
 }
 
 impl AppState {
+    fn cycle_theme(&mut self) {
+        self.theme_preset = self.theme_preset.next();
+        self.theme = Theme::preset(self.theme_preset);
+        let _ = settings::persist_theme(self.theme_preset.as_key());
+    }
+
     fn new(scan_result: &ScanResult) -> Self {
         let severity_filter = None;
         let source_filter = None;
         let service_filter = None;
         let remediation_filter = RemediationFilter::All;
         let sort_mode = FindingSortMode::Severity;
+        let theme_preset = settings::load()
+            .theme
+            .as_deref()
+            .and_then(ThemePreset::from_key)
+            .unwrap_or(ThemePreset::Ansi);
 
         Self {
             screen: Screen::Overview,
@@ -97,6 +114,9 @@ impl AppState {
             remediation_filter,
             service_filter: None,
             sort_mode,
+            theme: Theme::preset(theme_preset),
+            theme_preset,
+            tick: 0,
         }
     }
 
@@ -343,6 +363,7 @@ where
         if refresh(scan_result) {
             state.clamp_selection(scan_result);
         }
+        state.tick = state.tick.wrapping_add(1);
 
         terminal.draw(|frame| render(frame, scan_result, state))?;
 
@@ -387,6 +408,10 @@ fn handle_overview_key(
                     compose_file: path,
                     finding_id: None,
                 })
+        }
+        KeyCode::Char('t') => {
+            state.cycle_theme();
+            None
         }
         KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
             state.open_findings();
@@ -446,6 +471,10 @@ fn handle_findings_key(
                         .map(|finding| finding.id.clone()),
                 })
         }
+        KeyCode::Char('t') => {
+            state.cycle_theme();
+            None
+        }
         KeyCode::Char('1') => {
             state.jump_to_severity(scan_result, Severity::Critical);
             None
@@ -504,12 +533,12 @@ fn render(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, state: &mut 
     state.clamp_selection(scan_result);
 
     match state.screen {
-        Screen::Overview => render_overview(frame, scan_result),
+        Screen::Overview => render_overview(frame, scan_result, state),
         Screen::Findings => render_findings(frame, scan_result, state),
     }
 }
 
-fn render_overview(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult) {
+fn render_overview(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, state: &AppState) {
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -519,68 +548,66 @@ fn render_overview(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult) {
         ])
         .split(frame.area());
 
-    frame.render_widget(header_banner(), layout[0]);
+    frame.render_widget(header_banner(&state.theme), layout[0]);
 
     match overview_layout_mode(frame.area()) {
         OverviewLayoutMode::Wide => {
-            let dashboard = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .split(layout[1]);
-
-            let top_row = Layout::default()
+            let columns = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .split(dashboard[0]);
-
-            let bottom_row = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .split(dashboard[1]);
-
-            render_server_status_panel(frame, top_row[0], scan_result);
-            render_scan_results_panel(frame, top_row[1], scan_result);
-            render_security_scores_panel(frame, bottom_row[0], scan_result);
-            render_fix_paths_panel(frame, bottom_row[1], scan_result);
-        }
-        OverviewLayoutMode::Compact => {
-            let rows = Layout::default()
-                .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Percentage(34),
+                    Constraint::Percentage(31),
                     Constraint::Percentage(33),
-                    Constraint::Percentage(33),
+                    Constraint::Percentage(36),
                 ])
                 .split(layout[1]);
-            let top_row = Layout::default()
+            let right_column = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(10), Constraint::Min(10)])
+                .split(columns[2]);
+
+            render_server_status_panel(frame, columns[0], scan_result, &state.theme);
+            render_scan_results_panel(frame, columns[1], scan_result, state, &state.theme);
+            render_security_scores_panel(frame, right_column[0], scan_result, state, &state.theme);
+            render_fix_paths_panel(frame, right_column[1], scan_result, &state.theme);
+        }
+        OverviewLayoutMode::Compact => {
+            let columns = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .split(rows[0]);
+                .split(layout[1]);
+            let left = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(48), Constraint::Percentage(52)])
+                .split(columns[0]);
+            let right = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(10), Constraint::Min(9)])
+                .split(columns[1]);
 
-            render_server_status_panel(frame, top_row[0], scan_result);
-            render_scan_results_panel(frame, top_row[1], scan_result);
-            render_security_scores_panel(frame, rows[1], scan_result);
-            render_fix_paths_panel(frame, rows[2], scan_result);
+            render_server_status_panel(frame, left[0], scan_result, &state.theme);
+            render_scan_results_panel(frame, left[1], scan_result, state, &state.theme);
+            render_security_scores_panel(frame, right[0], scan_result, state, &state.theme);
+            render_fix_paths_panel(frame, right[1], scan_result, &state.theme);
         }
         OverviewLayoutMode::Narrow => {
             let rows = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Percentage(27),
-                    Constraint::Percentage(25),
-                    Constraint::Percentage(24),
+                    Constraint::Percentage(26),
+                    Constraint::Percentage(26),
+                    Constraint::Percentage(22),
                     Constraint::Percentage(24),
                 ])
                 .split(layout[1]);
 
-            render_server_status_panel(frame, rows[0], scan_result);
-            render_scan_results_panel(frame, rows[1], scan_result);
-            render_security_scores_panel(frame, rows[2], scan_result);
-            render_fix_paths_panel(frame, rows[3], scan_result);
+            render_server_status_panel(frame, rows[0], scan_result, &state.theme);
+            render_scan_results_panel(frame, rows[1], scan_result, state, &state.theme);
+            render_security_scores_panel(frame, rows[2], scan_result, state, &state.theme);
+            render_fix_paths_panel(frame, rows[3], scan_result, &state.theme);
         }
     }
 
-    frame.render_widget(overview_footer(), layout[2]);
+    frame.render_widget(overview_footer(&state.theme), layout[2]);
 }
 
 fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, state: &mut AppState) {
@@ -597,7 +624,7 @@ fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, sta
     let content = match mode {
         FindingsLayoutMode::SideBySide => Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+            .constraints([Constraint::Percentage(44), Constraint::Percentage(56)])
             .split(layout[1]),
         FindingsLayoutMode::Stacked => Layout::default()
             .direction(Direction::Vertical)
@@ -610,7 +637,7 @@ fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, sta
     };
 
     frame.render_widget(
-        findings_header(scan_result, state, layout[0].width, mode),
+        findings_header(scan_result, state, layout[0].width, mode, &state.theme),
         layout[0],
     );
 
@@ -624,6 +651,7 @@ fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, sta
         state,
         content[0].width,
         mode,
+        &state.theme,
     ))
     .block(
         Block::default()
@@ -631,19 +659,22 @@ fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, sta
             .borders(Borders::ALL)
             .border_style(focus_border_style(
                 state.findings_focus == FindingsFocus::List,
+                &state.theme,
             )),
     )
     .highlight_symbol("> ")
-    .highlight_style(Style::default().bg(Color::DarkGray));
+    .highlight_style(state.theme.highlight);
 
     let detail_block = Block::default()
         .title(findings_detail_title(state.findings_focus))
         .borders(Borders::ALL)
         .border_style(focus_border_style(
             state.findings_focus == FindingsFocus::Detail,
+            &state.theme,
         ));
     let detail_inner = detail_block.inner(content[1]);
-    let detail_text = finding_detail_text(scan_result, state, detail_inner.width, mode);
+    let detail_text =
+        finding_detail_text(scan_result, state, detail_inner.width, mode, &state.theme);
     let detail_content_height = estimated_wrapped_text_height(&detail_text, detail_inner.width);
     let detail_max_scroll = detail_content_height.saturating_sub(detail_inner.height as usize);
     state.clamp_detail_scroll(detail_max_scroll);
@@ -663,7 +694,7 @@ fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, sta
         state,
     );
     frame.render_widget(
-        findings_footer(state.findings_focus, layout[2].width, mode),
+        findings_footer(state.findings_focus, layout[2].width, mode, &state.theme),
         layout[2],
     );
 }
@@ -688,25 +719,23 @@ fn findings_layout_mode(area: Rect) -> FindingsLayoutMode {
     }
 }
 
-fn header_banner() -> Paragraph<'static> {
+fn header_banner(theme: &Theme) -> Paragraph<'static> {
     let mut spans = vec![
         Span::styled(
             format!("hostveil v{}", env!("CARGO_PKG_VERSION")),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
+            theme.title.add_modifier(Modifier::BOLD),
         ),
         Span::raw(" | "),
-        Span::styled(
-            t!("app.header.subtitle").into_owned(),
-            Style::default().fg(Color::White),
-        ),
+        Span::styled(t!("app.header.subtitle").into_owned(), theme.base),
         Span::raw(" | "),
         Span::styled(
             current_locale_badge(),
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.med).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" | "),
+        Span::styled(
+            t!("app.header.theme_badge", theme = theme.preset.label()),
+            theme.muted.add_modifier(Modifier::BOLD),
         ),
     ];
 
@@ -714,13 +743,18 @@ fn header_banner() -> Paragraph<'static> {
         spans.push(Span::raw(" | "));
         spans.push(Span::styled(
             "ROOT",
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.crit).add_modifier(Modifier::BOLD),
         ));
     }
 
     Paragraph::new(Text::from(Line::from(spans)))
         .alignment(Alignment::Center)
-        .block(Block::default().borders(Borders::TOP | Borders::BOTTOM))
+        .block(
+            Block::default()
+                .borders(Borders::TOP | Borders::BOTTOM)
+                .border_style(theme.border),
+        )
+        .style(theme.base)
 }
 
 fn is_root() -> bool {
@@ -738,11 +772,13 @@ fn render_server_status_panel(
     frame: &mut ratatui::Frame<'_>,
     area: Rect,
     scan_result: &ScanResult,
+    theme: &Theme,
 ) {
     let block = Block::default()
         .title(t!("app.panel.server_status").into_owned())
         .borders(Borders::ALL)
-        .border_style(panel_border_style());
+        .border_style(theme.border)
+        .title_style(theme.title);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -763,18 +799,22 @@ fn render_server_status_panel(
         kv_line(
             t!("app.server.host_name").into_owned(),
             display_hostname(scan_result),
+            theme,
         ),
         kv_line(
             t!("app.server.root_path").into_owned(),
             display_host_root(scan_result),
+            theme,
         ),
         kv_line(
             t!("app.server.docker_version").into_owned(),
             display_docker_version(scan_result),
+            theme,
         ),
         kv_line(
             t!("app.server.uptime").into_owned(),
             display_uptime(scan_result),
+            theme,
         ),
     ];
 
@@ -782,22 +822,30 @@ fn render_server_status_panel(
         Paragraph::new(Text::from(meta_lines)).wrap(Wrap { trim: true }),
         sections[0],
     );
-    render_load_gauge_row(frame, sections[1], scan_result);
+    render_load_gauge_row(frame, sections[1], scan_result, theme);
     frame.render_widget(
         Paragraph::new(Text::from(server_service_lines(
             scan_result,
             sections[2].width,
+            theme,
         )))
         .wrap(Wrap { trim: true }),
         sections[2],
     );
 }
 
-fn render_scan_results_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_result: &ScanResult) {
+fn render_scan_results_panel(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    scan_result: &ScanResult,
+    state: &AppState,
+    theme: &Theme,
+) {
     let block = Block::default()
         .title(t!("app.panel.scan_results").into_owned())
         .borders(Borders::ALL)
-        .border_style(panel_border_style());
+        .border_style(theme.border)
+        .title_style(theme.title);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -805,17 +853,15 @@ fn render_scan_results_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_re
         return;
     }
 
-    let mut lines = result_summary_lines(scan_result, inner.width);
+    let mut lines = result_summary_lines(scan_result, inner.width, theme);
     lines.push(Line::raw(String::new()));
-    lines.extend(severity_total_lines(scan_result, inner.width));
+    lines.extend(severity_total_lines(scan_result, inner.width, theme));
 
     if let Some(docker_status) = &scan_result.metadata.docker_status {
         lines.push(Line::raw(String::new()));
         lines.push(Line::styled(
             t!("app.result.discovery_heading").into_owned(),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
+            theme.title.add_modifier(Modifier::BOLD),
         ));
         lines.push(Line::raw(format!(
             "Docker: {}",
@@ -832,7 +878,7 @@ fn render_scan_results_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_re
         }
     }
 
-    let adapter_lines = adapter_summary_lines(scan_result, inner.width);
+    let adapter_lines = adapter_summary_lines(scan_result, inner.width, state, theme);
     if !adapter_lines.is_empty() {
         lines.push(Line::raw(String::new()));
         lines.extend(adapter_lines);
@@ -842,9 +888,7 @@ fn render_scan_results_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_re
         lines.push(Line::raw(String::new()));
         lines.push(Line::styled(
             t!("app.result.warnings_heading").into_owned(),
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.med).add_modifier(Modifier::BOLD),
         ));
         for warning in scan_result.metadata.warnings.iter().take(2) {
             let warning_width = inner.width.saturating_sub(4).max(20) as usize;
@@ -865,11 +909,14 @@ fn render_security_scores_panel(
     frame: &mut ratatui::Frame<'_>,
     area: Rect,
     scan_result: &ScanResult,
+    state: &AppState,
+    theme: &Theme,
 ) {
     let block = Block::default()
         .title(t!("app.panel.security_scores").into_owned())
         .borders(Borders::ALL)
-        .border_style(panel_border_style());
+        .border_style(theme.border)
+        .title_style(theme.title);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -878,25 +925,45 @@ fn render_security_scores_panel(
     }
 
     let rows = score_rows(scan_result);
-    let constraints = rows
-        .iter()
-        .map(|_| Constraint::Length(1))
-        .collect::<Vec<_>>();
+    let mut constraints = Vec::new();
+    if has_pending_adapters(scan_result) {
+        constraints.push(Constraint::Length(2));
+        constraints.push(Constraint::Length(1));
+    }
+    constraints.extend(rows.iter().map(|_| Constraint::Length(1)));
     let row_areas = Layout::default()
         .direction(Direction::Vertical)
         .constraints(constraints)
         .split(inner);
 
-    for ((label, score, emphasize), row_area) in rows.into_iter().zip(row_areas.iter().copied()) {
-        render_score_gauge_row(frame, row_area, &label, score, emphasize);
+    let mut offset = 0;
+    if has_pending_adapters(scan_result) {
+        render_adapter_progress_row(frame, row_areas[0], scan_result, state, theme);
+        frame.render_widget(
+            Paragraph::new(t!("app.overview.score_pending_detail")).style(theme.muted),
+            row_areas[1],
+        );
+        offset = 2;
+    }
+
+    for ((label, score, emphasize), row_area) in
+        rows.into_iter().zip(row_areas.iter().copied().skip(offset))
+    {
+        render_score_gauge_row(frame, row_area, &label, score, emphasize, theme);
     }
 }
 
-fn render_fix_paths_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_result: &ScanResult) {
+fn render_fix_paths_panel(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    scan_result: &ScanResult,
+    theme: &Theme,
+) {
     let block = Block::default()
-        .title(t!("app.panel.remediation_summary").into_owned())
+        .title(t!("app.panel.action_queue"))
         .borders(Borders::ALL)
-        .border_style(panel_border_style());
+        .border_style(theme.border)
+        .title_style(theme.title);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -904,7 +971,7 @@ fn render_fix_paths_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_resul
         return;
     }
 
-    let mut lines = remediation_lines(scan_result, inner.width);
+    let mut lines = remediation_lines(scan_result, inner.width, theme);
     if lines.is_empty() {
         lines.push(Line::raw(t!("app.fix.none").into_owned()));
     }
@@ -915,18 +982,25 @@ fn render_fix_paths_panel(frame: &mut ratatui::Frame<'_>, area: Rect, scan_resul
     );
 }
 
-fn overview_footer() -> Paragraph<'static> {
+fn overview_footer(theme: &Theme) -> Paragraph<'static> {
     Paragraph::new(Text::from(Line::from(vec![
-        hint_span("q", t!("app.footer.quit").into_owned()),
+        hint_span("q", t!("app.footer.quit").into_owned(), theme),
         Span::raw("  "),
-        hint_span("Enter", t!("app.footer.findings").into_owned()),
+        hint_span("Enter", t!("app.footer.findings").into_owned(), theme),
         Span::raw("  "),
-        hint_span("g", t!("app.footer.locale").into_owned()),
+        hint_span("g", t!("app.footer.locale").into_owned(), theme),
         Span::raw("  "),
-        hint_span("--json", t!("app.footer.json").into_owned()),
+        hint_span("t", t!("app.footer.theme").into_owned(), theme),
+        Span::raw("  "),
+        hint_span("--json", t!("app.footer.json").into_owned(), theme),
     ])))
     .alignment(Alignment::Left)
-    .block(Block::default().borders(Borders::TOP))
+    .block(
+        Block::default()
+            .borders(Borders::TOP)
+            .border_style(theme.border),
+    )
+    .style(theme.status_bar)
 }
 
 fn findings_header(
@@ -934,6 +1008,7 @@ fn findings_header(
     state: &AppState,
     available_width: u16,
     mode: FindingsLayoutMode,
+    theme: &Theme,
 ) -> Paragraph<'static> {
     let inner_width = available_width.saturating_sub(2).max(16) as usize;
     let filters = finding_filter_summary(state);
@@ -976,8 +1051,11 @@ fn findings_header(
         .block(
             Block::default()
                 .title(t!("app.panel.status").into_owned())
-                .borders(Borders::ALL),
+                .borders(Borders::ALL)
+                .border_style(theme.border)
+                .title_style(theme.title),
         )
+        .style(theme.base)
         .wrap(Wrap { trim: true })
 }
 
@@ -985,6 +1063,7 @@ fn findings_footer(
     focus: FindingsFocus,
     available_width: u16,
     mode: FindingsLayoutMode,
+    theme: &Theme,
 ) -> Paragraph<'static> {
     let inner_width = available_width.saturating_sub(2).max(16) as usize;
     let movement = match focus {
@@ -1007,7 +1086,12 @@ fn findings_footer(
         Line::raw(truncate_text(&movement, inner_width)),
         Line::raw(truncate_text(&controls, inner_width)),
     ]))
-    .block(Block::default().borders(Borders::TOP))
+    .block(
+        Block::default()
+            .borders(Borders::TOP)
+            .border_style(theme.border),
+    )
+    .style(theme.status_bar)
     .wrap(Wrap { trim: true })
 }
 
@@ -1016,6 +1100,7 @@ fn findings_list_items(
     state: &AppState,
     available_width: u16,
     mode: FindingsLayoutMode,
+    theme: &Theme,
 ) -> Vec<ListItem<'static>> {
     if state.finding_count() == 0 {
         return vec![ListItem::new(t!("app.finding.empty_title").into_owned())];
@@ -1054,12 +1139,12 @@ fn findings_list_items(
                         ),
                         inner_width,
                     ),
-                    severity_style(finding.severity).add_modifier(Modifier::BOLD),
+                    severity_style(finding.severity, theme).add_modifier(Modifier::BOLD),
                 )),
                 FindingsLayoutMode::Stacked => ListItem::new(Text::from(vec![
                     Line::styled(
                         title,
-                        severity_style(finding.severity).add_modifier(Modifier::BOLD),
+                        severity_style(finding.severity, theme).add_modifier(Modifier::BOLD),
                     ),
                     Line::raw(truncate_text(
                         &format!(
@@ -1074,7 +1159,7 @@ fn findings_list_items(
                 FindingsLayoutMode::SideBySide => ListItem::new(Text::from(vec![
                     Line::styled(
                         title,
-                        severity_style(finding.severity).add_modifier(Modifier::BOLD),
+                        severity_style(finding.severity, theme).add_modifier(Modifier::BOLD),
                     ),
                     Line::raw(truncate_text(
                         &format!(
@@ -1097,6 +1182,7 @@ fn finding_detail_text(
     state: &AppState,
     available_width: u16,
     mode: FindingsLayoutMode,
+    theme: &Theme,
 ) -> Text<'static> {
     let Some(finding) = state.selected_finding(scan_result) else {
         return Text::from(vec![
@@ -1113,7 +1199,7 @@ fn finding_detail_text(
     let mut lines = vec![
         Line::styled(
             finding.title.clone(),
-            severity_style(finding.severity).add_modifier(Modifier::BOLD),
+            severity_style(finding.severity, theme).add_modifier(Modifier::BOLD),
         ),
         Line::raw(if compact {
             truncate_text(
@@ -1246,13 +1332,17 @@ fn result_summary_rows(scan_result: &ScanResult) -> Vec<ResultSummaryRow> {
     rows.into_values().collect()
 }
 
-fn result_summary_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line<'static>> {
+fn result_summary_lines(
+    scan_result: &ScanResult,
+    available_width: u16,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
     let rows = result_summary_rows(scan_result);
     if rows.is_empty() {
         return vec![Line::raw(t!("app.result.none").into_owned())];
     }
 
-    let label_width = available_width.saturating_sub(20).clamp(8, 16) as usize;
+    let label_width = available_width.saturating_sub(20).clamp(10, 28) as usize;
 
     rows.into_iter()
         .map(|row| {
@@ -1261,13 +1351,13 @@ fn result_summary_lines(scan_result: &ScanResult, available_width: u16) -> Vec<L
                 None => t!("app.result.ok").into_owned(),
             };
             let status_style = match row.severity {
-                Some(severity) => severity_style(severity),
-                None => Style::default().fg(Color::Green),
+                Some(severity) => severity_style(severity, theme),
+                None => Style::default().fg(theme.safe),
             };
             let label = truncate_text(&row.label, label_width);
 
             Line::from(vec![
-                Span::styled("* ", Style::default().fg(Color::Green)),
+                Span::styled("* ", Style::default().fg(theme.safe)),
                 Span::raw(format!("{label: <width$}", width = label_width)),
                 Span::styled(
                     format!("[{status_text}]"),
@@ -1279,7 +1369,11 @@ fn result_summary_lines(scan_result: &ScanResult, available_width: u16) -> Vec<L
         .collect()
 }
 
-fn severity_total_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line<'static>> {
+fn severity_total_lines(
+    scan_result: &ScanResult,
+    available_width: u16,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
     let critical = scan_result
         .score_report
         .severity_counts
@@ -1308,23 +1402,23 @@ fn severity_total_lines(scan_result: &ScanResult, available_width: u16) -> Vec<L
     let first_pair = Line::from(vec![
         Span::styled(
             format!("{critical} {}", t!("severity.critical").into_owned()),
-            severity_style(Severity::Critical).add_modifier(Modifier::BOLD),
+            severity_style(Severity::Critical, theme).add_modifier(Modifier::BOLD),
         ),
         Span::raw("  "),
         Span::styled(
             format!("{high} {}", t!("severity.high").into_owned()),
-            severity_style(Severity::High).add_modifier(Modifier::BOLD),
+            severity_style(Severity::High, theme).add_modifier(Modifier::BOLD),
         ),
     ]);
     let second_pair = Line::from(vec![
         Span::styled(
             format!("{medium} {}", t!("severity.medium").into_owned()),
-            severity_style(Severity::Medium).add_modifier(Modifier::BOLD),
+            severity_style(Severity::Medium, theme).add_modifier(Modifier::BOLD),
         ),
         Span::raw("  "),
         Span::styled(
             format!("{low} {}", t!("severity.low").into_owned()),
-            severity_style(Severity::Low).add_modifier(Modifier::BOLD),
+            severity_style(Severity::Low, theme).add_modifier(Modifier::BOLD),
         ),
     ]);
 
@@ -1352,29 +1446,33 @@ fn severity_total_lines(scan_result: &ScanResult, available_width: u16) -> Vec<L
             Line::from(vec![
                 Span::styled(
                     format!("{critical} {}", t!("severity.critical").into_owned()),
-                    severity_style(Severity::Critical).add_modifier(Modifier::BOLD),
+                    severity_style(Severity::Critical, theme).add_modifier(Modifier::BOLD),
                 ),
                 Span::raw("  "),
                 Span::styled(
                     format!("{high} {}", t!("severity.high").into_owned()),
-                    severity_style(Severity::High).add_modifier(Modifier::BOLD),
+                    severity_style(Severity::High, theme).add_modifier(Modifier::BOLD),
                 ),
                 Span::raw("  "),
                 Span::styled(
                     format!("{medium} {}", t!("severity.medium").into_owned()),
-                    severity_style(Severity::Medium).add_modifier(Modifier::BOLD),
+                    severity_style(Severity::Medium, theme).add_modifier(Modifier::BOLD),
                 ),
                 Span::raw("  "),
                 Span::styled(
                     format!("{low} {}", t!("severity.low").into_owned()),
-                    severity_style(Severity::Low).add_modifier(Modifier::BOLD),
+                    severity_style(Severity::Low, theme).add_modifier(Modifier::BOLD),
                 ),
             ]),
         ]
     }
 }
 
-fn remediation_lines(scan_result: &ScanResult, _available_width: u16) -> Vec<Line<'static>> {
+fn remediation_lines(
+    scan_result: &ScanResult,
+    available_width: u16,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
     let mut fixable_by_service = BTreeMap::<String, usize>::new();
     let mut manual_by_service = BTreeMap::<String, usize>::new();
     let mut host_manual_count = 0;
@@ -1400,14 +1498,20 @@ fn remediation_lines(scan_result: &ScanResult, _available_width: u16) -> Vec<Lin
     let manual_count: usize = manual_by_service.values().sum::<usize>() + host_manual_count;
 
     let mut lines = Vec::new();
+    let text_width = available_width.saturating_sub(4).max(24) as usize;
+
+    let action_hint = t!("app.overview.action_queue_hint").to_string();
+    lines.push(Line::styled(
+        truncate_text(&action_hint, text_width),
+        theme.muted,
+    ));
+    lines.push(Line::raw(String::new()));
 
     if auto_fixable_count > 0 {
         lines.push(Line::from(vec![
             Span::styled(
                 format!("[{}] ", t!("remediation.auto_fixable").into_owned()),
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
+                remediation_style(RemediationKind::Safe, theme).add_modifier(Modifier::BOLD),
             ),
             Span::raw(
                 t!(
@@ -1421,7 +1525,7 @@ fn remediation_lines(scan_result: &ScanResult, _available_width: u16) -> Vec<Lin
         for (service, count) in fixable_by_service {
             lines.push(Line::from(vec![
                 Span::raw("  • "),
-                Span::styled(service, Style::default().add_modifier(Modifier::BOLD)),
+                Span::styled(service, theme.base.add_modifier(Modifier::BOLD)),
                 Span::raw(format!(": {}", count)),
             ]));
         }
@@ -1435,9 +1539,7 @@ fn remediation_lines(scan_result: &ScanResult, _available_width: u16) -> Vec<Lin
         lines.push(Line::from(vec![
             Span::styled(
                 format!("[{}] ", t!("remediation.manual").into_owned()),
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
+                remediation_style(RemediationKind::None, theme).add_modifier(Modifier::BOLD),
             ),
             Span::raw(t!("app.result.manual_summary", count = manual_count).into_owned()),
         ]));
@@ -1445,7 +1547,7 @@ fn remediation_lines(scan_result: &ScanResult, _available_width: u16) -> Vec<Lin
         for (service, count) in manual_by_service {
             lines.push(Line::from(vec![
                 Span::raw("  • "),
-                Span::styled(service, Style::default().add_modifier(Modifier::BOLD)),
+                Span::styled(service, theme.base.add_modifier(Modifier::BOLD)),
                 Span::raw(format!(": {}", count)),
             ]));
         }
@@ -1455,7 +1557,7 @@ fn remediation_lines(scan_result: &ScanResult, _available_width: u16) -> Vec<Lin
                 Span::raw("  • "),
                 Span::styled(
                     t!("scope.host").into_owned(),
-                    Style::default().add_modifier(Modifier::BOLD),
+                    theme.base.add_modifier(Modifier::BOLD),
                 ),
                 Span::raw(format!(": {}", host_manual_count)),
             ]));
@@ -1470,23 +1572,29 @@ fn remediation_lines(scan_result: &ScanResult, _available_width: u16) -> Vec<Lin
         lines.push(Line::raw(""));
         lines.push(Line::styled(
             t!("app.hint.press_f_to_fix").into_owned(),
-            Style::default().fg(Color::Green),
+            Style::default().fg(theme.safe),
         ));
     }
 
     lines
 }
 
-fn server_service_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line<'static>> {
+fn server_service_lines(
+    scan_result: &ScanResult,
+    available_width: u16,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
-    lines.extend(defensive_controls_lines(scan_result, available_width));
+    lines.extend(defensive_controls_lines(
+        scan_result,
+        available_width,
+        theme,
+    ));
 
     lines.push(Line::styled(
         t!("app.server.services_heading").into_owned(),
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD),
+        theme.title.add_modifier(Modifier::BOLD),
     ));
 
     if scan_result.metadata.services.is_empty() {
@@ -1502,7 +1610,7 @@ fn server_service_lines(scan_result: &ScanResult, available_width: u16) -> Vec<L
             .unwrap_or_else(|| t!("app.server.no_image").into_owned());
         let summary = truncate_text(&format!("{} - {}", service.name, image), text_width);
         lines.push(Line::from(vec![
-            Span::styled("* ", Style::default().fg(Color::Green)),
+            Span::styled("* ", Style::default().fg(theme.safe)),
             Span::raw(summary),
         ]));
     }
@@ -1520,7 +1628,11 @@ fn server_service_lines(scan_result: &ScanResult, available_width: u16) -> Vec<L
     lines
 }
 
-fn defensive_controls_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line<'static>> {
+fn defensive_controls_lines(
+    scan_result: &ScanResult,
+    available_width: u16,
+    _theme: &Theme,
+) -> Vec<Line<'static>> {
     let Some(runtime) = scan_result.metadata.host_runtime.as_ref() else {
         return Vec::new();
     };
@@ -1591,6 +1703,7 @@ fn render_score_gauge_row(
     label: &str,
     score: u8,
     emphasize: bool,
+    theme: &Theme,
 ) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -1607,33 +1720,45 @@ fn render_score_gauge_row(
         .split(area);
 
     let label_style = if emphasize {
-        Style::default().add_modifier(Modifier::BOLD)
+        theme.title.add_modifier(Modifier::BOLD)
     } else {
-        Style::default()
+        theme.base
     };
     let label_text = truncate_text(label, label_width.saturating_sub(1).max(4) as usize);
 
     frame.render_widget(Paragraph::new(label_text).style(label_style), row[0]);
     frame.render_widget(
         Paragraph::new(format!("{score:>3}"))
-            .style(score_style(score).add_modifier(Modifier::BOLD)),
+            .style(score_style(score, theme).add_modifier(Modifier::BOLD)),
         row[1],
     );
 
     if row[2].width > 0 {
+        let gauge_width = row[2].width.min(if emphasize { 24 } else { 18 });
+        let gauge_area = Rect::new(
+            row[2].x + row[2].width.saturating_sub(gauge_width),
+            row[2].y,
+            gauge_width,
+            row[2].height,
+        );
         frame.render_widget(
             LineGauge::default()
                 .ratio(score_ratio(score))
                 .label(String::new())
                 .line_set(symbols::line::THICK)
-                .filled_style(score_style(score))
-                .unfilled_style(Style::default().fg(Color::DarkGray)),
-            row[2],
+                .filled_style(score_style(score, theme))
+                .unfilled_style(theme.border),
+            gauge_area,
         );
     }
 }
 
-fn render_load_gauge_row(frame: &mut ratatui::Frame<'_>, area: Rect, scan_result: &ScanResult) {
+fn render_load_gauge_row(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    scan_result: &ScanResult,
+    theme: &Theme,
+) {
     if area.width == 0 || area.height == 0 {
         return;
     }
@@ -1654,7 +1779,7 @@ fn render_load_gauge_row(frame: &mut ratatui::Frame<'_>, area: Rect, scan_result
             &label_text,
             label_width.saturating_sub(1).max(6) as usize,
         ))
-        .style(Style::default().fg(Color::Cyan)),
+        .style(theme.title),
         row[0],
     );
 
@@ -1664,11 +1789,61 @@ fn render_load_gauge_row(frame: &mut ratatui::Frame<'_>, area: Rect, scan_result
                 .ratio(load_ratio(scan_result).unwrap_or(0.0))
                 .label(String::new())
                 .line_set(symbols::line::THICK)
-                .filled_style(Style::default().fg(Color::Green))
-                .unfilled_style(Style::default().fg(Color::DarkGray)),
+                .filled_style(theme.safe)
+                .unfilled_style(theme.border),
             row[1],
         );
     }
+}
+
+fn render_adapter_progress_row(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    scan_result: &ScanResult,
+    state: &AppState,
+    theme: &Theme,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let (complete, total) = adapter_completion(scan_result);
+    let ratio = if total == 0 {
+        1.0
+    } else {
+        complete as f64 / total as f64
+    };
+    let label_width = area.width.saturating_sub(18).clamp(12, 28);
+    let row = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(label_width),
+            Constraint::Length(5),
+            Constraint::Min(8),
+        ])
+        .split(area);
+
+    frame.render_widget(
+        Paragraph::new(truncate_text(
+            &adapter_progress_label(scan_result, state.tick),
+            label_width.max(8) as usize,
+        ))
+        .style(theme.muted),
+        row[0],
+    );
+    frame.render_widget(
+        Paragraph::new(format!("{complete}/{total}")).style(theme.base),
+        row[1],
+    );
+    frame.render_widget(
+        LineGauge::default()
+            .ratio(ratio)
+            .label(String::new())
+            .line_set(symbols::line::THICK)
+            .filled_style(theme.title)
+            .unfilled_style(theme.border),
+        row[2],
+    );
 }
 
 fn render_detail_scrollbar(
@@ -1964,7 +2139,12 @@ fn docker_status_label(status: &DockerDiscoveryStatus) -> String {
     }
 }
 
-fn adapter_summary_lines(scan_result: &ScanResult, available_width: u16) -> Vec<Line<'static>> {
+fn adapter_summary_lines(
+    scan_result: &ScanResult,
+    available_width: u16,
+    state: &AppState,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
     if scan_result.metadata.adapters.is_empty() {
         return Vec::new();
     }
@@ -1972,10 +2152,15 @@ fn adapter_summary_lines(scan_result: &ScanResult, available_width: u16) -> Vec<
     let text_width = available_width.saturating_sub(4).max(20) as usize;
     let mut lines = vec![Line::styled(
         t!("app.result.adapters_heading").into_owned(),
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD),
+        theme.title.add_modifier(Modifier::BOLD),
     )];
+
+    if has_pending_adapters(scan_result) {
+        lines.push(Line::styled(
+            truncate_text(&adapter_progress_label(scan_result, state.tick), text_width),
+            theme.muted,
+        ));
+    }
 
     for (name, status) in &scan_result.metadata.adapters {
         lines.push(Line::raw(truncate_text(
@@ -2002,7 +2187,7 @@ fn adapter_name_label(name: &str) -> String {
 
 fn adapter_status_label(status: &AdapterStatus) -> String {
     match status {
-        AdapterStatus::Pending => t!("adapter.pending").into_owned(),
+        AdapterStatus::Pending => t!("adapter.loading").into_owned(),
         AdapterStatus::Available => t!("adapter.available").into_owned(),
         AdapterStatus::Missing => t!("adapter.missing").into_owned(),
         AdapterStatus::Skipped(detail) => {
@@ -2012,6 +2197,52 @@ fn adapter_status_label(status: &AdapterStatus) -> String {
             t!("adapter.failed", detail = detail.as_str()).into_owned()
         }
     }
+}
+
+fn has_pending_adapters(scan_result: &ScanResult) -> bool {
+    scan_result
+        .metadata
+        .adapters
+        .values()
+        .any(|status| matches!(status, AdapterStatus::Pending))
+}
+
+fn adapter_completion(scan_result: &ScanResult) -> (usize, usize) {
+    let total = scan_result.metadata.adapters.len();
+    let complete = scan_result
+        .metadata
+        .adapters
+        .values()
+        .filter(|status| !matches!(status, AdapterStatus::Pending))
+        .count();
+
+    (complete, total)
+}
+
+fn spinner_frame(tick: usize) -> &'static str {
+    const FRAMES: [&str; 8] = ["-", "\\", "|", "/", "-", "\\", "|", "/"];
+    FRAMES[tick % FRAMES.len()]
+}
+
+fn adapter_progress_label(scan_result: &ScanResult, tick: usize) -> String {
+    let pending = scan_result
+        .metadata
+        .adapters
+        .iter()
+        .filter(|(_, status)| matches!(status, AdapterStatus::Pending))
+        .map(|(name, _)| adapter_name_label(name))
+        .collect::<Vec<_>>();
+
+    if pending.is_empty() {
+        return t!("app.overview.score_ready").to_string();
+    }
+
+    t!(
+        "app.overview.adapter_loading",
+        spinner = spinner_frame(tick),
+        adapters = pending.join(", ")
+    )
+    .into_owned()
 }
 
 fn display_host_root(scan_result: &ScanResult) -> String {
@@ -2080,9 +2311,9 @@ fn defensive_control_status_label(status: DefensiveControlStatus) -> String {
     }
 }
 
-fn kv_line(label: String, value: String) -> Line<'static> {
+fn kv_line(label: String, value: String, theme: &Theme) -> Line<'static> {
     Line::from(vec![
-        Span::styled(format!("{label: <14}"), Style::default().fg(Color::Cyan)),
+        Span::styled(format!("{label: <14}"), theme.title),
         Span::raw(value),
     ])
 }
@@ -2114,20 +2345,12 @@ fn current_locale_badge() -> String {
     format!("LANG {}", i18n::current_locale().to_ascii_uppercase())
 }
 
-fn panel_border_style() -> Style {
-    Style::default().fg(Color::Cyan)
+fn focus_border_style(active: bool, theme: &Theme) -> Style {
+    if active { theme.title } else { theme.border }
 }
 
-fn focus_border_style(active: bool) -> Style {
-    if active {
-        Style::default().fg(Color::Green)
-    } else {
-        panel_border_style()
-    }
-}
-
-fn hint_span(key: &str, label: String) -> Span<'static> {
-    Span::styled(format!("[{key}] {label}"), Style::default().fg(Color::Cyan))
+fn hint_span(key: &str, label: String, theme: &Theme) -> Span<'static> {
+    Span::styled(format!("[{key}] {label}"), theme.title)
 }
 
 fn truncate_text(value: &str, max_chars: usize) -> String {
@@ -2215,22 +2438,30 @@ fn remediation_badge_compact(remediation: RemediationKind) -> String {
     }
 }
 
-fn severity_style(severity: Severity) -> Style {
+fn severity_style(severity: Severity, theme: &Theme) -> Style {
     Style::default().fg(match severity {
-        Severity::Critical => Color::Red,
-        Severity::High => Color::LightRed,
-        Severity::Medium => Color::Yellow,
-        Severity::Low => Color::Green,
+        Severity::Critical => theme.crit,
+        Severity::High => theme.high,
+        Severity::Medium => theme.med,
+        Severity::Low => theme.low,
     })
 }
 
-fn score_style(score: u8) -> Style {
+fn remediation_style(remediation: RemediationKind, theme: &Theme) -> Style {
+    Style::default().fg(match remediation {
+        RemediationKind::Safe => theme.safe,
+        RemediationKind::Guided => theme.guided,
+        RemediationKind::None => theme.manual,
+    })
+}
+
+fn score_style(score: u8, theme: &Theme) -> Style {
     Style::default().fg(if score >= 80 {
-        Color::Green
+        theme.safe
     } else if score >= 60 {
-        Color::Yellow
+        theme.med
     } else {
-        Color::LightRed
+        theme.crit
     })
 }
 
@@ -2617,7 +2848,7 @@ mod tests {
         assert!(content.contains("Server Status"));
         assert!(content.contains("Scan Results"));
         assert!(content.contains("Security Scores"));
-        assert!(content.contains("Remediation Summary"));
+        assert!(content.contains("Action Queue"));
         assert!(content.contains("61"));
         assert!(content.contains("adminer"));
         assert!(content.contains("home-server"));
@@ -2630,7 +2861,7 @@ mod tests {
 
     #[test]
     fn overview_remediation_summary_shows_auto_and_manual_counts() {
-        let lines = remediation_lines(&sample_result(), 80);
+        let lines = remediation_lines(&sample_result(), 80, &Theme::preset(ThemePreset::Ansi));
 
         let text: String = lines
             .iter()
@@ -2657,7 +2888,7 @@ mod tests {
         assert!(content.contains("24.0.7"));
         assert!(content.contains("14d 3h 22m"));
         assert!(content.contains("0.42 0.31 0.27"));
-        assert!(content.contains("Fail2ban enabled (2 jails, 5 banned)"));
+        assert!(content.contains("Fail2ban enabled"));
         assert!(content.contains("Adapters"));
         assert!(content.contains("Lynis: available"));
         assert!(content.contains("Trivy: missing"));
@@ -2678,10 +2909,69 @@ mod tests {
         assert!(content.contains("Server Status"));
         assert!(content.contains("Scan Results"));
         assert!(content.contains("Security Scores"));
-        assert!(content.contains("Remediation Summary"));
+        assert!(content.contains("Action Queue"));
         assert!(content.contains("0.42 0.31 0.27"));
         assert!(!content.contains("########"));
         assert!(!content.contains("----------"));
+    }
+
+    #[test]
+    fn overview_renders_loading_copy_without_exposing_pending_state() {
+        let mut result = sample_result();
+        result
+            .metadata
+            .adapters
+            .insert(String::from("trivy"), AdapterStatus::Pending);
+        result
+            .metadata
+            .adapters
+            .insert(String::from("dockle"), AdapterStatus::Pending);
+        let mut state = AppState::new(&result);
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal should build");
+
+        terminal
+            .draw(|frame| render(frame, &result, &mut state))
+            .expect("overview should render");
+
+        let content = buffer_to_string(terminal.backend());
+
+        assert!(!content.contains("pending"));
+    }
+
+    #[test]
+    fn adapter_progress_label_uses_loading_copy_instead_of_pending() {
+        let mut result = sample_result();
+        result
+            .metadata
+            .adapters
+            .insert(String::from("trivy"), AdapterStatus::Pending);
+        result
+            .metadata
+            .adapters
+            .insert(String::from("dockle"), AdapterStatus::Pending);
+
+        let label = adapter_progress_label(&result, 0);
+
+        assert!(label.contains("loading adapters"));
+        assert!(label.contains("Trivy"));
+        assert!(label.contains("Dockle"));
+        assert!(!label.contains("pending"));
+    }
+
+    #[test]
+    fn theme_cycle_advances_to_next_preset() {
+        let result = sample_result();
+        let mut state = AppState::new(&result);
+
+        let initial = state.theme_preset;
+        handle_key(
+            &mut state,
+            &result,
+            KeyEvent::new(KeyCode::Char('t'), crossterm::event::KeyModifiers::NONE),
+        );
+
+        assert_eq!(state.theme_preset, initial.next());
+        assert_eq!(state.theme.preset, initial.next());
     }
 
     #[test]

--- a/src/src/tui/theme.rs
+++ b/src/src/tui/theme.rs
@@ -1,0 +1,203 @@
+use ratatui::style::{Color, Style};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThemePreset {
+    Ansi,
+    Catppuccin,
+    Nord,
+    TokyoNight,
+    Gruvbox,
+}
+
+impl ThemePreset {
+    pub const ALL: [Self; 5] = [
+        Self::Ansi,
+        Self::Catppuccin,
+        Self::Nord,
+        Self::TokyoNight,
+        Self::Gruvbox,
+    ];
+
+    pub const fn as_key(self) -> &'static str {
+        match self {
+            Self::Ansi => "ansi",
+            Self::Catppuccin => "catppuccin",
+            Self::Nord => "nord",
+            Self::TokyoNight => "tokyo_night",
+            Self::Gruvbox => "gruvbox",
+        }
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Ansi => "ANSI",
+            Self::Catppuccin => "Catppuccin",
+            Self::Nord => "Nord",
+            Self::TokyoNight => "Tokyo Night",
+            Self::Gruvbox => "Gruvbox",
+        }
+    }
+
+    pub fn from_key(value: &str) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|preset| preset.as_key() == value.trim().to_ascii_lowercase())
+    }
+
+    pub const fn next(self) -> Self {
+        match self {
+            Self::Ansi => Self::Catppuccin,
+            Self::Catppuccin => Self::Nord,
+            Self::Nord => Self::TokyoNight,
+            Self::TokyoNight => Self::Gruvbox,
+            Self::Gruvbox => Self::Ansi,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Theme {
+    pub preset: ThemePreset,
+    pub base: Style,
+    pub border: Style,
+    pub title: Style,
+    pub muted: Style,
+    pub highlight: Style,
+    pub status_bar: Style,
+    pub accent: Color,
+    pub crit: Color,
+    pub high: Color,
+    pub med: Color,
+    pub low: Color,
+    pub safe: Color,
+    pub guided: Color,
+    pub manual: Color,
+}
+
+impl Theme {
+    pub const fn preset(preset: ThemePreset) -> Self {
+        match preset {
+            ThemePreset::Ansi => Self::ansi(),
+            ThemePreset::Catppuccin => Self::catppuccin(),
+            ThemePreset::Nord => Self::nord(),
+            ThemePreset::TokyoNight => Self::tokyo_night(),
+            ThemePreset::Gruvbox => Self::gruvbox(),
+        }
+    }
+
+    const fn ansi() -> Self {
+        Self {
+            preset: ThemePreset::Ansi,
+            base: Style::new().fg(Color::Reset),
+            border: Style::new().fg(Color::DarkGray),
+            title: Style::new().fg(Color::Cyan),
+            muted: Style::new().fg(Color::Gray),
+            highlight: Style::new().bg(Color::DarkGray),
+            status_bar: Style::new().fg(Color::Gray),
+            accent: Color::Cyan,
+            crit: Color::LightRed,
+            high: Color::Yellow,
+            med: Color::LightYellow,
+            low: Color::LightGreen,
+            safe: Color::Green,
+            guided: Color::Yellow,
+            manual: Color::LightBlue,
+        }
+    }
+
+    const fn catppuccin() -> Self {
+        Self {
+            preset: ThemePreset::Catppuccin,
+            base: Style::new().fg(Color::Rgb(205, 214, 244)),
+            border: Style::new().fg(Color::Rgb(88, 91, 112)),
+            title: Style::new().fg(Color::Rgb(137, 180, 250)),
+            muted: Style::new().fg(Color::Rgb(127, 132, 156)),
+            highlight: Style::new()
+                .fg(Color::Rgb(205, 214, 244))
+                .bg(Color::Rgb(49, 50, 68)),
+            status_bar: Style::new()
+                .fg(Color::Rgb(147, 153, 178))
+                .bg(Color::Rgb(24, 24, 37)),
+            accent: Color::Rgb(137, 180, 250),
+            crit: Color::Rgb(243, 139, 168),
+            high: Color::Rgb(250, 179, 135),
+            med: Color::Rgb(249, 226, 175),
+            low: Color::Rgb(166, 227, 161),
+            safe: Color::Rgb(166, 227, 161),
+            guided: Color::Rgb(249, 226, 175),
+            manual: Color::Rgb(137, 180, 250),
+        }
+    }
+
+    const fn nord() -> Self {
+        Self {
+            preset: ThemePreset::Nord,
+            base: Style::new().fg(Color::Rgb(216, 222, 233)),
+            border: Style::new().fg(Color::Rgb(76, 86, 106)),
+            title: Style::new().fg(Color::Rgb(136, 192, 208)),
+            muted: Style::new().fg(Color::Rgb(143, 188, 187)),
+            highlight: Style::new()
+                .fg(Color::Rgb(229, 233, 240))
+                .bg(Color::Rgb(59, 66, 82)),
+            status_bar: Style::new()
+                .fg(Color::Rgb(129, 161, 193))
+                .bg(Color::Rgb(46, 52, 64)),
+            accent: Color::Rgb(136, 192, 208),
+            crit: Color::Rgb(191, 97, 106),
+            high: Color::Rgb(208, 135, 112),
+            med: Color::Rgb(235, 203, 139),
+            low: Color::Rgb(163, 190, 140),
+            safe: Color::Rgb(163, 190, 140),
+            guided: Color::Rgb(235, 203, 139),
+            manual: Color::Rgb(129, 161, 193),
+        }
+    }
+
+    const fn tokyo_night() -> Self {
+        Self {
+            preset: ThemePreset::TokyoNight,
+            base: Style::new().fg(Color::Rgb(169, 177, 214)),
+            border: Style::new().fg(Color::Rgb(68, 76, 113)),
+            title: Style::new().fg(Color::Rgb(122, 162, 247)),
+            muted: Style::new().fg(Color::Rgb(125, 135, 185)),
+            highlight: Style::new()
+                .fg(Color::Rgb(192, 202, 245))
+                .bg(Color::Rgb(41, 46, 66)),
+            status_bar: Style::new()
+                .fg(Color::Rgb(125, 135, 185))
+                .bg(Color::Rgb(26, 27, 38)),
+            accent: Color::Rgb(122, 162, 247),
+            crit: Color::Rgb(247, 118, 142),
+            high: Color::Rgb(255, 158, 100),
+            med: Color::Rgb(224, 175, 104),
+            low: Color::Rgb(158, 206, 106),
+            safe: Color::Rgb(158, 206, 106),
+            guided: Color::Rgb(224, 175, 104),
+            manual: Color::Rgb(122, 162, 247),
+        }
+    }
+
+    const fn gruvbox() -> Self {
+        Self {
+            preset: ThemePreset::Gruvbox,
+            base: Style::new().fg(Color::Rgb(235, 219, 178)),
+            border: Style::new().fg(Color::Rgb(102, 92, 84)),
+            title: Style::new().fg(Color::Rgb(131, 165, 152)),
+            muted: Style::new().fg(Color::Rgb(168, 153, 132)),
+            highlight: Style::new()
+                .fg(Color::Rgb(251, 241, 199))
+                .bg(Color::Rgb(60, 56, 54)),
+            status_bar: Style::new()
+                .fg(Color::Rgb(168, 153, 132))
+                .bg(Color::Rgb(40, 40, 40)),
+            accent: Color::Rgb(131, 165, 152),
+            crit: Color::Rgb(204, 36, 29),
+            high: Color::Rgb(214, 93, 14),
+            med: Color::Rgb(215, 153, 33),
+            low: Color::Rgb(152, 151, 26),
+            safe: Color::Rgb(152, 151, 26),
+            guided: Color::Rgb(215, 153, 33),
+            manual: Color::Rgb(69, 133, 136),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This release packages the recent TUI UX stabilization work as `v0.8.0`.

It ships:
- better space usage across wide, compact, and narrow terminal layouts
- visible adapter-loading and auto-update progress messaging
- clearer score semantics while adapters are still loading
- theme presets with persisted selection and ANSI fallback
- refreshed English/Korean docs for the current TUI and lifecycle behavior

## Why
The recent UX pass addressed several real usability gaps:
- large terminals wasted space while still truncating important text
- users could not tell whether startup delays came from auto-update or adapter loading
- score changes during adapter completion felt abrupt and unexplained
- Overview vs Findings needed clearer separation
- terminal color support needed modern preset options without losing default ANSI support
- the docs had fallen behind the implemented behavior

## User Impact
Users now get a denser and more legible dashboard, explicit background-work feedback, more stable scoring context during startup, selectable color palettes, and docs that match what the app actually does.

## Validation
- `cargo fmt --manifest-path src/Cargo.toml --check`
- `cargo clippy --manifest-path src/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path src/Cargo.toml --workspace`
- `cargo build --manifest-path src/Cargo.toml`
- `./scripts/smoke-test.sh target/debug/hostveil`
- `./scripts/test-install-script.sh target/debug/hostveil`
- Manual Trivy regression: `cargo run --manifest-path src/Cargo.toml -- --user-mode --json --compose src/tests/fixtures/services/jellyfin/vulnerable.yml --adapters trivy`
- Native-only regression: `cargo run --manifest-path src/Cargo.toml -- --user-mode --json --compose src/tests/fixtures/services/jellyfin/vulnerable.yml --adapters none`

## Issues
Closes #173
Closes #174
Closes #175
Closes #176
Closes #177
Closes #178