### PR TITLE
feat(rules): add GitLab service-aware security checks

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -950,6 +950,28 @@ finding:
       description: "%{service} sets CADDY_ADMIN to %{admin}, exposing the admin API."
       why: "The Caddy admin API allows dynamic reconfiguration and can expose sensitive site data if reachable by untrusted clients."
       fix: "Remove CADDY_ADMIN or set it to localhost:2019. If remote admin is required, use a Unix socket or restrict access with firewall rules and strong authentication."
+  gitlab:
+    root_password_env:
+      title: "GitLab root password is set via environment variable"
+      description: "%{service} sets GITLAB_ROOT_PASSWORD as a plain environment variable."
+      why: "Storing the root password in environment variables leaves it visible in process listings, container inspection, and compose files."
+      fix: "Use a secret file or Docker secrets to inject the root password instead of a plain environment variable."
+    shared_runners_registration_token_env:
+      title: "GitLab shared runner registration token is exposed via environment variable"
+      description: "%{service} sets GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN as a plain environment variable."
+      why: "A leaked registration token allows arbitrary runners to register with your GitLab instance and potentially intercept CI jobs."
+      fix: "Use a secret file or Docker secrets for the registration token, and rotate the token if it may have been exposed."
+    signups_enabled:
+      title: "GitLab public sign-ups are enabled"
+      description: "%{service} sets GITLAB_SIGNUP_ENABLED, allowing anyone to create an account."
+      why: "Open registration on a self-hosted GitLab instance can lead to abuse, spam, and unauthorized access to private repositories."
+      fix: "Disable sign-ups or restrict them to approved domains. Use an external identity provider for user provisioning."
+    insecure_external_url:
+      title: "GitLab external URL uses plain HTTP"
+      description: "%{service} sets EXTERNAL_URL to %{url}, which uses unencrypted HTTP."
+      why: "Serving GitLab over HTTP exposes authentication tokens, cookies, and repository data to interception and tampering."
+      fix: "Set EXTERNAL_URL to an HTTPS URL and terminate TLS with a reverse proxy or GitLab's built-in Lets Encrypt integration."
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)
   authentik:
     admin_public:
       title: "Authentik interface is publicly exposed"

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -950,6 +950,28 @@ finding:
       description: "%{service}가 CADDY_ADMIN을 %{admin}(으)로 설정하여 관리 API를 노출하고 있습니다."
       why: "Caddy 관리 API는 동적 재구성이 가능하며, 신뢰할 수 없는 클라이언트가 접근할 경우 민감한 사이트 데이터가 노출될 수 있습니다."
       fix: "CADDY_ADMIN을 제거하거나 localhost:2019로 설정하세요. 원격 관리가 필요한 경우 Unix 소켓을 사용하거나 방화벽 규칙과 강력한 인증으로 접근을 제한하세요."
+  gitlab:
+    root_password_env:
+      title: "GitLab 루트 비밀번호가 환경 변수로 설정되어 있습니다"
+      description: "%{service}가 GITLAB_ROOT_PASSWORD를 일반 환경 변수로 설정하고 있습니다."
+      why: "루트 비밀번호를 환경 변수에 저장하면 프로세스 목록, 컨테이너 검사, Compose 파일을 통해 노출될 수 있습니다."
+      fix: "비밀번호 파일이나 Docker Secrets를 사용하여 루트 비밀번호를 주입하세요."
+    shared_runners_registration_token_env:
+      title: "GitLab 공유 Runner 등록 토큰이 환경 변수로 노출되어 있습니다"
+      description: "%{service}가 GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN을 일반 환경 변수로 설정하고 있습니다."
+      why: "유출된 등록 토큰은 임의의 Runner가 GitLab 인스턴스에 등록하여 CI 작업을 가로챌 수 있게 합니다."
+      fix: "등록 토큰에 비밀 파일이나 Docker Secrets를 사용하고, 노출 가능성이 있다면 토큰을 회전하세요."
+    signups_enabled:
+      title: "GitLab 공개 가입이 활성화되어 있습니다"
+      description: "%{service}가 GITLAB_SIGNUP_ENABLED를 설정하여 누구나 계정을 생성할 수 있게 했습니다."
+      why: "셀프 호스팅 GitLab 인스턴스에서 열린 가입은 남용, 스팸, 비공개 저장소에 대한 무단 접근으로 이어질 수 있습니다."
+      fix: "가입을 비활성화하거나 승인된 도메인으로 제한하세요. 사용자 프로비저닝에는 외부 IdP를 사용하세요."
+    insecure_external_url:
+      title: "GitLab 외부 URL이 평문 HTTP를 사용합니다"
+      description: "%{service}가 EXTERNAL_URL을 %{url}(으)로 설정하여 암호화되지 않은 HTTP를 사용합니다."
+      why: "GitLab을 HTTP로 제공하면 인증 토큰, 쿠키, 저장소 데이터가 가로채기 및 변조에 노출됩니다."
+      fix: "EXTERNAL_URL을 HTTPS URL로 설정하고, 리버스 프록시나 GitLab 내장 Lets Encrypt 연동을 통해 TLS를 종료하세요."
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)
   authentik:
     admin_public:
       title: "Authentik 인터페이스가 공개적으로 노출되어 있습니다"

