### PR TITLE
chore(release): bump version to v0.20.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "chrono",
  "crossterm 0.29.0",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary
- bump the crate and binary version from `0.20.0` to `0.20.1`
- keep `src/Cargo.toml` and `Cargo.lock` aligned for the next patch release
- validate the release path against `target/release/hostveil`

## Validation
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo build --release --workspace
- ./scripts/smoke-test.sh target/release/hostveil
- ./scripts/test-install-script.sh target/release/hostveil

## Notes
- `cargo build --release --workspace` still emits two existing `unused variable` warnings in `src/src/settings.rs` under non-debug builds, but the release build and all required validation complete successfully.
- Tagging `v0.20.1` should happen after this PR merges so the release workflow runs from the merged `main` commit.

Closes #303