### PR TITLE
fix(tui): disable f key on overview, scope f to selected finding, preserve selection text color, improve fix review shell display and border-aware layout

### DIFF
--- a/src/src/fix/mod.rs
+++ b/src/src/fix/mod.rs
@@ -409,8 +409,19 @@ fn build_fix_plan(
     }
 
     // Classify external adapter findings (Dockle, Lynis, NativeHost) if provided
+    // Filter to only_findings scope so that pressing 'f' on a single finding
+    // does not pull in all unrelated external findings.
+    let scoped_external: Vec<Finding> = if let Some(ids) = only_findings {
+        external_findings
+            .iter()
+            .filter(|f| ids.contains(&f.id))
+            .cloned()
+            .collect()
+    } else {
+        external_findings.to_vec()
+    };
     let (adapter_actions, adapter_auto, adapter_review) =
-        adapter::classify_adapter_findings(external_findings);
+        adapter::classify_adapter_findings(&scoped_external);
     let mut compose_actions: Vec<FixAction> = Vec::new();
     let (host_actions, system_actions): (Vec<_>, Vec<_>) =
         adapter_actions.into_iter().partition(|a| match a {

--- a/src/src/tui/fix_review.rs
+++ b/src/src/tui/fix_review.rs
@@ -425,10 +425,7 @@ fn render(
                 ]));
                 summary.push(Line::from(vec![
                     Span::raw("    "),
-                    Span::styled(
-                        format!("$ {}", command),
-                        Style::default().fg(Color::Cyan),
-                    ),
+                    Span::styled(format!("$ {}", command), Style::default().fg(Color::Cyan)),
                 ]));
             }
         }

--- a/src/src/tui/fix_review.rs
+++ b/src/src/tui/fix_review.rs
@@ -423,10 +423,12 @@ fn render(
                     Span::raw(": "),
                     Span::raw(action_summary),
                 ]));
-                let cmd_preview: String = command.chars().take(60).collect();
                 summary.push(Line::from(vec![
                     Span::raw("    "),
-                    Span::styled(cmd_preview, Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        format!("$ {}", command),
+                        Style::default().fg(Color::Cyan),
+                    ),
                 ]));
             }
         }
@@ -468,6 +470,8 @@ fn render(
 
     let summary_lines_count = summary.len();
 
+    let footer_height = if theme.borders_enabled { 5 } else { 3 };
+
     let summary_widget = Paragraph::new(Text::from(summary))
         .wrap(Wrap { trim: true })
         .style(theme.panel_bg)
@@ -484,9 +488,9 @@ fn render(
         .direction(Direction::Vertical)
         .spacing(1)
         .constraints([
-            Constraint::Length((summary_lines_count as u16 + 2).clamp(5, 15)),
+            Constraint::Length((summary_lines_count as u16 + 2).clamp(5, 20)),
             Constraint::Min(5),
-            Constraint::Length(3),
+            Constraint::Length(footer_height),
         ])
         .split(frame.area());
 

--- a/src/src/tui/mod.rs
+++ b/src/src/tui/mod.rs
@@ -1101,12 +1101,6 @@ fn handle_overview_key(
 ) -> Option<TuiAction> {
     match key.code {
         KeyCode::Char('q') | KeyCode::Esc => Some(TuiAction::Exit),
-        KeyCode::Char('f') => {
-            state.scope_filter = None;
-            state.screen = Screen::Findings;
-            state.clamp_selection(scan_result);
-            None
-        }
         KeyCode::Char('h') => {
             state.scope_filter = Some(Scope::Host);
             state.screen = Screen::Findings;
@@ -2831,18 +2825,19 @@ fn findings_list_items(
 
             let mut lines = Vec::new();
             let style = severity_style(finding.severity, theme).add_modifier(Modifier::BOLD);
+            let muted = theme.muted;
             for (i, line) in title_lines.iter().enumerate() {
                 if i == 0 {
                     lines.push(Line::styled(line.clone(), style));
                 } else {
-                    lines.push(Line::raw(format!("  {}", line)));
+                    lines.push(Line::styled(format!("  {}", line), style));
                 }
             }
 
             match mode {
                 FindingsLayoutMode::Narrow => {
                     let subtitle = format!("[{}] {}", remediation_compact, compact_subject);
-                    lines.push(Line::raw(format!("  {}", subtitle)));
+                    lines.push(Line::styled(format!("  {}", subtitle), muted));
                 }
                 FindingsLayoutMode::Stacked => {
                     let subtitle = format!(
@@ -2852,7 +2847,7 @@ fn findings_list_items(
                         remediation_badge
                     );
                     for sub_line in wrap_text_to_lines(&subtitle, inner_width) {
-                        lines.push(Line::raw(format!("  {}", sub_line)));
+                        lines.push(Line::styled(format!("  {}", sub_line), muted));
                     }
                 }
                 FindingsLayoutMode::SideBySide | FindingsLayoutMode::CompactList => {
@@ -2864,7 +2859,7 @@ fn findings_list_items(
                         remediation_badge
                     );
                     for sub_line in wrap_text_to_lines(&subtitle, inner_width) {
-                        lines.push(Line::raw(format!("  {}", sub_line)));
+                        lines.push(Line::styled(format!("  {}", sub_line), muted));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- **Disable `f` key on Overview screen**: `f` no longer navigates to Findings from Overview (use `Enter`/`l`/`h` instead). This prevents accidental fix triggers from the wrong screen.
- **Scope `f` (Fix) to the selected finding only**: `build_fix_plan` now filters `external_findings` by `only_findings`, so pressing `f` on a single NativeHost/Dockle/Lynis finding only classifies that finding's actions — not all external findings.
- **Fix selected finding text color disappearing**: All lines in `findings_list_items` now use `Line::styled` with explicit severity/muted styles instead of `Line::raw`, preventing `highlight_style` foreground from overriding the text color on selection.
- **Fix Review UI improvements**:
  - Shell commands displayed as diff-like `$ cmd` in cyan, with 60-char truncation removed
  - Footer height dynamically adapts to `borders_enabled` (5 with borders, 3 without)
  - Summary panel upper clamp raised from 15 to 20 to prevent content cutoff

## Verification
- 719 tests passing
- `cargo clippy -D warnings` clean