### PR TITLE
chore(release): bump version to v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "chrono",
  "crossterm 0.29.0",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary
- bump the crate and binary version from `0.21.0` to `0.21.1`
- keep the release scoped to the merged Rocky/RHEL 9 RPM baseline fix

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo build --release --workspace`
- `./scripts/smoke-test.sh target/release/hostveil`
- `./scripts/test-install-script.sh target/release/hostveil`

Closes #317