### PR TITLE
feat(host): add firewalld, nftables, and no-firewall detection

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -723,6 +723,26 @@ finding:
       description: "%{service} is missing the following hardening markers: %{flags}."
       why: "Systemd directives like NoNewPrivileges, ProtectSystem, ProtectHome, and PrivateTmp constrain service runtime and reduce blast radius if a service is compromised. Their absence leaves more host resources exposed."
       fix: "Edit %{service} and add the missing directives under [Service]. Start with NoNewPrivileges=true and PrivateTmp=true, then test. Add ProtectSystem=strict and ProtectHome=true after validating the service still starts and functions correctly. Run 'systemctl daemon-reload && systemctl restart %{service}' after editing."
+    firewalld_installed_but_disabled:
+      title: "Firewalld is installed but disabled"
+      description: "Firewalld is present at %{path} but the service is not enabled."
+      why: "A host firewall helps narrow inbound exposure. Installing firewalld without enabling it leaves the host with no active firewall policy."
+      fix: "Enable firewalld with 'systemctl enable --now firewalld'. Configure necessary zones and services (e.g., 'firewall-cmd --permanent --add-service=ssh'), then reload with 'firewall-cmd --reload'. Verify with 'firewall-cmd --state'."
+    firewalld_default_zone_trusted:
+      title: "Firewalld default zone is trusted"
+      description: "%{path} sets DefaultZone to %{zone}."
+      why: "The trusted zone allows all traffic by default, which effectively disables firewall protection for incoming connections."
+      fix: "Change the default zone to 'public' or a more restrictive custom zone in %{path}, then run 'firewall-cmd --set-default-zone=public' and 'firewall-cmd --reload'. Review allowed services with 'firewall-cmd --list-services'."
+    nftables_installed_no_rules:
+      title: "nftables is installed but has no rules"
+      description: "nftables configuration at %{path} is empty."
+      why: "An empty nftables ruleset means no packet filtering is active, leaving the host exposed to unwanted traffic."
+      fix: "Define a basic nftables ruleset in %{path} (e.g., drop incoming traffic by default and allow established/related connections and necessary ports). Load it with 'nft -f %{path}' and enable the nftables service with 'systemctl enable --now nftables'."
+    no_firewall_detected:
+      title: "No host firewall was detected"
+      description: "No UFW, firewalld, or nftables installation markers were found."
+      why: "Without a host firewall, any service that accidentally binds to a public interface or port becomes immediately reachable, and lateral movement is harder to contain."
+      fix: "Install and enable a host firewall. On Debian/Ubuntu, use UFW ('apt install ufw'). On Fedora/RHEL/Rocky, use firewalld ('dnf install firewalld'). For advanced setups, configure nftables directly. Allow only necessary ports before enabling."
   vaultwarden:
     signups_enabled:
       title: "Vaultwarden signups are left enabled"

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -723,6 +723,26 @@ finding:
       description: "%{service}에 다음 하드닝 마커가 누락되었습니다: %{flags}."
       why: "NoNewPrivileges, ProtectSystem, ProtectHome, PrivateTmp 같은 Systemd 지시문은 서비스 런타임을 제한하고 서비스가 침핵되었을 때의 영향 범위를 줄입니다. 이들이 없으면 더 많은 호스트 리소스가 노출됩니다."
       fix: "%{service}를 수정하여 [Service] 아래 누락된 지시문을 추가하세요. NoNewPrivileges=true와 PrivateTmp=true부터 시작하고 테스트하세요. ProtectSystem=strict와 ProtectHome=true는 서비스가 정상 시작하고 작동하는지 검증한 뒤 추가하세요. 수정 후 'systemctl daemon-reload && systemctl restart %{service}'를 실행하세요."
