### PR TITLE
feat(host): add SSH cryptographic settings check

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -557,6 +557,21 @@ finding:
       description: "%{path} enables X11Forwarding yes."
       why: "X11 forwarding widens SSH session attack surface and can leak display/session trust boundaries from client systems to remote hosts."
       fix: "Edit %{path}, set 'X11Forwarding no', run 'sshd -t', and reload the SSH service. If GUI access is required, consider a remote desktop solution or local X forwarding over a VPN instead."
+    ssh_weak_kex:
+      title: "SSH allows weak key-exchange algorithms"
+      description: "%{path} includes weak KexAlgorithms: %{algorithms}."
+      why: "Weak key-exchange algorithms such as diffie-hellman-group1-sha1 are vulnerable to Logjam-style attacks and downgrade attacks."
+      fix: "Edit %{path} and remove weak algorithms from KexAlgorithms. Prefer curve25519-sha256, ecdh-sha2-nistp521, or diffie-hellman-group-exchange-sha256. Run 'sshd -t' and reload the service."
+    ssh_weak_macs:
+      title: "SSH allows weak MAC algorithms"
+      description: "%{path} includes weak MACs: %{algorithms}."
+      why: "Weak MAC algorithms such as hmac-md5 do not provide adequate integrity protection for modern SSH sessions."
+      fix: "Edit %{path} and remove weak algorithms from MACs. Prefer hmac-sha2-512-etm@openssh.com or hmac-sha2-256-etm@openssh.com. Run 'sshd -t' and reload the service."
+    ssh_weak_ciphers:
+      title: "SSH allows weak ciphers"
+      description: "%{path} includes weak Ciphers: %{algorithms}."
+      why: "Weak ciphers such as arcfour and 3des-cbc are vulnerable to known cryptanalytic attacks and do not provide adequate confidentiality."
+      fix: "Edit %{path} and remove weak algorithms from Ciphers. Prefer chacha20-poly1305@openssh.com or aes256-gcm@openssh.com. Run 'sshd -t' and reload the service."
     ssh_listen_all:
       title: "SSH listens on all network interfaces"
       description: "%{path} binds SSH to all interfaces (ListenAddress %{values})."

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -557,6 +557,21 @@ finding:
       description: "%{path}에서 X11Forwarding yes가 설정되어 있습니다."
       why: "X11 포워딩은 SSH 세션 공격 표면을 넓히고 클라이언트의 디스플레이/세션 신뢰 경계를 원격 호스트까지 확장시킬 수 있습니다."
       fix: "%{path}를 수정하여 'X11Forwarding no'로 설정하고, 'sshd -t' 후 reload하세요. GUI 접근이 필요하면 원격 데스크톱이나 VPN 내 X 포워딩을 대안으로 고려하세요."
+    ssh_weak_kex:
+      title: "SSH가 약한 키 교환 알고리즘을 허용합니다"
+      description: "%{path}에 약한 KexAlgorithms이 포함되어 있습니다: %{algorithms}."
+      why: "diffie-hellman-group1-sha1 같은 약한 키 교환 알고리즘은 Logjam 스타일 공격과 다운그레이드 공격에 취약합니다."
+      fix: "%{path}에서 KexAlgorithms의 약한 알고리즘을 제거하세요. curve25519-sha256, ecdh-sha2-nistp521, diffie-hellman-group-exchange-sha256을 우선적으로 사용하세요. 'sshd -t' 후 서비스를 reload하세요."
+    ssh_weak_macs:
+      title: "SSH가 약한 MAC 알고리즘을 허용합니다"
+      description: "%{path}에 약한 MAC이 포함되어 있습니다: %{algorithms}."
+      why: "hmac-md5 같은 약한 MAC 알고리즘은 현대 SSH 세션에 충분한 무결성 보호를 제공하지 않습니다."
+      fix: "%{path}에서 MACs의 약한 알고리즘을 제거하세요. hmac-sha2-512-etm@openssh.com이나 hmac-sha2-256-etm@openssh.com을 우선적으로 사용하세요. 'sshd -t' 후 서비스를 reload하세요."
+    ssh_weak_ciphers:
+      title: "SSH가 약한 암호화를 허용합니다"
+      description: "%{path}에 약한 Ciphers가 포함되어 있습니다: %{algorithms}."
+      why: "arcfour나 3des-cbc 같은 약한 암호화는 알려진 암호분석 공격에 취약하고 적절한 기밀성을 제공하지 않습니다."
+      fix: "%{path}에서 Ciphers의 약한 알고리즘을 제거하세요. chacha20-poly1305@openssh.com이나 aes256-gcm@openssh.com을 우선적으로 사용하세요. 'sshd -t' 후 서비스를 reload하세요."
     ssh_listen_all:
       title: "SSH가 모든 네트워크 인터페이스에서 수신 중입니다"
       description: "%{path}가 SSH를 모든 인터페이스에 바인딩합니다 (ListenAddress %{values})."

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -13,6 +13,18 @@ use crate::domain::{
 };
 
 const SSH_CONFIG_PATH: &str = "etc/ssh/sshd_config";
