### PR TITLE
feat(host): add Secure Boot status check

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -719,6 +719,12 @@ finding:
       description: "%{path} is missing or set to N, allowing unsigned kernel modules to be loaded."
       why: "Without module signing enforcement, a compromised root account or attacker with physical access can load malicious kernel modules that bypass user-space security controls."
       fix: "Enable CONFIG_MODULE_SIG_FORCE in your kernel config and ensure the kernel command line includes 'module.sig_enforce=1'. On most distributions this requires rebuilding or installing a signed kernel package."
+    secure_boot_disabled:
+      title: "UEFI Secure Boot is disabled"
+      description: "%{path} indicates Secure Boot is not enabled."
+      why: "Secure Boot prevents unauthorized bootloaders and kernel images from loading. Without it, an attacker with physical access or a compromised bootloader can inject malicious code before the OS starts."
+      fix: "Enable Secure Boot in your system's UEFI firmware settings. Ensure your OS bootloader and kernel are signed with a trusted key."
+>>>>>>> a71fabf (feat(host): add Secure Boot status check)
     grub_password_missing:
       title: "GRUB bootloader lacks password protection"
       description: "%{path} does not contain a GRUB password or unrestricted restriction."

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -719,6 +719,12 @@ finding:
       description: "%{path}가 없거나 N으로 설정되어 서명되지 않은 커널 모듈을 로드할 수 있습니다."
       why: "모듈 서명 강제 없이는 침해당한 root 계정이나 물리적 접근 권한을 가진 공격자가 사용자 공간 보안 제어를 우회하는 악성 커널 모듈을 로드할 수 있습니다."
       fix: "커널 설정에서 CONFIG_MODULE_SIG_FORCE를 활성화하고 커널 커맨드 라인에 'module.sig_enforce=1'을 포함하세요. 대부분의 배포판에서는 커널을 재빌드하거나 서명된 커널 패키지를 설치해야 합니다."
+    secure_boot_disabled:
+      title: "UEFI Secure Boot가 비활성화되어 있습니다"
+      description: "%{path}에서 Secure Boot가 활성화되지 않았음을 나타냅니다."
+      why: "Secure Boot는 신뢰할 수 없는 부트로더와 커널 이미지의 로드를 방지합니다. 이 기능이 없으면 물리적 접근 권한이 있거나 부트로더가 침해당한 공격자가 OS 시작 전에 악성 코드를 주입할 수 있습니다."
+      fix: "시스템의 UEFI 펌웨어 설정에서 Secure Boot를 활성화하세요. OS 부트로더와 커널이 신뢰할 수 있는 키로 서명되어 있는지 확인하세요."
+>>>>>>> a71fabf (feat(host): add Secure Boot status check)
     grub_password_missing:
       title: "GRUB 부트로더에 암호 보호가 없습니다"
       description: "%{path}에 GRUB 암호나 unrestricted 제한이 없습니다."

--- a/src/src/host/mod.rs
+++ b/src/src/host/mod.rs
@@ -103,6 +103,7 @@ impl HostScanner {
         findings.extend(scan_firewall_hardening(context));
         findings.extend(scan_package_update_hardening(context));
         findings.extend(scan_kernel_hardening(context));
+        findings.extend(scan_secure_boot(context));
         findings.extend(scan_user_namespace_settings(context));
         findings.extend(scan_mount_flags(context));
         findings.extend(scan_proc_hidepid(context));
@@ -1269,6 +1270,54 @@ fn scan_kernel_hardening(context: &HostContext) -> Vec<Finding> {
                     String::from("disabled")
                 },
             )]),
