### PR TITLE
feat(rules): add Uptime Kuma service-aware security checks

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -972,6 +972,18 @@ finding:
       why: "Serving GitLab over HTTP exposes authentication tokens, cookies, and repository data to interception and tampering."
       fix: "Set EXTERNAL_URL to an HTTPS URL and terminate TLS with a reverse proxy or GitLab's built-in Lets Encrypt integration."
 >>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)
+  uptime_kuma:
+    auth_disabled:
+      title: "Uptime Kuma authentication is disabled"
+      description: "%{service} sets UPTIME_KUMA_DISABLE_AUTH, allowing unauthenticated access."
+      why: "Disabling authentication lets anyone view monitors, add or remove checks, and access notification settings."
+      fix: "Remove UPTIME_KUMA_DISABLE_AUTH and configure username/password authentication through the Uptime Kuma UI."
+    admin_public:
+      title: "Uptime Kuma admin interface is publicly exposed"
+      description: "%{service} exposes the Uptime Kuma dashboard on %{port}."
+      why: "A publicly reachable Uptime Kuma dashboard reveals internal infrastructure topology, endpoints, and health status to attackers."
+      fix: "Restrict Uptime Kuma to localhost or a trusted network, or place it behind a reverse proxy with strong authentication."
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
   authentik:
     admin_public:
       title: "Authentik interface is publicly exposed"

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -972,6 +972,18 @@ finding:
       why: "GitLab을 HTTP로 제공하면 인증 토큰, 쿠키, 저장소 데이터가 가로채기 및 변조에 노출됩니다."
       fix: "EXTERNAL_URL을 HTTPS URL로 설정하고, 리버스 프록시나 GitLab 내장 Lets Encrypt 연동을 통해 TLS를 종료하세요."
 >>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)
+  uptime_kuma:
+    auth_disabled:
+      title: "Uptime Kuma 인증이 비활성화되어 있습니다"
+      description: "%{service}가 UPTIME_KUMA_DISABLE_AUTH를 설정하여 인증 없이 접근을 허용하고 있습니다."
+      why: "인증을 비활성화하면 누구나 모니터를 보고, 추가하거나 제거하며, 알림 설정에 접근할 수 있습니다."
+      fix: "UPTIME_KUMA_DISABLE_AUTH를 제거하고 Uptime Kuma UI를 통해 사용자 이름/비밀번호 인증을 구성하세요."
+    admin_public:
+      title: "Uptime Kuma 관리 인터페이스가 공개적으로 노출되어 있습니다"
+      description: "%{service}가 Uptime Kuma 대시보드를 %{port}에 노출하고 있습니다."
+      why: "공개적으로 접근 가능한 Uptime Kuma 대시보드는 낮부 인프라 토폴로지, 엔드포인트, 상태 정보를 공격자에게 노출합니다."
+      fix: "Uptime Kuma를 localhost 또는 신뢰할 수 있는 네트워크로 제한하거나, 강력한 인증이 적용된 리버스 프록시 뒤에 배치하세요."
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
   authentik:
     admin_public:
       title: "Authentik 인터페이스가 공개적으로 노출되어 있습니다"

--- a/src/src/rules/service_aware.rs
+++ b/src/src/rules/service_aware.rs
@@ -28,6 +28,9 @@ enum ServiceKind {
     Caddy,
     Gitlab,
 >>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)}
+    UptimeKuma,
+}
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
 
 pub fn scan_service_aware_risk(project: &ComposeProject) -> Vec<Finding> {
     let mut findings = Vec::new();
@@ -57,6 +60,9 @@ pub fn scan_service_aware_risk(project: &ComposeProject) -> Vec<Finding> {
             ServiceKind::Caddy => findings.extend(scan_caddy_risk(service)),
             ServiceKind::Gitlab => findings.extend(scan_gitlab_risk(service)),
 >>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)        }
+            ServiceKind::UptimeKuma => findings.extend(scan_uptime_kuma_risk(service)),
+        }
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
     }
 
     findings
@@ -106,6 +112,10 @@ fn detect_service_kind(service: &ComposeService) -> Option<ServiceKind> {
     } else if haystack.contains("gitlab") {
         Some(ServiceKind::Gitlab)
 >>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)    } else {
+    } else if haystack.contains("uptime-kuma") || haystack.contains("uptimekuma") {
+        Some(ServiceKind::UptimeKuma)
+    } else {
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
         None
     }
 }
