### PR TITLE
chore(release): bump version to v0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hostveil"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "chrono",
  "crossterm 0.29.0",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostveil"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 description = "Rust product implementation for hostveil"
 license = "GPL-3.0-only"

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -2119,9 +2119,15 @@ fn render_modal_backdrop(frame: &mut ratatui::Frame<'_>, area: Rect, _theme: &Th
     }
 }
 
-fn render_modal_frame(frame: &mut ratatui::Frame<'_>, modal: Rect, theme: &Theme) -> Rect {
+fn render_modal_frame(
+    frame: &mut ratatui::Frame<'_>,
+    modal: Rect,
+    title: &str,
+    theme: &Theme,
+) -> Rect {
     frame.render_widget(Clear, modal);
     let block = Block::default()
+        .title(format!(" {} ", title))
         .borders(panel_borders(theme))
         .border_style(theme.modal_border)
         .style(theme.modal_bg);
@@ -2149,7 +2155,7 @@ fn render_settings_modal(frame: &mut ratatui::Frame<'_>, state: &mut AppState) {
     let theme = &state.theme;
 
     render_modal_backdrop(frame, area, theme);
-    let inner = render_modal_frame(frame, modal, theme);
+    let inner = render_modal_frame(frame, modal, &t!("app.panel.settings"), theme);
 
     let layout = Layout::default()
         .direction(Direction::Vertical)
@@ -2235,7 +2241,7 @@ fn render_help_overlay(frame: &mut ratatui::Frame<'_>, state: &mut AppState) {
     let theme = &state.theme;
 
     render_modal_backdrop(frame, area, theme);
-    let inner = render_modal_frame(frame, modal, theme);
+    let inner = render_modal_frame(frame, modal, &t!("app.panel.help"), theme);
 
     let shortcuts = vec![
         (
@@ -2310,7 +2316,7 @@ fn render_search_modal(frame: &mut ratatui::Frame<'_>, state: &mut AppState) {
     let theme = &state.theme;
 
     render_modal_backdrop(frame, area, theme);
-    let inner = render_modal_frame(frame, modal, theme);
+    let inner = render_modal_frame(frame, modal, &t!("app.panel.search"), theme);
 
     let layout = Layout::default()
         .direction(Direction::Vertical)


### PR DESCRIPTION
## Summary
- Restore modal titles broken by render_modal_frame extraction (fixes TUI Visual QA)
- Bump version: 0.25.0 → 0.26.0

## Changes
- fix(tui): Add title parameter to render_modal_frame, update all 3 modals
- chore(release): version bump in Cargo.toml + Cargo.lock

Closes #354