### PR TITLE
docs: add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,3 +432,26 @@ a way that goes unnoticed. These rules are enforced by tests in
   report uploaded as an artifact on failure.
 
 All three jobs must be green before a PR can be merged.
+
+## Cursor Cloud specific instructions
+
+Environment setup (Go 1.26, Node 22, `go mod download`, `npm ci`, and
+Playwright Chromium) is handled by the startup update script; the four
+development checks in **Development Commands** work as documented.
+
+Non-obvious caveats for this VM:
+
+- **Docker, `trivy`, and `lynis` are NOT installed** and root is not
+  available for host scanning. All three are optional runtime deps that
+  hostveil skips gracefully, so a plain `./hostveil` / `./hostveil serve`
+  scan simply produces zero real findings here. To run and demo the Web
+  UI (or TUI) with realistic data, use fixture mode:
+  `./hostveil serve --fixture test/e2e/fixtures/mock-snapshot.json --addr 127.0.0.1:8787`
+  (this is also exactly what the E2E suite runs). This is the recommended
+  way to exercise the app end-to-end in the cloud environment.
+- Do not run the live TUI (`./hostveil` with no `--no-scan`) expecting
+  results — it re-execs via `sudo` for host scanning, which is neither
+  useful nor available here.
+- Playwright browsers install to `~/.cache/ms-playwright`; only Chromium
+  is provisioned. The E2E run is long (~9 min, ~1900 specs). Remember the
+  mandatory E2E cleanup listed under **Running tests**.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the hostveil development environment for Cursor Cloud agents, and documents non-obvious caveats for future agents in `AGENTS.md`.

The only code change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified.

## Environment

- Go 1.26.3 and Node 22 are present in the VM.
- Startup update script refreshes dependencies:
  - `go mod download`
  - `( cd test/e2e && npm ci && npx playwright install chromium )`
- `docker`, `trivy`, and `lynis` are NOT installed and root is unavailable; hostveil skips these optional scanners gracefully. The Web UI / TUI are exercised via fixture mode (`--fixture test/e2e/fixtures/mock-snapshot.json`), which is also what the E2E suite uses.

## Verification

All four documented checks pass:

- `gofmt -l .` — clean
- `go build ./...` + `go vet ./...` — clean
- `go test -race ./...` — all 11 packages pass
- Playwright E2E (`npx playwright test`) — 1945 passed, 1 skipped

Ran the Web UI in fixture mode and completed a hello-world flow: loaded the dashboard (score 49/100, 14 findings), opened a finding detail panel, filtered by "cve" (14 → 3), and opened the Export modal.

[hostveil_web_ui_demo.mp4](https://cursor.com/agents/bc-a2ef9dd0-5c45-49d1-9db1-19f2fe08b426/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhostveil_web_ui_demo.mp4)

[hostveil dashboard loaded](https://cursor.com/agents/bc-a2ef9dd0-5c45-49d1-9db1-19f2fe08b426/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhostveil_dashboard.webp)
[findings filtered by cve](https://cursor.com/agents/bc-a2ef9dd0-5c45-49d1-9db1-19f2fe08b426/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhostveil_filter_cve.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2ef9dd0-5c45-49d1-9db1-19f2fe08b426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2ef9dd0-5c45-49d1-9db1-19f2fe08b426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

