### PR TITLE
feat(host): add Docker Rootless mode detection

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -588,6 +588,11 @@ finding:
       description: "%{path} sets iptables to false in daemon.json."
       why: "Disabling Docker's iptables integration can leave published ports and container networking exposed in ways the operator does not expect."
       fix: "Remove 'iptables': false from %{path} (or set it to true), then restart Docker with 'systemctl restart docker'. Ensure your host firewall (ufw/firewalld) rules do not conflict with Docker's NAT rules."
+    docker_not_rootless:
+      title: "Docker is not running in rootless mode"
+      description: "The Docker daemon is running as root."
+      why: "Rootless Docker reduces the attack surface by running the daemon as an unprivileged user. Running as root means a Docker daemon compromise can lead directly to full host root access."
+      fix: "Consider migrating to Docker Rootless mode. See the official Docker documentation for rootless installation and migration steps. Note: this is a guided change, not an automatic fix."
     fail2ban_not_enabled:
       title: "Fail2ban is installed but not active"
       description: "%{path} shows local Fail2ban markers, but no enabled service marker was detected."

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -588,6 +588,11 @@ finding:
       description: "%{path}가 daemon.json에서 iptables를 false로 설정합니다."
       why: "Docker의 iptables 통합을 끄면 게시된 포트와 컨테이너 네트워킹이 운영자 예상과 다른 방식으로 노출될 수 있습니다."
       fix: "%{path}에서 'iptables': false를 제거하거나 true로 설정한 뒤 'systemctl restart docker'를 실행하세요. 호스트 방화벽(ufw/firewalld) 규칙이 Docker NAT와 충돌하지 않는지 확인하세요."
+    docker_not_rootless:
+      title: "Docker가 rootless 모드로 실행되지 않고 있습니다"
+      description: "Docker 데몬이 root 권한으로 실행 중입니다."
+      why: "Rootless Docker는 데몬을 비특권 사용자로 실행해 공격 표면을 줄입니다. root로 실행하면 Docker 데몬 침해가 곧바로 호스트 root 접근으로 이어질 수 있습니다."
+      fix: "Docker Rootless 모드 마이그레이션을 고려하세요. 공식 Docker 문서에서 rootless 설치 및 마이그레이션 단계를 참조하세요. 참고: 이는 가이드 변경이며 자동 수정은 아닙니다."
     fail2ban_not_enabled:
       title: "Fail2ban이 설치되어 있지만 활성 상태가 아닙니다"
       description: "%{path}에서 로컬 Fail2ban 흔적이 보이지만, 활성화된 서비스 표시는 감지되지 않았습니다."

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -475,7 +475,29 @@ fn scan_docker_host_exposure(context: &HostContext) -> Vec<Finding> {
         }
     }
 
+    if is_live_root(&context.root)
+        && let Some(false) = docker_is_rootless()
+    {
+        findings.push(host_finding(
+            "host.docker_not_rootless",
+            Severity::Low,
+            &context.root.join(DOCKER_SOCKET_PATH),
+            HostFindingText {
+                title: t!("finding.host.docker_not_rootless.title").into_owned(),
+                description: t!("finding.host.docker_not_rootless.description").into_owned(),
+                why_risky: t!("finding.host.docker_not_rootless.why").into_owned(),
+                how_to_fix: t!("finding.host.docker_not_rootless.fix").into_owned(),
+            },
+            BTreeMap::new(),
+        ));
+    }
+
     findings
+}
+
+fn docker_is_rootless() -> Option<bool> {
+    let output = try_command(&["docker", "info"])?;
+    Some(output.to_ascii_lowercase().contains("rootless"))
 }
 
 fn scan_firewall_hardening(context: &HostContext) -> Vec<Finding> {


### PR DESCRIPTION
## Summary

- Detect non-rootless Docker daemon via docker info output
- Report informational finding when Docker runs as root
- Live scan only; skips check on non-live host roots
- Add i18n strings for en and ko

Closes #260