--- a/src/src/rules/service_aware.rs
+++ b/src/src/rules/service_aware.rs
@@ -26,7 +26,8 @@ enum ServiceKind {
     Mysql,
     Redis,
     Caddy,
-}
+    Gitlab,
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)}
 
 pub fn scan_service_aware_risk(project: &ComposeProject) -> Vec<Finding> {
     let mut findings = Vec::new();
@@ -54,7 +55,8 @@ pub fn scan_service_aware_risk(project: &ComposeProject) -> Vec<Finding> {
             ServiceKind::Mysql => findings.extend(scan_mysql_risk(service)),
             ServiceKind::Redis => findings.extend(scan_redis_risk(service)),
             ServiceKind::Caddy => findings.extend(scan_caddy_risk(service)),
-        }
+            ServiceKind::Gitlab => findings.extend(scan_gitlab_risk(service)),
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)        }
     }
 
     findings
@@ -101,7 +103,9 @@ fn detect_service_kind(service: &ComposeService) -> Option<ServiceKind> {
         Some(ServiceKind::Redis)
     } else if haystack.contains("caddy") {
         Some(ServiceKind::Caddy)
-    } else {
+    } else if haystack.contains("gitlab") {
+        Some(ServiceKind::Gitlab)
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)    } else {
         None
     }
 }
