### PR TITLE
fix(settings): handle missing config and persist failures

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -133,10 +133,12 @@ app:
     theme: "Theme"
     layout: "Layout"
     locale: "Locale"
+    findings_view: "Findings view"
     category_appearance: "Appearance"
     category_behavior: "Behavior"
     category_localization: "Localization"
     hint: "Up/Down choose, Left/Right change, Enter/Esc/q close"
+    persist_failed: "Failed to save %{setting} settings."
   panel:
     status: "Status"
     hints: "Hints"

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -133,10 +133,12 @@ app:
     theme: "테마"
     layout: "레이아웃"
     locale: "언어"
+    findings_view: "Findings 화면"
     category_appearance: "표시"
     category_behavior: "동작"
     category_localization: "언어"
     hint: "Up/Down 선택, Left/Right 변경, Enter/Esc/q 닫기"
+    persist_failed: "%{setting} 설정을 저장하지 못했습니다."
   panel:
     status: "상태"
     hints: "힌트"

--- a/src/src/settings.rs
+++ b/src/src/settings.rs
@@ -23,25 +23,7 @@ pub struct AppSettings {
 }
 
 pub fn load() -> AppSettings {
-    match config_file_path() {
-        Ok(path) => match load_from_path(&path) {
-            Ok(settings) => settings,
-            Err(error) => {
-                #[cfg(debug_assertions)]
-                eprintln!(
-                    "hostveil: failed to load settings from {}: {}",
-                    path.display(),
-                    error
-                );
-                AppSettings::default()
-            }
-        },
-        Err(error) => {
-            #[cfg(debug_assertions)]
-            eprintln!("hostveil: failed to resolve config directory: {}", error);
-            AppSettings::default()
-        }
-    }
+    load_with_path_result(config_file_path())
 }
 
 pub fn persist_locale(locale: &str) -> io::Result<()> {
@@ -88,6 +70,29 @@ fn load_from_path(path: &Path) -> io::Result<AppSettings> {
     serde_json::from_str(&text).map_err(|error| io::Error::other(error.to_string()))
 }
 
+fn load_with_path_result(path_result: io::Result<PathBuf>) -> AppSettings {
+    match path_result {
+        Ok(path) => match load_from_path(&path) {
+            Ok(settings) => settings,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => AppSettings::default(),
+            Err(error) => {
+                #[cfg(debug_assertions)]
+                eprintln!(
+                    "hostveil: failed to load settings from {}: {}",
+                    path.display(),
+                    error
+                );
+                AppSettings::default()
+            }
+        },
+        Err(error) => {
+            #[cfg(debug_assertions)]
+            eprintln!("hostveil: failed to resolve config directory: {}", error);
+            AppSettings::default()
+        }
+    }
+}
+
 fn save_to_path(path: &Path, settings: &AppSettings) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -132,10 +137,16 @@ pub fn resolve_config_dir(
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::io;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{AppSettings, load_from_path, resolve_config_dir, save_to_path};
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::{
+        AppSettings, load_from_path, load_with_path_result, resolve_config_dir, save_to_path,
+    };
 
     fn temp_settings_path(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -244,5 +255,67 @@ mod tests {
         if let Some(parent) = path.parent() {
             let _ = fs::remove_dir_all(parent);
         }
+    }
+
+    #[test]
+    fn load_returns_default_for_missing_file_without_error() {
+        let path = temp_settings_path("load-missing-default");
+
+        let loaded = load_with_path_result(Ok(path));
+        assert_eq!(loaded, AppSettings::default());
+    }
+
+    #[test]
+    fn load_returns_default_for_malformed_json() {
+        let path = temp_settings_path("load-malformed-default");
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("parent dir should be created");
+        }
+        fs::write(&path, "not json at all").expect("write should succeed");
+
+        let loaded = load_with_path_result(Ok(path.clone()));
+        assert_eq!(loaded, AppSettings::default());
+
+        fs::remove_dir_all(path.parent().expect("config dir should exist"))
+            .expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn load_returns_default_for_path_resolution_failure() {
+        let loaded = load_with_path_result(Err(io::Error::other("boom")));
+        assert_eq!(loaded, AppSettings::default());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_to_path_returns_error_for_unwritable_dir() {
+        let root = std::env::temp_dir().join(format!(
+            "hostveil-settings-unwritable-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time should move forward")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("temp dir should be created");
+        let path = root.join("config.json");
+        let settings = AppSettings {
+            locale: Some(String::from("en")),
+            ..Default::default()
+        };
+
+        let original_permissions = fs::metadata(&root)
+            .expect("dir metadata should exist")
+            .permissions();
+        let mut read_only_permissions = original_permissions.clone();
+        read_only_permissions.set_mode(0o555);
+        fs::set_permissions(&root, read_only_permissions).expect("dir should become read-only");
+
+        let result = save_to_path(&path, &settings);
+
+        fs::set_permissions(&root, original_permissions).expect("dir permissions should restore");
+        fs::remove_dir_all(&root).expect("temp dir should be removed");
+
+        assert!(result.is_err(), "save should fail for unwritable dir");
     }
 }

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::io;
+use std::io::{self, ErrorKind};
 use std::path::Path;
 use std::time::Duration;
 
@@ -204,10 +204,27 @@ struct AppState {
 }
 
 impl AppState {
+    fn handle_persist_error(&mut self, setting_label: String, error: io::Error) {
+        if error.kind() == ErrorKind::NotFound {
+            return;
+        }
+
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "hostveil: failed to persist {} settings: {}",
+            setting_label, error
+        );
+        self.set_status_message(
+            t!("app.settings.persist_failed", setting = setting_label).into_owned(),
+        );
+    }
+
     fn cycle_theme(&mut self) {
         self.theme_preset = self.theme_preset.next();
         self.theme = Theme::preset(self.theme_preset);
-        persist_theme_choice(self.theme_preset.as_key());
+        if let Err(error) = persist_theme_choice(self.theme_preset.as_key()) {
+            self.handle_persist_error(t!("app.settings.theme").into_owned(), error);
+        }
     }
 
     fn new(scan_result: &ScanResult) -> Self {
@@ -305,12 +322,16 @@ impl AppState {
 
     fn cycle_layout(&mut self) {
         self.layout_preset = self.layout_preset.next();
-        persist_layout_choice(self.layout_preset.as_key());
+        if let Err(error) = persist_layout_choice(self.layout_preset.as_key()) {
+            self.handle_persist_error(t!("app.settings.layout").into_owned(), error);
+        }
     }
 
     fn cycle_layout_backward(&mut self) {
         self.layout_preset = self.layout_preset.previous();
-        persist_layout_choice(self.layout_preset.as_key());
+        if let Err(error) = persist_layout_choice(self.layout_preset.as_key()) {
+            self.handle_persist_error(t!("app.settings.layout").into_owned(), error);
+        }
     }
 
     fn open_settings(&mut self) {
@@ -339,7 +360,9 @@ impl AppState {
             SettingsRow::Theme => self.cycle_theme(),
             SettingsRow::Layout => self.cycle_layout(),
             SettingsRow::Locale => {
-                let _ = i18n::cycle_persisted_locale();
+                if let Err(error) = i18n::cycle_persisted_locale() {
+                    self.handle_persist_error(t!("app.settings.locale").into_owned(), error);
+                }
             }
         }
     }
@@ -353,7 +376,9 @@ impl AppState {
             }
             SettingsRow::Layout => self.cycle_layout_backward(),
             SettingsRow::Locale => {
-                let _ = i18n::cycle_persisted_locale_backward();
+                if let Err(error) = i18n::cycle_persisted_locale_backward() {
+                    self.handle_persist_error(t!("app.settings.locale").into_owned(), error);
+                }
             }
         }
     }
@@ -603,9 +628,9 @@ impl AppState {
         }
     }
 
-    fn persist_findings_view(&self) {
+    fn persist_findings_view(&mut self) {
         #[cfg(not(test))]
-        let _ = settings::persist_findings_view(
+        if let Err(error) = settings::persist_findings_view(
             self.severity_filter.map(|s| s.as_key()),
             self.source_filter.map(|s| s.as_key()),
             self.service_filter.as_deref(),
@@ -621,22 +646,30 @@ impl AppState {
                 FindingSortMode::Source => "source",
                 FindingSortMode::Subject => "subject",
             }),
-        );
+        ) {
+            self.handle_persist_error(t!("app.settings.findings_view").into_owned(), error);
+        }
     }
 }
 
-fn persist_theme_choice(theme: &str) {
+fn persist_theme_choice(theme: &str) -> io::Result<()> {
     #[cfg(not(test))]
-    let _ = settings::persist_theme(theme);
+    return settings::persist_theme(theme);
     #[cfg(test)]
-    let _ = theme;
+    {
+        let _ = theme;
+        Ok(())
+    }
 }
 
-fn persist_layout_choice(layout: &str) {
+fn persist_layout_choice(layout: &str) -> io::Result<()> {
     #[cfg(not(test))]
-    let _ = settings::persist_layout(layout);
+    return settings::persist_layout(layout);
     #[cfg(test)]
-    let _ = layout;
+    {
+        let _ = layout;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5433,5 +5466,34 @@ Verify with 'sysctl kernel.unprivileged_userns_clone'.",
                 .fg
                 .expect("muted style should define a foreground color")
         );
+    }
+
+    #[test]
+    fn persist_error_sets_status_message() {
+        let result = sample_result();
+        let mut state = AppState::new(&result);
+
+        state.handle_persist_error(
+            String::from("Theme"),
+            io::Error::new(io::ErrorKind::PermissionDenied, "nope"),
+        );
+
+        assert_eq!(
+            state.status_message,
+            Some(t!("app.settings.persist_failed", setting = "Theme").into_owned())
+        );
+    }
+
+    #[test]
+    fn persist_not_found_error_is_ignored() {
+        let result = sample_result();
+        let mut state = AppState::new(&result);
+
+        state.handle_persist_error(
+            String::from("Theme"),
+            io::Error::new(io::ErrorKind::NotFound, "missing"),
+        );
+
+        assert_eq!(state.status_message, None);
     }
 }


### PR DESCRIPTION
## Summary
- treat a missing `config.json` as a normal first-run case and return default settings without noisy debug stderr
- keep malformed settings and real config path failures debuggable while routing `load()` back to defaults
- surface theme/layout/locale/findings-view persistence failures through a shared TUI status-message path instead of silently discarding errors
- add regression tests for missing, malformed, failed-path, and unwritable settings scenarios

## Validation
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo build --workspace
- ./scripts/smoke-test.sh target/debug/hostveil
- ./scripts/test-install-script.sh target/debug/hostveil
- verified `target/debug/hostveil --version` and `cargo run -- --version` no longer emit missing-config noise

Closes #301