### PR TITLE
docs(roadmap): align shipped scope before design review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,6 +254,14 @@ hostveil is in active early development. The implementation is planned in two ph
 - **Host checks are first-class** — SSH and other host-hardening signals belong in the same product, not in a separate side tool
 - **Safe remediation stays narrow in v1** — automatic writes remain limited to Compose-focused changes with clear review boundaries
 
+### Pre-Presentation Design Freeze
+
+The May 13 capstone design review is treated as an architecture freeze point.
+
+- Before the presentation, feature work is paused unless it is required to resolve a design mismatch, a release/install reliability problem, or a gap between the accepted design and the shipped implementation.
+- The pre-presentation freeze focuses on locking the unified scan result contract, the Compose-only remediation boundary, and the wrapper-install versus package-install lifecycle split.
+- Presentation-facing architecture notes should live in ADRs, milestone issues, and PR descriptions rather than in additional user-facing documents.
+
 ### Current Implementation Status
 
 - Cargo workspace initialized at the repository root


### PR DESCRIPTION
## Summary\n- lock the pre-presentation design freeze rules in CONTRIBUTING\n- keep feature work paused before the May 13 review except for design mismatch or reliability fixes\n- point presentation-facing architecture notes toward ADRs, milestone issues, and PR descriptions\n\n## Testing\n- cargo fmt --check\n- cargo clippy --workspace --all-targets --all-features -- -D warnings\n- cargo test --workspace\n\nCloses #321\nRefs #325