### PR TITLE
fix(release): build rpm packages on rocky baseline

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -55,13 +55,19 @@ jobs:
         run: ./scripts/test-install-script.sh target/debug/hostveil
 
       - name: Install package build tools
-        run: cargo install cargo-deb cargo-generate-rpm
+        run: cargo install cargo-deb
 
       - name: Build release binary for package validation
         run: cargo build --release --workspace --target x86_64-unknown-linux-gnu
 
-      - name: Build release packages
-        run: ./scripts/build-release-packages.sh x86_64-unknown-linux-gnu
+      - name: Build Debian package smoke
+        run: ./scripts/build-release-packages.sh x86_64-unknown-linux-gnu target/package-assets deb
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Rocky baseline RPM smoke
+        run: ./scripts/build-rpm-release.sh x86_64 target/package-assets
 
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Run installer tests
         run: ./scripts/test-install-script.sh target/release/hostveil
 
-  build:
-    name: build ${{ matrix.target }}
+  build-deb-and-tarballs:
+    name: build tarball/deb ${{ matrix.target }}
     needs: validate
     runs-on: ubuntu-latest
     strategy:
@@ -103,7 +103,7 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
 
       - name: Install package build tools
-        run: cargo install cargo-deb cargo-generate-rpm
+        run: cargo install cargo-deb
 
       - name: Package release archive
         run: |
@@ -112,22 +112,52 @@ jobs:
           cp README.md LICENSE dist/package/
           tar -C dist/package -czf dist/hostveil-${{ github.ref_name }}-${{ matrix.target }}.tar.gz hostveil README.md LICENSE
 
-      - name: Build release packages
-        run: |
-          ./scripts/build-release-packages.sh "${{ matrix.target }}" dist
+      - name: Build Debian release packages
+        run: ./scripts/build-release-packages.sh "${{ matrix.target }}" dist deb
 
       - name: Upload packaged archive
         uses: actions/upload-artifact@v7
         with:
