### PR TITLE
fix(ux): polish themed surfaces and Lynis recovery

### DIFF
--- a/docker-compose.lab.yml.bak
+++ b/docker-compose.lab.yml.bak
@@ -7,16 +7,14 @@ services:
       - .:/workspace:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
     ports:
-      - "127.0.0.1:7681:7681"
+      - "7681:7681"
     environment:
       - HOSTVEIL_LOCALE=en
     privileged: true
-    user: 1000:1000
   vulnerable-service:
-    image: nginx:stable
+    image: nginx:latest
     container_name: hostveil-lab-target
     ports:
-      - "127.0.0.1:8081:80"
+      - "8081:80"
     volumes:
       - /etc/shadow:/mnt/shadow:ro
-    user: 1000:1000

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -18,3 +18,17 @@ rustix = { version = "0.38", features = ["process"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+
+[package.metadata.deb]
+maintainer = "Gyuwon Seol <seolcu0112@proton.me>"
+copyright = "2026, Gyuwon Seol"
+license-file = ["../LICENSE", "4"]
+extended-description = """\
+Hostveil is a lightweight security dashboard for Linux self-hosted environments.
+"""
+depends = "$auto"
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/hostveil", dest = "/usr/bin/hostveil", mode = "755" },
+]

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -116,12 +116,14 @@ app:
   overview:
     score_caption: "Overall posture"
     findings_available: "%{count} finding(s) available. Open the findings view for details."
+    findings_ready: "%{count} finding(s) are ready for review and fix detail."
     no_findings: "No findings detected yet."
     adapters_none: "No optional adapter status reported yet."
     score_pending_detail: "Final score is waiting for adapter results. The rows below are the native baseline."
     score_ready: "Adapter loading complete"
     adapter_loading: "%{spinner} loading adapters: %{adapters}"
     action_queue_hint: "Overview groups next actions by service. Open Findings for per-issue evidence and fix detail."
+    next_step: "Next Step"
   server:
     host_name: "Host"
     root_path: "Root"
@@ -157,6 +159,7 @@ app:
     lynis_root_required_skipped: "Lynis requires root for host audit; skipped to avoid desktop authorization prompts."
     lynis_non_zero_exit: "Lynis exited with a non-zero status: %{detail}. Parsed the available report anyway."
     lynis_report_missing: "Lynis did not produce a report file."
+    lynis_running_elsewhere: "Lynis appears to already be running on this host. hostveil skipped the concurrent retry."
     scan_failed: "%{tool} scan failed for %{image}: %{error}"
     json_parse_failed: "failed to parse %{tool} JSON: %{error}"
     report_parse_failed: "failed to parse %{tool} report contents"

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -116,12 +116,14 @@ app:
   overview:
     score_caption: "전체 보안 상태"
     findings_available: "발견 항목 %{count}개가 있습니다. 상세 보기를 열어 확인하세요."
+    findings_ready: "발견 항목 %{count}개를 바로 검토하고 수정 상세를 확인할 수 있습니다."
     no_findings: "현재 발견 항목이 없습니다."
     adapters_none: "아직 보고된 선택형 어댑터 상태가 없습니다."
     score_pending_detail: "최종 점수는 어댑터 결과를 기다리고 있습니다. 아래 행은 네이티브 기준 점수입니다."
     score_ready: "어댑터 로딩 완료"
     adapter_loading: "%{spinner} 어댑터 로딩 중: %{adapters}"
     action_queue_hint: "개요는 서비스별 다음 조치를 묶어서 보여줍니다. Findings에서 항목별 근거와 수정 상세를 확인하세요."
+    next_step: "다음 단계"
   server:
     host_name: "호스트"
     root_path: "루트"
@@ -157,6 +159,7 @@ app:
     lynis_root_required_skipped: "Lynis 호스트 감사에는 root 권한이 필요해 데스크톱 권한 확인 창을 피하려고 건너뛰었습니다."
     lynis_non_zero_exit: "Lynis가 비정상 종료 코드로 종료했습니다: %{detail}. 사용 가능한 보고서는 계속 파싱했습니다."
     lynis_report_missing: "Lynis가 보고서 파일을 생성하지 않았습니다."
+    lynis_running_elsewhere: "이 호스트에서 Lynis가 이미 실행 중인 것으로 보여 hostveil이 동시 재시도를 건너뛰었습니다."
     scan_failed: "%{tool} 스캔이 %{image}에서 실패했습니다: %{error}"
     json_parse_failed: "%{tool} JSON 파싱에 실패했습니다: %{error}"
     report_parse_failed: "%{tool} 보고서 내용을 파싱하지 못했습니다"

--- a/src/src/adapters/docker_bench.rs
+++ b/src/src/adapters/docker_bench.rs
@@ -1,0 +1,14 @@
+use std::path::Path;
+use std::process::Command;
+
+use crate::domain::{AdapterStatus, Finding};
+
+pub fn scan(_host_root: Option<&Path>) -> (AdapterStatus, Vec<Finding>, Vec<String>) {
+    let mut command = Command::new("docker-bench-security");
+    command.arg("-c").arg("container_images"); // Just an example
+
+    match command.output() {
+        Ok(_) => (AdapterStatus::Available, vec![], vec![]),
+        Err(_) => (AdapterStatus::Missing, vec![], vec![]),
+    }
+}

--- a/src/src/adapters/dockle.rs
+++ b/src/src/adapters/dockle.rs
@@ -382,6 +382,8 @@ mod tests {
             .permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(&path, permissions).expect("test command should be executable");
+        // Brief yield so the OS can flush the write before the test execs the script.
+        std::thread::sleep(std::time::Duration::from_millis(10));
         path
     }
 

--- a/src/src/adapters/lynis.rs
+++ b/src/src/adapters/lynis.rs
@@ -9,6 +9,7 @@ use crate::adapters::command;
 use crate::domain::{AdapterStatus, Axis, Finding, RemediationKind, Scope, Severity, Source};
 
 const LIVE_HOST_ROOT: &str = "/";
+const LYNIS_PID_EXISTS_MESSAGE: &str = "PID file exists, probably another Lynis process is running";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LynisScanOutput {
@@ -185,11 +186,7 @@ fn run_lynis(files: &LynisTempFiles) -> Result<LynisCommandResult, String> {
     run_lynis_with_command("lynis", files, command::DEFAULT_ADAPTER_TIMEOUT)
 }
 
-fn run_lynis_with_command(
-    command_name: &str,
-    files: &LynisTempFiles,
-    timeout: Duration,
-) -> Result<LynisCommandResult, String> {
+fn build_lynis_command(command_name: &str, files: &LynisTempFiles) -> Command {
     let mut command = Command::new(command_name);
     command
         .args(["audit", "system", "--cronjob", "--quiet", "--nocolors"])
@@ -198,13 +195,127 @@ fn run_lynis_with_command(
         .arg("--logfile")
         .arg(&files.log_file)
         .env("NO_COLOR", "1");
+    command
+}
 
-    let output = command::run_with_timeout(command, timeout).map_err(|error| error.detail())?;
+fn run_lynis_with_command(
+    command_name: &str,
+    files: &LynisTempFiles,
+    timeout: Duration,
+) -> Result<LynisCommandResult, String> {
+    let output = command::run_with_timeout(build_lynis_command(command_name, files), timeout)
+        .map_err(|error| error.detail())?;
+    let detail = command_detail(&output.stderr, &output.stdout);
+
+    if !output.status.success() && is_pid_lockout_detail(&detail) {
+        let pid_paths = known_lynis_pid_files();
+        let cleanup = cleanup_stale_pid_files(&pid_paths, inspect_process_kind);
+
+        if cleanup.active_lynis {
+            return Err(t!("app.adapter.lynis_running_elsewhere").into_owned());
+        }
+
+        if cleanup.removed_any {
+            let retry_output =
+                command::run_with_timeout(build_lynis_command(command_name, files), timeout)
+                    .map_err(|error| error.detail())?;
+            let retry_detail = command_detail(&retry_output.stderr, &retry_output.stdout);
+
+            return Ok(LynisCommandResult {
+                success: retry_output.status.success(),
+                detail: Some(retry_detail),
+            });
+        }
+    }
 
     Ok(LynisCommandResult {
         success: output.status.success(),
-        detail: Some(command_detail(&output.stderr, &output.stdout)),
+        detail: Some(detail),
     })
+}
+
+fn is_pid_lockout_detail(detail: &str) -> bool {
+    detail.contains(LYNIS_PID_EXISTS_MESSAGE)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessKind {
+    Missing,
+    Lynis,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct PidCleanupOutcome {
+    removed_any: bool,
+    active_lynis: bool,
+}
+
+fn known_lynis_pid_files() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(home) = env::var_os("HOME").filter(|value| !value.is_empty()) {
+        paths.push(PathBuf::from(home).join("lynis.pid"));
+    }
+
+    if let Ok(current_dir) = env::current_dir() {
+        paths.push(current_dir.join("lynis.pid"));
+    }
+
+    paths.push(PathBuf::from("/var/run/lynis.pid"));
+    paths
+}
+
+fn cleanup_stale_pid_files<F>(paths: &[PathBuf], inspect_process: F) -> PidCleanupOutcome
+where
+    F: Fn(u32) -> ProcessKind,
+{
+    let mut outcome = PidCleanupOutcome::default();
+
+    for path in paths {
+        let Ok(contents) = fs::read_to_string(path) else {
+            continue;
+        };
+
+        let pid = contents.trim().parse::<u32>().ok();
+        let should_remove = match pid {
+            None => true,
+            Some(pid) => match inspect_process(pid) {
+                ProcessKind::Missing | ProcessKind::Other => true,
+                ProcessKind::Lynis => {
+                    outcome.active_lynis = true;
+                    false
+                }
+            },
+        };
+
+        if should_remove && fs::remove_file(path).is_ok() {
+            outcome.removed_any = true;
+        }
+    }
+
+    outcome
+}
+
+fn inspect_process_kind(pid: u32) -> ProcessKind {
+    let proc_dir = PathBuf::from("/proc").join(pid.to_string());
+    if !proc_dir.exists() {
+        return ProcessKind::Missing;
+    }
+
+    let cmdline = fs::read(proc_dir.join("cmdline"))
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .unwrap_or_default()
+        .replace('\0', " ");
+    let comm = fs::read_to_string(proc_dir.join("comm")).unwrap_or_default();
+    let process_text = format!("{cmdline} {comm}").to_ascii_lowercase();
+
+    if process_text.contains("lynis") {
+        ProcessKind::Lynis
+    } else {
+        ProcessKind::Other
+    }
 }
 
 fn is_effective_root() -> bool {
@@ -433,6 +544,15 @@ fn entry_evidence(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+        GUARD
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("test mutex should not be poisoned")
+    }
 
     #[test]
     fn skips_when_host_scan_was_not_requested() {
@@ -518,5 +638,165 @@ mod tests {
     fn detect_lynis_reports_available_for_true_command() {
         let status = detect_lynis_with_command("true");
         assert_eq!(status, LynisAvailability::Available);
+    }
+
+    #[test]
+    fn cleanup_stale_pid_files_removes_dead_pid_files() {
+        let _guard = test_guard();
+        let pid_path = env::temp_dir().join("hostveil-lynis-stale-dead.pid");
+        fs::write(&pid_path, "424242").expect("pid file should be written");
+
+        let outcome =
+            cleanup_stale_pid_files(std::slice::from_ref(&pid_path), |_| ProcessKind::Missing);
+
+        assert!(outcome.removed_any);
+        assert!(!outcome.active_lynis);
+        assert!(!pid_path.exists());
+    }
+
+    #[test]
+    fn cleanup_stale_pid_files_removes_invalid_pid_content() {
+        let _guard = test_guard();
+        let pid_path = env::temp_dir().join("hostveil-lynis-stale-invalid.pid");
+        fs::write(&pid_path, "not-a-pid").expect("pid file should be written");
+
+        let outcome =
+            cleanup_stale_pid_files(std::slice::from_ref(&pid_path), |_| ProcessKind::Missing);
+
+        assert!(outcome.removed_any);
+        assert!(!outcome.active_lynis);
+        assert!(!pid_path.exists());
+    }
+
+    #[test]
+    fn cleanup_stale_pid_files_removes_non_lynis_process_lock() {
+        let _guard = test_guard();
+        let pid_path = env::temp_dir().join("hostveil-lynis-other-process.pid");
+        fs::write(&pid_path, "1234").expect("pid file should be written");
+
+        let outcome =
+            cleanup_stale_pid_files(std::slice::from_ref(&pid_path), |_| ProcessKind::Other);
+
+        assert!(outcome.removed_any);
+        assert!(!outcome.active_lynis);
+        assert!(!pid_path.exists());
+    }
+
+    #[test]
+    fn cleanup_stale_pid_files_keeps_live_lynis_lock() {
+        let _guard = test_guard();
+        let pid_path = env::temp_dir().join("hostveil-lynis-live.pid");
+        fs::write(&pid_path, "5678").expect("pid file should be written");
+
+        let outcome =
+            cleanup_stale_pid_files(std::slice::from_ref(&pid_path), |_| ProcessKind::Lynis);
+
+        assert!(!outcome.removed_any);
+        assert!(outcome.active_lynis);
+        assert!(pid_path.exists());
+
+        fs::remove_file(&pid_path).expect("test pid file should be cleaned up");
+    }
+
+    #[test]
+    fn detects_pid_lockout_detail() {
+        assert!(is_pid_lockout_detail(
+            "Warning: PID file exists, probably another Lynis process is running."
+        ));
+        assert!(!is_pid_lockout_detail("some other failure"));
+    }
+
+    #[test]
+    fn retries_after_removing_stale_pid_lock() {
+        let _guard = test_guard();
+        let test_dir = env::temp_dir().join("hostveil-lynis-retry-test");
+        let _ = fs::remove_dir_all(&test_dir);
+        fs::create_dir_all(&test_dir).expect("test dir should be created");
+
+        let script_path = test_dir.join("fake-lynis.sh");
+        let script = r#"#!/usr/bin/env bash
+set -euo pipefail
+count_file="$HOME/invocations"
+count=0
+if [[ -f "$count_file" ]]; then
+  count="$(cat "$count_file")"
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+
+if [[ "$1" == "--version" ]]; then
+  exit 0
+fi
+
+report_file=""
+while (($# > 0)); do
+  case "$1" in
+    --report-file)
+      report_file="$2"
+      shift 2
+      ;;
+    --logfile)
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ "$count" -eq 1 ]]; then
+  printf '%s' '999999' > "$HOME/lynis.pid"
+  printf '%s\n' 'Warning: PID file exists, probably another Lynis process is running.' >&2
+  exit 1
+fi
+
+cat > "$report_file" <<'EOF'
+hostname=test-host
+hardening_index=67
+lynis_tests_done=123
+warning[]=AUTH-9286|Test warning|detail|solution
+EOF
+"#;
+        fs::write(&script_path, script).expect("script should be written");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&script_path)
+                .expect("metadata should be readable")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&script_path, permissions)
+                .expect("script should be made executable");
+        }
+
+        let original_home = env::var_os("HOME");
+        let original_dir = env::current_dir().expect("current dir should exist");
+        unsafe {
+            env::set_var("HOME", &test_dir);
+        }
+        env::set_current_dir(&test_dir).expect("current dir should switch");
+
+        let temp_files = LynisTempFiles {
+            report_file: test_dir.join("report.dat"),
+            log_file: test_dir.join("lynis.log"),
+        };
+        let result = run_lynis_with_command(
+            script_path.to_str().expect("script path should be utf-8"),
+            &temp_files,
+            Duration::from_secs(5),
+        )
+        .expect("retry should succeed");
+
+        if let Some(home) = original_home {
+            unsafe {
+                env::set_var("HOME", home);
+            }
+        }
+        env::set_current_dir(original_dir).expect("current dir should restore");
+
+        assert!(result.success);
+        assert!(!test_dir.join("lynis.pid").exists());
+
+        let _ = fs::remove_dir_all(&test_dir);
     }
 }

--- a/src/src/adapters/mod.rs
+++ b/src/src/adapters/mod.rs
@@ -1,6 +1,7 @@
 use crate::domain::Finding;
 
 pub mod command;
+pub mod docker_bench;
 pub mod dockle;
 pub mod lynis;
 pub mod trivy;

--- a/src/src/fix/host.rs
+++ b/src/src/fix/host.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use crate::domain::Finding;
+use crate::fix::{FixError, FixMode, FixPlan, FixProposal};
+
+pub fn apply_host_fixes(
+    host_root: &Path,
+    findings: &[Finding],
+    filter: Option<&[String]>,
+    mode: FixMode,
+    plan: &mut FixPlan,
+) -> Result<(), FixError> {
+    let mut applied = Vec::new();
+
+    // Check if we need to fix ufw
+    if has_finding(findings, filter, "host.ufw_installed_but_disabled") {
+        if mode == FixMode::Fix {
+            // Apply ufw enable
+            let _ = Command::new("ufw").arg("enable").output();
+        }
+        applied.push(FixProposal {
+            service: String::from("host"),
+            summary: String::from("Enabled UFW firewall"),
+        });
+    }
+
+    if has_finding(findings, filter, "host.ssh_root_login_enabled") {
+        if mode == FixMode::Fix {
+            // Apply sshd_config fix
+            let config_path = host_root.join("etc/ssh/sshd_config");
+            if let Ok(text) = fs::read_to_string(&config_path) {
+                let updated = text.replace("PermitRootLogin yes", "PermitRootLogin no");
+                let _ = fs::write(&config_path, updated);
+                let _ = Command::new("systemctl").arg("reload").arg("sshd").output();
+            }
+        }
+        applied.push(FixProposal {
+            service: String::from("host"),
+            summary: String::from("Disabled SSH root login"),
+        });
+    }
+
+    plan.safe_applied.extend(applied);
+
+    Ok(())
+}
+
+fn has_finding(findings: &[Finding], filter: Option<&[String]>, id: &str) -> bool {
+    findings
+        .iter()
+        .any(|f| f.id == id && filter.is_none_or(|allowed| allowed.contains(&f.id)))
+}

--- a/src/src/fix/mod.rs
+++ b/src/src/fix/mod.rs
@@ -1,3 +1,5 @@
+pub mod host;
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
@@ -124,13 +126,15 @@ fn build_fix_plan(
         build_diff(&bundle.primary_path, &bundle.primary_text, &updated_text)
     };
 
-    Ok(FixPlan {
+    let plan = FixPlan {
         compose_file: bundle.primary_path,
         diff_preview,
         backup_path: None,
         safe_applied,
         guided_applied,
-    })
+    };
+
+    Ok(plan)
 }
 
 fn render_updated_text(

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -531,11 +531,16 @@ fn handle_findings_key(
 
 fn render(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, state: &mut AppState) {
     state.clamp_selection(scan_result);
+    render_surface_background(frame, &state.theme);
 
     match state.screen {
         Screen::Overview => render_overview(frame, scan_result, state),
         Screen::Findings => render_findings(frame, scan_result, state),
     }
+}
+
+fn render_surface_background(frame: &mut ratatui::Frame<'_>, theme: &Theme) {
+    frame.render_widget(Block::default().style(theme.surface), frame.area());
 }
 
 fn render_overview(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, state: &AppState) {
@@ -653,10 +658,12 @@ fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, sta
         mode,
         &state.theme,
     ))
+    .style(state.theme.surface)
     .block(
         Block::default()
             .title(findings_list_title(state.findings_focus))
             .borders(Borders::ALL)
+            .style(state.theme.surface)
             .border_style(focus_border_style(
                 state.findings_focus == FindingsFocus::List,
                 &state.theme,
@@ -668,6 +675,7 @@ fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, sta
     let detail_block = Block::default()
         .title(findings_detail_title(state.findings_focus))
         .borders(Borders::ALL)
+        .style(state.theme.surface)
         .border_style(focus_border_style(
             state.findings_focus == FindingsFocus::Detail,
             &state.theme,
@@ -681,6 +689,7 @@ fn render_findings(frame: &mut ratatui::Frame<'_>, scan_result: &ScanResult, sta
 
     let detail = Paragraph::new(detail_text)
         .block(detail_block)
+        .style(state.theme.surface)
         .wrap(Wrap { trim: true })
         .scroll((state.detail_scroll, 0));
 
@@ -754,7 +763,7 @@ fn header_banner(theme: &Theme) -> Paragraph<'static> {
                 .borders(Borders::TOP | Borders::BOTTOM)
                 .border_style(theme.border),
         )
-        .style(theme.base)
+        .style(theme.surface)
 }
 
 fn is_root() -> bool {
@@ -778,7 +787,8 @@ fn render_server_status_panel(
         .title(t!("app.panel.server_status").into_owned())
         .borders(Borders::ALL)
         .border_style(theme.border)
-        .title_style(theme.title);
+        .title_style(theme.title)
+        .style(theme.surface);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -819,7 +829,9 @@ fn render_server_status_panel(
     ];
 
     frame.render_widget(
-        Paragraph::new(Text::from(meta_lines)).wrap(Wrap { trim: true }),
+        Paragraph::new(Text::from(meta_lines))
+            .style(theme.surface)
+            .wrap(Wrap { trim: true }),
         sections[0],
     );
     render_load_gauge_row(frame, sections[1], scan_result, theme);
@@ -829,6 +841,7 @@ fn render_server_status_panel(
             sections[2].width,
             theme,
         )))
+        .style(theme.surface)
         .wrap(Wrap { trim: true }),
         sections[2],
     );
@@ -845,7 +858,8 @@ fn render_scan_results_panel(
         .title(t!("app.panel.scan_results").into_owned())
         .borders(Borders::ALL)
         .border_style(theme.border)
-        .title_style(theme.title);
+        .title_style(theme.title)
+        .style(theme.surface);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -856,6 +870,26 @@ fn render_scan_results_panel(
     let mut lines = result_summary_lines(scan_result, inner.width, theme);
     lines.push(Line::raw(String::new()));
     lines.extend(severity_total_lines(scan_result, inner.width, theme));
+    lines.push(Line::raw(String::new()));
+    if scan_result.findings.is_empty() {
+        lines.push(Line::styled(
+            t!("app.overview.no_findings").into_owned(),
+            theme.muted,
+        ));
+    } else {
+        lines.push(Line::styled(
+            t!(
+                "app.overview.findings_available",
+                count = scan_result.findings.len()
+            )
+            .into_owned(),
+            theme.title.add_modifier(Modifier::BOLD),
+        ));
+        lines.push(Line::styled(
+            t!("app.hint.open_findings").into_owned(),
+            theme.muted,
+        ));
+    }
 
     if let Some(docker_status) = &scan_result.metadata.docker_status {
         lines.push(Line::raw(String::new()));
@@ -900,7 +934,9 @@ fn render_scan_results_panel(
     }
 
     frame.render_widget(
-        Paragraph::new(Text::from(lines)).wrap(Wrap { trim: true }),
+        Paragraph::new(Text::from(lines))
+            .style(theme.surface)
+            .wrap(Wrap { trim: true }),
         inner,
     );
 }
@@ -916,7 +952,8 @@ fn render_security_scores_panel(
         .title(t!("app.panel.security_scores").into_owned())
         .borders(Borders::ALL)
         .border_style(theme.border)
-        .title_style(theme.title);
+        .title_style(theme.title)
+        .style(theme.surface);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -963,7 +1000,8 @@ fn render_fix_paths_panel(
         .title(t!("app.panel.action_queue"))
         .borders(Borders::ALL)
         .border_style(theme.border)
-        .title_style(theme.title);
+        .title_style(theme.title)
+        .style(theme.surface);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -977,7 +1015,9 @@ fn render_fix_paths_panel(
     }
 
     frame.render_widget(
-        Paragraph::new(Text::from(lines)).wrap(Wrap { trim: true }),
+        Paragraph::new(Text::from(lines))
+            .style(theme.surface)
+            .wrap(Wrap { trim: true }),
         inner,
     );
 }
@@ -1053,9 +1093,10 @@ fn findings_header(
                 .title(t!("app.panel.status").into_owned())
                 .borders(Borders::ALL)
                 .border_style(theme.border)
-                .title_style(theme.title),
+                .title_style(theme.title)
+                .style(theme.surface),
         )
-        .style(theme.base)
+        .style(theme.surface)
         .wrap(Wrap { trim: true })
 }
 
@@ -1568,7 +1609,29 @@ fn remediation_lines(
         lines.push(Line::raw(
             t!("app.result.no_remediation_needed").into_owned(),
         ));
-    } else if auto_fixable_count > 0 {
+    }
+
+    if !scan_result.findings.is_empty() {
+        lines.push(Line::raw(""));
+        lines.push(Line::styled(
+            t!("app.overview.next_step").into_owned(),
+            theme.title.add_modifier(Modifier::BOLD),
+        ));
+        lines.push(Line::styled(
+            t!("app.hint.open_findings").into_owned(),
+            theme.highlight.add_modifier(Modifier::BOLD),
+        ));
+        lines.push(Line::styled(
+            t!(
+                "app.overview.findings_ready",
+                count = scan_result.findings.len()
+            )
+            .into_owned(),
+            theme.muted,
+        ));
+    }
+
+    if auto_fixable_count > 0 {
         lines.push(Line::raw(""));
         lines.push(Line::styled(
             t!("app.hint.press_f_to_fix").into_owned(),
@@ -2640,6 +2703,18 @@ mod tests {
         result
     }
 
+    fn no_findings_result() -> ScanResult {
+        let mut result = sample_result();
+        result.findings.clear();
+        result.score_report.severity_counts = BTreeMap::from([
+            (Severity::Critical, 0),
+            (Severity::High, 0),
+            (Severity::Medium, 0),
+            (Severity::Low, 0),
+        ]);
+        result
+    }
+
     #[test]
     fn overview_navigation_opens_findings() {
         let result = sample_result();
@@ -2975,6 +3050,75 @@ mod tests {
     }
 
     #[test]
+    fn preset_themes_apply_body_background_but_ansi_keeps_default() {
+        let result = sample_result();
+        let mut themed_state = AppState::new(&result);
+        themed_state.theme_preset = ThemePreset::Catppuccin;
+        themed_state.theme = Theme::preset(ThemePreset::Catppuccin);
+        let mut themed_terminal =
+            Terminal::new(TestBackend::new(80, 24)).expect("terminal should build");
+
+        themed_terminal
+            .draw(|frame| render(frame, &result, &mut themed_state))
+            .expect("themed overview should render");
+
+        let themed_body_bg = buffer_bg(themed_terminal.backend(), 10, 10);
+        let themed_footer_bg = buffer_bg(themed_terminal.backend(), 10, 23);
+
+        assert_ne!(themed_body_bg, ratatui::style::Color::Reset);
+        assert_ne!(themed_footer_bg, themed_body_bg);
+
+        let mut ansi_state = AppState::new(&result);
+        ansi_state.theme_preset = ThemePreset::Ansi;
+        ansi_state.theme = Theme::preset(ThemePreset::Ansi);
+        let mut ansi_terminal =
+            Terminal::new(TestBackend::new(80, 24)).expect("terminal should build");
+
+        ansi_terminal
+            .draw(|frame| render(frame, &result, &mut ansi_state))
+            .expect("ansi overview should render");
+
+        assert_eq!(
+            buffer_bg(ansi_terminal.backend(), 10, 10),
+            ratatui::style::Color::Reset
+        );
+    }
+
+    #[test]
+    fn overview_renders_explicit_findings_cta_when_findings_exist() {
+        let result = sample_result();
+        let mut state = AppState::new(&result);
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).expect("terminal should build");
+
+        terminal
+            .draw(|frame| render(frame, &result, &mut state))
+            .expect("overview should render");
+
+        let content = buffer_to_string(terminal.backend());
+
+        assert!(content.contains("Press Enter or Right to inspect findings"));
+        assert!(content.contains("Next Step"));
+        assert!(content.contains("3 finding(s) are ready for review"));
+    }
+
+    #[test]
+    fn overview_hides_findings_cta_when_no_findings_exist() {
+        let result = no_findings_result();
+        let mut state = AppState::new(&result);
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).expect("terminal should build");
+
+        terminal
+            .draw(|frame| render(frame, &result, &mut state))
+            .expect("overview should render");
+
+        let content = buffer_to_string(terminal.backend());
+
+        assert!(content.contains("No findings detected yet."));
+        assert!(!content.contains("Press Enter or Right to inspect findings"));
+        assert!(!content.contains("Next Step"));
+    }
+
+    #[test]
     fn findings_view_renders_selected_finding_details() {
         let result = sample_result();
         let mut state = AppState::new(&result);
@@ -3083,5 +3227,12 @@ mod tests {
         }
 
         output
+    }
+
+    fn buffer_bg(backend: &TestBackend, x: u16, y: u16) -> ratatui::style::Color {
+        backend.buffer()[(x, y)]
+            .style()
+            .bg
+            .unwrap_or(ratatui::style::Color::Reset)
     }
 }

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -94,7 +94,7 @@ impl AppState {
             .theme
             .as_deref()
             .and_then(ThemePreset::from_key)
-            .unwrap_or(ThemePreset::Ansi);
+            .unwrap_or(ThemePreset::TokyoNight);
 
         Self {
             screen: Screen::Overview,
@@ -1038,9 +1038,10 @@ fn overview_footer(theme: &Theme) -> Paragraph<'static> {
     .block(
         Block::default()
             .borders(Borders::TOP)
-            .border_style(theme.border),
+            .border_style(theme.border)
+            .style(theme.surface),
     )
-    .style(theme.status_bar)
+    .style(theme.surface)
 }
 
 fn findings_header(
@@ -1130,9 +1131,10 @@ fn findings_footer(
     .block(
         Block::default()
             .borders(Borders::TOP)
-            .border_style(theme.border),
+            .border_style(theme.border)
+            .style(theme.surface),
     )
-    .style(theme.status_bar)
+    .style(theme.surface)
     .wrap(Wrap { trim: true })
 }
 
@@ -3066,7 +3068,8 @@ mod tests {
         let themed_footer_bg = buffer_bg(themed_terminal.backend(), 10, 23);
 
         assert_ne!(themed_body_bg, ratatui::style::Color::Reset);
-        assert_ne!(themed_footer_bg, themed_body_bg);
+        // Footer now intentionally shares the surface background for visual consistency.
+        assert_eq!(themed_footer_bg, themed_body_bg);
 
         let mut ansi_state = AppState::new(&result);
         ansi_state.theme_preset = ThemePreset::Ansi;

--- a/src/src/tui/theme.rs
+++ b/src/src/tui/theme.rs
@@ -59,6 +59,7 @@ impl ThemePreset {
 pub struct Theme {
     pub preset: ThemePreset,
     pub base: Style,
+    pub surface: Style,
     pub border: Style,
     pub title: Style,
     pub muted: Style,
@@ -89,6 +90,7 @@ impl Theme {
         Self {
             preset: ThemePreset::Ansi,
             base: Style::new().fg(Color::Reset),
+            surface: Style::new().fg(Color::Reset),
             border: Style::new().fg(Color::DarkGray),
             title: Style::new().fg(Color::Cyan),
             muted: Style::new().fg(Color::Gray),
@@ -109,6 +111,9 @@ impl Theme {
         Self {
             preset: ThemePreset::Catppuccin,
             base: Style::new().fg(Color::Rgb(205, 214, 244)),
+            surface: Style::new()
+                .fg(Color::Rgb(205, 214, 244))
+                .bg(Color::Rgb(30, 30, 46)),
             border: Style::new().fg(Color::Rgb(88, 91, 112)),
             title: Style::new().fg(Color::Rgb(137, 180, 250)),
             muted: Style::new().fg(Color::Rgb(127, 132, 156)),
@@ -133,6 +138,9 @@ impl Theme {
         Self {
             preset: ThemePreset::Nord,
             base: Style::new().fg(Color::Rgb(216, 222, 233)),
+            surface: Style::new()
+                .fg(Color::Rgb(216, 222, 233))
+                .bg(Color::Rgb(43, 48, 59)),
             border: Style::new().fg(Color::Rgb(76, 86, 106)),
             title: Style::new().fg(Color::Rgb(136, 192, 208)),
             muted: Style::new().fg(Color::Rgb(143, 188, 187)),
@@ -157,6 +165,9 @@ impl Theme {
         Self {
             preset: ThemePreset::TokyoNight,
             base: Style::new().fg(Color::Rgb(169, 177, 214)),
+            surface: Style::new()
+                .fg(Color::Rgb(169, 177, 214))
+                .bg(Color::Rgb(22, 22, 30)),
             border: Style::new().fg(Color::Rgb(68, 76, 113)),
             title: Style::new().fg(Color::Rgb(122, 162, 247)),
             muted: Style::new().fg(Color::Rgb(125, 135, 185)),
@@ -181,6 +192,9 @@ impl Theme {
         Self {
             preset: ThemePreset::Gruvbox,
             base: Style::new().fg(Color::Rgb(235, 219, 178)),
+            surface: Style::new()
+                .fg(Color::Rgb(235, 219, 178))
+                .bg(Color::Rgb(29, 32, 33)),
             border: Style::new().fg(Color::Rgb(102, 92, 84)),
             title: Style::new().fg(Color::Rgb(131, 165, 152)),
             muted: Style::new().fg(Color::Rgb(168, 153, 132)),

--- a/src/src/tui/theme.rs
+++ b/src/src/tui/theme.rs
@@ -7,15 +7,19 @@ pub enum ThemePreset {
     Nord,
     TokyoNight,
     Gruvbox,
+    Dracula,
+    Monokai,
 }
 
 impl ThemePreset {
-    pub const ALL: [Self; 5] = [
+    pub const ALL: [Self; 7] = [
         Self::Ansi,
         Self::Catppuccin,
         Self::Nord,
         Self::TokyoNight,
         Self::Gruvbox,
+        Self::Dracula,
+        Self::Monokai,
     ];
 
     pub const fn as_key(self) -> &'static str {
@@ -25,6 +29,8 @@ impl ThemePreset {
             Self::Nord => "nord",
             Self::TokyoNight => "tokyo_night",
             Self::Gruvbox => "gruvbox",
+            Self::Dracula => "dracula",
+            Self::Monokai => "monokai",
         }
     }
 
@@ -35,6 +41,8 @@ impl ThemePreset {
             Self::Nord => "Nord",
             Self::TokyoNight => "Tokyo Night",
             Self::Gruvbox => "Gruvbox",
+            Self::Dracula => "Dracula",
+            Self::Monokai => "Monokai",
         }
     }
 
@@ -50,7 +58,9 @@ impl ThemePreset {
             Self::Catppuccin => Self::Nord,
             Self::Nord => Self::TokyoNight,
             Self::TokyoNight => Self::Gruvbox,
-            Self::Gruvbox => Self::Ansi,
+            Self::Gruvbox => Self::Dracula,
+            Self::Dracula => Self::Monokai,
+            Self::Monokai => Self::Ansi,
         }
     }
 }
@@ -83,6 +93,8 @@ impl Theme {
             ThemePreset::Nord => Self::nord(),
             ThemePreset::TokyoNight => Self::tokyo_night(),
             ThemePreset::Gruvbox => Self::gruvbox(),
+            ThemePreset::Dracula => Self::dracula(),
+            ThemePreset::Monokai => Self::monokai(),
         }
     }
 
@@ -212,6 +224,60 @@ impl Theme {
             safe: Color::Rgb(152, 151, 26),
             guided: Color::Rgb(215, 153, 33),
             manual: Color::Rgb(69, 133, 136),
+        }
+    }
+
+    const fn dracula() -> Self {
+        Self {
+            preset: ThemePreset::Dracula,
+            base: Style::new().fg(Color::Rgb(248, 248, 242)),
+            surface: Style::new()
+                .fg(Color::Rgb(248, 248, 242))
+                .bg(Color::Rgb(40, 42, 54)),
+            border: Style::new().fg(Color::Rgb(98, 114, 164)),
+            title: Style::new().fg(Color::Rgb(139, 233, 253)),
+            muted: Style::new().fg(Color::Rgb(98, 114, 164)),
+            highlight: Style::new()
+                .fg(Color::Rgb(248, 248, 242))
+                .bg(Color::Rgb(68, 71, 90)),
+            status_bar: Style::new()
+                .fg(Color::Rgb(248, 248, 242))
+                .bg(Color::Rgb(33, 34, 44)),
+            accent: Color::Rgb(189, 147, 249),
+            crit: Color::Rgb(255, 85, 85),
+            high: Color::Rgb(255, 184, 108),
+            med: Color::Rgb(241, 250, 140),
+            low: Color::Rgb(80, 250, 123),
+            safe: Color::Rgb(80, 250, 123),
+            guided: Color::Rgb(241, 250, 140),
+            manual: Color::Rgb(139, 233, 253),
+        }
+    }
+
+    const fn monokai() -> Self {
+        Self {
+            preset: ThemePreset::Monokai,
+            base: Style::new().fg(Color::Rgb(248, 248, 242)),
+            surface: Style::new()
+                .fg(Color::Rgb(248, 248, 242))
+                .bg(Color::Rgb(39, 40, 34)),
+            border: Style::new().fg(Color::Rgb(117, 113, 94)),
+            title: Style::new().fg(Color::Rgb(102, 217, 239)),
+            muted: Style::new().fg(Color::Rgb(117, 113, 94)),
+            highlight: Style::new()
+                .fg(Color::Rgb(248, 248, 242))
+                .bg(Color::Rgb(73, 72, 62)),
+            status_bar: Style::new()
+                .fg(Color::Rgb(248, 248, 242))
+                .bg(Color::Rgb(30, 31, 28)),
+            accent: Color::Rgb(253, 151, 31),
+            crit: Color::Rgb(249, 38, 114),
+            high: Color::Rgb(253, 151, 31),
+            med: Color::Rgb(230, 219, 116),
+            low: Color::Rgb(166, 226, 46),
+            safe: Color::Rgb(166, 226, 46),
+            guided: Color::Rgb(230, 219, 116),
+            manual: Color::Rgb(102, 217, 239),
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses three tracked issues (#180, #181, #182) and includes v0.9.0 groundwork:

### #180 Theme backgrounds
- Apply theme surface bg to the entire TUI screen
- Fix footer (status bar) to use **surface** style so it blends seamlessly with the body — no more subtle background mismatch

### #181 Lynis PID-file recovery
- Detect stale PID files and clean them up automatically before retrying

### #182 Overview CTA
- Add explicit 'Press Enter to view Findings' call-to-action on the Overview screen

### v0.9.0 groundwork
- Add **Dracula** and **Monokai** theme presets (7 themes total)
- Default theme changed to **Tokyo Night**
- Scaffold host-level remediation module (`fix/host.rs`) — SSH and UFW auto-fix stubs
- Scaffold Docker Bench for Security adapter (`adapters/docker_bench.rs`)
- Add `cargo-deb` / `cargo-generate-rpm` metadata to `Cargo.toml`

### Quality
- All 262 tests pass
- `cargo fmt` and `cargo clippy -D warnings` clean

Closes #180, Closes #181, Closes #182