+    firewalld_installed_but_disabled:
+      title: "Firewalld가 설치되어 있지만 비활성화되어 있습니다"
+      description: "Firewalld가 %{path}에 존재하지만 서비스가 활성화되지 않았습니다."
+      why: "호스트 방화벽은 인바운드 노출을 줄이는 데 도움이 됩니다. Firewalld를 설치만 하고 활성화하지 않으면 호스트에 활성 방화벽 정책이 없는 상태가 됩니다."
+      fix: "'systemctl enable --now firewalld'로 Firewalld를 활성화하세요. 필요한 zone과 service를 구성한 뒤(예: 'firewall-cmd --permanent --add-service=ssh'), 'firewall-cmd --reload'를 실행하세요. 'firewall-cmd --state'로 상태를 확인하세요."
+    firewalld_default_zone_trusted:
+      title: "Firewalld 기본 zone이 trusted입니다"
+      description: "%{path}가 DefaultZone을 %{zone}로 설정했습니다."
+      why: "trusted zone은 기본적으로 모든 트래픽을 허용하므로, 들어오는 연결에 대한 방화벽 보호가 사실상 비활성화됩니다."
+      fix: "%{path}에서 기본 zone을 'public'이나 더 제한적인 사용자 정의 zone으로 변경하세요. 그런 다음 'firewall-cmd --set-default-zone=public'과 'firewall-cmd --reload'를 실행하세요. 'firewall-cmd --list-services'로 허용된 서비스를 확인하세요."
+    nftables_installed_no_rules:
+      title: "nftables가 설치되어 있지만 규칙이 없습니다"
+      description: "%{path}의 nftables 설정이 비어 있습니다."
+      why: "빈 nftables 규칙 세트는 패킷 필터링이 활성화되지 않았음을 의미하므로, 호스트가 원치 않는 트래픽에 노출됩니다."
+      fix: "%{path}에 기본 nftables 규칙 세트를 정의하세요(예: 기본적으로 들어오는 트래픽을 차단하고 established/related 연결과 필요한 포트만 허용). 'nft -f %{path}'로 로드하고 'systemctl enable --now nftables'로 서비스를 활성화하세요."
+    no_firewall_detected:
+      title: "호스트 방화벽이 감지되지 않았습니다"
+      description: "UFW, Firewalld, nftables 설치 마커를 찾을 수 없습니다."
+      why: "호스트 방화벽이 없으면 실수로 공개 인터페이스나 포트에 바인딩된 서비스가 즉시 외부에서 접근 가능해지며, 횡적 이동을 제어하기 어렵습니다."
+      fix: "호스트 방화벽을 설치하고 활성화하세요. Debian/Ubuntu는 UFW('apt install ufw')를, Fedora/RHEL/Rocky는 Firewalld('dnf install firewalld')를 사용하세요. 고급 설정에는 nftables를 직접 구성하세요. 활성화 전에 필요한 포트만 허용하세요."
   vaultwarden:
     signups_enabled:
       title: "Vaultwarden 가입이 계속 활성화되어 있습니다"

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -18,6 +18,19 @@ const DOCKER_SOCKET_PATH: &str = "var/run/docker.sock";
 const UFW_CONFIG_PATH: &str = "etc/ufw/ufw.conf";
 const UFW_DEFAULT_POLICY_PATH: &str = "etc/default/ufw";
 const UFW_INSTALL_MARKERS: [&str; 3] = ["etc/ufw/ufw.conf", "usr/sbin/ufw", "usr/bin/ufw"];
+const FIREWALLD_CONFIG_PATH: &str = "etc/firewalld/firewalld.conf";
+const FIREWALLD_CMD_PATHS: [&str; 2] = ["usr/bin/firewall-cmd", "usr/sbin/firewall-cmd"];
+const FIREWALLD_SERVICE_PATHS: [&str; 3] = [
+    "usr/lib/systemd/system/firewalld.service",
+    "lib/systemd/system/firewalld.service",
+    "etc/systemd/system/firewalld.service",
+];
+const FIREWALLD_ENABLED_MARKERS: [&str; 2] = [
+    "etc/systemd/system/multi-user.target.wants/firewalld.service",
+    "etc/systemd/system/default.target.wants/firewalld.service",
+];
+const NFTABLES_CONF_PATH: &str = "etc/nftables.conf";
+const NFT_PATHS: [&str; 2] = ["usr/sbin/nft", "sbin/nft"];
 const APT_AUTO_UPGRADES_CONFIG_PATH: &str = "etc/apt/apt.conf.d/20auto-upgrades";
 const APT_PERIODIC_UNATTENDED_UPGRADE_KEY: &str = "APT::Periodic::Unattended-Upgrade";
 const APT_PERIODIC_UPDATE_PACKAGE_LISTS_KEY: &str = "APT::Periodic::Update-Package-Lists";