-          name: hostveil-${{ matrix.target }}
+          name: hostveil-deb-${{ matrix.target }}
           path: |
             dist/hostveil-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
             dist/*.deb
-            dist/*.rpm
+
+  build-rpm:
+    name: build rpm ${{ matrix.arch }}
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+          - arch: aarch64
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Rocky baseline RPM packages
+        run: ./scripts/build-rpm-release.sh "${{ matrix.arch }}" dist
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: hostveil-rpm-${{ matrix.arch }}
+          path: dist/*.rpm
 
   checksums:
     name: generate checksums
-    needs: build
+    needs:
+      - build-deb-and-tarballs
+      - build-rpm
     runs-on: ubuntu-latest
 
     steps:
@@ -182,10 +212,12 @@ jobs:
             sudo apt install ./hostveil_<version>_amd64.deb
             ```
 
-            Fedora-family users can install the release `.rpm` asset with:
+            Fedora-family and Rocky/RHEL 9-class users can install the release `.rpm` asset with:
             ```sh
             sudo dnf install ./hostveil-<version>-1.x86_64.rpm
             ```
+
+            RPM packages are built on a Rocky Linux 9 compatible baseline.
 
             Optional dependency setup after install:
             ```sh

--- a/README.ko.md
+++ b/README.ko.md
@@ -32,14 +32,14 @@ curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/instal
 
 터미널이 가능하면 설치 직후 `hostveil setup`으로 넘어가 Lynis, Trivy, Dockle, Fail2Ban 같은 추천 도구를 바로 설치하고 기본 설정까지 진행할 수 있습니다.
 
-Debian/Fedora 계열 사용자는 패키지 자산으로도 설치할 수 있습니다:
+Debian 계열 사용자와 Fedora 또는 Rocky/RHEL 9 계열 사용자는 패키지 자산으로도 설치할 수 있습니다:
 
 ```sh
 sudo apt install ./hostveil_<version>_amd64.deb
 sudo dnf install ./hostveil-<version>-1.x86_64.rpm
 ```
 
-패키지 설치는 hostveil의 실행 시 자동 업데이트 흐름 대신 시스템 패키지 관리자를 사용해 업그레이드와 제거를 처리합니다.
+RPM 패키지는 Rocky Linux 9 호환 기준선에서 빌드됩니다. 패키지 설치는 hostveil의 실행 시 자동 업데이트 흐름 대신 시스템 패키지 관리자를 사용해 업그레이드와 제거를 처리합니다.
 
 나중에 다시 setup을 실행하려면:
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ The installer selects the correct architecture (`x86_64` or `aarch64`) and insta
 
 If a terminal is available, the installer can hand off to `hostveil setup` so you can install recommended optional tools such as Lynis, Trivy, Dockle, and Fail2Ban right away.
 
-Package installs are also available for Debian/Fedora-family users:
+Package installs are also available for Debian users and for Fedora-family or Rocky/RHEL 9-class users:
 
 ```sh
 sudo apt install ./hostveil_<version>_amd64.deb
 sudo dnf install ./hostveil-<version>-1.x86_64.rpm
 ```
 
-Package installs use your system package manager for upgrades and removal instead of hostveil's launch-time auto-upgrade flow.
+RPM packages are built on a Rocky Linux 9 compatible baseline. Package installs use your system package manager for upgrades and removal instead of hostveil's launch-time auto-upgrade flow.
 
 Run the setup flow again later:
 

--- a/docker/release/rpm-builder.Dockerfile
+++ b/docker/release/rpm-builder.Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+
+FROM rockylinux:9
+
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN dnf install -y \
+      bash \
+      ca-certificates \
+      curl-minimal \
+      findutils \
+      gcc \
+      gcc-c++ \
+      git \
+      gzip \
+      make \
+      pkgconf-pkg-config \
+      tar \
+      which \
+    && dnf clean all
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal \
+    && cargo install --locked cargo-generate-rpm \
+    && rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu \
+    && chmod -R a+rwX /usr/local/cargo /usr/local/rustup
+
+WORKDIR /workspace

--- a/scripts/build-release-packages.sh
+++ b/scripts/build-release-packages.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CRATE_DIR="$ROOT_DIR/src"
 TARGET_TRIPLE="${1:-}"
 OUTPUT_DIR="${2:-$ROOT_DIR/target/package-assets}"
+PACKAGE_SET="${3:-all}"
 
 require_arg() {
   local name="$1"
@@ -65,14 +66,34 @@ resolve_output_dir() {
   esac
 }
 
+validate_package_set() {
+  case "$1" in
+    all|deb|rpm) ;;
+    *)
+      printf 'error: unsupported package set: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+}
+
 version_from_cargo() {
   sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRATE_DIR/Cargo.toml" | head -n 1
 }
 
 stage_built_binary() {
   local target_triple="$1"
+  local target_root="${CARGO_TARGET_DIR:-$ROOT_DIR/target}"
   local root_binary="$ROOT_DIR/target/$target_triple/release/hostveil"
   local crate_binary="$CRATE_DIR/target/$target_triple/release/hostveil"
+
+  if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+    root_binary="$target_root/$target_triple/release/hostveil"
+    [[ -x "$root_binary" ]] || {
+      printf 'error: release binary is missing for %s: %s\n' "$target_triple" "$root_binary" >&2
+      exit 1
+    }
+    return
+  fi
 
   [[ -x "$root_binary" ]] || {
     printf 'error: release binary is missing for %s: %s\n' "$target_triple" "$root_binary" >&2
@@ -87,6 +108,7 @@ TARGET_TRIPLE="${TARGET_TRIPLE:-$(detect_default_target)}"
 require_arg "target triple" "$TARGET_TRIPLE"
 require_tool cargo
 OUTPUT_DIR="$(resolve_output_dir "$OUTPUT_DIR")"
+validate_package_set "$PACKAGE_SET"
 
 VERSION="$(version_from_cargo)"
 require_arg "Cargo version" "$VERSION"
@@ -96,8 +118,13 @@ mkdir -p "$OUTPUT_DIR"
 stage_built_binary "$TARGET_TRIPLE"
 
 pushd "$CRATE_DIR" >/dev/null
-cargo deb --no-build --target "$TARGET_TRIPLE" --output "$OUTPUT_DIR/hostveil_${VERSION}_${DEB_ARCH}.deb"
-cargo generate-rpm --target "$TARGET_TRIPLE" -o "$OUTPUT_DIR/hostveil-${VERSION}-1.${RPM_ARCH}.rpm"
+if [[ "$PACKAGE_SET" == "all" || "$PACKAGE_SET" == "deb" ]]; then
+  cargo deb --no-build --target "$TARGET_TRIPLE" --output "$OUTPUT_DIR/hostveil_${VERSION}_${DEB_ARCH}.deb"
+fi
+
+if [[ "$PACKAGE_SET" == "all" || "$PACKAGE_SET" == "rpm" ]]; then
+  cargo generate-rpm --target "$TARGET_TRIPLE" -o "$OUTPUT_DIR/hostveil-${VERSION}-1.${RPM_ARCH}.rpm"
+fi
 popd >/dev/null
 
 printf 'Built package assets in %s\n' "$OUTPUT_DIR"

--- a/scripts/build-rpm-release.sh
+++ b/scripts/build-rpm-release.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_ARCH="${1:-}"
+OUTPUT_DIR="${2:-$ROOT_DIR/target/package-assets}"
+IMAGE_TAG_BASE="${HOSTVEIL_RPM_BUILDER_IMAGE:-hostveil-rpm-builder}"
+
+require_arg() {
+  local name="$1"
+  local value="${2:-}"
+  [[ -n "$value" ]] || {
+    printf 'error: missing %s\n' "$name" >&2
+    exit 1
+  }
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'error: required tool is not installed: %s\n' "$1" >&2
+    exit 1
+  }
+}
+
+detect_default_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)
+      printf '%s\n' "x86_64"
+      ;;
+    aarch64|arm64)
+      printf '%s\n' "aarch64"
+      ;;
+    *)
+      printf 'error: unsupported architecture: %s\n' "$(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+resolve_output_dir() {
+  local output_dir="$1"
+
+  case "$output_dir" in
+    /*)
+      printf '%s\n' "$output_dir"
+      ;;
+    *)
+      printf '%s\n' "$ROOT_DIR/$output_dir"
+      ;;
+  esac
+}
+
+rpm_target_config() {
+  case "$1" in
+    x86_64|amd64)
+      printf '%s %s %s\n' "x86_64-unknown-linux-gnu" "linux/amd64" "x86_64"
+      ;;
+    aarch64|arm64)
+      printf '%s %s %s\n' "aarch64-unknown-linux-gnu" "linux/arm64" "aarch64"
+      ;;
+    *)
+      printf 'error: unsupported RPM release architecture: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+relative_to_root() {
+  local absolute="$1"
+
+  case "$absolute" in
+    "$ROOT_DIR")
+      printf '.\n'
+      ;;
+    "$ROOT_DIR"/*)
+      printf '%s\n' "${absolute#"$ROOT_DIR"/}"
+      ;;
+    *)
+      printf 'error: output directory must be inside repository root: %s\n' "$absolute" >&2
+      exit 1
+      ;;
+  esac
+}
+
+TARGET_ARCH="${TARGET_ARCH:-$(detect_default_arch)}"
+OUTPUT_DIR="$(resolve_output_dir "$OUTPUT_DIR")"
+require_arg "target architecture" "$TARGET_ARCH"
+require_tool docker
+
+read -r TARGET_TRIPLE DOCKER_PLATFORM RPM_ARCH < <(rpm_target_config "$TARGET_ARCH")
+OUTPUT_DIR_REL="$(relative_to_root "$OUTPUT_DIR")"
+IMAGE_TAG="${IMAGE_TAG_BASE}:${RPM_ARCH}"
+RPM_TARGET_DIR_REL="target/rocky-rpm/${RPM_ARCH}"
+
+mkdir -p "$OUTPUT_DIR"
+
+docker buildx build \
+  --load \
+  --platform "$DOCKER_PLATFORM" \
+  -t "$IMAGE_TAG" \
+  -f "$ROOT_DIR/docker/release/rpm-builder.Dockerfile" \
+  "$ROOT_DIR"
+
+docker run --rm \
+  --platform "$DOCKER_PLATFORM" \
+  --user "$(id -u):$(id -g)" \
+  -e HOME=/tmp \
+  -e CARGO_TARGET_DIR="/workspace/${RPM_TARGET_DIR_REL}" \
+  -v "$ROOT_DIR:/workspace" \
+  -w /workspace \
+  "$IMAGE_TAG" \
+  bash -lc "rm -rf \"/workspace/${RPM_TARGET_DIR_REL}\" && cargo build --release --workspace --target \"$TARGET_TRIPLE\" && ./scripts/build-release-packages.sh \"$TARGET_TRIPLE\" \"$OUTPUT_DIR_REL\" rpm"
+
+printf 'Built Rocky 9-compatible RPM assets in %s\n' "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- build RPM release artifacts inside a Rocky Linux 9 container instead of the Ubuntu packaging lane
- add a dedicated `scripts/build-rpm-release.sh` helper and PR CI smoke coverage for Rocky-baseline RPM generation
- update package-install docs to clarify Rocky/RHEL 9-class RPM support

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `./scripts/smoke-test.sh target/debug/hostveil`
- `./scripts/test-install-script.sh target/debug/hostveil`
- `./scripts/build-release-packages.sh x86_64-unknown-linux-gnu target/package-assets deb`
- `./scripts/build-rpm-release.sh x86_64 target/package-assets`
- `bash scripts/lab.sh host up ubuntu-lab fedora-lab rocky-lab`
- Ubuntu lab: install generated `.deb`, `hostveil --version`, JSON scan path, `hostveil uninstall`
- Fedora lab: install generated `.rpm`, `hostveil --version`, JSON scan path, `hostveil auto-upgrade disable`
- Rocky lab: install generated `.rpm`, `hostveil --version`, JSON scan path, `hostveil auto-upgrade disable`

Closes #312