### PR TITLE
feat: refresh web UI visual design

### DIFF
--- a/internal/web/assets/app.css
+++ b/internal/web/assets/app.css
@@ -1,20 +1,29 @@
-::root {
+:root {
   color-scheme: dark;
-  --bg: #090b12;
-  --panel: #111522;
-  --panel-2: #171c2b;
-  --surface-sunken: #0b0e17;
-  --text-dim: #b9c3dd;
-  --text-section: #dbe3f5;
-  --line: rgba(139, 155, 191, 0.22);
-  --text: #e7ecf8;
-  --muted: #8390ad;
-  --critical: #ff5573;
-  --high: #ff9868;
-  --medium: #f7c66b;
-  --low: #87d978;
-  --accent: #64c8ff;
-  --shadow: rgba(0, 0, 0, 0.45);
+  --bg: #07090f;
+  --bg-elevated: #0c1018;
+  --panel: rgba(14, 18, 28, 0.92);
+  --panel-2: #151b2b;
+  --surface-sunken: #080b12;
+  --text: #eef2fb;
+  --text-dim: #c4cee6;
+  --text-section: #dce4f7;
+  --text-muted: #7d8aa8;
+  --muted: var(--text-muted);
+  --line: rgba(148, 163, 196, 0.18);
+  --border: rgba(148, 163, 196, 0.22);
+  --critical: #ff5c7a;
+  --high: #ff9a6a;
+  --medium: #f5c86a;
+  --low: #6ee7a0;
+  --accent: #5eb8ff;
+  --accent-soft: rgba(94, 184, 255, 0.14);
+  --shadow: rgba(0, 0, 0, 0.55);
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --font-display: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
 * { box-sizing: border-box; }
@@ -24,10 +33,14 @@ body {
   min-height: 100vh;
   color: var(--text);
   background:
-    radial-gradient(circle at 12% 8%, rgba(100, 200, 255, 0.08), transparent 28rem),
-    radial-gradient(circle at 90% 0%, rgba(255, 85, 115, 0.04), transparent 22rem),
-    linear-gradient(135deg, #090b12 0%, #0c101a 42%, #080a10 100%);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    radial-gradient(ellipse 80% 50% at 10% -10%, rgba(94, 184, 255, 0.12), transparent 50%),
+    radial-gradient(ellipse 60% 40% at 95% 5%, rgba(255, 92, 122, 0.07), transparent 45%),
+    radial-gradient(ellipse 50% 30% at 50% 100%, rgba(110, 231, 160, 0.04), transparent 40%),
+    linear-gradient(160deg, #07090f 0%, #0a0e16 45%, #060810 100%);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
 }
 
 body::before {
@@ -36,19 +49,19 @@ body::before {
   inset: 0;
   pointer-events: none;
   background-image:
-    linear-gradient(rgba(255,255,255,0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255,255,255,0.035) 1px, transparent 1px);
-  background-size: 36px 36px;
-  mask-image: linear-gradient(to bottom, black, transparent 82%);
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: 40px 40px;
+  mask-image: radial-gradient(ellipse 90% 70% at 50% 0%, black 20%, transparent 85%);
 }
 
 button, input, select { font: inherit; }
 
 .sysinfo {
-  margin: 4px 0 0;
+  margin: 6px 0 0;
   color: var(--muted);
-  font-size: 13px;
-  letter-spacing: 0.02em;
+  font-size: 12px;
+  letter-spacing: 0.04em;
 }
 
 .shell {
@@ -73,74 +86,139 @@ button, input, select { font: inherit; }
   display: flex;
   align-items: stretch;
   justify-content: space-between;
-  gap: 20px;
-  margin-bottom: 16px;
+  gap: 24px;
+  margin-bottom: 20px;
   flex-shrink: 0;
 }
 
+.brand-block {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
 .eyebrow {
-  margin: 0 0 8px;
+  margin: 0 0 6px;
   color: var(--accent);
-  font-size: 12px;
-  letter-spacing: 0.16em;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
-h1, h2, h3 { margin: 0; }
+h1, h2, h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+}
 
 h1 {
-  font-size: clamp(38px, 5vw, 76px);
-  line-height: 0.9;
-  letter-spacing: -0.08em;
+  font-size: clamp(36px, 4.5vw, 64px);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  background: linear-gradient(135deg, var(--text) 0%, var(--text-dim) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .scoreplate {
-  min-width: 250px;
+  position: relative;
+  min-width: 220px;
   padding: 20px 24px;
   border: 1px solid var(--line);
-  background: rgba(17, 21, 34, 0.95);
-  box-shadow: 0 24px 60px var(--shadow);
-  border-radius: 4px;
+  background: var(--panel);
+  box-shadow:
+    0 20px 50px var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.scoreplate::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.04) 0%, transparent 50%);
+  pointer-events: none;
 }
 
 .score-label {
   display: block;
   color: var(--muted);
-  font-size: 13px;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
 }
 
 .scoreplate strong {
   display: block;
-  margin-top: 8px;
-  font-size: 54px;
+  margin-top: 6px;
+  font-family: var(--font-display);
+  font-size: clamp(42px, 5vw, 52px);
+  font-weight: 800;
   line-height: 1;
+  letter-spacing: -0.03em;
 }
 
 .metrics {
   display: grid;
   grid-template-columns: repeat(6, minmax(120px, 1fr));
-  gap: 10px;
-  margin-bottom: 16px;
+  gap: 12px;
+  margin-bottom: 18px;
   flex-shrink: 0;
 }
 
 .metric {
+  position: relative;
   padding: 14px 16px;
   border: 1px solid var(--line);
-  border-radius: 4px;
-  background: rgba(17, 21, 34, 0.88);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  transition: border-color 180ms ease, transform 180ms ease;
+}
+
+.metric:hover {
+  border-color: rgba(148, 163, 196, 0.32);
+  transform: translateY(-1px);
+}
+
+.metric::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 12px;
+  right: 12px;
+  height: 2px;
+  border-radius: 0 0 2px 2px;
+  background: var(--line);
+  opacity: 0.6;
 }
 
 .metric--total {
-  border-color: var(--accent);
-  background-image: linear-gradient(
-    to bottom,
-    rgba(100, 200, 255, 0.22),
-    transparent 35%
-  );
+  border-color: rgba(94, 184, 255, 0.35);
+  background:
+    linear-gradient(to bottom, rgba(94, 184, 255, 0.12), transparent 55%),
+    var(--panel);
 }
+
+.metric--total::before {
+  background: var(--accent);
+  opacity: 1;
+}
+
+.metric--critical::before { background: var(--critical); opacity: 1; }
+.metric--high::before { background: var(--high); opacity: 1; }
+.metric--medium::before { background: var(--medium); opacity: 1; }
+.metric--low::before { background: var(--low); opacity: 1; }
+.metric--fixable::before { background: var(--accent); opacity: 1; }
 
 .metric--fixable strong {
   color: var(--accent);
@@ -149,24 +227,29 @@ h1 {
 .metric span {
   display: block;
   color: var(--muted);
-  font-size: 11px;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .metric strong {
   display: block;
-  margin-top: 6px;
-  font-size: 25px;
+  margin-top: 8px;
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .metric--total strong {
   color: var(--accent);
-  font-size: 34px;
+  font-size: 32px;
 }
 
 .score-breakdown {
-  margin-bottom: 16px;
+  margin-bottom: 18px;
   flex-shrink: 0;
 }
 
@@ -175,11 +258,12 @@ h1 {
 }
 
 .history-panel {
-  margin-bottom: 16px;
-  padding: 14px 16px;
+  margin-bottom: 18px;
+  padding: 16px 18px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   background: var(--panel);
+  box-shadow: 0 12px 40px var(--shadow);
 }
 
 .history-panel[hidden] {
@@ -200,10 +284,16 @@ h1 {
 }
 
 .history-item {
-  padding: 10px 12px;
+  padding: 12px 14px;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.02);
+  transition: border-color 150ms ease, background 150ms ease;
+}
+
+.history-item:hover {
+  border-color: rgba(94, 184, 255, 0.3);
+  background: rgba(94, 184, 255, 0.04);
 }
 
 .history-item-top {
@@ -231,33 +321,41 @@ h1 {
   align-items: baseline;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .score-breakdown-head span {
   color: var(--muted);
+  font-family: var(--font-display);
   font-size: 11px;
+  font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .score-breakdown-head p {
   margin: 0;
-  color: var(--muted);
+  color: rgba(125, 138, 168, 0.85);
   font-size: 12px;
+  max-width: 520px;
 }
 
 .score-axis-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 10px;
+  gap: 12px;
 }
 
 .score-axis {
-  padding: 12px;
+  padding: 14px;
   border: 1px solid var(--line);
-  border-radius: 4px;
-  background: rgba(17, 21, 34, 0.88);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  transition: border-color 180ms ease;
+}
+
+.score-axis:hover {
+  border-color: rgba(148, 163, 196, 0.32);
 }
 
 .score-axis-top {
@@ -269,23 +367,36 @@ h1 {
 
 .score-axis-top span {
   color: var(--muted);
-  font-size: 11px;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 600;
   letter-spacing: 0.08em;
-  line-height: 1.25;
+  line-height: 1.3;
   text-transform: uppercase;
 }
 
 .score-axis-top strong {
   white-space: nowrap;
+  font-family: var(--font-display);
   font-size: 18px;
+  font-weight: 700;
 }
 
-.score-axis-bar { height: 6px; margin: 10px 0 8px; overflow: hidden; background: var(--surface-sunken); border-radius: 3px; border: none; }
+.score-axis-bar {
+  height: 6px;
+  margin: 12px 0 8px;
+  overflow: hidden;
+  background: var(--surface-sunken);
+  border-radius: 999px;
+  border: none;
+}
 
 .score-axis-bar span {
   display: block;
   height: 100%;
   background: currentColor;
+  border-radius: 999px;
+  transition: width 400ms ease;
 }
 
 .score-axis-meta {
@@ -307,11 +418,29 @@ h1 {
   flex: 1;
   min-height: 0;
   display: flex;
-  gap: 14px;
+  gap: 16px;
   overflow: hidden;
 }
 
-.filters { width: 340px; flex-shrink: 0; align-self: flex-start; padding: 18px; border: 1px solid var(--line); border-radius: 4px; background: rgba(17, 21, 34, 0.88); box-shadow: 0 24px 60px var(--shadow); -webkit-backdrop-filter: blur(18px); backdrop-filter: blur(18px); max-height: 100%; overflow-y: auto; }
+.panel-surface {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  box-shadow:
+    0 20px 50px var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+}
+
+.filters {
+  width: 320px;
+  flex-shrink: 0;
+  align-self: flex-start;
+  padding: 20px;
+  max-height: 100%;
+  overflow-y: auto;
+}
 
 .findings-panel {
   flex: 1;
@@ -319,32 +448,22 @@ h1 {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  background: rgba(17, 21, 34, 0.88);
-  box-shadow: 0 24px 60px var(--shadow);
-  -webkit-backdrop-filter: blur(18px);
-  backdrop-filter: blur(18px);
 }
 
 .detail {
   flex: 0.72;
   min-width: 0;
   overflow-y: auto;
-  padding: 18px;
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  background: rgba(17, 21, 34, 0.88);
-  box-shadow: 0 24px 60px var(--shadow);
-  -webkit-backdrop-filter: blur(18px);
-  backdrop-filter: blur(18px);
+  padding: 20px;
 }
 
 .search span, .filter-block h2 {
   display: block;
   margin: 0 0 10px;
   color: var(--muted);
-  font-size: 12px;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -354,18 +473,23 @@ input, select {
   color: var(--text);
   border: 1px solid var(--line);
   background: var(--surface-sunken);
-  padding: 12px;
+  padding: 11px 12px;
+  border-radius: var(--radius-sm);
   outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
 }
 
-input:focus, select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(100, 200, 255, 0.14); }
+input:focus, select:focus {
+  border-color: rgba(94, 184, 255, 0.65);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
 
 .search-input {
   position: relative;
 }
 
 .search-input input {
-  padding-left: 36px;
+  padding-left: 38px;
 }
 
 .search-icon {
@@ -375,9 +499,20 @@ input:focus, select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px r
   transform: translateY(-50%);
   color: var(--muted);
   pointer-events: none;
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.search-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .filter-block { margin-top: 22px; }
@@ -387,18 +522,23 @@ input:focus, select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px r
   cursor: pointer;
   color: var(--muted);
   border: 1px solid var(--line);
-  border-radius: 4px;
-  background: rgba(255,255,255,0.03);
-  padding: 6px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.02);
+  padding: 7px 12px;
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 500;
+  transition: color 150ms ease, border-color 150ms ease, background 150ms ease, transform 150ms ease;
 }
-
-
-.section pre, .evidence-details pre { white-space: pre-wrap; word-break: break-word; padding: 14px; border: 1px solid var(--line); border-radius: 4px; background: var(--surface-sunken); }
 
 .chip.active, button:not(:disabled):hover {
   color: var(--text);
-  border-color: rgba(100, 200, 255, 0.7);
-  background: rgba(100, 200, 255, 0.12);
+  border-color: rgba(94, 184, 255, 0.55);
+  background: var(--accent-soft);
+}
+
+.chip.active {
+  box-shadow: inset 0 0 0 1px rgba(94, 184, 255, 0.2);
 }
 
 .panel-head {
@@ -406,8 +546,13 @@ input:focus, select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px r
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  padding: 18px;
+  padding: 18px 20px;
   border-bottom: 1px solid var(--line);
+}
+
+.panel-head h2 {
+  font-size: 18px;
+  letter-spacing: -0.02em;
 }
 
 .panel-head-actions {
@@ -418,70 +563,274 @@ input:focus, select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px r
   justify-content: flex-end;
 }
 
-.table-wrap { flex: 1; min-width: 0; overflow: auto; padding: 0 18px; scroll-padding-top: 44px; }
-table { width: 100%; min-width: 680px; border-collapse: collapse; table-layout: fixed; }
-th, td { padding: 12px 14px; border-bottom: 1px solid rgba(139, 155, 191, 0.13); text-align: left; vertical-align: top; }
-th { position: sticky; top: 0; z-index: 2; color: var(--muted); background: var(--panel); font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; }
-tbody tr { cursor: pointer; transition: background 150ms ease, color 150ms ease; border-bottom: 1px solid rgba(139, 155, 191, 0.06); }
-tbody tr:hover, tbody tr.selected { background: rgba(100, 200, 255, 0.09); }
-tbody tr.disabled { cursor: pointer; opacity: 0.65; }
+.table-wrap {
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+  padding: 0 12px 12px;
+  scroll-padding-top: 44px;
+}
+
+table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+
+th, td {
+  padding: 11px 12px;
+  border-bottom: 1px solid rgba(148, 163, 196, 0.1);
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  color: var(--muted);
+  background: rgba(14, 18, 28, 0.98);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+tbody tr {
+  cursor: pointer;
+  transition: background 150ms ease;
+  border-left: 3px solid transparent;
+}
+
+tbody tr[data-severity="critical"] { border-left-color: rgba(255, 92, 122, 0.55); }
+tbody tr[data-severity="high"] { border-left-color: rgba(255, 154, 106, 0.5); }
+tbody tr[data-severity="medium"] { border-left-color: rgba(245, 200, 106, 0.45); }
+tbody tr[data-severity="low"] { border-left-color: rgba(110, 231, 160, 0.45); }
+
+tbody tr:hover,
+tbody tr.selected {
+  background: rgba(94, 184, 255, 0.08);
+}
+
+tbody tr.disabled {
+  cursor: pointer;
+  opacity: 0.55;
+  border-left-color: transparent !important;
+}
+
 tbody tr.disabled .row-check { cursor: not-allowed; }
-tbody tr.disabled:hover { background: inherit; color: inherit; }
-.row-check:disabled { opacity: 0.4; cursor: not-allowed; }
-.id { color: var(--text-dim); white-space: nowrap; }
+tbody tr.disabled:hover { background: inherit; }
+.row-check:disabled { opacity: 0.35; cursor: not-allowed; }
+
+.id {
+  color: var(--text-dim);
+  white-space: nowrap;
+  font-size: 12px;
+}
+
 th:nth-child(1) { width: 40px; }
 th:nth-child(2) { width: 90px; }
 th:nth-child(3) { width: 80px; }
 th:nth-child(4) { width: 140px; pointer-events: none; }
 th:nth-child(5) { width: auto; }
 th:nth-child(6) { width: 125px; }
-.title { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.badge { display: inline-block; padding: 4px 7px; border: 1px solid currentColor; font-size: 11px; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
+
+.title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .critical { color: var(--critical); }
 .high { color: var(--high); }
 .medium { color: var(--medium); }
 .low { color: var(--low); }
 .muted { color: var(--muted); }
 
-.empty-detail { display: grid; min-height: 380px; place-content: center; text-align: center; color: var(--muted); }
-.empty-detail span { width: 56px; height: 56px; margin: 0 auto 16px; border: 1px solid var(--line); border-radius: 12px; background: rgba(100,200,255,0.08); display: flex; align-items: center; justify-content: center; font-size: 24px; color: var(--muted); }
+.empty-detail {
+  display: grid;
+  min-height: 380px;
+  place-content: center;
+  text-align: center;
+  color: var(--muted);
+  padding: 24px;
+}
+
+.empty-detail-icon {
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--accent-soft), rgba(255, 255, 255, 0.02));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+}
+
+.empty-detail-icon svg {
+  width: 28px;
+  height: 28px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.75;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.empty-detail h2 {
+  font-size: 22px;
+  color: var(--text-dim);
+  margin-bottom: 8px;
+}
+
+.empty-detail p {
+  margin: 0;
+  max-width: 280px;
+  line-height: 1.6;
+}
+
 .detail .badge { display: inline-block; margin-bottom: 12px; }
 .detail .fix-btn { margin-top: 18px; }
-.detail h2 { font-size: 26px; line-height: 1.1; letter-spacing: -0.04em; overflow-wrap: anywhere; }
-.detail-meta { display: grid; grid-template-columns: minmax(92px, 110px) minmax(0, 1fr); gap: 8px 12px; margin: 20px 0; padding: 16px; background: rgba(255,255,255,0.035); border: 1px solid var(--line); border-radius: 4px; }
-.detail-meta dt { color: var(--muted); }
-.detail-meta dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.detail h2 {
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  overflow-wrap: anywhere;
+}
+
+.detail-meta {
+  display: grid;
+  grid-template-columns: minmax(92px, 110px) minmax(0, 1fr);
+  gap: 8px 12px;
+  margin: 20px 0;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+}
+
+.detail-meta dt {
+  color: var(--muted);
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.detail-meta dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .section { margin-top: 22px; }
-.section h3 { color: var(--accent); font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: 10px; }
-.section p, .section pre, .evidence-details pre { color: var(--text-section); line-height: 1.65; overflow-wrap: anywhere; }
-.section pre, .evidence-details pre { white-space: pre-wrap; word-break: break-word; padding: 14px; border: 1px solid var(--line); background: var(--surface-sunken); }
+
+.section h3 {
+  color: var(--accent);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.section p, .section pre, .evidence-details pre {
+  color: var(--text-section);
+  line-height: 1.65;
+  overflow-wrap: anywhere;
+}
+
+.section pre, .evidence-details pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-sunken);
+}
+
 .copy { margin-top: 10px; }
 
 .fix-btn {
   margin-top: 12px;
-  padding: 10px 20px;
-  color: var(--bg);
-  background: var(--low);
+  padding: 11px 22px;
+  color: #041208;
+  background: linear-gradient(135deg, var(--low) 0%, #4dd68a 100%);
   border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-display);
   font-weight: 700;
+  font-size: 13px;
   cursor: pointer;
+  box-shadow: 0 4px 16px rgba(110, 231, 160, 0.25);
+  transition: filter 150ms ease, transform 150ms ease, box-shadow 150ms ease;
 }
-.fix-btn:not(:disabled):hover { filter: brightness(1.2); }
+
+.fix-btn:not(:disabled):hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(110, 231, 160, 0.35);
+}
+
 .fix-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .fix-btn.loading { pointer-events: none; cursor: wait; }
 
 .fix-success { color: var(--low); margin-top: 12px; font-weight: 700; }
 .fix-error { color: var(--critical); margin-top: 12px; font-weight: 700; }
-.fix-diff { margin-top: 8px; padding: 10px; background: var(--surface-sunken); border: 1px solid var(--line); white-space: pre-wrap; font-size: 12px; }
+
+.fix-diff {
+  margin-top: 8px;
+  padding: 12px;
+  background: var(--surface-sunken);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  white-space: pre-wrap;
+  font-size: 12px;
+}
 
 .loading .findings-panel,
 .loading .filters { display: none; }
 
 .loading .detail { flex: 1 1 100%; }
 
+.loading-state {
+  display: grid;
+  place-content: center;
+  min-height: 420px;
+  text-align: center;
+  padding: 32px;
+}
+
+.loading-state h2 {
+  font-size: 28px;
+  margin-bottom: 20px;
+  background: linear-gradient(135deg, var(--text), var(--accent));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 .tool-status {
-  margin: 24px 0;
+  margin: 24px auto 0;
   max-width: 480px;
+  text-align: left;
 }
 
 .tool-row {
@@ -489,46 +838,51 @@ th:nth-child(6) { width: 125px; }
   align-items: center;
   gap: 12px;
   padding: 10px 0;
-  border-bottom: 1px solid rgba(139, 155, 191, 0.12);
+  border-bottom: 1px solid rgba(148, 163, 196, 0.1);
 }
 
 .tool-icon {
   width: 24px;
   text-align: center;
-  font-size: 18px;
+  font-size: 16px;
 }
 
 .tool-icon.done { color: var(--low); }
 .tool-icon.error { color: var(--critical); }
-.tool-icon.running { color: var(--accent); }
+.tool-icon.running { color: var(--accent); animation: pulse 1.2s ease infinite; }
 .tool-icon.muted { color: var(--muted); }
 .tool-icon.degraded { color: var(--high); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
 
 .tool-name {
   width: 70px;
   color: var(--text);
-  font-weight: 700;
+  font-family: var(--font-display);
+  font-weight: 600;
   font-size: 13px;
-  letter-spacing: 0.06em;
 }
 
-.tool-msg { color: var(--muted); }
+.tool-msg { color: var(--muted); font-size: 13px; }
 
 .progress-bar {
   width: 100%;
   max-width: 480px;
   height: 6px;
-  background: rgba(139, 155, 191, 0.12);
-  border-radius: 3px;
+  background: rgba(148, 163, 196, 0.12);
+  border-radius: 999px;
   overflow: hidden;
-  margin-top: 16px;
+  margin: 0 auto;
 }
 
 .progress-fill {
   height: 100%;
-  background: var(--accent);
-  border-radius: 3px;
-  transition: width 0.3s ease;
+  background: linear-gradient(90deg, var(--accent), #8fd4ff);
+  border-radius: 999px;
+  transition: width 0.4s ease;
 }
 
 th.sortable {
@@ -564,9 +918,9 @@ th.sortable.desc::after {
 @media (min-width: 1321px) and (max-height: 700px) {
   .shell { padding: 12px 0; }
   .topbar { margin-bottom: 10px; }
-  h1 { font-size: clamp(34px, 4vw, 56px); }
+  h1 { font-size: clamp(32px, 4vw, 48px); }
   .scoreplate { padding: 14px 18px; }
-  .scoreplate strong { font-size: 42px; }
+  .scoreplate strong { font-size: 38px; }
   .metrics { margin-bottom: 10px; }
   .metric { padding: 8px 12px; }
   .metric strong { font-size: 20px; }
@@ -604,32 +958,62 @@ th.sortable.desc::after {
   th:nth-child(4), td:nth-child(4) { display: none; }
 }
 
-.fixed td { opacity: 0.65; }
+.fixed td { opacity: 0.55; }
+.fixed { border-left-color: transparent !important; }
 
 .fix-warning { color: var(--high); }
 
-.clear-btn { width: 100%; text-align: center; }
+.clear-btn {
+  width: 100%;
+  text-align: center;
+  border-radius: var(--radius-sm);
+}
 
 .evidence-details { margin-top: 22px; }
-.evidence-details summary { color: var(--accent); cursor: pointer; font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase; }
+
+.evidence-details summary {
+  color: var(--accent);
+  cursor: pointer;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
 .evidence-details[open] { margin-bottom: 8px; }
 
 .collapsible .collapse-body p { margin: 0; }
-.toggle-more { background: none; border: none; color: var(--accent); cursor: pointer; padding: 4px 0; font-size: 12px; }
+
+.toggle-more {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 4px 0;
+  font-size: 12px;
+}
+
 .toggle-more:hover { text-decoration: underline; }
 
 .modal-overlay {
-  position: fixed; inset: 0; z-index: 200;
-  background: rgba(0, 0, 0, 0.65);
-  display: grid; place-items: center;
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(4, 6, 10, 0.72);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  display: grid;
+  place-items: center;
   padding: 16px;
   overflow-y: auto;
   overflow-x: hidden;
 }
+
 .modal-content {
-  background: var(--panel);
+  background: var(--panel-2);
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 32px;
   max-width: 480px;
   width: min(100%, 480px);
@@ -638,11 +1022,27 @@ th.sortable.desc::after {
   overflow-x: hidden;
   box-shadow: 0 24px 80px var(--shadow);
 }
-.modal-content h2 { margin-bottom: 12px; font-size: 22px; }
+
+.modal-content h2 {
+  margin-bottom: 12px;
+  font-size: 22px;
+}
+
 .modal-content p { margin: 8px 0; line-height: 1.5; }
 .modal-actions { display: flex; gap: 10px; margin-top: 20px; }
-.modal-actions button { flex: 1; padding: 10px 16px; height: 42px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; margin-top: 0; }
-/* Help modal: center the single Close button instead of stretching full width. */
+
+.modal-actions button {
+  flex: 1;
+  padding: 10px 16px;
+  height: 42px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0;
+  border-radius: var(--radius-sm);
+}
+
 .modal-help .modal-actions { justify-content: center; }
 .modal-help .modal-actions button { flex: 0 0 auto; min-width: 160px; }
 
@@ -655,8 +1055,9 @@ th.sortable.desc::after {
 }
 
 .action-summary {
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.025);
   border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   padding: 14px;
   margin: 12px 0;
 }
@@ -676,24 +1077,26 @@ th.sortable.desc::after {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   border: 1px solid;
+  border-radius: 999px;
 }
+
 .type-edit { color: var(--accent); border-color: var(--accent); }
 .type-exec { color: var(--medium); border-color: var(--medium); }
 .type-prompt { color: var(--muted); border-color: var(--muted); }
 
-.action-command, .action-edit-path {
-  margin-top: 8px;
-  font-size: 12px;
-}
+.action-command, .action-edit-path { margin-top: 8px; font-size: 12px; }
+
 .action-command code, .action-edit-path code {
   display: block;
   margin-top: 4px;
   padding: 8px 10px;
   background: var(--surface-sunken);
   border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   font-size: 11px;
   word-break: break-word;
 }
+
 .command-label, .path-label {
   color: var(--muted);
   font-size: 10px;
@@ -701,21 +1104,21 @@ th.sortable.desc::after {
   letter-spacing: 0.1em;
 }
 
-.diff-preview {
-  margin-top: 12px;
-  font-size: 12px;
-}
+.diff-preview { margin-top: 12px; font-size: 12px; }
+
 .diff-preview .preview-label {
   color: var(--muted);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
+
 .diff-preview pre {
   margin-top: 4px;
   padding: 10px;
   background: var(--surface-sunken);
   border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   font-size: 11px;
   white-space: pre-wrap;
   word-break: break-word;
@@ -735,17 +1138,20 @@ th.sortable.desc::after {
 .action-option {
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   padding: 14px;
   cursor: pointer;
   transition: border-color 150ms ease, background 150ms ease;
 }
+
 .action-option:hover {
-  border-color: rgba(100, 200, 255, 0.4);
-  background: rgba(100, 200, 255, 0.05);
+  border-color: rgba(94, 184, 255, 0.4);
+  background: rgba(94, 184, 255, 0.05);
 }
+
 .action-option.selected {
   border-color: var(--accent);
-  background: rgba(100, 200, 255, 0.08);
+  background: rgba(94, 184, 255, 0.08);
 }
 
 .action-option-header {
@@ -753,11 +1159,14 @@ th.sortable.desc::after {
   align-items: center;
   gap: 10px;
 }
+
 .action-option-header input[type="radio"] {
   width: auto;
   margin: 0;
   cursor: pointer;
+  accent-color: var(--accent);
 }
+
 .action-option-header label {
   display: flex;
   align-items: center;
@@ -773,18 +1182,21 @@ th.sortable.desc::after {
 .check-col { width: 40px !important; text-align: center; }
 .check-cell { width: 40px; text-align: center; }
 .row-check { cursor: pointer; accent-color: var(--accent); }
-.row-selected { background: rgba(100, 200, 255, 0.12) !important; }
+.row-selected { background: rgba(94, 184, 255, 0.12) !important; }
 
 .fix-selected-btn {
   color: var(--low);
-  border-color: var(--low);
-  background: rgba(135, 217, 120, 0.1);
+  border-color: rgba(110, 231, 160, 0.5);
+  background: rgba(110, 231, 160, 0.1);
   font-weight: 700;
+  border-radius: var(--radius-sm);
 }
+
 .fix-selected-btn:not(:disabled):hover {
-  background: rgba(135, 217, 120, 0.2);
+  background: rgba(110, 231, 160, 0.18);
   border-color: var(--low);
 }
+
 .fix-selected-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .fix-selected-btn.loading { cursor: wait; }
 
@@ -795,12 +1207,16 @@ th.sortable.desc::after {
   z-index: 300;
   padding: 14px 20px;
   border: 1px solid var(--line);
-  background: var(--panel);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
   color: var(--text);
+  font-family: var(--font-display);
   font-size: 13px;
+  font-weight: 500;
   box-shadow: 0 12px 40px var(--shadow);
   animation: toast-in 0.3s ease;
 }
+
 .toast-hide { animation: toast-out 0.3s ease forwards; }
 .toast-success { border-left: 3px solid var(--low); }
 .toast-error { border-left: 3px solid var(--critical); }
@@ -810,6 +1226,7 @@ th.sortable.desc::after {
   from { opacity: 0; transform: translateY(12px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
 @keyframes toast-out {
   from { opacity: 1; transform: translateY(0); }
   to { opacity: 0; transform: translateY(12px); }
@@ -821,6 +1238,7 @@ th.sortable.desc::after {
   gap: 12px;
   margin: 20px 0;
 }
+
 .export-option {
   display: flex;
   flex-direction: column;
@@ -828,14 +1246,18 @@ th.sortable.desc::after {
   gap: 8px;
   padding: 24px 16px;
   border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.02);
   cursor: pointer;
-  transition: border-color 150ms ease, background 150ms ease;
+  transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
 }
+
 .export-option:hover {
   border-color: var(--accent);
-  background: rgba(100, 200, 255, 0.06);
+  background: rgba(94, 184, 255, 0.06);
+  transform: translateY(-2px);
 }
+
 .export-icon {
   font-size: 24px;
   font-weight: 700;
@@ -843,34 +1265,38 @@ th.sortable.desc::after {
   white-space: nowrap;
   word-break: keep-all;
 }
+
 .export-label {
   font-weight: 700;
   color: var(--text);
   white-space: nowrap;
   word-break: keep-all;
 }
+
 .export-desc {
   font-size: 11px;
   color: var(--muted);
 }
 
-/* Help modal */
 .modal-help {
   max-width: 640px;
   width: min(100%, 640px);
 }
+
 .modal-help h2 {
   margin-bottom: 16px;
   font-size: 20px;
 }
+
 .help-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 20px 24px;
   margin: 16px 0 20px;
 }
+
 .help-section h3 {
-  font-size: 13px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--muted);
@@ -878,26 +1304,24 @@ th.sortable.desc::after {
   padding-bottom: 6px;
   border-bottom: 1px solid var(--line);
 }
+
 .help-section dl {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 6px 12px;
   font-size: 12px;
 }
-.help-section dt {
-  white-space: nowrap;
-  color: var(--text);
-}
-.help-section dd {
-  color: var(--muted);
-}
+
+.help-section dt { white-space: nowrap; color: var(--text); }
+.help-section dd { color: var(--muted); }
+
 .help-section kbd {
   display: inline-block;
   background: var(--surface-sunken);
   border: 1px solid var(--line);
-  border-radius: 3px;
+  border-radius: 4px;
   padding: 1px 5px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   color: var(--text);
   white-space: nowrap;
@@ -909,7 +1333,6 @@ th.sortable.desc::after {
   .help-section dl { grid-template-columns: auto minmax(0, 1fr); }
 }
 
-/* Per-axis penalty bar colors */
 .score-axis[data-axis="vulnerabilities"] .score-axis-bar span { background: var(--critical); }
 .score-axis[data-axis="container_exposure"] .score-axis-bar span { background: var(--high); }
 .score-axis[data-axis="host_hardening"] .score-axis-bar span { background: var(--medium); }
@@ -919,27 +1342,66 @@ th.sortable.desc::after {
 .score-axis[data-axis="host_hardening"] .score-axis-top strong { color: var(--medium); }
 .score-axis[data-axis="secrets"] .score-axis-top strong { color: var(--accent); }
 
-/* Score plate severity-based glow */
-.scoreplate.score-low { border-color: rgba(135, 217, 120, 0.35); box-shadow: 0 24px 60px var(--shadow), 0 0 20px rgba(135, 217, 120, 0.08); }
-.scoreplate.score-medium { border-color: rgba(247, 198, 107, 0.35); box-shadow: 0 24px 60px var(--shadow), 0 0 20px rgba(247, 198, 107, 0.08); }
-.scoreplate.score-high { border-color: rgba(255, 152, 104, 0.35); box-shadow: 0 24px 60px var(--shadow), 0 0 20px rgba(255, 152, 104, 0.08); }
-.scoreplate.score-critical { border-color: rgba(255, 85, 115, 0.35); box-shadow: 0 24px 60px var(--shadow), 0 0 20px rgba(255, 85, 115, 0.08); }
+.scoreplate.score-low {
+  border-color: rgba(110, 231, 160, 0.35);
+  box-shadow: 0 20px 50px var(--shadow), 0 0 30px rgba(110, 231, 160, 0.08);
+}
 
-/* Score breakdown description visibility */
-.score-breakdown-head p { color: rgba(131, 144, 173, 0.8); }
+.scoreplate.score-medium {
+  border-color: rgba(245, 200, 106, 0.35);
+  box-shadow: 0 20px 50px var(--shadow), 0 0 30px rgba(245, 200, 106, 0.08);
+}
 
-/* Filter panel scrollbar styling */
-.filters::-webkit-scrollbar { width: 6px; }
-.filters::-webkit-scrollbar-track { background: transparent; }
-.filters::-webkit-scrollbar-thumb { background: rgba(139, 155, 191, 0.3); border-radius: 3px; }
-.filters::-webkit-scrollbar-thumb:hover { background: rgba(139, 155, 191, 0.5); }
+.scoreplate.score-high {
+  border-color: rgba(255, 154, 106, 0.35);
+  box-shadow: 0 20px 50px var(--shadow), 0 0 30px rgba(255, 154, 106, 0.08);
+}
 
-/* Metrics card color coding */
-.metric { border-color: rgba(139, 155, 191, 0.18); }
+.scoreplate.score-critical {
+  border-color: rgba(255, 92, 122, 0.35);
+  box-shadow: 0 20px 50px var(--shadow), 0 0 30px rgba(255, 92, 122, 0.08);
+}
+
+.filters::-webkit-scrollbar,
+.table-wrap::-webkit-scrollbar,
+.detail::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.filters::-webkit-scrollbar-track,
+.table-wrap::-webkit-scrollbar-track,
+.detail::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.filters::-webkit-scrollbar-thumb,
+.table-wrap::-webkit-scrollbar-thumb,
+.detail::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 196, 0.28);
+  border-radius: 999px;
+}
+
+.filters::-webkit-scrollbar-thumb:hover,
+.table-wrap::-webkit-scrollbar-thumb:hover,
+.detail::-webkit-scrollbar-thumb:hover {
+  background: rgba(148, 163, 196, 0.45);
+}
+
 .metric strong.critical { color: var(--critical); }
 .metric strong.high { color: var(--high); }
 .metric strong.medium { color: var(--medium); }
 .metric strong.low { color: var(--low); }
 
-/* Badge border radius for softer look */
-.badge { border-radius: 4px; }
+.filters,
+.findings-panel,
+.detail {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  box-shadow:
+    0 20px 50px var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+}

--- a/internal/web/assets/app.css
+++ b/internal/web/assets/app.css
@@ -1,29 +1,25 @@
 :root {
   color-scheme: dark;
-  --bg: #07090f;
-  --bg-elevated: #0c1018;
-  --panel: rgba(14, 18, 28, 0.92);
-  --panel-2: #151b2b;
-  --surface-sunken: #080b12;
-  --text: #eef2fb;
-  --text-dim: #c4cee6;
-  --text-section: #dce4f7;
-  --text-muted: #7d8aa8;
-  --muted: var(--text-muted);
-  --line: rgba(148, 163, 196, 0.18);
-  --border: rgba(148, 163, 196, 0.22);
-  --critical: #ff5c7a;
-  --high: #ff9a6a;
-  --medium: #f5c86a;
-  --low: #6ee7a0;
-  --accent: #5eb8ff;
-  --accent-soft: rgba(94, 184, 255, 0.14);
-  --shadow: rgba(0, 0, 0, 0.55);
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
-  --font-display: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --bg: #07100f;
+  --panel: #101816;
+  --panel-2: #16231f;
+  --panel-strong: #16231f;
+  --surface-sunken: #050a09;
+  --text-dim: #c8bea7;
+  --text-section: #e7dfca;
+  --line: #31413b;
+  --line-strong: #516057;
+  --border: #31413b;
+  --text: #f5ead2;
+  --text-muted: #9aa89f;
+  --muted: #9aa89f;
+  --critical: #e05757;
+  --high: #d8843b;
+  --medium: #d6ae58;
+  --low: #91b987;
+  --accent: #d2bc74;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #020504;
 }
 
 * { box-sizing: border-box; }
@@ -32,36 +28,27 @@ body {
   margin: 0;
   min-height: 100vh;
   color: var(--text);
-  background:
-    radial-gradient(ellipse 80% 50% at 10% -10%, rgba(94, 184, 255, 0.12), transparent 50%),
-    radial-gradient(ellipse 60% 40% at 95% 5%, rgba(255, 92, 122, 0.07), transparent 45%),
-    radial-gradient(ellipse 50% 30% at 50% 100%, rgba(110, 231, 160, 0.04), transparent 40%),
-    linear-gradient(160deg, #07090f 0%, #0a0e16 45%, #060810 100%);
-  font-family: var(--font-mono);
-  font-size: 14px;
-  line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
+  background: var(--bg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
 body::before {
   content: "";
   position: fixed;
-  inset: 0;
+  inset: 0 auto 0 0;
+  z-index: 0;
+  width: 10px;
+  background: var(--accent);
   pointer-events: none;
-  background-image:
-    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
-  background-size: 40px 40px;
-  mask-image: radial-gradient(ellipse 90% 70% at 50% 0%, black 20%, transparent 85%);
 }
 
 button, input, select { font: inherit; }
 
 .sysinfo {
-  margin: 6px 0 0;
+  margin: 4px 0 0;
   color: var(--muted);
-  font-size: 12px;
-  letter-spacing: 0.04em;
+  font-size: 13px;
+  letter-spacing: 0.02em;
 }
 
 .shell {
@@ -86,139 +73,70 @@ button, input, select { font: inherit; }
   display: flex;
   align-items: stretch;
   justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 20px;
+  gap: 20px;
+  margin-bottom: 16px;
   flex-shrink: 0;
 }
 
-.brand-block {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
 .eyebrow {
-  margin: 0 0 6px;
+  margin: 0 0 8px;
   color: var(--accent);
-  font-family: var(--font-display);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.18em;
+  font-size: 12px;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
-h1, h2, h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  font-weight: 700;
-}
+h1, h2, h3 { margin: 0; }
 
 h1 {
-  font-size: clamp(36px, 4.5vw, 64px);
-  line-height: 0.95;
-  letter-spacing: -0.04em;
-  background: linear-gradient(135deg, var(--text) 0%, var(--text-dim) 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
+  font-size: clamp(38px, 5vw, 76px);
+  line-height: 0.9;
+  letter-spacing: -0.08em;
 }
 
 .scoreplate {
-  position: relative;
-  min-width: 220px;
+  min-width: 250px;
   padding: 20px 24px;
-  border: 1px solid var(--line);
-  background: var(--panel);
-  box-shadow:
-    0 20px 50px var(--shadow),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.scoreplate::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.04) 0%, transparent 50%);
-  pointer-events: none;
+  border: 2px solid var(--line-strong);
+  background: var(--panel-strong);
+  box-shadow: 8px 8px 0 var(--shadow-cut);
+  border-radius: 0;
 }
 
 .score-label {
   display: block;
   color: var(--muted);
-  font-family: var(--font-display);
-  font-size: 11px;
-  font-weight: 600;
+  font-size: 13px;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.12em;
 }
 
 .scoreplate strong {
   display: block;
-  margin-top: 6px;
-  font-family: var(--font-display);
-  font-size: clamp(42px, 5vw, 52px);
-  font-weight: 800;
+  margin-top: 8px;
+  font-size: 54px;
   line-height: 1;
-  letter-spacing: -0.03em;
 }
 
 .metrics {
   display: grid;
   grid-template-columns: repeat(6, minmax(120px, 1fr));
-  gap: 12px;
-  margin-bottom: 18px;
+  gap: 10px;
+  margin-bottom: 16px;
   flex-shrink: 0;
 }
 
 .metric {
-  position: relative;
   padding: 14px 16px;
   border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
+  border-radius: 0;
   background: var(--panel);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-  transition: border-color 180ms ease, transform 180ms ease;
-}
-
-.metric:hover {
-  border-color: rgba(148, 163, 196, 0.32);
-  transform: translateY(-1px);
-}
-
-.metric::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 12px;
-  right: 12px;
-  height: 2px;
-  border-radius: 0 0 2px 2px;
-  background: var(--line);
-  opacity: 0.6;
 }
 
 .metric--total {
-  border-color: rgba(94, 184, 255, 0.35);
-  background:
-    linear-gradient(to bottom, rgba(94, 184, 255, 0.12), transparent 55%),
-    var(--panel);
+  border-color: var(--accent);
+  background: var(--panel);
 }
-
-.metric--total::before {
-  background: var(--accent);
-  opacity: 1;
-}
-
-.metric--critical::before { background: var(--critical); opacity: 1; }
-.metric--high::before { background: var(--high); opacity: 1; }
-.metric--medium::before { background: var(--medium); opacity: 1; }
-.metric--low::before { background: var(--low); opacity: 1; }
-.metric--fixable::before { background: var(--accent); opacity: 1; }
 
 .metric--fixable strong {
   color: var(--accent);
@@ -227,29 +145,24 @@ h1 {
 .metric span {
   display: block;
   color: var(--muted);
-  font-family: var(--font-display);
-  font-size: 10px;
-  font-weight: 600;
+  font-size: 11px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .metric strong {
   display: block;
-  margin-top: 8px;
-  font-family: var(--font-display);
-  font-size: 26px;
-  font-weight: 700;
-  line-height: 1;
+  margin-top: 6px;
+  font-size: 25px;
 }
 
 .metric--total strong {
   color: var(--accent);
-  font-size: 32px;
+  font-size: 34px;
 }
 
 .score-breakdown {
-  margin-bottom: 18px;
+  margin-bottom: 16px;
   flex-shrink: 0;
 }
 
@@ -258,12 +171,12 @@ h1 {
 }
 
 .history-panel {
-  margin-bottom: 18px;
-  padding: 16px 18px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  margin-bottom: 16px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: 0;
   background: var(--panel);
-  box-shadow: 0 12px 40px var(--shadow);
+  box-shadow: 6px 6px 0 var(--shadow-cut);
 }
 
 .history-panel[hidden] {
@@ -284,16 +197,10 @@ h1 {
 }
 
 .history-item {
-  padding: 12px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.02);
-  transition: border-color 150ms ease, background 150ms ease;
-}
-
-.history-item:hover {
-  border-color: rgba(94, 184, 255, 0.3);
-  background: rgba(94, 184, 255, 0.04);
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 0;
+  background: var(--surface-sunken);
 }
 
 .history-item-top {
@@ -321,41 +228,33 @@ h1 {
   align-items: baseline;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
 .score-breakdown-head span {
   color: var(--muted);
-  font-family: var(--font-display);
   font-size: 11px;
-  font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .score-breakdown-head p {
   margin: 0;
-  color: rgba(125, 138, 168, 0.85);
+  color: var(--muted);
   font-size: 12px;
-  max-width: 520px;
 }
 
 .score-axis-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+  gap: 10px;
 }
 
 .score-axis {
-  padding: 14px;
+  padding: 12px;
   border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
+  border-radius: 0;
   background: var(--panel);
-  transition: border-color 180ms ease;
-}
-
-.score-axis:hover {
-  border-color: rgba(148, 163, 196, 0.32);
 }
 
 .score-axis-top {
@@ -367,36 +266,23 @@ h1 {
 
 .score-axis-top span {
   color: var(--muted);
-  font-family: var(--font-display);
-  font-size: 10px;
-  font-weight: 600;
+  font-size: 11px;
   letter-spacing: 0.08em;
-  line-height: 1.3;
+  line-height: 1.25;
   text-transform: uppercase;
 }
 
 .score-axis-top strong {
   white-space: nowrap;
-  font-family: var(--font-display);
   font-size: 18px;
-  font-weight: 700;
 }
 
-.score-axis-bar {
-  height: 6px;
-  margin: 12px 0 8px;
-  overflow: hidden;
-  background: var(--surface-sunken);
-  border-radius: 999px;
-  border: none;
-}
+.score-axis-bar { height: 6px; margin: 10px 0 8px; overflow: hidden; background: var(--surface-sunken); border-radius: 3px; border: none; }
 
 .score-axis-bar span {
   display: block;
   height: 100%;
   background: currentColor;
-  border-radius: 999px;
-  transition: width 400ms ease;
 }
 
 .score-axis-meta {
@@ -418,29 +304,11 @@ h1 {
   flex: 1;
   min-height: 0;
   display: flex;
-  gap: 16px;
+  gap: 14px;
   overflow: hidden;
 }
 
-.panel-surface {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  background: var(--panel);
-  box-shadow:
-    0 20px 50px var(--shadow),
-    inset 0 1px 0 rgba(255, 255, 255, 0.03);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
-}
-
-.filters {
-  width: 320px;
-  flex-shrink: 0;
-  align-self: flex-start;
-  padding: 20px;
-  max-height: 100%;
-  overflow-y: auto;
-}
+.filters { width: 340px; flex-shrink: 0; align-self: flex-start; padding: 18px; border: 1px solid var(--line); border-radius: 0; background: var(--panel); box-shadow: 6px 6px 0 var(--shadow-cut); max-height: 100%; overflow-y: auto; }
 
 .findings-panel {
   flex: 1;
@@ -448,22 +316,28 @@ h1 {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0;
+  background: var(--panel);
+  box-shadow: 6px 6px 0 var(--shadow-cut);
 }
 
 .detail {
   flex: 0.72;
   min-width: 0;
   overflow-y: auto;
-  padding: 20px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 0;
+  background: var(--panel);
+  box-shadow: 6px 6px 0 var(--shadow-cut);
 }
 
 .search span, .filter-block h2 {
   display: block;
   margin: 0 0 10px;
   color: var(--muted);
-  font-family: var(--font-display);
-  font-size: 11px;
-  font-weight: 600;
+  font-size: 12px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -473,23 +347,18 @@ input, select {
   color: var(--text);
   border: 1px solid var(--line);
   background: var(--surface-sunken);
-  padding: 11px 12px;
-  border-radius: var(--radius-sm);
+  padding: 12px;
   outline: none;
-  transition: border-color 150ms ease, box-shadow 150ms ease;
 }
 
-input:focus, select:focus {
-  border-color: rgba(94, 184, 255, 0.65);
-  box-shadow: 0 0 0 3px var(--accent-soft);
-}
+input:focus, select:focus { border-color: var(--accent); outline: none; }
 
 .search-input {
   position: relative;
 }
 
 .search-input input {
-  padding-left: 38px;
+  padding-left: 36px;
 }
 
 .search-icon {
@@ -499,20 +368,9 @@ input:focus, select:focus {
   transform: translateY(-50%);
   color: var(--muted);
   pointer-events: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 0;
-}
-
-.search-icon svg {
-  width: 16px;
-  height: 16px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .filter-block { margin-top: 22px; }
@@ -522,23 +380,18 @@ input:focus, select:focus {
   cursor: pointer;
   color: var(--muted);
   border: 1px solid var(--line);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.02);
-  padding: 7px 12px;
-  font-family: var(--font-display);
-  font-size: 12px;
-  font-weight: 500;
-  transition: color 150ms ease, border-color 150ms ease, background 150ms ease, transform 150ms ease;
+  border-radius: 0;
+  background: var(--surface-sunken);
+  padding: 6px 10px;
 }
+
+
+.section pre, .evidence-details pre { white-space: pre-wrap; word-break: break-word; padding: 14px; border: 1px solid var(--line); border-radius: 4px; background: var(--surface-sunken); }
 
 .chip.active, button:not(:disabled):hover {
   color: var(--text);
-  border-color: rgba(94, 184, 255, 0.55);
-  background: var(--accent-soft);
-}
-
-.chip.active {
-  box-shadow: inset 0 0 0 1px rgba(94, 184, 255, 0.2);
+  border-color: var(--accent);
+  background: rgba(210, 188, 116, 0.1);
 }
 
 .panel-head {
@@ -546,13 +399,8 @@ input:focus, select:focus {
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  padding: 18px 20px;
+  padding: 18px;
   border-bottom: 1px solid var(--line);
-}
-
-.panel-head h2 {
-  font-size: 18px;
-  letter-spacing: -0.02em;
 }
 
 .panel-head-actions {
@@ -563,274 +411,81 @@ input:focus, select:focus {
   justify-content: flex-end;
 }
 
-.table-wrap {
-  flex: 1;
-  min-width: 0;
-  overflow: auto;
-  padding: 0 12px 12px;
-  scroll-padding-top: 44px;
-}
+.table-wrap { flex: 1; min-width: 0; overflow: auto; padding: 0 18px; scroll-padding-top: 44px; }
+table { width: 100%; min-width: 680px; border-collapse: collapse; table-layout: fixed; }
+.fixed { border-left-color: transparent !important; }
 
-table {
-  width: 100%;
-  min-width: 680px;
-  border-collapse: separate;
-  border-spacing: 0;
-  table-layout: fixed;
-}
-
-th, td {
-  padding: 11px 12px;
-  border-bottom: 1px solid rgba(148, 163, 196, 0.1);
-  text-align: left;
-  vertical-align: top;
-}
-
-th {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  color: var(--muted);
-  background: rgba(14, 18, 28, 0.98);
-  font-family: var(--font-display);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
+th, td { padding: 12px 14px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+th { position: sticky; top: 0; z-index: 2; color: var(--muted); background: var(--panel); font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; }
 tbody tr {
   cursor: pointer;
-  transition: background 150ms ease;
-  border-left: 3px solid transparent;
+  border-left: 4px solid transparent;
 }
 
-tbody tr[data-severity="critical"] { border-left-color: rgba(255, 92, 122, 0.55); }
-tbody tr[data-severity="high"] { border-left-color: rgba(255, 154, 106, 0.5); }
-tbody tr[data-severity="medium"] { border-left-color: rgba(245, 200, 106, 0.45); }
-tbody tr[data-severity="low"] { border-left-color: rgba(110, 231, 160, 0.45); }
+tbody tr[data-severity="critical"] { border-left-color: var(--critical); }
+tbody tr[data-severity="high"] { border-left-color: var(--high); }
+tbody tr[data-severity="medium"] { border-left-color: var(--medium); }
+tbody tr[data-severity="low"] { border-left-color: var(--low); }
 
-tbody tr:hover,
-tbody tr.selected {
-  background: rgba(94, 184, 255, 0.08);
-}
-
-tbody tr.disabled {
-  cursor: pointer;
-  opacity: 0.55;
-  border-left-color: transparent !important;
-}
-
+tbody tr:hover, tbody tr.selected { background: rgba(210, 188, 116, 0.07); }
+tbody tr.disabled { cursor: pointer; opacity: 0.65; }
 tbody tr.disabled .row-check { cursor: not-allowed; }
-tbody tr.disabled:hover { background: inherit; }
-.row-check:disabled { opacity: 0.35; cursor: not-allowed; }
-
-.id {
-  color: var(--text-dim);
-  white-space: nowrap;
-  font-size: 12px;
-}
-
+tbody tr.disabled:hover { background: inherit; color: inherit; }
+.row-check:disabled { opacity: 0.4; cursor: not-allowed; }
+.id { color: var(--text-dim); white-space: nowrap; }
 th:nth-child(1) { width: 40px; }
 th:nth-child(2) { width: 90px; }
 th:nth-child(3) { width: 80px; }
 th:nth-child(4) { width: 140px; pointer-events: none; }
 th:nth-child(5) { width: auto; }
 th:nth-child(6) { width: 125px; }
-
-.title {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.badge {
-  display: inline-block;
-  padding: 3px 8px;
-  border: 1px solid currentColor;
-  border-radius: 999px;
-  font-family: var(--font-display);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
+.title { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.badge { display: inline-block; padding: 4px 7px; border: 1px solid currentColor; font-size: 11px; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
 .critical { color: var(--critical); }
 .high { color: var(--high); }
 .medium { color: var(--medium); }
 .low { color: var(--low); }
 .muted { color: var(--muted); }
 
-.empty-detail {
-  display: grid;
-  min-height: 380px;
-  place-content: center;
-  text-align: center;
-  color: var(--muted);
-  padding: 24px;
-}
-
-.empty-detail-icon {
-  width: 64px;
-  height: 64px;
-  margin: 0 auto 18px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  background: linear-gradient(135deg, var(--accent-soft), rgba(255, 255, 255, 0.02));
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--accent);
-}
-
-.empty-detail-icon svg {
-  width: 28px;
-  height: 28px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.75;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.empty-detail h2 {
-  font-size: 22px;
-  color: var(--text-dim);
-  margin-bottom: 8px;
-}
-
-.empty-detail p {
-  margin: 0;
-  max-width: 280px;
-  line-height: 1.6;
-}
-
+.empty-detail { display: grid; min-height: 380px; place-content: center; text-align: center; color: var(--muted); }
+.empty-detail span { width: 48px; height: 48px; margin: 0 auto 16px; border: 1px solid var(--line); background: var(--surface-sunken); display: flex; align-items: center; justify-content: center; font-size: 20px; font-weight: 700; color: var(--accent); }
 .detail .badge { display: inline-block; margin-bottom: 12px; }
 .detail .fix-btn { margin-top: 18px; }
-.detail h2 {
-  font-size: 24px;
-  line-height: 1.15;
-  letter-spacing: -0.03em;
-  overflow-wrap: anywhere;
-}
-
-.detail-meta {
-  display: grid;
-  grid-template-columns: minmax(92px, 110px) minmax(0, 1fr);
-  gap: 8px 12px;
-  margin: 20px 0;
-  padding: 16px;
-  background: rgba(255, 255, 255, 0.025);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-}
-
-.detail-meta dt {
-  color: var(--muted);
-  font-family: var(--font-display);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.detail-meta dd {
-  margin: 0;
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
+.detail h2 { font-size: 26px; line-height: 1.1; letter-spacing: -0.04em; overflow-wrap: anywhere; }
+.detail-meta { display: grid; grid-template-columns: minmax(92px, 110px) minmax(0, 1fr); gap: 8px 12px; margin: 20px 0; padding: 16px; background: var(--surface-sunken); border: 1px solid var(--line); border-radius: 0; }
+.detail-meta dt { color: var(--muted); }
+.detail-meta dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
 .section { margin-top: 22px; }
-
-.section h3 {
-  color: var(--accent);
-  font-family: var(--font-display);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  margin-bottom: 10px;
-}
-
-.section p, .section pre, .evidence-details pre {
-  color: var(--text-section);
-  line-height: 1.65;
-  overflow-wrap: anywhere;
-}
-
-.section pre, .evidence-details pre {
-  white-space: pre-wrap;
-  word-break: break-word;
-  padding: 14px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: var(--surface-sunken);
-}
-
+.section h3 { color: var(--accent); font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: 10px; }
+.section p, .section pre, .evidence-details pre { color: var(--text-section); line-height: 1.65; overflow-wrap: anywhere; }
+.section pre, .evidence-details pre { white-space: pre-wrap; word-break: break-word; padding: 14px; border: 1px solid var(--line); background: var(--surface-sunken); }
 .copy { margin-top: 10px; }
 
 .fix-btn {
   margin-top: 12px;
-  padding: 11px 22px;
-  color: #041208;
-  background: linear-gradient(135deg, var(--low) 0%, #4dd68a 100%);
-  border: none;
-  border-radius: var(--radius-sm);
-  font-family: var(--font-display);
+  padding: 10px 20px;
+  color: var(--bg);
+  background: var(--low);
+  border: 2px solid var(--low);
   font-weight: 700;
-  font-size: 13px;
   cursor: pointer;
-  box-shadow: 0 4px 16px rgba(110, 231, 160, 0.25);
-  transition: filter 150ms ease, transform 150ms ease, box-shadow 150ms ease;
 }
-
-.fix-btn:not(:disabled):hover {
-  filter: brightness(1.08);
-  transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(110, 231, 160, 0.35);
-}
-
+.fix-btn:not(:disabled):hover { background: var(--bg); color: var(--low); }
 .fix-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .fix-btn.loading { pointer-events: none; cursor: wait; }
 
 .fix-success { color: var(--low); margin-top: 12px; font-weight: 700; }
 .fix-error { color: var(--critical); margin-top: 12px; font-weight: 700; }
-
-.fix-diff {
-  margin-top: 8px;
-  padding: 12px;
-  background: var(--surface-sunken);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  white-space: pre-wrap;
-  font-size: 12px;
-}
+.fix-diff { margin-top: 8px; padding: 10px; background: var(--surface-sunken); border: 1px solid var(--line); white-space: pre-wrap; font-size: 12px; }
 
 .loading .findings-panel,
 .loading .filters { display: none; }
 
 .loading .detail { flex: 1 1 100%; }
 
-.loading-state {
-  display: grid;
-  place-content: center;
-  min-height: 420px;
-  text-align: center;
-  padding: 32px;
-}
-
-.loading-state h2 {
-  font-size: 28px;
-  margin-bottom: 20px;
-  background: linear-gradient(135deg, var(--text), var(--accent));
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-
 .tool-status {
-  margin: 24px auto 0;
+  margin: 24px 0;
   max-width: 480px;
-  text-align: left;
 }
 
 .tool-row {
@@ -838,51 +493,45 @@ th:nth-child(6) { width: 125px; }
   align-items: center;
   gap: 12px;
   padding: 10px 0;
-  border-bottom: 1px solid rgba(148, 163, 196, 0.1);
+  border-bottom: 1px solid var(--line);
 }
 
 .tool-icon {
   width: 24px;
   text-align: center;
-  font-size: 16px;
+  font-size: 18px;
 }
 
 .tool-icon.done { color: var(--low); }
 .tool-icon.error { color: var(--critical); }
-.tool-icon.running { color: var(--accent); animation: pulse 1.2s ease infinite; }
+.tool-icon.running { color: var(--accent); }
 .tool-icon.muted { color: var(--muted); }
 .tool-icon.degraded { color: var(--high); }
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.45; }
-}
 
 .tool-name {
   width: 70px;
   color: var(--text);
-  font-family: var(--font-display);
-  font-weight: 600;
+  font-weight: 700;
   font-size: 13px;
+  letter-spacing: 0.06em;
 }
 
-.tool-msg { color: var(--muted); font-size: 13px; }
+.tool-msg { color: var(--muted); }
 
 .progress-bar {
   width: 100%;
   max-width: 480px;
   height: 6px;
-  background: rgba(148, 163, 196, 0.12);
-  border-radius: 999px;
+  background: var(--line);
+  border-radius: 0;
   overflow: hidden;
-  margin: 0 auto;
+  margin-top: 16px;
 }
 
 .progress-fill {
   height: 100%;
-  background: linear-gradient(90deg, var(--accent), #8fd4ff);
-  border-radius: 999px;
-  transition: width 0.4s ease;
+  background: var(--accent);
+  border-radius: 0;
 }
 
 th.sortable {
@@ -918,9 +567,9 @@ th.sortable.desc::after {
 @media (min-width: 1321px) and (max-height: 700px) {
   .shell { padding: 12px 0; }
   .topbar { margin-bottom: 10px; }
-  h1 { font-size: clamp(32px, 4vw, 48px); }
+  h1 { font-size: clamp(34px, 4vw, 56px); }
   .scoreplate { padding: 14px 18px; }
-  .scoreplate strong { font-size: 38px; }
+  .scoreplate strong { font-size: 42px; }
   .metrics { margin-bottom: 10px; }
   .metric { padding: 8px 12px; }
   .metric strong { font-size: 20px; }
@@ -958,91 +607,45 @@ th.sortable.desc::after {
   th:nth-child(4), td:nth-child(4) { display: none; }
 }
 
-.fixed td { opacity: 0.55; }
-.fixed { border-left-color: transparent !important; }
+.fixed td { opacity: 0.65; }
 
 .fix-warning { color: var(--high); }
 
-.clear-btn {
-  width: 100%;
-  text-align: center;
-  border-radius: var(--radius-sm);
-}
+.clear-btn { width: 100%; text-align: center; }
 
 .evidence-details { margin-top: 22px; }
-
-.evidence-details summary {
-  color: var(--accent);
-  cursor: pointer;
-  font-family: var(--font-display);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
+.evidence-details summary { color: var(--accent); cursor: pointer; font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase; }
 .evidence-details[open] { margin-bottom: 8px; }
 
 .collapsible .collapse-body p { margin: 0; }
-
-.toggle-more {
-  background: none;
-  border: none;
-  color: var(--accent);
-  cursor: pointer;
-  padding: 4px 0;
-  font-size: 12px;
-}
-
+.toggle-more { background: none; border: none; color: var(--accent); cursor: pointer; padding: 4px 0; font-size: 12px; }
 .toggle-more:hover { text-decoration: underline; }
 
 .modal-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 200;
-  background: rgba(4, 6, 10, 0.72);
-  -webkit-backdrop-filter: blur(6px);
-  backdrop-filter: blur(6px);
-  display: grid;
-  place-items: center;
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(0, 0, 0, 0.65);
+  display: grid; place-items: center;
   padding: 16px;
   overflow-y: auto;
   overflow-x: hidden;
 }
-
 .modal-content {
-  background: var(--panel-2);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
+  background: var(--panel);
+  border: 2px solid var(--line-strong);
+  border-radius: 0;
   padding: 32px;
   max-width: 480px;
   width: min(100%, 480px);
   max-height: calc(100vh - 32px);
   overflow-y: auto;
   overflow-x: hidden;
-  box-shadow: 0 24px 80px var(--shadow);
+  box-shadow: 10px 10px 0 var(--shadow-cut);
 }
-
-.modal-content h2 {
-  margin-bottom: 12px;
-  font-size: 22px;
-}
-
+.modal-content h2 { margin-bottom: 12px; font-size: 22px; }
 .modal-content p { margin: 8px 0; line-height: 1.5; }
 .modal-actions { display: flex; gap: 10px; margin-top: 20px; }
-
-.modal-actions button {
-  flex: 1;
-  padding: 10px 16px;
-  height: 42px;
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: 0;
-  border-radius: var(--radius-sm);
-}
-
+.modal-actions button { flex: 1; padding: 10px 16px; height: 42px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; margin-top: 0; }
+/* Help modal: center the single Close button instead of stretching full width. */
 .modal-help .modal-actions { justify-content: center; }
 .modal-help .modal-actions button { flex: 0 0 auto; min-width: 160px; }
 
@@ -1055,9 +658,8 @@ th.sortable.desc::after {
 }
 
 .action-summary {
-  background: rgba(255, 255, 255, 0.025);
+  background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
   padding: 14px;
   margin: 12px 0;
 }
@@ -1077,26 +679,24 @@ th.sortable.desc::after {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   border: 1px solid;
-  border-radius: 999px;
 }
-
 .type-edit { color: var(--accent); border-color: var(--accent); }
 .type-exec { color: var(--medium); border-color: var(--medium); }
 .type-prompt { color: var(--muted); border-color: var(--muted); }
 
-.action-command, .action-edit-path { margin-top: 8px; font-size: 12px; }
-
+.action-command, .action-edit-path {
+  margin-top: 8px;
+  font-size: 12px;
+}
 .action-command code, .action-edit-path code {
   display: block;
   margin-top: 4px;
   padding: 8px 10px;
   background: var(--surface-sunken);
   border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
   font-size: 11px;
   word-break: break-word;
 }
-
 .command-label, .path-label {
   color: var(--muted);
   font-size: 10px;
@@ -1104,21 +704,21 @@ th.sortable.desc::after {
   letter-spacing: 0.1em;
 }
 
-.diff-preview { margin-top: 12px; font-size: 12px; }
-
+.diff-preview {
+  margin-top: 12px;
+  font-size: 12px;
+}
 .diff-preview .preview-label {
   color: var(--muted);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
-
 .diff-preview pre {
   margin-top: 4px;
   padding: 10px;
   background: var(--surface-sunken);
   border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
   font-size: 11px;
   white-space: pre-wrap;
   word-break: break-word;
@@ -1136,22 +736,18 @@ th.sortable.desc::after {
 }
 
 .action-option {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--surface-sunken);
   border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
   padding: 14px;
   cursor: pointer;
-  transition: border-color 150ms ease, background 150ms ease;
 }
-
 .action-option:hover {
-  border-color: rgba(94, 184, 255, 0.4);
-  background: rgba(94, 184, 255, 0.05);
+  border-color: var(--accent);
+  background: rgba(210, 188, 116, 0.06);
 }
-
 .action-option.selected {
   border-color: var(--accent);
-  background: rgba(94, 184, 255, 0.08);
+  background: rgba(210, 188, 116, 0.1);
 }
 
 .action-option-header {
@@ -1159,14 +755,11 @@ th.sortable.desc::after {
   align-items: center;
   gap: 10px;
 }
-
 .action-option-header input[type="radio"] {
   width: auto;
   margin: 0;
   cursor: pointer;
-  accent-color: var(--accent);
 }
-
 .action-option-header label {
   display: flex;
   align-items: center;
@@ -1182,21 +775,18 @@ th.sortable.desc::after {
 .check-col { width: 40px !important; text-align: center; }
 .check-cell { width: 40px; text-align: center; }
 .row-check { cursor: pointer; accent-color: var(--accent); }
-.row-selected { background: rgba(94, 184, 255, 0.12) !important; }
+.row-selected { background: rgba(210, 188, 116, 0.12) !important; }
 
 .fix-selected-btn {
   color: var(--low);
-  border-color: rgba(110, 231, 160, 0.5);
-  background: rgba(110, 231, 160, 0.1);
+  border-color: var(--low);
+  background: rgba(145, 185, 135, 0.08);
   font-weight: 700;
-  border-radius: var(--radius-sm);
 }
-
 .fix-selected-btn:not(:disabled):hover {
-  background: rgba(110, 231, 160, 0.18);
+  background: rgba(145, 185, 135, 0.14);
   border-color: var(--low);
 }
-
 .fix-selected-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .fix-selected-btn.loading { cursor: wait; }
 
@@ -1207,16 +797,12 @@ th.sortable.desc::after {
   z-index: 300;
   padding: 14px 20px;
   border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: var(--panel-2);
+  background: var(--panel);
   color: var(--text);
-  font-family: var(--font-display);
   font-size: 13px;
-  font-weight: 500;
   box-shadow: 0 12px 40px var(--shadow);
   animation: toast-in 0.3s ease;
 }
-
 .toast-hide { animation: toast-out 0.3s ease forwards; }
 .toast-success { border-left: 3px solid var(--low); }
 .toast-error { border-left: 3px solid var(--critical); }
@@ -1226,7 +812,6 @@ th.sortable.desc::after {
   from { opacity: 0; transform: translateY(12px); }
   to { opacity: 1; transform: translateY(0); }
 }
-
 @keyframes toast-out {
   from { opacity: 1; transform: translateY(0); }
   to { opacity: 0; transform: translateY(12px); }
@@ -1238,7 +823,6 @@ th.sortable.desc::after {
   gap: 12px;
   margin: 20px 0;
 }
-
 .export-option {
   display: flex;
   flex-direction: column;
@@ -1246,18 +830,13 @@ th.sortable.desc::after {
   gap: 8px;
   padding: 24px 16px;
   border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--surface-sunken);
   cursor: pointer;
-  transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
 }
-
 .export-option:hover {
   border-color: var(--accent);
-  background: rgba(94, 184, 255, 0.06);
-  transform: translateY(-2px);
+  background: rgba(210, 188, 116, 0.06);
 }
-
 .export-icon {
   font-size: 24px;
   font-weight: 700;
@@ -1265,38 +844,34 @@ th.sortable.desc::after {
   white-space: nowrap;
   word-break: keep-all;
 }
-
 .export-label {
   font-weight: 700;
   color: var(--text);
   white-space: nowrap;
   word-break: keep-all;
 }
-
 .export-desc {
   font-size: 11px;
   color: var(--muted);
 }
 
+/* Help modal */
 .modal-help {
   max-width: 640px;
   width: min(100%, 640px);
 }
-
 .modal-help h2 {
   margin-bottom: 16px;
   font-size: 20px;
 }
-
 .help-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 20px 24px;
   margin: 16px 0 20px;
 }
-
 .help-section h3 {
-  font-size: 11px;
+  font-size: 13px;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--muted);
@@ -1304,24 +879,26 @@ th.sortable.desc::after {
   padding-bottom: 6px;
   border-bottom: 1px solid var(--line);
 }
-
 .help-section dl {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 6px 12px;
   font-size: 12px;
 }
-
-.help-section dt { white-space: nowrap; color: var(--text); }
-.help-section dd { color: var(--muted); }
-
+.help-section dt {
+  white-space: nowrap;
+  color: var(--text);
+}
+.help-section dd {
+  color: var(--muted);
+}
 .help-section kbd {
   display: inline-block;
   background: var(--surface-sunken);
   border: 1px solid var(--line);
-  border-radius: 4px;
+  border-radius: 3px;
   padding: 1px 5px;
-  font-family: var(--font-mono);
+  font-family: monospace;
   font-size: 10px;
   color: var(--text);
   white-space: nowrap;
@@ -1333,6 +910,7 @@ th.sortable.desc::after {
   .help-section dl { grid-template-columns: auto minmax(0, 1fr); }
 }
 
+/* Per-axis penalty bar colors */
 .score-axis[data-axis="vulnerabilities"] .score-axis-bar span { background: var(--critical); }
 .score-axis[data-axis="container_exposure"] .score-axis-bar span { background: var(--high); }
 .score-axis[data-axis="host_hardening"] .score-axis-bar span { background: var(--medium); }
@@ -1342,66 +920,27 @@ th.sortable.desc::after {
 .score-axis[data-axis="host_hardening"] .score-axis-top strong { color: var(--medium); }
 .score-axis[data-axis="secrets"] .score-axis-top strong { color: var(--accent); }
 
-.scoreplate.score-low {
-  border-color: rgba(110, 231, 160, 0.35);
-  box-shadow: 0 20px 50px var(--shadow), 0 0 30px rgba(110, 231, 160, 0.08);
-}
+/* Score plate severity border only */
+.scoreplate.score-low { border-color: var(--low); }
+.scoreplate.score-medium { border-color: var(--medium); }
+.scoreplate.score-high { border-color: var(--high); }
+.scoreplate.score-critical { border-color: var(--critical); }
 
-.scoreplate.score-medium {
-  border-color: rgba(245, 200, 106, 0.35);
-  box-shadow: 0 20px 50px var(--shadow), 0 0 30px rgba(245, 200, 106, 0.08);
-}
+.score-breakdown-head p { color: var(--muted); }
 
-.scoreplate.score-high {
-  border-color: rgba(255, 154, 106, 0.35);
-  box-shadow: 0 20px 50px var(--shadow), 0 0 30px rgba(255, 154, 106, 0.08);
-}
-
-.scoreplate.score-critical {
-  border-color: rgba(255, 92, 122, 0.35);
-  box-shadow: 0 20px 50px var(--shadow), 0 0 30px rgba(255, 92, 122, 0.08);
-}
-
-.filters::-webkit-scrollbar,
-.table-wrap::-webkit-scrollbar,
-.detail::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-.filters::-webkit-scrollbar-track,
-.table-wrap::-webkit-scrollbar-track,
-.detail::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.filters::-webkit-scrollbar-thumb,
-.table-wrap::-webkit-scrollbar-thumb,
-.detail::-webkit-scrollbar-thumb {
-  background: rgba(148, 163, 196, 0.28);
-  border-radius: 999px;
-}
-
-.filters::-webkit-scrollbar-thumb:hover,
-.table-wrap::-webkit-scrollbar-thumb:hover,
-.detail::-webkit-scrollbar-thumb:hover {
-  background: rgba(148, 163, 196, 0.45);
-}
+.filters::-webkit-scrollbar { width: 6px; }
+.filters::-webkit-scrollbar-track { background: transparent; }
+.filters::-webkit-scrollbar-thumb { background: var(--line-strong); }
 
 .metric strong.critical { color: var(--critical); }
 .metric strong.high { color: var(--high); }
 .metric strong.medium { color: var(--medium); }
 .metric strong.low { color: var(--low); }
 
-.filters,
-.findings-panel,
-.detail {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  background: var(--panel);
-  box-shadow:
-    0 20px 50px var(--shadow),
-    inset 0 1px 0 rgba(255, 255, 255, 0.03);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
+.badge { border-radius: 0; }
+
+tbody tr.disabled { border-left-color: transparent !important; }
+
+@media (max-width: 760px) {
+  body::before { width: 6px; }
 }

--- a/internal/web/assets/app.js
+++ b/internal/web/assets/app.js
@@ -635,10 +635,10 @@ function renderMetrics() {
   const fixable = items.filter((f) => ["auto", "review"].includes(remediation(f))).length;
   const metrics = [
     ["Total", items.length, "", "metric--total"],
-    ["Critical", counts.critical || 0, "critical"],
-    ["High", counts.high || 0, "high"],
-    ["Medium", counts.medium || 0, "medium"],
-    ["Low", counts.low || 0, "low"],
+    ["Critical", counts.critical || 0, "critical", "metric--critical"],
+    ["High", counts.high || 0, "high", "metric--high"],
+    ["Medium", counts.medium || 0, "medium", "metric--medium"],
+    ["Low", counts.low || 0, "low", "metric--low"],
     ["Fixable", fixable, "", "metric--fixable"],
   ];
   $("metrics").innerHTML = metrics.map(([label, value, cls = "", extra = ""]) => `<article class="metric ${extra}"><span>${label}</span><strong class="${cls}">${value}</strong></article>`).join("");
@@ -735,7 +735,8 @@ function renderTable(visible) {
     const titleDisplay = f.fixed ? `<span style="opacity:0.5;text-decoration:line-through">${escapeHTML(title(f))}</span>` : escapeHTML(title(f));
     const checked = selectableRow && state.selectedSet.has(f.id) ? "checked" : "";
     const disabledAttr = !selectableRow ? "disabled" : "";
-    return `<tr class="${rowClass}" data-index="${index}" data-id="${escapeHTML(f.id)}">
+    const sevAttr = f.fixed ? "" : ` data-severity="${severity(f)}"`;
+    return `<tr class="${rowClass}" data-index="${index}" data-id="${escapeHTML(f.id)}"${sevAttr}>
       <td class="check-cell"><input type="checkbox" ${checked} ${disabledAttr} data-id="${escapeHTML(f.id)}" class="row-check"></td>
       <td>${sevDisplay}</td>
       <td>${srcDisplay}</td>
@@ -812,7 +813,7 @@ function isBatchSelectable(f) {
 
 function renderDetail(f) {
   if (!f) {
-    $("detail").innerHTML = `<div class="empty-detail"><span>\u26C5</span><h2>Select a finding</h2><p>Choose an item from the table to inspect evidence and remediation guidance.</p></div>`;
+    $("detail").innerHTML = `<div class="empty-detail"><div class="empty-detail-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"/><path d="M12 12l8-4.5M12 12v9M12 12L4 7.5"/></svg></div><h2>Select a finding</h2><p>Choose an item from the table to inspect evidence and remediation guidance.</p></div>`;
     return;
   }
   const evidence = f.evidence || {};

--- a/internal/web/assets/app.js
+++ b/internal/web/assets/app.js
@@ -813,7 +813,7 @@ function isBatchSelectable(f) {
 
 function renderDetail(f) {
   if (!f) {
-    $("detail").innerHTML = `<div class="empty-detail"><div class="empty-detail-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"/><path d="M12 12l8-4.5M12 12v9M12 12L4 7.5"/></svg></div><h2>Select a finding</h2><p>Choose an item from the table to inspect evidence and remediation guidance.</p></div>`;
+    $("detail").innerHTML = `<div class="empty-detail"><span>&gt;</span><h2>Select a finding</h2><p>Choose an item from the table to inspect evidence and remediation guidance.</p></div>`;
     return;
   }
   const evidence = f.evidence || {};

--- a/internal/web/assets/index.html
+++ b/internal/web/assets/index.html
@@ -9,7 +9,7 @@
   <body>
     <div class="shell">
       <header class="topbar">
-        <div class="brand-block">
+        <div>
           <p class="eyebrow">Finds and fixes security issues</p>
           <h1>hostveil</h1>
           <p class="sysinfo" id="sysinfo"></p>
@@ -40,9 +40,7 @@
           <label class="search">
             <span>Search findings</span>
             <div class="search-input">
-              <span class="search-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
-              </span>
+              <span class="search-icon">&gt;</span>
               <input id="query" type="search" placeholder="ssh, auth, cve, …" autocomplete="off" />
             </div>
           </label>
@@ -108,9 +106,7 @@
 
         <aside class="detail" id="detail">
           <div class="empty-detail">
-            <div class="empty-detail-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"/><path d="M12 12l8-4.5M12 12v9M12 12L4 7.5"/></svg>
-            </div>
+            <span>&gt;</span>
             <h2>Select a finding</h2>
             <p>Choose an item from the table to inspect evidence and remediation guidance.</p>
           </div>

--- a/internal/web/assets/index.html
+++ b/internal/web/assets/index.html
@@ -9,7 +9,7 @@
   <body>
     <div class="shell">
       <header class="topbar">
-        <div>
+        <div class="brand-block">
           <p class="eyebrow">Finds and fixes security issues</p>
           <h1>hostveil</h1>
           <p class="sysinfo" id="sysinfo"></p>
@@ -40,7 +40,9 @@
           <label class="search">
             <span>Search findings</span>
             <div class="search-input">
-              <span class="search-icon">&gt;</span>
+              <span class="search-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+              </span>
               <input id="query" type="search" placeholder="ssh, auth, cve, …" autocomplete="off" />
             </div>
           </label>
@@ -106,7 +108,9 @@
 
         <aside class="detail" id="detail">
           <div class="empty-detail">
-            <span></span>
+            <div class="empty-detail-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"/><path d="M12 12l8-4.5M12 12v9M12 12L4 7.5"/></svg>
+            </div>
             <h2>Select a finding</h2>
             <p>Choose an item from the table to inspect evidence and remediation guidance.</p>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the embedded Web UI to match the marketing site's brutalist identity and strip common AI-slop patterns.

### Removed (slop tells)
- Cyan `#64c8ff` accent → gold `#d2bc74` (matches site)
- Background gradients and grid overlay
- Glassmorphism (`backdrop-filter`) on panels
- Soft glow shadows on score plate
- Pill chips / rounded-everything styling
- SVG search icon and decorative empty-state cube
- Segoe UI / display font mixing
- Cyan-tinted hover/focus rings

### Added / kept
- Left gold stripe (same as marketing site)
- Monospace throughout — appropriate for a scanner tool
- Hard offset shadows on panels and score plate
- Sharp corners, solid fills
- Severity-colored left border on table rows (`data-severity`)
- Terminal-style `>` prompt for search and empty detail state
- Metric severity color classes

### Files
- `internal/web/assets/app.css` — palette + layout refresh
- `internal/web/assets/index.html` — revert decorative SVG chrome
- `internal/web/assets/app.js` — keep row severity accents, simple empty state

## Test plan
- [x] `go test -race ./internal/web/...`
- [x] E2E: 120 passed, 2 skipped

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-097e1e77-af98-462a-b1a0-2da22fdf794b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-097e1e77-af98-462a-b1a0-2da22fdf794b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

