### PR TITLE
chore(release): bump version to v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "crossterm 0.29.0",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.20.1"
+version = "0.21.0"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary
- bump the crate and lockfile version to `0.21.0`
- prepare the first official package-asset release after `#310`

## Why
`#310` adds first-class `.deb` and `.rpm` GitHub Release assets, which is a meaningful user-visible distribution expansion. Per the release policy in `CONTRIBUTING.md`, this is a minor release rather than a patch release.

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo build --release --workspace`
- `./scripts/smoke-test.sh target/release/hostveil`
- `./scripts/test-install-script.sh target/release/hostveil`

Closes #311