### PR TITLE
feat(host): add Docker daemon hardening checks

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -608,6 +608,27 @@ finding:
       description: "The Docker daemon is running as root."
       why: "Rootless Docker reduces the attack surface by running the daemon as an unprivileged user. Running as root means a Docker daemon compromise can lead directly to full host root access."
       fix: "Consider migrating to Docker Rootless mode. See the official Docker documentation for rootless installation and migration steps. Note: this is a guided change, not an automatic fix."
+    docker_userns_remap_missing:
+      title: "Docker user namespace remapping is not configured"
+      description: "%{path} does not set userns-remap."
+      why: "Without user namespace remapping, container processes run with host UIDs, increasing the blast radius of a container breakout."
+      fix: "Add 'userns-remap': 'default' to %{path}, create the dockremap user/subuid/subgid mappings, then restart Docker."
+    docker_live_restore_disabled:
+      title: "Docker live-restore is not enabled"
+      description: "%{path} does not set live-restore to true."
+      why: "Without live-restore, all containers stop when the Docker daemon restarts, causing unnecessary downtime and potential data loss."
+      fix: "Add 'live-restore': true to %{path}, then restart Docker with 'systemctl restart docker'."
+    docker_log_driver_missing:
+      title: "Docker log driver is not explicitly configured"
+      description: "%{path} does not set an explicit log-driver."
+      why: "The default json-file log driver grows without bounds, which can exhaust disk space and make log analysis difficult."
+      fix: "Add 'log-driver': 'json-file' and 'log-opts': { 'max-size': '10m', 'max-file': '3' } to %{path}, or use a centralized log driver like 'local'."
+    docker_default_ulimits_missing:
+      title: "Docker default ulimits are not configured"
+      description: "%{path} does not set default-ulimits."
+      why: "Without default ulimits, a single misbehaving container can exhaust host file descriptors or spawn excessive processes."
+      fix: "Add 'default-ulimits': { 'nofile': { 'Name': 'nofile', 'Hard': 64000, 'Soft': 64000 } } to %{path}, then restart Docker."
+>>>>>>> 6337434 (feat(host): add Docker daemon hardening checks)
     fail2ban_not_enabled:
       title: "Fail2ban is installed but not active"
       description: "%{path} shows local Fail2ban markers, but no enabled service marker was detected."

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -608,6 +608,27 @@ finding:
       description: "Docker 데몬이 root 권한으로 실행 중입니다."
       why: "Rootless Docker는 데몬을 비특권 사용자로 실행해 공격 표면을 줄입니다. root로 실행하면 Docker 데몬 침해가 곧바로 호스트 root 접근으로 이어질 수 있습니다."
       fix: "Docker Rootless 모드 마이그레이션을 고려하세요. 공식 Docker 문서에서 rootless 설치 및 마이그레이션 단계를 참조하세요. 참고: 이는 가이드 변경이며 자동 수정은 아닙니다."
