### PR TITLE
chore: point site to hostveil.seolcu.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ One binary, no config file, no cloud account.
 [![Go Version](https://img.shields.io/github/go-mod/go-version/seolcu/hostveil)](go.mod)
 [![License: GPL-3.0](https://img.shields.io/github/license/seolcu/hostveil)](LICENSE)
 
-[Website](https://seolcu.github.io/hostveil/) · [Documentation](docs/) · [Latest release](https://github.com/seolcu/hostveil/releases/latest)
+[Website](https://hostveil.seolcu.com/) · [Documentation](docs/) · [Latest release](https://github.com/seolcu/hostveil/releases/latest)
 
 Point it at a Linux box running Docker Compose. It scans the compose
 files, the container images, and the host OS in parallel, merges

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+hostveil.seolcu.com

--- a/site/index.html
+++ b/site/index.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="hostveil — security scanner with fixes">
     <meta property="og:description" content="One local binary for Docker Compose misconfigurations, image CVEs, host hardening, scoring, fixes, rollback, and AI-ready remediation briefs.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://seolcu.github.io/hostveil/">
-    <meta property="og:image" content="https://seolcu.github.io/hostveil/assets/web.png">
-    <link rel="canonical" href="https://seolcu.github.io/hostveil/">
+    <meta property="og:url" content="https://hostveil.seolcu.com/">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the GitHub Pages `CNAME` file and updates public URLs to the custom domain `hostveil.seolcu.com`.

## Changes
- Add `site/CNAME` with `hostveil.seolcu.com` (required for GitHub Pages custom domain)
- Update `site/index.html` canonical, `og:url`, and `og:image` URLs
- Update README website link

## After merge
The existing Pages workflow will deploy on push to `main`. Once deployed, the landing page should be live at https://hostveil.seolcu.com/.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96cf5a09-4dde-4606-bc28-4627c3ddbdbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96cf5a09-4dde-4606-bc28-4627c3ddbdbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

