### PR TITLE
feat(host): add dnf/yum automatic update markers

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -623,6 +623,26 @@ finding:
       description: "%{path} disables APT::Periodic::Update-Package-Lists."
       why: "Outdated package indexes can delay security patch visibility and weaken automated patching expectations."
       fix: "Set APT::Periodic::Update-Package-Lists to 1 in /etc/apt/apt.conf.d/20auto-upgrades, or run 'dpkg-reconfigure -plow unattended-upgrades'. Verify with 'apt-config dump | grep Update-Package-Lists'."
+    dnf_automatic_disabled:
+      title: "dnf-automatic updates are disabled"
+      description: "%{path} has apply_updates disabled under [commands]."
+      why: "Without dnf-automatic, Fedora/RHEL/Rocky systems may miss security updates until manual intervention."
+      fix: "Install dnf-automatic ('dnf install dnf-automatic'), set apply_updates = yes in %{path}, and enable the timer with 'systemctl enable --now dnf-automatic.timer'. Verify with 'systemctl list-timers | grep dnf-automatic'."
+    dnf_automatic_timer_disabled:
+      title: "dnf-automatic timer is not enabled"
+      description: "%{path} exists but the dnf-automatic timer is not enabled."
+      why: "Even with apply_updates configured, the timer must be active for scheduled updates to run."
+      fix: "Enable the timer with 'systemctl enable --now dnf-automatic.timer'. Verify with 'systemctl status dnf-automatic.timer'."
+    yum_cron_disabled:
+      title: "yum-cron updates are disabled"
+      description: "%{path} has apply_updates disabled under [commands]."
+      why: "Without yum-cron, older RHEL systems may miss security updates until manual intervention."
+      fix: "Install yum-cron, set apply_updates = yes in %{path}, and start the service with 'systemctl enable --now yum-cron'."
+    yum_cron_service_disabled:
+      title: "yum-cron service is not enabled"
+      description: "%{path} exists but the yum-cron service is not enabled."
+      why: "Even with apply_updates configured, the service must be active for scheduled updates to run."
+      fix: "Enable the service with 'systemctl enable --now yum-cron'. Verify with 'systemctl status yum-cron'."
     kernel_aslr_disabled:
       title: "Kernel ASLR is disabled"
       description: "%{path} is set to 0, disabling address space layout randomization."

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -623,6 +623,26 @@ finding:
       description: "%{path}가 APT::Periodic::Update-Package-Lists를 비활성화합니다."
       why: "오래된 패키지 인덱스는 보안 패치 가시성을 지연시키고 자동 패치 기대를 약화시킬 수 있습니다."
       fix: "/etc/apt/apt.conf.d/20auto-upgrades에서 APT::Periodic::Update-Package-Lists를 1로 설정하거나, 'dpkg-reconfigure -plow unattended-upgrades'를 실행하세요. 'apt-config dump | grep Update-Package-Lists'로 확인하세요."
+    dnf_automatic_disabled:
+      title: "dnf-automatic 업데이트가 비활성화되어 있습니다"
+      description: "%{path}의 [commands]에서 apply_updates가 비활성화되어 있습니다."
+      why: "dnf-automatic이 없으면 Fedora/RHEL/Rocky 시스템이 수동 개입 전까지 보안 업데이트를 놓칠 수 있습니다."
+      fix: "dnf-automatic을 설치('dnf install dnf-automatic')하고 %{path}에서 apply_updates = yes로 설정한 뒤, 'systemctl enable --now dnf-automatic.timer'로 타이머를 활성화하세요. 'systemctl list-timers | grep dnf-automatic'으로 확인하세요."
+    dnf_automatic_timer_disabled:
+      title: "dnf-automatic 타이머가 활성화되지 않았습니다"
+      description: "%{path}는 존재하지만 dnf-automatic 타이머가 활성화되지 않았습니다."
+      why: "apply_updates가 구성되어 있어도 타이머가 활성화되어야 예약된 업데이트가 실행됩니다."
+      fix: "'systemctl enable --now dnf-automatic.timer'로 타이머를 활성화하세요. 'systemctl status dnf-automatic.timer'로 상태를 확인하세요."
+    yum_cron_disabled:
+      title: "yum-cron 업데이트가 비활성화되어 있습니다"
+      description: "%{path}의 [commands]에서 apply_updates가 비활성화되어 있습니다."
+      why: "yum-cron이 없으면 이전 RHEL 시스템이 수동 개입 전까지 보안 업데이트를 놓칠 수 있습니다."
+      fix: "yum-cron을 설치하고 %{path}에서 apply_updates = yes로 설정한 뒤, 'systemctl enable --now yum-cron'으로 서비스를 시작하세요."
+    yum_cron_service_disabled:
+      title: "yum-cron 서비스가 활성화되지 않았습니다"
+      description: "%{path}는 존재하지만 yum-cron 서비스가 활성화되지 않았습니다."
+      why: "apply_updates가 구성되어 있어도 서비스가 활성화되어야 예약된 업데이트가 실행됩니다."
+      fix: "'systemctl enable --now yum-cron'으로 서비스를 활성화하세요. 'systemctl status yum-cron'으로 상태를 확인하세요."
     kernel_aslr_disabled:
       title: "커널 ASLR이 비활성화되어 있습니다"
       description: "%{path}가 0으로 설정되어 주소 공간 배치 무작위화가 꺼져 있습니다."

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -34,6 +34,16 @@ const NFT_PATHS: [&str; 2] = ["usr/sbin/nft", "sbin/nft"];
 const APT_AUTO_UPGRADES_CONFIG_PATH: &str = "etc/apt/apt.conf.d/20auto-upgrades";
 const APT_PERIODIC_UNATTENDED_UPGRADE_KEY: &str = "APT::Periodic::Unattended-Upgrade";
 const APT_PERIODIC_UPDATE_PACKAGE_LISTS_KEY: &str = "APT::Periodic::Update-Package-Lists";
