### PR TITLE
fix(release): normalize package output paths

### DIFF
--- a/scripts/build-release-packages.sh
+++ b/scripts/build-release-packages.sh
@@ -52,6 +52,19 @@ require_tool() {
   }
 }
 
+resolve_output_dir() {
+  local output_dir="$1"
+
+  case "$output_dir" in
+    /*)
+      printf '%s\n' "$output_dir"
+      ;;
+    *)
+      printf '%s\n' "$ROOT_DIR/$output_dir"
+      ;;
+  esac
+}
+
 version_from_cargo() {
   sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRATE_DIR/Cargo.toml" | head -n 1
 }
@@ -73,6 +86,7 @@ stage_built_binary() {
 TARGET_TRIPLE="${TARGET_TRIPLE:-$(detect_default_target)}"
 require_arg "target triple" "$TARGET_TRIPLE"
 require_tool cargo
+OUTPUT_DIR="$(resolve_output_dir "$OUTPUT_DIR")"
 
 VERSION="$(version_from_cargo)"
 require_arg "Cargo version" "$VERSION"


### PR DESCRIPTION
## Summary
- resolve relative package output paths against the repository root in `build-release-packages.sh`
- keep tag-workflow tarballs and package assets in the same `dist/` directory so checksum/release jobs can see them

## Why
The first `v0.21.0` tag run failed in `generate checksums` because the helper wrote `dist` outputs under `src/dist` instead of repository-root `dist/`.

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo build --release --workspace --target x86_64-unknown-linux-gnu`
- `./scripts/build-release-packages.sh x86_64-unknown-linux-gnu dist`
- verified package assets land in repo-root `dist/` and not `src/dist`

Closes #314