+    docker_userns_remap_missing:
+      title: "Docker 사용자 네임스페이스 재매핑이 구성되지 않았습니다"
+      description: "%{path}에 userns-remap이 설정되지 않았습니다."
+      why: "사용자 네임스페이스 재매핑 없이는 컨테이너 프로세스가 호스트 UID로 실행되어, 컨테이너 탈출 시 영향 범위가 커집니다."
+      fix: "%{path}에 'userns-remap': 'default'를 추가하고 dockremap 사용자/subuid/subgid 매핑을 생성한 뒤 Docker를 재시작하세요."
+    docker_live_restore_disabled:
+      title: "Docker live-restore이 활성화되지 않았습니다"
+      description: "%{path}에 live-restore이 true로 설정되지 않았습니다."
+      why: "live-restore 없이는 Docker 데몬 재시작 시 모든 컨테이너가 중단되어 불필요한 다운타임과 데이터 손실이 발생할 수 있습니다."
+      fix: "%{path}에 'live-restore': true를 추가한 뒤 'systemctl restart docker'를 실행하세요."
+    docker_log_driver_missing:
+      title: "Docker 로그 드라이버가 명시적으로 구성되지 않았습니다"
+      description: "%{path}에 명시적인 log-driver이 설정되지 않았습니다."
+      why: "기본 json-file 로그 드라이버는 무제한으로 증가하여 디스크 공간을 소진하고 로그 분석을 어렵게 합니다."
+      fix: "%{path}에 'log-driver': 'json-file'과 'log-opts': { 'max-size': '10m', 'max-file': '3' }를 추가하거나, 'local' 같은 중앙 집중식 로그 드라이버를 사용하세요."
+    docker_default_ulimits_missing:
+      title: "Docker 기본 ulimits가 구성되지 않았습니다"
+      description: "%{path}에 default-ulimits이 설정되지 않았습니다."
+      why: "기본 ulimits이 없으면 비정상적으로 동작하는 컨테이너 하나가 호스트의 파일 디스크립터를 소진하거나 과도한 프로세스를 생성할 수 있습니다."
+      fix: "%{path}에 'default-ulimits': { 'nofile': { 'Name': 'nofile', 'Hard': 64000, 'Soft': 64000 } }를 추가한 뒤 Docker를 재시작하세요."
+>>>>>>> 6337434 (feat(host): add Docker daemon hardening checks)
     fail2ban_not_enabled:
       title: "Fail2ban이 설치되어 있지만 활성 상태가 아닙니다"
       description: "%{path}에서 로컬 Fail2ban 흔적이 보이지만, 활성화된 서비스 표시는 감지되지 않았습니다."

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -99,6 +99,7 @@ impl HostScanner {
         let mut findings = Vec::new();
         findings.extend(scan_ssh_hardening(context));
         findings.extend(scan_docker_host_exposure(context));
+        findings.extend(scan_docker_daemon_hardening(context));
         findings.extend(scan_firewall_hardening(context));
         findings.extend(scan_package_update_hardening(context));
         findings.extend(scan_kernel_hardening(context));
@@ -626,6 +627,93 @@ fn scan_docker_host_exposure(context: &HostContext) -> Vec<Finding> {
 fn docker_is_rootless() -> Option<bool> {
     let output = try_command(&["docker", "info"])?;
     Some(output.to_ascii_lowercase().contains("rootless"))
+fn scan_docker_daemon_hardening(context: &HostContext) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    if let Some(daemon_path) = resolve_existing_path(&context.root, DOCKER_DAEMON_CONFIG_PATH)
+        && let Ok(text) = fs::read_to_string(&daemon_path)
+        && let Ok(json) = serde_json::from_str::<JsonValue>(&text)
+    {
+
+    if !docker_daemon_userns_remapped(&json) {
+        findings.push(host_finding(
+            "host.docker_userns_remap_missing",
+            Severity::Medium,
+            &daemon_path,
+            HostFindingText {
+                title: t!("finding.host.docker_userns_remap_missing.title").into_owned(),
+                description: t!(
+                    "finding.host.docker_userns_remap_missing.description",
+                    path = daemon_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.docker_userns_remap_missing.why").into_owned(),
+                how_to_fix: t!("finding.host.docker_userns_remap_missing.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("path"), daemon_path.display().to_string())]),
+        ));
+    }
+
+    if !docker_daemon_live_restore_enabled(&json) {
+        findings.push(host_finding(
+            "host.docker_live_restore_disabled",
+            Severity::Medium,
+            &daemon_path,
+            HostFindingText {
+                title: t!("finding.host.docker_live_restore_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.docker_live_restore_disabled.description",
+                    path = daemon_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.docker_live_restore_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.docker_live_restore_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("path"), daemon_path.display().to_string())]),
+        ));
+    }
+
+    if !docker_daemon_log_driver_configured(&json) {
+        findings.push(host_finding(
+            "host.docker_log_driver_missing",
+            Severity::Low,
+            &daemon_path,
+            HostFindingText {
+                title: t!("finding.host.docker_log_driver_missing.title").into_owned(),
+                description: t!(
+                    "finding.host.docker_log_driver_missing.description",
+                    path = daemon_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.docker_log_driver_missing.why").into_owned(),
+                how_to_fix: t!("finding.host.docker_log_driver_missing.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("path"), daemon_path.display().to_string())]),
+        ));
+    }
+
+    if !docker_daemon_default_ulimits_configured(&json) {
+        findings.push(host_finding(
+            "host.docker_default_ulimits_missing",
+            Severity::Low,
+            &daemon_path,
+            HostFindingText {
+                title: t!("finding.host.docker_default_ulimits_missing.title").into_owned(),
+                description: t!(
+                    "finding.host.docker_default_ulimits_missing.description",
+                    path = daemon_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.docker_default_ulimits_missing.why").into_owned(),
+                how_to_fix: t!("finding.host.docker_default_ulimits_missing.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("path"), daemon_path.display().to_string())]),
+        ));
+    }
+    }
+
+    findings
+>>>>>>> 6337434 (feat(host): add Docker daemon hardening checks)
 }
 
 fn scan_firewall_hardening(context: &HostContext) -> Vec<Finding> {
@@ -2477,6 +2565,31 @@ fn docker_daemon_setting_state(document: &JsonValue, key: &str) -> String {
     }
 }
 
+fn docker_daemon_userns_remapped(document: &JsonValue) -> bool {
+    document
+        .get("userns-remap")
+        .and_then(|v| v.as_str())
+        .is_some_and(|v| !v.is_empty())
+}
+
+fn docker_daemon_live_restore_enabled(document: &JsonValue) -> bool {
+    document.get("live-restore").and_then(JsonValue::as_bool) == Some(true)
+}
+
+fn docker_daemon_log_driver_configured(document: &JsonValue) -> bool {
+    document
+        .get("log-driver")
+        .and_then(|v| v.as_str())
+        .is_some_and(|v| !v.is_empty())
+}
+
+fn docker_daemon_default_ulimits_configured(document: &JsonValue) -> bool {
+    document
+        .get("default-ulimits")
+        .and_then(JsonValue::as_object)
+        .is_some_and(|obj| !obj.is_empty())
+}
+
 fn host_is_public_tcp(value: &JsonValue) -> bool {
     let Some(host) = value.as_str() else {
         return false;
@@ -2565,6 +2678,11 @@ mod tests {
                 "host.docker_daemon_tcp_no_tlsverify",
                 "host.docker_daemon_iptables_disabled",
                 "host.no_firewall_detected",
+                "host.docker_userns_remap_missing",
+                "host.docker_live_restore_disabled",
+                "host.docker_log_driver_missing",
+                "host.docker_default_ulimits_missing",
+>>>>>>> 6337434 (feat(host): add Docker daemon hardening checks)
                 "host.mac_framework_missing",
                 "host.defensive_controls_missing",
             ]
@@ -2810,7 +2928,7 @@ mod tests {
         );
         write_file(
             &root.join(DOCKER_DAEMON_CONFIG_PATH),
-            r#"{"hosts": ["unix:///var/run/docker.sock", "tcp://127.0.0.1:2375"]}"#,
+            r#"{"hosts": ["unix:///var/run/docker.sock", "tcp://127.0.0.1:2375"], "userns-remap": "default", "live-restore": true, "log-driver": "json-file", "log-opts": {"max-size": "10m", "max-file": "3"}, "default-ulimits": {"nofile": {"Name": "nofile", "Hard": 64000, "Soft": 64000}}}"#,
         );
         write_file(
             &root.join("etc/fail2ban/jail.local"),


### PR DESCRIPTION
## Summary
Add native checks for Docker daemon hardening settings in `/etc/docker/daemon.json`:
- **userns-remap missing** (Medium)
- **live-restore disabled** (Medium)
- **log-driver not configured** (Low)
- **default-ulimits missing** (Low)

## Changes
- `scan_docker_daemon_hardening` function in `src/src/host/mod.rs`
- 4 JSON helper functions for daemon.json parsing
- Updated snapshot tests (insecure expects new findings, hardened includes hardening settings)
- English and Korean i18n strings

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace` passes (362 tests)
- [x] `scripts/smoke-test.sh` passes
- [x] `scripts/test-install-script.sh` passes
- [x] `scripts/verify-fixes.sh` passes

Refs #272