@@ -479,10 +492,40 @@ fn scan_docker_host_exposure(context: &HostContext) -> Vec<Finding> {
 }
 
 fn scan_firewall_hardening(context: &HostContext) -> Vec<Finding> {
-    if !detect_ufw_installed(&context.root) {
-        return Vec::new();
+    let mut findings = Vec::new();
+
+    if detect_ufw_installed(&context.root) {
+        findings.extend(scan_ufw_hardening(context));
+        return findings;
     }
 
+    if detect_firewalld_installed(&context.root) {
+        findings.extend(scan_firewalld_hardening(context));
+        return findings;
+    }
+
+    if detect_nftables_installed(&context.root) {
+        findings.extend(scan_nftables_hardening(context));
+        return findings;
+    }
+
+    findings.push(host_finding(
+        "host.no_firewall_detected",
+        Severity::Medium,
+        &context.root,
+        HostFindingText {
+            title: t!("finding.host.no_firewall_detected.title").into_owned(),
+            description: t!("finding.host.no_firewall_detected.description").into_owned(),
+            why_risky: t!("finding.host.no_firewall_detected.why").into_owned(),
+            how_to_fix: t!("finding.host.no_firewall_detected.fix").into_owned(),
+        },
+        BTreeMap::new(),
+    ));
+
+    findings
+}
+
+fn scan_ufw_hardening(context: &HostContext) -> Vec<Finding> {
     let mut findings = Vec::new();
 
     if let Some(config_path) = resolve_existing_path(&context.root, UFW_CONFIG_PATH)
@@ -535,6 +578,138 @@ fn scan_firewall_hardening(context: &HostContext) -> Vec<Finding> {
                 (String::from("path"), defaults_path.display().to_string()),
                 (String::from("policy"), policy),
             ]),
+        ));
+    }
+
+    findings
+}
+
+fn detect_firewalld_installed(root: &Path) -> bool {
+    resolve_existing_path(root, FIREWALLD_CONFIG_PATH).is_some()
+        || FIREWALLD_CMD_PATHS
+            .iter()
+            .any(|path| resolve_existing_path(root, path).is_some())
+        || FIREWALLD_SERVICE_PATHS
+            .iter()
+            .any(|path| resolve_existing_path(root, path).is_some())
+}
+
+fn detect_firewalld_enabled(root: &Path) -> bool {
+    FIREWALLD_ENABLED_MARKERS
+        .iter()
+        .any(|marker| resolve_existing_path(root, marker).is_some())
+}
+
+fn scan_firewalld_hardening(context: &HostContext) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    if !detect_firewalld_enabled(&context.root) {
+        let config_path = resolve_existing_path(&context.root, FIREWALLD_CONFIG_PATH)
+            .or_else(|| resolve_existing_path(&context.root, FIREWALLD_SERVICE_PATHS[0]))
+            .unwrap_or_else(|| context.root.join(FIREWALLD_CONFIG_PATH));
+
+        findings.push(host_finding(
+            "host.firewalld_installed_but_disabled",
+            Severity::Medium,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.firewalld_installed_but_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.firewalld_installed_but_disabled.description",
+                    path = config_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.firewalld_installed_but_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.firewalld_installed_but_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), config_path.display().to_string()),
+                (String::from("enabled"), String::from("no")),
+            ]),
+        ));
+        return findings;
+    }
+
+    if let Some(config_path) = resolve_existing_path(&context.root, FIREWALLD_CONFIG_PATH)
+        && let Ok(text) = fs::read_to_string(&config_path)
+        && let Some(zone) = parse_firewalld_default_zone(&text)
+        && zone.eq_ignore_ascii_case("trusted")
+    {
+        findings.push(host_finding(
+            "host.firewalld_default_zone_trusted",
+            Severity::High,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.firewalld_default_zone_trusted.title").into_owned(),
+                description: t!(
+                    "finding.host.firewalld_default_zone_trusted.description",
+                    path = config_path.display().to_string(),
+                    zone = zone.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.firewalld_default_zone_trusted.why").into_owned(),
+                how_to_fix: t!("finding.host.firewalld_default_zone_trusted.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), config_path.display().to_string()),
+                (String::from("zone"), zone),
+            ]),
+        ));
+    }
+
+    findings
+}
+
+fn parse_firewalld_default_zone(text: &str) -> Option<String> {
+    for raw_line in text.lines() {
+        let line = strip_ini_comments(raw_line);
+        if line.is_empty() {
+            continue;
+        }
+        let Some((key, value)) = parse_ini_key_value(line) else {
+            continue;
+        };
+        if !key.eq_ignore_ascii_case("DefaultZone") {
+            continue;
+        }
+        let zone = value.trim_matches('"').trim_matches('\'').trim();
+        if zone.is_empty() {
+            continue;
+        }
+        return Some(zone.to_owned());
+    }
+    None
+}
+
+fn detect_nftables_installed(root: &Path) -> bool {
+    resolve_existing_path(root, NFTABLES_CONF_PATH).is_some()
+        || NFT_PATHS
+            .iter()
+            .any(|path| resolve_existing_path(root, path).is_some())
+}
+
+fn scan_nftables_hardening(context: &HostContext) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    if let Some(conf_path) = resolve_existing_path(&context.root, NFTABLES_CONF_PATH)
+        && let Ok(text) = fs::read_to_string(&conf_path)
+        && text.trim().is_empty()
+    {
+        findings.push(host_finding(
+            "host.nftables_installed_no_rules",
+            Severity::Medium,
+            &conf_path,
+            HostFindingText {
+                title: t!("finding.host.nftables_installed_no_rules.title").into_owned(),
+                description: t!(
+                    "finding.host.nftables_installed_no_rules.description",
+                    path = conf_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.nftables_installed_no_rules.why").into_owned(),
+                how_to_fix: t!("finding.host.nftables_installed_no_rules.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("path"), conf_path.display().to_string())]),
         ));
     }
 
@@ -2094,6 +2269,7 @@ mod tests {
                 "host.docker_daemon_tcp_public",
                 "host.docker_daemon_tcp_no_tlsverify",
                 "host.docker_daemon_iptables_disabled",
+                "host.no_firewall_detected",
                 "host.mac_framework_missing",
                 "host.defensive_controls_missing",
             ]
@@ -2135,6 +2311,7 @@ mod tests {
                 .map(|finding| finding.id.as_str())
                 .collect::<Vec<_>>(),
             vec![
+                "host.no_firewall_detected",
                 "host.kernel.aslr_disabled",
                 "host.kernel.syn_cookies_disabled",
                 "host.kernel.broadcast_ping_allowed",
@@ -2164,6 +2341,7 @@ mod tests {
             "0\n",
         );
         write_file(&root.join("proc/sys/user/max_user_namespaces"), "0\n");
+        write_file(&root.join("etc/ufw/ufw.conf"), "ENABLED=yes\n");
         write_file(
             &root.join("etc/fail2ban/jail.local"),
             "[sshd]\nenabled = true\n",
@@ -2388,6 +2566,7 @@ mod tests {
                 "ext4 / ext4 rw,relatime 0 0\n",
             ),
         );
+        write_file(&root.join("etc/ufw/ufw.conf"), "ENABLED=yes\n");
 
         let findings = HostScanner.scan(&HostContext { root: root.clone() });
 
@@ -3071,5 +3250,92 @@ mod tests {
             parse_ufw_default_input_policy("DEFAULT_INPUT_POLICY="),
             None
         );
+    }
+
+    #[test]
+    fn host_scanner_detects_firewalld_disabled() {
+        let root = temp_host_root("firewalld-disabled");
+        write_file(&root.join("usr/bin/firewall-cmd"), "");
+        write_file(
+            &root.join("etc/firewalld/firewalld.conf"),
+            "DefaultZone=public\n",
+        );
+        write_file(&root.join("etc/hostname"), "firewalld-test\n");
+        write_file(&root.join("proc/uptime"), "60.00 0.00\n");
+        write_file(&root.join("proc/loadavg"), "0.10 0.20 0.30 1/100 123\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.firewalld_installed_but_disabled")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn host_scanner_detects_firewalld_trusted_zone() {
+        let root = temp_host_root("firewalld-trusted");
+        write_file(&root.join("usr/bin/firewall-cmd"), "");
+        write_file(
+            &root.join("etc/systemd/system/multi-user.target.wants/firewalld.service"),
+            "",
+        );
+        write_file(
+            &root.join("etc/firewalld/firewalld.conf"),
+            "DefaultZone=trusted\n",
+        );
+        write_file(&root.join("etc/hostname"), "firewalld-test\n");
+        write_file(&root.join("proc/uptime"), "60.00 0.00\n");
+        write_file(&root.join("proc/loadavg"), "0.10 0.20 0.30 1/100 123\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.firewalld_default_zone_trusted")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn host_scanner_detects_nftables_empty() {
+        let root = temp_host_root("nftables-empty");
+        write_file(&root.join("etc/nftables.conf"), "");
+        write_file(&root.join("etc/hostname"), "nftables-test\n");
+        write_file(&root.join("proc/uptime"), "60.00 0.00\n");
+        write_file(&root.join("proc/loadavg"), "0.10 0.20 0.30 1/100 123\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.nftables_installed_no_rules")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn host_scanner_warns_when_no_firewall() {
+        let root = temp_host_root("no-firewall");
+        write_file(&root.join("etc/hostname"), "no-fw\n");
+        write_file(&root.join("proc/uptime"), "60.00 0.00\n");
+        write_file(&root.join("proc/loadavg"), "0.10 0.20 0.30 1/100 123\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.no_firewall_detected")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
     }
 }


### PR DESCRIPTION
## Summary

- Detect firewalld installation and enabled status via systemd markers
- Flag firewalld when installed but disabled
- Flag firewalld DefaultZone set to trusted
- Detect nftables with empty ruleset
- Report when no firewall (UFW, firewalld, nftables) is detected
- Add fixture tests and i18n strings for en and ko

Closes #258