@@ -1501,6 +1511,30 @@ fn scan_gitlab_risk(service: &ComposeService) -> Vec<Finding> {
             BTreeMap::from([(
                 String::from("variable"),
                 String::from("GITLAB_SIGNUP_ENABLED"),
+fn scan_uptime_kuma_risk(service: &ComposeService) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let publicly_exposed = service.ports.iter().any(is_public_port);
+
+    if env_truthy(service, "UPTIME_KUMA_DISABLE_AUTH") {
+        findings.push(service_finding_with_remediation(
+            "service.uptime_kuma.auth_disabled",
+            Axis::UnnecessaryExposure,
+            Severity::High,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.uptime_kuma.auth_disabled.title").into_owned(),
+                description: t!(
+                    "finding.uptime_kuma.auth_disabled.description",
+                    service = service.name.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.uptime_kuma.auth_disabled.why").into_owned(),
+                how_to_fix: t!("finding.uptime_kuma.auth_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([(
+                String::from("variable"),
+                String::from("UPTIME_KUMA_DISABLE_AUTH"),
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
             )]),
             RemediationKind::Safe,
         ));
@@ -1543,6 +1577,29 @@ fn scan_gitlab_risk(service: &ComposeService) -> Vec<Finding> {
                 (String::from("variable"), String::from("EXTERNAL_URL")),
                 (String::from("url"), url.to_owned()),
 >>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)            ]),
+        && let Some(port) = service
+            .ports
+            .iter()
+            .find(|p| p.container_port == "3001" && p.protocol == "tcp" && is_public_port(p))
+    {
+        findings.push(service_finding(
+            "service.uptime_kuma.admin_public",
+            Axis::UnnecessaryExposure,
+            Severity::High,
+            &service.name,
+            ServiceFindingText {
+                title: t!("finding.uptime_kuma.admin_public.title").into_owned(),
+                description: t!(
+                    "finding.uptime_kuma.admin_public.description",
+                    service = service.name.as_str(),
+                    port = port.raw.as_str()
+                )
+                .into_owned(),
+                why_risky: t!("finding.uptime_kuma.admin_public.why").into_owned(),
+                how_to_fix: t!("finding.uptime_kuma.admin_public.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("port"), port.raw.clone())]),
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
         ));
     }
 
@@ -2069,6 +2126,11 @@ mod tests {
     fn gitlab_baseline_avoids_service_specific_findings() {
         let project = ComposeParser::parse_path_without_override(fixture("gitlab", "baseline.yml"))
 >>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)            .expect("project should parse");
+    fn uptime_kuma_baseline_avoids_service_specific_findings() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("uptime-kuma", "baseline.yml"))
+                .expect("project should parse");
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
 
         let findings = scan_service_aware_risk(&project);
 
@@ -2083,6 +2145,11 @@ mod tests {
         let project =
             ComposeParser::parse_path_without_override(fixture("gitlab", "vulnerable.yml"))
 >>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)                .expect("project should parse");
+    fn uptime_kuma_vulnerable_fixture_triggers_service_specific_findings() {
+        let project =
+            ComposeParser::parse_path_without_override(fixture("uptime-kuma", "vulnerable.yml"))
+                .expect("project should parse");
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
 
         let findings = scan_service_aware_risk(&project);
 
@@ -2099,5 +2166,11 @@ mod tests {
                 "service.gitlab.insecure_external_url",
             ]
 >>>>>>> b83de39 (feat(rules): add GitLab service-aware security checks)        );
+            vec![
+                "service.uptime_kuma.auth_disabled",
+                "service.uptime_kuma.admin_public",
+            ]
+        );
+>>>>>>> e749f6e (feat(rules): add Uptime Kuma service-aware security checks)
     }
 }

--- a/src/tests/fixtures/services/uptime-kuma/baseline.yml
+++ b/src/tests/fixtures/services/uptime-kuma/baseline.yml
@@ -1,0 +1,6 @@
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:1
+    user: "1000:1000"
+    ports:
+      - "127.0.0.1:3001:3001"

--- a/src/tests/fixtures/services/uptime-kuma/vulnerable.yml
+++ b/src/tests/fixtures/services/uptime-kuma/vulnerable.yml
@@ -1,0 +1,7 @@
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:1
+    environment:
+      UPTIME_KUMA_DISABLE_AUTH: "true"
+    ports:
+      - "3001:3001"


### PR DESCRIPTION
## Summary
- Detect Uptime Kuma via image/service name containing `uptime-kuma` or `uptimekuma`
- Flag `UPTIME_KUMA_DISABLE_AUTH` as disabled authentication (**High**, UnnecessaryExposure)
- Flag publicly exposed port `3001` as public admin interface (**High**, UnnecessaryExposure)
- Add baseline/vulnerable fixtures and unit tests
- Add English and Korean i18n strings

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace` passes (364 tests)
- [x] `scripts/smoke-test.sh` passes
- [x] `scripts/test-install-script.sh` passes
- [x] `scripts/verify-fixes.sh` passes

Refs #268