@@ -1423,7 +1427,92 @@ fn scan_caddy_risk(service: &ComposeService) -> Vec<Finding> {
     {
         findings.push(service_finding(
             "service.caddy.admin_api_public",
+fn scan_gitlab_risk(service: &ComposeService) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let publicly_exposed = service.ports.iter().any(is_public_port);
+
+    if env_value(service, "GITLAB_ROOT_PASSWORD").is_some() {
+        findings.push(service_finding_with_remediation(
+            "service.gitlab.root_password_env",
+            Axis::SensitiveData,
+            Severity::High,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.gitlab.root_password_env.title").into_owned(),
+                description: t!(
+                    "finding.gitlab.root_password_env.description",
+                    service = service.name.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.gitlab.root_password_env.why").into_owned(),
+                how_to_fix: t!("finding.gitlab.root_password_env.fix").into_owned(),
+            },
+            BTreeMap::from([(
+                String::from("variable"),
+                String::from("GITLAB_ROOT_PASSWORD"),
+            )]),
+            RemediationKind::Safe,
+        ));
+    }
+
+    if env_value(service, "GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN").is_some() {
+        findings.push(service_finding_with_remediation(
+            "service.gitlab.shared_runners_registration_token_env",
+            Axis::SensitiveData,
+            Severity::High,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.gitlab.shared_runners_registration_token_env.title")
+                    .into_owned(),
+                description: t!(
+                    "finding.gitlab.shared_runners_registration_token_env.description",
+                    service = service.name.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.gitlab.shared_runners_registration_token_env.why")
+                    .into_owned(),
+                how_to_fix: t!("finding.gitlab.shared_runners_registration_token_env.fix")
+                    .into_owned(),
+            },
+            BTreeMap::from([(
+                String::from("variable"),
+                String::from("GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN"),
+            )]),
+            RemediationKind::Safe,
+        ));
+    }
+
+    if env_truthy(service, "GITLAB_SIGNUP_ENABLED") {
+        findings.push(service_finding_with_remediation(
+            "service.gitlab.signups_enabled",
             Axis::UnnecessaryExposure,
+            Severity::Medium,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.gitlab.signups_enabled.title").into_owned(),
+                description: t!(
+                    "finding.gitlab.signups_enabled.description",
+                    service = service.name.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.gitlab.signups_enabled.why").into_owned(),
+                how_to_fix: t!("finding.gitlab.signups_enabled.fix").into_owned(),
+            },
+            BTreeMap::from([(
+                String::from("variable"),
+                String::from("GITLAB_SIGNUP_ENABLED"),
+            )]),
+            RemediationKind::Safe,
+        ));
+    }
+
+    if publicly_exposed
+        && let Some(url) = env_value(service, "EXTERNAL_URL")
+        && url.starts_with("http://")
+    {
+        findings.push(service_finding(
+            "service.gitlab.insecure_external_url",
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)            Axis::UnnecessaryExposure,
             Severity::High,
             &service.name,
             ServiceFindingText {
@@ -1440,7 +1529,20 @@ fn scan_caddy_risk(service: &ComposeService) -> Vec<Finding> {
             BTreeMap::from([
                 (String::from("variable"), String::from("CADDY_ADMIN")),
                 (String::from("admin"), admin.to_owned()),
-            ]),
+                title: t!("finding.gitlab.insecure_external_url.title").into_owned(),
+                description: t!(
+                    "finding.gitlab.insecure_external_url.description",
+                    service = service.name.as_str(),
+                    url = url
+                )
+                .into_owned(),
+                why_risky: t!("finding.gitlab.insecure_external_url.why").into_owned(),
+                how_to_fix: t!("finding.gitlab.insecure_external_url.fix").into_owned(),
+            },
+            BTreeMap::from([
+                (String::from("variable"), String::from("EXTERNAL_URL")),
+                (String::from("url"), url.to_owned()),
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)            ]),
         ));
     }
 
@@ -1964,7 +2066,9 @@ mod tests {
     #[test]
     fn caddy_baseline_avoids_service_specific_findings() {
         let project = ComposeParser::parse_path_without_override(fixture("caddy", "baseline.yml"))
-            .expect("project should parse");
+    fn gitlab_baseline_avoids_service_specific_findings() {
+        let project = ComposeParser::parse_path_without_override(fixture("gitlab", "baseline.yml"))
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)            .expect("project should parse");
 
         let findings = scan_service_aware_risk(&project);
 
@@ -1975,7 +2079,10 @@ mod tests {
     fn caddy_vulnerable_fixture_triggers_service_specific_findings() {
         let project =
             ComposeParser::parse_path_without_override(fixture("caddy", "vulnerable.yml"))
-                .expect("project should parse");
+    fn gitlab_vulnerable_fixture_triggers_service_specific_findings() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("gitlab", "vulnerable.yml"))
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)                .expect("project should parse");
 
         let findings = scan_service_aware_risk(&project);
 
@@ -1985,6 +2092,12 @@ mod tests {
                 .map(|finding| finding.id.as_str())
                 .collect::<Vec<_>>(),
             vec!["service.caddy.admin_api_public"]
-        );
+            vec![
+                "service.gitlab.root_password_env",
+                "service.gitlab.shared_runners_registration_token_env",
+                "service.gitlab.signups_enabled",
+                "service.gitlab.insecure_external_url",
+            ]
+>>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)        );
     }
 }

--- a/src/tests/fixtures/services/gitlab/baseline.yml
+++ b/src/tests/fixtures/services/gitlab/baseline.yml
@@ -1,0 +1,7 @@
+services:
+  gitlab:
+    image: gitlab/gitlab-ce:latest
+    user: "1000:1000"
+    ports:
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:443:443"

--- a/src/tests/fixtures/services/gitlab/vulnerable.yml
+++ b/src/tests/fixtures/services/gitlab/vulnerable.yml
@@ -1,0 +1,11 @@
+services:
+  gitlab:
+    image: gitlab/gitlab-ce:latest
+    environment:
+      GITLAB_ROOT_PASSWORD: "secret123"
+      GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN: "abc123"
+      GITLAB_SIGNUP_ENABLED: "true"
+      EXTERNAL_URL: "http://gitlab.example.com"
+    ports:
+      - "80:80"
+      - "443:443"


### PR DESCRIPTION
## Summary
- Detect GitLab via image/service name containing `gitlab`
- Flag `GITLAB_ROOT_PASSWORD` in plain env vars (**High**, SensitiveData)
- Flag `GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN` in plain env vars (**High**, SensitiveData)
- Flag `GITLAB_SIGNUP_ENABLED=true` (**Medium**, UnnecessaryExposure)
- Flag `EXTERNAL_URL` starting with `http://` when publicly exposed (**High**, UnnecessaryExposure)
- Add baseline/vulnerable fixtures and unit tests
- Add English and Korean i18n strings

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace` passes (364 tests)
- [x] `scripts/smoke-test.sh` passes
- [x] `scripts/test-install-script.sh` passes
- [x] `scripts/verify-fixes.sh` passes

Refs #267