+const WEAK_KEX_ALGORITHMS: [&str; 2] =
+    ["diffie-hellman-group1-sha1", "diffie-hellman-group14-sha1"];
+const WEAK_MAC_ALGORITHMS: [&str; 4] =
+    ["hmac-md5", "hmac-md5-96", "hmac-sha1-96", "hmac-ripemd160"];
+const WEAK_CIPHER_ALGORITHMS: [&str; 6] = [
+    "arcfour",
+    "arcfour128",
+    "arcfour256",
+    "blowfish-cbc",
+    "3des-cbc",
+    "cast128-cbc",
+];
 const DOCKER_DAEMON_CONFIG_PATH: &str = "etc/docker/daemon.json";
 const DOCKER_SOCKET_PATH: &str = "var/run/docker.sock";
 const UFW_CONFIG_PATH: &str = "etc/ufw/ufw.conf";
@@ -366,7 +378,100 @@ fn scan_ssh_hardening(context: &HostContext) -> Vec<Finding> {
         ));
     }
 
+    if let Some(setting) = settings.get("kexalgorithms") {
+        let weak = find_weak_algorithms(&setting.value, &WEAK_KEX_ALGORITHMS);
+        if !weak.is_empty() {
+            let subject_path = &setting.source;
+            findings.push(host_finding(
+                "host.ssh_weak_kex",
+                Severity::High,
+                subject_path,
+                HostFindingText {
+                    title: t!("finding.host.ssh_weak_kex.title").into_owned(),
+                    description: t!(
+                        "finding.host.ssh_weak_kex.description",
+                        path = subject_path.display().to_string(),
+                        algorithms = weak.join(", ")
+                    )
+                    .into_owned(),
+                    why_risky: t!("finding.host.ssh_weak_kex.why").into_owned(),
+                    how_to_fix: t!("finding.host.ssh_weak_kex.fix").into_owned(),
+                },
+                BTreeMap::from([
+                    (String::from("path"), subject_path.display().to_string()),
+                    (String::from("algorithms"), weak.join(", ")),
+                ]),
+            ));
+        }
+    }
+
+    if let Some(setting) = settings.get("macs") {
+        let weak = find_weak_algorithms(&setting.value, &WEAK_MAC_ALGORITHMS);
+        if !weak.is_empty() {
+            let subject_path = &setting.source;
+            findings.push(host_finding(
+                "host.ssh_weak_macs",
+                Severity::High,
+                subject_path,
+                HostFindingText {
+                    title: t!("finding.host.ssh_weak_macs.title").into_owned(),
+                    description: t!(
+                        "finding.host.ssh_weak_macs.description",
+                        path = subject_path.display().to_string(),
+                        algorithms = weak.join(", ")
+                    )
+                    .into_owned(),
+                    why_risky: t!("finding.host.ssh_weak_macs.why").into_owned(),
+                    how_to_fix: t!("finding.host.ssh_weak_macs.fix").into_owned(),
+                },
+                BTreeMap::from([
+                    (String::from("path"), subject_path.display().to_string()),
+                    (String::from("algorithms"), weak.join(", ")),
+                ]),
+            ));
+        }
+    }
+
+    if let Some(setting) = settings.get("ciphers") {
+        let weak = find_weak_algorithms(&setting.value, &WEAK_CIPHER_ALGORITHMS);
+        if !weak.is_empty() {
+            let subject_path = &setting.source;
+            findings.push(host_finding(
+                "host.ssh_weak_ciphers",
+                Severity::High,
+                subject_path,
+                HostFindingText {
+                    title: t!("finding.host.ssh_weak_ciphers.title").into_owned(),
+                    description: t!(
+                        "finding.host.ssh_weak_ciphers.description",
+                        path = subject_path.display().to_string(),
+                        algorithms = weak.join(", ")
+                    )
+                    .into_owned(),
+                    why_risky: t!("finding.host.ssh_weak_ciphers.why").into_owned(),
+                    how_to_fix: t!("finding.host.ssh_weak_ciphers.fix").into_owned(),
+                },
+                BTreeMap::from([
+                    (String::from("path"), subject_path.display().to_string()),
+                    (String::from("algorithms"), weak.join(", ")),
+                ]),
+            ));
+        }
+    }
+
     findings
+}
+
+fn find_weak_algorithms(value: &str, weak_list: &[&str]) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|alg| {
+            let lower = alg.to_ascii_lowercase();
+            weak_list.contains(&lower.as_str())
+        })
+        .map(String::from)
+        .collect()
 }
 
 fn is_wildcard_listen_address(value: &str) -> bool {
@@ -3440,6 +3545,39 @@ mod tests {
             parse_ufw_default_input_policy("DEFAULT_INPUT_POLICY="),
             None
         );
+    }
+
+    #[test]
+    fn host_scanner_detects_weak_ssh_algorithms() {
+        let root = temp_host_root("ssh-weak-algos");
+        write_file(
+            &root.join(SSH_CONFIG_PATH),
+            concat!(
+                "KexAlgorithms diffie-hellman-group1-sha1,curve25519-sha256\n",
+                "MACs hmac-md5,hmac-sha2-512-etm@openssh.com\n",
+                "Ciphers arcfour,aes256-gcm@openssh.com\n",
+            ),
+        );
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.ssh_weak_kex")
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.ssh_weak_macs")
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.id == "host.ssh_weak_ciphers")
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Parse KexAlgorithms, MACs, and Ciphers from sshd_config
- Flag known weak algorithms (diffie-hellman-group1-sha1, hmac-md5, arcfour, etc.)
- Add find_weak_algorithms helper for comma-separated algorithm lists
- Add fixture tests and i18n strings for en and ko

Closes #261