+        ));
+    }
+
+    findings
+}
+
+fn scan_secure_boot(context: &HostContext) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    let efi_vars_path = context.root.join("sys/firmware/efi/efivars");
+    if !efi_vars_path.exists() {
+        return findings;
+    }
+
+    let secure_boot_path = resolve_existing_path(&context.root, "sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c");
+
+    if secure_boot_path.is_none() {
+        return findings;
+    }
+
+    let secure_boot_path = secure_boot_path.unwrap();
+    let Ok(data) = fs::read(&secure_boot_path) else {
+        return findings;
+    };
+
+    // EFI variable format: 4 bytes attributes + 1 byte value
+    if data.len() < 5 {
+        return findings;
+    }
+
+    let secure_boot_enabled = data[4] == 1;
+
+    if !secure_boot_enabled {
+        findings.push(host_finding(
+            "host.secure_boot_disabled",
+            Severity::Low,
+            &secure_boot_path,
+            HostFindingText {
+                title: t!("finding.host.secure_boot_disabled.title").into_owned(),
+                description: t!(
+                    "finding.host.secure_boot_disabled.description",
+                    path = secure_boot_path.display().to_string()
+                )
+                .into_owned(),
+                why_risky: t!("finding.host.secure_boot_disabled.why").into_owned(),
+                how_to_fix: t!("finding.host.secure_boot_disabled.fix").into_owned(),
+            },
+            BTreeMap::from([(String::from("path"), secure_boot_path.display().to_string())]),
         ));
     }
 
@@ -2857,6 +2906,50 @@ mod tests {
         let findings = HostScanner.scan(&HostContext { root: root.clone() });
 
         assert!(findings.is_empty());
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn host_scanner_detects_secure_boot_disabled() {
+        let root = temp_host_root("secure-boot-disabled");
+        let sb_path = root.join("sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c");
+        fs::create_dir_all(sb_path.parent().unwrap()).expect("parent should be created");
+        fs::write(&sb_path, [0x00, 0x00, 0x00, 0x00, 0x00]).expect("file should be written");
+        write_file(&root.join("etc/hostname"), "sb-test\n");
+        write_file(&root.join("proc/uptime"), "60.00 0.00\n");
+        write_file(&root.join("proc/loadavg"), "0.10 0.20 0.30 1/100 123\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert_eq!(
+            findings.iter().map(|f| f.id.as_str()).collect::<Vec<_>>(),
+            vec![
+                "host.secure_boot_disabled",
+                "host.mac_framework_missing",
+                "host.defensive_controls_missing",
+            ]
+        );
+
+        fs::remove_dir_all(root).expect("temp root should be removed");
+    }
+
+    #[test]
+    fn host_scanner_skips_secure_boot_when_enabled() {
+        let root = temp_host_root("secure-boot-enabled");
+        let sb_path = root.join("sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c");
+        fs::create_dir_all(sb_path.parent().unwrap()).expect("parent should be created");
+        fs::write(&sb_path, [0x00, 0x00, 0x00, 0x00, 0x01]).expect("file should be written");
+        write_file(&root.join("etc/hostname"), "sb-test\n");
+        write_file(&root.join("proc/uptime"), "60.00 0.00\n");
+        write_file(&root.join("proc/loadavg"), "0.10 0.20 0.30 1/100 123\n");
+
+        let findings = HostScanner.scan(&HostContext { root: root.clone() });
+
+        assert_eq!(
+            findings.iter().map(|f| f.id.as_str()).collect::<Vec<_>>(),
+            vec!["host.mac_framework_missing", "host.defensive_controls_missing"]
+        );
 
         fs::remove_dir_all(root).expect("temp root should be removed");
     }


### PR DESCRIPTION
## Summary
Add native check for UEFI Secure Boot status by reading the EFI variable at `/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c`.

## Changes
- `scan_secure_boot` parses the binary EFI variable format (4 bytes attributes + 1 byte value)
- Flags when Secure Boot is disabled (**Low** severity)
- Skips gracefully on non-EFI systems (missing `efivars` directory)
- Dedicated tests for disabled and enabled states
- English and Korean i18n strings

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace` passes (364 tests)
- [x] `scripts/smoke-test.sh` passes
- [x] `scripts/test-install-script.sh` passes
- [x] `scripts/verify-fixes.sh` passes

Refs #274