+const DNF_AUTOMATIC_CONF_PATH: &str = "etc/dnf/automatic.conf";
+const DNF_AUTOMATIC_TIMER_ENABLED: [&str; 2] = [
+    "etc/systemd/system/multi-user.target.wants/dnf-automatic.timer",
+    "etc/systemd/system/timers.target.wants/dnf-automatic.timer",
+];
+const YUM_CRON_CONF_PATH: &str = "etc/yum/yum-cron.conf";
+const YUM_CRON_SERVICE_ENABLED: [&str; 2] = [
+    "etc/systemd/system/multi-user.target.wants/yum-cron.service",
+    "etc/systemd/system/default.target.wants/yum-cron.service",
+];
 const FAIL2BAN_INSTALL_MARKERS: [&str; 6] = [
     "etc/fail2ban",
     "usr/bin/fail2ban-client",
@@ -1073,6 +1083,14 @@ fn read_sysctl(context: &HostContext, relative: &str) -> Option<String> {
 }
 
 fn scan_package_update_hardening(context: &HostContext) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    findings.extend(scan_apt_auto_upgrades(context));
+    findings.extend(scan_dnf_auto_updates(context));
+    findings.extend(scan_yum_cron(context));
+    findings
+}
+
+fn scan_apt_auto_upgrades(context: &HostContext) -> Vec<Finding> {
     let Some(config_path) = resolve_existing_path(&context.root, APT_AUTO_UPGRADES_CONFIG_PATH)
     else {
         return Vec::new();
@@ -1136,6 +1154,156 @@ fn scan_package_update_hardening(context: &HostContext) -> Vec<Finding> {
     }
 
     findings
+}
+
+fn scan_dnf_auto_updates(context: &HostContext) -> Vec<Finding> {
+    let Some(config_path) = resolve_existing_path(&context.root, DNF_AUTOMATIC_CONF_PATH) else {
+        return Vec::new();
+    };
+
+    let Ok(config_text) = fs::read_to_string(&config_path) else {
+        return Vec::new();
+    };
+
+    let mut findings = Vec::new();
+
+    if let Some(enabled) = parse_ini_bool_in_section(&config_text, "commands", "apply_updates")
+        && !enabled
+    {
+        findings.push(host_finding(
+            "host.dnf_automatic_disabled",
+            Severity::Medium,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.dnf_automatic_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.dnf_automatic_disabled.description",
+                    path = config_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.dnf_automatic_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.dnf_automatic_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), config_path.display().to_string()),
+                (String::from("apply_updates"), String::from("disabled")),
+            ]),
+        ));
+    }
+
+    if !DNF_AUTOMATIC_TIMER_ENABLED
+        .iter()
+        .any(|marker| resolve_existing_path(&context.root, marker).is_some())
+    {
+        findings.push(host_finding(
+            "host.dnf_automatic_timer_disabled",
+            Severity::Medium,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.dnf_automatic_timer_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.dnf_automatic_timer_disabled.description",
+                    path = config_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.dnf_automatic_timer_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.dnf_automatic_timer_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), config_path.display().to_string()),
+                (String::from("timer"), String::from("disabled")),
+            ]),
+        ));
+    }
+
+    findings
+}
+
+fn scan_yum_cron(context: &HostContext) -> Vec<Finding> {
+    let Some(config_path) = resolve_existing_path(&context.root, YUM_CRON_CONF_PATH) else {
+        return Vec::new();
+    };
+
+    let Ok(config_text) = fs::read_to_string(&config_path) else {
+        return Vec::new();
+    };
+
+    let mut findings = Vec::new();
+
+    if let Some(enabled) = parse_ini_bool_in_section(&config_text, "commands", "apply_updates")
+        && !enabled
+    {
+        findings.push(host_finding(
+            "host.yum_cron_disabled",
+            Severity::Medium,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.yum_cron_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.yum_cron_disabled.description",
+                    path = config_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.yum_cron_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.yum_cron_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), config_path.display().to_string()),
+                (String::from("apply_updates"), String::from("disabled")),
+            ]),
+        ));
+    }
+
+    if !YUM_CRON_SERVICE_ENABLED
+        .iter()
+        .any(|marker| resolve_existing_path(&context.root, marker).is_some())
+    {
+        findings.push(host_finding(
+            "host.yum_cron_service_disabled",
+            Severity::Medium,
+            &config_path,
+            HostFindingText {
+                title: t!("finding.host.yum_cron_service_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.yum_cron_service_disabled.description",
+                    path = config_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.yum_cron_service_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.yum_cron_service_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("path"), config_path.display().to_string()),
+                (String::from("service"), String::from("disabled")),
+            ]),
+        ));
+    }
+
+    findings
+}
+
+fn parse_ini_bool_in_section(text: &str, target_section: &str, target_key: &str) -> Option<bool> {
+    let mut in_section = false;
+    for raw_line in text.lines() {
+        let line = strip_ini_comments(raw_line);
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(section) = parse_ini_section(line) {
+            in_section = section.eq_ignore_ascii_case(target_section);
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        let Some((key, value)) = parse_ini_key_value(line) else {
+            continue;
+        };
+        if key.eq_ignore_ascii_case(target_key) {
+            return parse_ini_bool(value);
+        }
+    }
+    None
 }
 
 fn scan_mount_flags(context: &HostContext) -> Vec<Finding> {
@@ -3359,5 +3527,79 @@ mod tests {
         );
 
         fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn host_scanner_detects_dnf_automatic_disabled() {
+        let root = temp_host_root("dnf-automatic-disabled");
+        write_file(
+            &root.join("etc/dnf/automatic.conf"),
+            "[commands]\napply_updates = no\n",
+        );
+        write_file(&root.join("etc/hostname"), "dnf-test\n");
+        write_file(&root.join("proc/uptime"), "60.00 0.00\n");
+        write_file(&root.join("proc/loadavg"), "0.10 0.20 0.30 1/100 123\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.dnf_automatic_disabled")
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.dnf_automatic_timer_disabled")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn host_scanner_detects_yum_cron_disabled() {
+        let root = temp_host_root("yum-cron-disabled");
+        write_file(
+            &root.join("etc/yum/yum-cron.conf"),
+            "[commands]\napply_updates = no\n",
+        );
+        write_file(&root.join("etc/hostname"), "yum-test\n");
+        write_file(&root.join("proc/uptime"), "60.00 0.00\n");
+        write_file(&root.join("proc/loadavg"), "0.10 0.20 0.30 1/100 123\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.yum_cron_disabled")
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.yum_cron_service_disabled")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn parse_ini_bool_in_section_handles_sections() {
+        let text = concat!(
+            "[commands]\n",
+            "apply_updates = yes\n",
+            "\n",
+            "[email]\n",
+            "apply_updates = no\n",
+        );
+        assert_eq!(
+            parse_ini_bool_in_section(text, "commands", "apply_updates"),
+            Some(true)
+        );
+        assert_eq!(
+            parse_ini_bool_in_section(text, "email", "apply_updates"),
+            Some(false)
+        );
+        assert_eq!(parse_ini_bool_in_section(text, "commands", "missing"), None);
     }
 }


### PR DESCRIPTION
## Summary

- Detect dnf-automatic configuration and flag disabled apply_updates
- Detect dnf-automatic timer enabled status via systemd markers
- Detect yum-cron configuration and flag disabled apply_updates
- Detect yum-cron service enabled status via systemd markers
- Add parse_ini_bool_in_section helper for INI section-aware parsing
- Add fixture tests and i18n strings for en and ko

Closes #259