### PR TITLE
feat(host): add kernel module signing enforcement check

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -714,6 +714,11 @@ finding:
       description: "%{path} is set to 0, allowing unrestricted kernel module loading."
       why: "Unrestricted module loading allows attackers with root or physical access to load arbitrary kernel code. Restricting it reduces the kernel attack surface and makes certain persistence techniques harder."
       fix: "Run 'sysctl -w kernel.modules_disabled=1' to prevent new module loading. Create /etc/sysctl.d/99-modules.conf with 'kernel.modules_disabled = 1' to persist. Note: ensure all required modules are loaded before setting this, as it cannot be undone without a reboot."
+    kernel_module_signing_not_enforced:
+      title: "Kernel module signing is not enforced"
+      description: "%{path} is missing or set to N, allowing unsigned kernel modules to be loaded."
+      why: "Without module signing enforcement, a compromised root account or attacker with physical access can load malicious kernel modules that bypass user-space security controls."
+      fix: "Enable CONFIG_MODULE_SIG_FORCE in your kernel config and ensure the kernel command line includes 'module.sig_enforce=1'. On most distributions this requires rebuilding or installing a signed kernel package."
     grub_password_missing:
       title: "GRUB bootloader lacks password protection"
       description: "%{path} does not contain a GRUB password or unrestricted restriction."

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -714,6 +714,11 @@ finding:
       description: "%{path}가 0으로 설정되어 커널 모듈을 제한 없이 로드할 수 있습니다."
       why: "제한 없는 모듈 로딩은 root나 물리적 접근 권한을 가진 공격자가 임의의 커널 코드를 로드할 수 있게 합니다. 이를 제한하면 커널 공격 표면이 줄어들고 특정 지속 기법을 어렵게 만듭니다."
       fix: "'sysctl -w kernel.modules_disabled=1'로 새 모듈 로딩을 방지하세요. /etc/sysctl.d/99-modules.conf를 만들어 'kernel.modules_disabled = 1'를 추가하면 영구화됩니다. 참고: 설정 전에 필요한 모듈을 모두 로드해야 하며, 재부팅 없이는 되돌릴 수 없습니다."
+    kernel_module_signing_not_enforced:
+      title: "커널 모듈 서명이 강제되지 않았습니다"
+      description: "%{path}가 없거나 N으로 설정되어 서명되지 않은 커널 모듈을 로드할 수 있습니다."
+      why: "모듈 서명 강제 없이는 침해당한 root 계정이나 물리적 접근 권한을 가진 공격자가 사용자 공간 보안 제어를 우회하는 악성 커널 모듈을 로드할 수 있습니다."
+      fix: "커널 설정에서 CONFIG_MODULE_SIG_FORCE를 활성화하고 커널 커맨드 라인에 'module.sig_enforce=1'을 포함하세요. 대부분의 배포판에서는 커널을 재빌드하거나 서명된 커널 패키지를 설치해야 합니다."
     grub_password_missing:
       title: "GRUB 부트로더에 암호 보호가 없습니다"
       description: "%{path}에 GRUB 암호나 unrestricted 제한이 없습니다."

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -713,7 +713,6 @@ fn scan_docker_daemon_hardening(context: &HostContext) -> Vec<Finding> {
     }
 
     findings
->>>>>>> 6337434 (feat(host): add Docker daemon hardening checks)
 }
 
 fn scan_firewall_hardening(context: &HostContext) -> Vec<Finding> {
@@ -1196,6 +1195,39 @@ fn scan_kernel_hardening(context: &HostContext) -> Vec<Finding> {
                 how_to_fix: t!("finding.host.kernel_modules_disabled_not_set.fix").into_owned(),
             },
             BTreeMap::from([(String::from("value"), String::from("0"))]),
+        ));
+    }
+
+    let sig_enforce_path = "sys/module/module/parameters/sig_enforce";
+    let sig_enforce_value = read_sysctl(context, sig_enforce_path);
+    let sig_enforce_missing = sig_enforce_value.is_none();
+    let sig_enforce_disabled = sig_enforce_value.as_deref().is_some_and(|v| v.trim() == "N");
+
+    if sig_enforce_missing || sig_enforce_disabled {
+        findings.push(host_finding(
+            "host.kernel.module_signing_not_enforced",
+            Severity::Low,
+            &context.root.join(sig_enforce_path),
+            HostFindingText {
+                title: t!("finding.host.kernel_module_signing_not_enforced.title").into_owned(),
+                description: t!(
+                    "finding.host.kernel_module_signing_not_enforced.description",
+                    path = context.root.join(sig_enforce_path).display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.kernel_module_signing_not_enforced.why")
+                    .into_owned(),
+                how_to_fix: t!("finding.host.kernel_module_signing_not_enforced.fix")
+                    .into_owned(),
+            },
+            BTreeMap::from([(
+                String::from("state"),
+                if sig_enforce_missing {
+                    String::from("missing")
+                } else {
+                    String::from("disabled")
+                },
+            )]),
         ));
     }
 
@@ -2682,7 +2714,7 @@ mod tests {
                 "host.docker_live_restore_disabled",
                 "host.docker_log_driver_missing",
                 "host.docker_default_ulimits_missing",
->>>>>>> 6337434 (feat(host): add Docker daemon hardening checks)
+                "host.kernel.module_signing_not_enforced",
                 "host.mac_framework_missing",
                 "host.defensive_controls_missing",
             ]
@@ -2729,6 +2761,7 @@ mod tests {
                 "host.kernel.syn_cookies_disabled",
                 "host.kernel.broadcast_ping_allowed",
                 "host.kernel.ip_forward_enabled",
+                "host.kernel.module_signing_not_enforced",
                 "host.kernel.unprivileged_userns_clone_enabled",
                 "host.kernel.max_user_namespaces_enabled",
                 "host.mac_framework_missing",
@@ -2766,6 +2799,10 @@ mod tests {
         write_file(
             &root.join("sys/kernel/security/apparmor/profiles"),
             "/usr/sbin/dnsmasq (enforce)\n",
+        );
+        write_file(
+            &root.join("sys/module/module/parameters/sig_enforce"),
+            "Y\n",
         );
         write_file(&root.join("etc/hostname"), "hardened\n");
         write_file(&root.join("proc/uptime"), "60.00 0.00\n");
@@ -2957,6 +2994,10 @@ mod tests {
         );
         write_file(&root.join("proc/sys/user/max_user_namespaces"), "0\n");
         write_file(&root.join("proc/sys/kernel/modules_disabled"), "1\n");
+        write_file(
+            &root.join("sys/module/module/parameters/sig_enforce"),
+            "Y\n",
+        );
         write_file(
             &root.join("sys/kernel/security/apparmor/profiles"),
             "/usr/sbin/dnsmasq (enforce)\n",


### PR DESCRIPTION
## Summary
Extend `scan_kernel_hardening` to detect whether the kernel enforces module signing via `/sys/module/module/parameters/sig_enforce`.

## Changes
- Flag when `sig_enforce` is missing or set to `N` (**Low** severity)
- Updated snapshot tests (insecure sysctl expects new finding, hardened includes `sig_enforce=Y`)
- English and Korean i18n strings

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace` passes (362 tests)
- [x] `scripts/smoke-test.sh` passes
- [x] `scripts/test-install-script.sh` passes
- [x] `scripts/verify-fixes.sh` passes

Refs #273