### PR TITLE
chore(release): bump version to v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "chrono",
  "crossterm 0.29.0",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Bump crate and binary version to **v0.23.0** to ship the Gitleaks adapter integration.

### Changes since v0.22.0

- **feat(adapters)**: add Gitleaks project secret scanning (#334)
  - Optional `gitleaks` adapter for scanning Compose project roots
  - `--adapters=gitleaks` CLI support
  - `hostveil setup` can auto-install Gitleaks on x86_64/aarch64 Linux
  - Aggregated findings with evidence masking (no raw secret exposure)

### Verification

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace` (461 passed) ✅