### PR TITLE
fix: long-syntax compose fixes and release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.6.0] — 2026-07-04
+
 ### Added
 - **`compose.ds016`: Docker socket mount detection.** Flags any service
   that bind-mounts `/var/run/docker.sock` or `/run/docker.sock` —
@@ -143,6 +145,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
   `Snapshot()` caller — e.g. the Web UI's HTTP handlers in `hostveil
   tui-web`, which runs the TUI and Web server against one shared
   `ScanProgress`. Now goes through the mutex-protected `MarkFixed`.
+- **Compose fixes ignored long-syntax YAML and could drop mixed entries.**
+  Port restrict, volume `:ro`, and volume-remove fixes rebuilt the
+  entire `ports`/`volumes` list from short-syntax scalars only, so
+  mapping-form entries (`target:`/`published:`/`host_ip:`, `type:`/
+  `source:`/`target:`) were silently skipped or erased when a service
+  mixed short and long syntax. Fixes now edit YAML nodes in place via
+  `RestrictPortBindings`, `SetVolumeReadOnly`, and `RemoveVolumeMount`,
+  and return an error when nothing changed (per the fix-engine
+  success-must-reflect-change rule). `compose.dr003` detection now uses
+  `GetVolumeMounts` so long-syntax read-write mounts are flagged too.
 
 ### Security
 - **`GET /api/result` was vulnerable to DNS rebinding.** Unlike the
@@ -194,7 +206,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
   (`sha256sum -c scripts/install.sh.sha256`) so it can never silently
   drift again.
 
-## [2.5.2] — 2025-xx-xx
+## [2.5.2] — 2026-06-11
 
 ### Changed
 - TUI and Web UI share the same in-memory snapshot via `domain.Snapshot`.
@@ -221,7 +233,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Cross-platform installer (`scripts/install.sh`) tested against
   Ubuntu, Debian, Fedora, Arch, Alpine, and openSUSE.
 
-[Unreleased]: https://github.com/seolcu/hostveil/compare/v2.5.2...HEAD
+[Unreleased]: https://github.com/seolcu/hostveil/compare/v2.6.0...HEAD
+[2.6.0]: https://github.com/seolcu/hostveil/compare/v2.5.2...v2.6.0
 [2.5.2]: https://github.com/seolcu/hostveil/compare/v2.5.0...v2.5.2
 [2.5.0]: https://github.com/seolcu/hostveil/compare/v2.0.0...v2.5.0
 [2.0.0]: https://github.com/seolcu/hostveil/releases/tag/v2.0.0

--- a/internal/compose/ports.go
+++ b/internal/compose/ports.go
@@ -1,0 +1,98 @@
+package compose
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RestrictPortBindings rewrites exposed port entries so host-side bindings
+// use bindIP instead of 0.0.0.0 or an implicit all-interfaces bind.
+// Short-syntax scalars and long-syntax mapping entries are updated in place
+// so mixed-syntax port lists keep their original form.
+func (f *File) RestrictPortBindings(service, bindIP string) (bool, error) {
+	node := f.walkPath(service, "ports")
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return false, nil
+	}
+	changed := false
+	for _, item := range node.Content {
+		switch item.Kind {
+		case yaml.ScalarNode:
+			newV, ok := restrictPortScalar(item.Value, bindIP)
+			if ok {
+				item.Value = newV
+				changed = true
+			}
+		case yaml.MappingNode:
+			if restrictPortMapping(item, bindIP) {
+				changed = true
+			}
+		}
+	}
+	if changed {
+		f.dirty = true
+	}
+	return changed, nil
+}
+
+func restrictPortScalar(v, bindIP string) (string, bool) {
+	if v == "" {
+		return v, false
+	}
+	rest := v
+	proto := ""
+	if idx := strings.LastIndex(v, "/"); idx > 0 {
+		rest = v[:idx]
+		proto = v[idx:]
+	}
+	if !strings.Contains(rest, ":") {
+		return v, false
+	}
+	firstColon := strings.Index(rest, ":")
+	lastColon := strings.LastIndex(rest, ":")
+	if firstColon == lastColon {
+		return bindIP + ":" + rest + proto, true
+	}
+	secondColon := strings.Index(rest[firstColon+1:], ":") + firstColon + 1
+	hostPort := rest[firstColon+1 : secondColon]
+	containerPort := rest[secondColon+1:]
+	if strings.Contains(hostPort, "-") || strings.Contains(containerPort, "-") {
+		return v, false
+	}
+	hostIP := rest[:firstColon]
+	if hostIP != "0.0.0.0" && hostIP != "" {
+		return v, false
+	}
+	return bindIP + ":" + hostPort + ":" + containerPort + proto, true
+}
+
+func restrictPortMapping(item *yaml.Node, bindIP string) bool {
+	fields := mappingFields(item)
+	hostIP := fields["host_ip"]
+	published := fields["published"]
+	if published == "" {
+		return false
+	}
+	if hostIP != "" && hostIP != "0.0.0.0" {
+		return false
+	}
+	setMappingScalar(item, "host_ip", bindIP)
+	return true
+}
+
+func setMappingScalar(mapping *yaml.Node, key, value string) {
+	for i := 0; i < len(mapping.Content)-1; i += 2 {
+		if mapping.Content[i].Value == key {
+			val := mapping.Content[i+1]
+			val.Kind = yaml.ScalarNode
+			val.Tag = "!!str"
+			val.Value = value
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
+	)
+}

--- a/internal/compose/ports_test.go
+++ b/internal/compose/ports_test.go
@@ -1,0 +1,171 @@
+package compose
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRestrictPortBindings_LongSyntaxMapping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yml")
+	content := `services:
+  web:
+    image: nginx
+    ports:
+      - target: 80
+        published: 8080
+        host_ip: 0.0.0.0
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed, err := f.RestrictPortBindings("web", "127.0.0.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected port restriction to change the file")
+	}
+	if err := f.Save(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(data)
+	if !strings.Contains(out, `host_ip: 127.0.0.1`) && !strings.Contains(out, `host_ip: "127.0.0.1"`) {
+		t.Errorf("expected host_ip set to 127.0.0.1\n%s", out)
+	}
+}
+
+func TestRestrictPortBindings_MixedSyntaxPreservesLongForm(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yml")
+	content := `services:
+  web:
+    image: nginx
+    ports:
+      - "8080:80"
+      - target: 443
+        published: 8443
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed, err := f.RestrictPortBindings("web", "127.0.0.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected port restriction to change the file")
+	}
+	if err := f.Save(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "127.0.0.1:8080:80") {
+		t.Errorf("expected short-form port restricted\n%s", out)
+	}
+	if !strings.Contains(out, "target: 443") {
+		t.Errorf("expected long-form mapping preserved\n%s", out)
+	}
+	if !strings.Contains(out, "127.0.0.1") || !strings.Contains(out, "8443") {
+		t.Errorf("expected long-form host_ip restricted\n%s", out)
+	}
+}
+
+func TestSetVolumeReadOnly_LongSyntax(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yml")
+	content := `services:
+  web:
+    image: nginx
+    volumes:
+      - type: bind
+        source: /etc
+        target: /host-etc
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed, err := f.SetVolumeReadOnly("web", "/etc:/host-etc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected volume to be marked read-only")
+	}
+	if err := f.Save(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "read_only:") {
+		t.Errorf("expected read_only in file\n%s", string(data))
+	}
+}
+
+func TestRemoveVolumeMount_LongSyntax(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yml")
+	content := `services:
+  agent:
+    image: portainer/agent
+    volumes:
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+      - type: volume
+        source: data
+        target: /data
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed, err := f.RemoveVolumeMount("agent", "/var/run/docker.sock:/var/run/docker.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected docker.sock mount to be removed")
+	}
+	if err := f.Save(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(data)
+	if strings.Contains(out, "docker.sock") {
+		t.Errorf("docker.sock mount should be removed\n%s", out)
+	}
+	if !strings.Contains(out, "target: /data") {
+		t.Errorf("unrelated volume should remain\n%s", out)
+	}
+}

--- a/internal/compose/volumes.go
+++ b/internal/compose/volumes.go
@@ -139,3 +139,121 @@ func longVolumeRaw(source, target, mode, volType string) string {
 	}
 	return volType + ":" + target
 }
+
+// SetVolumeReadOnly marks the targeted volume mount read-only. When
+// targetVolume is empty every non-read-only mount on the service is
+// updated. Short-syntax scalars get a :ro suffix; long-syntax maps get
+// read_only: true. Returns true when at least one entry changed.
+func (f *File) SetVolumeReadOnly(service, targetVolume string) (bool, error) {
+	node := f.walkPath(service, "volumes")
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return false, nil
+	}
+	changed := false
+	for _, item := range node.Content {
+		switch item.Kind {
+		case yaml.ScalarNode:
+			if !volumeScalarMatches(item.Value, targetVolume) {
+				continue
+			}
+			if strings.Contains(item.Value, ":ro") {
+				continue
+			}
+			item.Value = item.Value + ":ro"
+			changed = true
+		case yaml.MappingNode:
+			mount, ok := parseVolumeLong(item)
+			if !ok || !volumeMountMatches(mount, targetVolume) {
+				continue
+			}
+			if hasVolumeMode(mount.Mode, "ro") || fieldsTrue(item, "read_only") {
+				continue
+			}
+			setMappingScalar(item, "read_only", "true")
+			changed = true
+		}
+	}
+	if changed {
+		f.dirty = true
+	}
+	return changed, nil
+}
+
+// RemoveVolumeMount drops the volume entry matching targetVolume from
+// the service. Matching uses the same raw/source forms recorded in
+// finding evidence. Returns true when an entry was removed.
+func (f *File) RemoveVolumeMount(service, targetVolume string) (bool, error) {
+	if targetVolume == "" {
+		return false, nil
+	}
+	node := f.walkPath(service, "volumes")
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return false, nil
+	}
+	var kept []*yaml.Node
+	removed := false
+	for _, item := range node.Content {
+		if volumeItemMatches(item, targetVolume) {
+			removed = true
+			continue
+		}
+		kept = append(kept, item)
+	}
+	if removed {
+		node.Content = kept
+		f.dirty = true
+	}
+	return removed, nil
+}
+
+func volumeItemMatches(item *yaml.Node, targetVolume string) bool {
+	switch item.Kind {
+	case yaml.ScalarNode:
+		return volumeScalarMatches(item.Value, targetVolume)
+	case yaml.MappingNode:
+		mount, ok := parseVolumeLong(item)
+		return ok && volumeMountMatches(mount, targetVolume)
+	default:
+		return false
+	}
+}
+
+func volumeScalarMatches(v, targetVolume string) bool {
+	if targetVolume == "" {
+		return true
+	}
+	if v == targetVolume {
+		return true
+	}
+	prefix := strings.Split(targetVolume, ":")[0]
+	return prefix != "" && strings.HasPrefix(v, prefix+":")
+}
+
+func volumeMountMatches(mount VolumeMount, targetVolume string) bool {
+	if targetVolume == "" {
+		return true
+	}
+	if mount.Raw == targetVolume {
+		return true
+	}
+	pair := mount.Source + ":" + mount.Target
+	if pair == targetVolume {
+		return true
+	}
+	prefix := strings.Split(targetVolume, ":")[0]
+	return prefix != "" && mount.Source == prefix
+}
+
+func fieldsTrue(item *yaml.Node, key string) bool {
+	fields := mappingFields(item)
+	return fields[key] == "true"
+}
+
+func hasVolumeMode(mode, want string) bool {
+	for _, part := range strings.Split(mode, ",") {
+		if strings.TrimSpace(part) == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/composeaudit/rules.go
+++ b/internal/composeaudit/rules.go
@@ -526,28 +526,34 @@ func checkPortBinding(f *compose.File, svc string, project Project) []domain.Fin
 }
 
 func checkVolumeRO(f *compose.File, svc string, project Project) []domain.Finding {
-	vols, err := f.GetFieldStrings(svc, "volumes")
-	if err != nil || len(vols) == 0 {
-		return nil
-	}
-	for _, v := range vols {
-		if !strings.Contains(v, ":ro") && !strings.Contains(v, ":") {
-			// Named volumes with no suffix are fine (Docker manages them)
+	mounts := f.GetVolumeMounts(svc)
+	for _, mount := range mounts {
+		if hasVolumeMode(mount.Mode, "ro") {
 			continue
-		} else if !strings.Contains(v, ":ro") {
-			return []domain.Finding{{
-				ID:          "compose.dr003",
-				Title:       "Container mounts volumes as read-write",
-				Description: fmt.Sprintf("Service %q mounts volume %q without :ro flag.", svc, v),
-				HowToFix:    `Append ":ro" to volume mount when write access is not required.`,
-				Severity:    domain.SeverityLow,
-				Source:      domain.SourceCompose,
-				Service:     svc,
-				Remediation: domain.RemediationUnavailable,
-				Evidence:    map[string]string{"volume": v},
-				Metadata:    composeMeta(project, svc),
-			}}
 		}
+		raw := mount.Raw
+		if raw == "" {
+			if mount.Target != "" {
+				raw = mount.Source + ":" + mount.Target
+			} else {
+				raw = mount.Source
+			}
+		}
+		if !strings.Contains(raw, ":") {
+			continue
+		}
+		return []domain.Finding{{
+			ID:          "compose.dr003",
+			Title:       "Container mounts volumes as read-write",
+			Description: fmt.Sprintf("Service %q mounts volume %q without :ro flag.", svc, raw),
+			HowToFix:    `Append ":ro" to volume mount when write access is not required.`,
+			Severity:    domain.SeverityLow,
+			Source:      domain.SourceCompose,
+			Service:     svc,
+			Remediation: domain.RemediationUnavailable,
+			Evidence:    map[string]string{"volume": raw},
+			Metadata:    composeMeta(project, svc),
+		}}
 	}
 	return nil
 }

--- a/internal/composeaudit/secrets_test.go
+++ b/internal/composeaudit/secrets_test.go
@@ -55,3 +55,18 @@ func TestCheckSensitiveHostMount_LongSyntax(t *testing.T) {
 		t.Error("expected compose.ds017 for long-syntax /etc mount")
 	}
 }
+
+func TestCheckVolumeRO_LongSyntax(t *testing.T) {
+	f := openCompose(t, `services:
+  web:
+    image: nginx
+    volumes:
+      - type: bind
+        source: ./data
+        target: /data
+`)
+	findings := checkVolumeRO(f, "web", Project{Name: "test", ComposePath: "test.yml"})
+	if !hasFinding(findings, "compose.dr003") {
+		t.Error("expected compose.dr003 for long-syntax read-write mount")
+	}
+}

--- a/internal/fix/compose.go
+++ b/internal/fix/compose.go
@@ -214,30 +214,18 @@ func composePortRestrict(ctx Context, bind string) error {
 	if err != nil {
 		return err
 	}
+	changed := false
 	for _, svc := range svcs {
-		vals, err := f.GetFieldStrings(svc, "ports")
+		ok, err := f.RestrictPortBindings(svc, bind)
 		if err != nil {
-			ctx.Log("fix: cannot read ports for service %q: %v", svc, err)
-			continue
-		}
-		if len(vals) == 0 {
-			continue
-		}
-		changed := false
-		fixed := make([]interface{}, 0, len(vals))
-		for _, v := range vals {
-			newV, ok := restrictPort(v, bind)
-			if ok {
-				changed = true
-			}
-			fixed = append(fixed, newV)
-		}
-		if !changed {
-			ctx.Log("fix: no host-bound port found for service %q (already restricted or no host port)", svc)
-		}
-		if err := f.SetField(svc, "ports", fixed); err != nil {
 			return err
 		}
+		if ok {
+			changed = true
+		}
+	}
+	if !changed {
+		return fmt.Errorf("no host-bound port mapping was restricted")
 	}
 	ctx.Diff = f.Diff()
 	return f.Save()
@@ -253,24 +241,18 @@ func composeVolumeRO(ctx Context) error {
 		return err
 	}
 	targetVol := ctx.Finding.Evidence["volume"]
+	changed := false
 	for _, svc := range svcs {
-		vols, err := f.GetFieldStrings(svc, "volumes")
-		if err != nil || len(vols) == 0 {
-			return fmt.Errorf("no volumes found for service %q", svc)
-		}
-		fixed := make([]interface{}, len(vols))
-		for i, v := range vols {
-			if strings.Contains(v, ":ro") {
-				fixed[i] = v
-			} else if targetVol == "" || strings.HasPrefix(v, strings.Split(targetVol, ":")[0]) {
-				fixed[i] = v + ":ro"
-			} else {
-				fixed[i] = v
-			}
-		}
-		if err := f.SetField(svc, "volumes", fixed); err != nil {
+		ok, err := f.SetVolumeReadOnly(svc, targetVol)
+		if err != nil {
 			return fmt.Errorf("failed to set read-only volumes: %w", err)
 		}
+		if ok {
+			changed = true
+		}
+	}
+	if !changed {
+		return fmt.Errorf("no volume mount was updated to read-only")
 	}
 	ctx.Diff = f.Diff()
 	return f.Save()
@@ -285,7 +267,29 @@ func composeDropVolume(ctx Context) error {
 	if targetVol == "" {
 		return fmt.Errorf("no volume recorded in finding evidence")
 	}
-	return composeDrop(ctx, "volumes", targetVol)
+	f, err := openComposeFile(ctx)
+	if err != nil {
+		return err
+	}
+	svcs, err := targetServices(f, ctx.Finding.Service)
+	if err != nil {
+		return err
+	}
+	changed := false
+	for _, svc := range svcs {
+		ok, err := f.RemoveVolumeMount(svc, targetVol)
+		if err != nil {
+			return err
+		}
+		if ok {
+			changed = true
+		}
+	}
+	if !changed {
+		return fmt.Errorf("volume mount %q was not found", targetVol)
+	}
+	ctx.Diff = f.Diff()
+	return f.Save()
 }
 
 func composeEdit(ctx Context, field string, value interface{}) error {

--- a/internal/fix/compose_test.go
+++ b/internal/fix/compose_test.go
@@ -329,3 +329,80 @@ func TestComposePortRestrict_LongForm(t *testing.T) {
 		t.Errorf("compose file should not contain 0.0.0.0:8080:80\n%s", content)
 	}
 }
+
+func TestComposePortRestrict_LongSyntaxMapping(t *testing.T) {
+	const yml = `services:
+  web:
+    image: nginx:alpine
+    ports:
+      - target: 80
+        published: 8080
+        host_ip: 0.0.0.0
+`
+	path := writeTestCompose(t, yml)
+	ctx := testContext(t, path, "web")
+	if err := composePortRestrict(ctx, "127.0.0.1"); err != nil {
+		t.Fatalf("composePortRestrict: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "127.0.0.1") {
+		t.Errorf("compose file should restrict long-syntax host_ip\n%s", content)
+	}
+}
+
+func TestComposeVolumeRO_LongSyntax(t *testing.T) {
+	const yml = `services:
+  web:
+    image: nginx
+    volumes:
+      - type: bind
+        source: /etc
+        target: /host-etc
+`
+	path := writeTestCompose(t, yml)
+	ctx := testContext(t, path, "web")
+	ctx.Finding.Evidence["volume"] = "/etc:/host-etc"
+	if err := composeVolumeRO(ctx); err != nil {
+		t.Fatalf("composeVolumeRO: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "read_only:") {
+		t.Errorf("compose file should set read_only\n%s", string(data))
+	}
+}
+
+func TestComposeDropVolume_LongSyntax(t *testing.T) {
+	const yml = `services:
+  agent:
+    image: portainer/agent
+    volumes:
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+      - data:/data
+`
+	path := writeTestCompose(t, yml)
+	ctx := testContext(t, path, "agent")
+	ctx.Finding.Evidence["volume"] = "/var/run/docker.sock:/var/run/docker.sock"
+	if err := composeDropVolume(ctx); err != nil {
+		t.Fatalf("composeDropVolume: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if strings.Contains(content, "docker.sock") {
+		t.Errorf("docker.sock mount should be removed\n%s", content)
+	}
+	if !strings.Contains(content, "data:/data") {
+		t.Errorf("unrelated volume should remain\n%s", content)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -18,7 +18,7 @@ import (
 	"github.com/seolcu/hostveil/internal/scan"
 )
 
-var Version = "v2.5.2"
+var Version = "v2.6.0"
 
 type paneMode int
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes compose port/volume remediation for long-syntax YAML (mapping-form `ports` and `volumes` entries) and prepares the v2.6.0 release.

### Bug fixes
- **Port restrict / volume :ro / volume remove** previously rebuilt lists from short-syntax scalars only, silently skipping or dropping long-syntax mapping entries and mixed-syntax lists.
- New `internal/compose` helpers edit YAML nodes in place: `RestrictPortBindings`, `SetVolumeReadOnly`, `RemoveVolumeMount`.
- Fixes now return an error when no change was made (fix-engine invariant).
- **`compose.dr003` detection** now uses `GetVolumeMounts` so long-syntax read-write mounts are flagged.

### Release
- Bump embedded version to `v2.6.0`.
- Finalize `CHANGELOG.md` (move [Unreleased] content to [2.6.0]).

## Test plan
- [x] `gofmt -l .`
- [x] `go build ./... && go vet ./...`
- [x] `go test -race ./...`
- [ ] E2E (`npx playwright test`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0850f981-91b8-430a-9682-c3c6a99b45ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0850f981-91b8-430a-9682-c3c6a99b45ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

