### PR TITLE
fix(release): move arm64 RPM builds to native runners

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -63,9 +63,6 @@ jobs:
       - name: Build Debian package smoke
         run: ./scripts/build-release-packages.sh x86_64-unknown-linux-gnu target/package-assets deb
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build Rocky baseline RPM smoke
         run: ./scripts/build-rpm-release.sh x86_64 target/package-assets
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -123,41 +123,48 @@ jobs:
             dist/hostveil-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
             dist/*.deb
 
-  build-rpm:
-    name: build rpm ${{ matrix.arch }}
+  build-rpm-x86_64:
+    name: build rpm x86_64
     needs: validate
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-          - arch: aarch64
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build Rocky baseline RPM packages
-        run: ./scripts/build-rpm-release.sh "${{ matrix.arch }}" dist
+        run: ./scripts/build-rpm-release.sh x86_64 dist
 
       - name: Upload RPM artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: hostveil-rpm-${{ matrix.arch }}
+          name: hostveil-rpm-x86_64
+          path: dist/*.rpm
+
+  build-rpm-aarch64:
+    name: build rpm aarch64
+    needs: validate
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Build Rocky baseline RPM packages
+        run: ./scripts/build-rpm-release.sh aarch64 dist
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: hostveil-rpm-aarch64
           path: dist/*.rpm
 
   checksums:
     name: generate checksums
     needs:
       - build-deb-and-tarballs
-      - build-rpm
+      - build-rpm-x86_64
+      - build-rpm-aarch64
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Use this matrix to understand which gates run in CI versus tag-based release val
 | ------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Push / Pull Request | `.github/workflows/rust-ci.yml`                           | `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, `cargo build --workspace`, `./scripts/smoke-test.sh target/debug/hostveil`, `./scripts/test-install-script.sh target/debug/hostveil`, `cargo-tarpaulin` coverage report (artifact)          |
 | Tag push (`vX.Y.Z`) | `.github/workflows/rust-release.yml` (validate job)       | tag-version match (`src/Cargo.toml`), `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, `cargo build --release --workspace`, `./scripts/smoke-test.sh target/release/hostveil`, `./scripts/test-install-script.sh target/release/hostveil` |
-| Tag push (`vX.Y.Z`) | `.github/workflows/rust-release.yml` (build/release jobs) | cross-target release build (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), artifact packaging, `SHA256SUMS`, GitHub Release publish                                                                                                                                                                  |
+| Tag push (`vX.Y.Z`) | `.github/workflows/rust-release.yml` (build/release jobs) | cross-target tarball / `.deb` builds (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), Rocky 9-based RPM packaging (`x86_64` on `ubuntu-latest`, `aarch64` on `ubuntu-24.04-arm`), `SHA256SUMS`, GitHub Release publish                                                                           |
 
 ### Coverage Policy
 
@@ -273,12 +273,13 @@ hostveil is in active early development. The implementation is planned in two ph
 - Non-root live host scans skip Lynis instead of invoking desktop authorization prompts
 - Initial Rust Compose remediation flow added for previewable `--quick-fix` and `--fix` operations with backup-safe writes
 - No-arg live scan now defaults to host scanning plus Docker-based Compose auto-discovery, with current-directory Compose fallback
+- GitHub Releases now publish tarballs, `.deb` packages, and Rocky 9-compatible `.rpm` packages for both `x86_64` and `aarch64`
 - Service-aware Compose checks expanded to Traefik, Portainer, Home Assistant, Pi-hole, Grafana, Caddy, GitLab, Uptime Kuma, PostgreSQL, MySQL, Redis, Duplicati, Restic, Borg, and Kopia in addition to Vaultwarden, Jellyfin, Gitea, Immich, and Nextcloud
 
 ### Deferred from Current Early-Release Scope
 
 - Additional optional adapters beyond Trivy, Lynis, and Dockle
-- Package-manager distribution such as apt, dnf, Homebrew, or AUR
+- Package-repository hosting such as apt/dnf repositories, Homebrew, or AUR
 - Stable scoring-weight guarantees across future releases
 
 ## Code of Conduct

--- a/scripts/build-rpm-release.sh
+++ b/scripts/build-rpm-release.sh
@@ -83,6 +83,7 @@ relative_to_root() {
 }
 
 TARGET_ARCH="${TARGET_ARCH:-$(detect_default_arch)}"
+HOST_ARCH="$(detect_default_arch)"
 OUTPUT_DIR="$(resolve_output_dir "$OUTPUT_DIR")"
 require_arg "target architecture" "$TARGET_ARCH"
 require_tool docker
@@ -94,21 +95,42 @@ RPM_TARGET_DIR_REL="target/rocky-rpm/${RPM_ARCH}"
 
 mkdir -p "$OUTPUT_DIR"
 
-docker buildx build \
-  --load \
-  --platform "$DOCKER_PLATFORM" \
-  -t "$IMAGE_TAG" \
-  -f "$ROOT_DIR/docker/release/rpm-builder.Dockerfile" \
-  "$ROOT_DIR"
+if [[ "$HOST_ARCH" == "$TARGET_ARCH" ]]; then
+  docker build \
+    -t "$IMAGE_TAG" \
+    -f "$ROOT_DIR/docker/release/rpm-builder.Dockerfile" \
+    "$ROOT_DIR"
 
-docker run --rm \
-  --platform "$DOCKER_PLATFORM" \
-  --user "$(id -u):$(id -g)" \
-  -e HOME=/tmp \
-  -e CARGO_TARGET_DIR="/workspace/${RPM_TARGET_DIR_REL}" \
-  -v "$ROOT_DIR:/workspace" \
-  -w /workspace \
-  "$IMAGE_TAG" \
-  bash -lc "rm -rf \"/workspace/${RPM_TARGET_DIR_REL}\" && cargo build --release --workspace --target \"$TARGET_TRIPLE\" && ./scripts/build-release-packages.sh \"$TARGET_TRIPLE\" \"$OUTPUT_DIR_REL\" rpm"
+  docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
+    -e CARGO_TARGET_DIR="/workspace/${RPM_TARGET_DIR_REL}" \
+    -v "$ROOT_DIR:/workspace" \
+    -w /workspace \
+    "$IMAGE_TAG" \
+    bash -lc "rm -rf \"/workspace/${RPM_TARGET_DIR_REL}\" && cargo build --release --workspace --target \"$TARGET_TRIPLE\" && ./scripts/build-release-packages.sh \"$TARGET_TRIPLE\" \"$OUTPUT_DIR_REL\" rpm"
+else
+  docker buildx version >/dev/null 2>&1 || {
+    printf 'error: docker buildx is required for cross-architecture RPM builds (%s host -> %s target)\n' "$HOST_ARCH" "$TARGET_ARCH" >&2
+    exit 1
+  }
+
+  docker buildx build \
+    --load \
+    --platform "$DOCKER_PLATFORM" \
+    -t "$IMAGE_TAG" \
+    -f "$ROOT_DIR/docker/release/rpm-builder.Dockerfile" \
+    "$ROOT_DIR"
+
+  docker run --rm \
+    --platform "$DOCKER_PLATFORM" \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
+    -e CARGO_TARGET_DIR="/workspace/${RPM_TARGET_DIR_REL}" \
+    -v "$ROOT_DIR:/workspace" \
+    -w /workspace \
+    "$IMAGE_TAG" \
+    bash -lc "rm -rf \"/workspace/${RPM_TARGET_DIR_REL}\" && cargo build --release --workspace --target \"$TARGET_TRIPLE\" && ./scripts/build-release-packages.sh \"$TARGET_TRIPLE\" \"$OUTPUT_DIR_REL\" rpm"
+fi
 
 printf 'Built Rocky 9-compatible RPM assets in %s\n' "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- move the release `aarch64` Rocky RPM lane from QEMU emulation on `ubuntu-latest` to a native `ubuntu-24.04-arm` runner
- keep `x86_64` RPM builds on `ubuntu-latest` while simplifying same-architecture Docker builds to use the native engine path
- update release contributor docs so the published package/release behavior matches the current repo state

## Validation
- `bash -n scripts/build-rpm-release.sh`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `./scripts/build-rpm-release.sh x86_64 target/package-assets`
- `./scripts/smoke-test.sh target/debug/hostveil`
- `./scripts/test-install-script.sh target/debug/hostveil`

Closes #319