### PR TITLE
feat: color scheme picker for TUI and Web UI

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -38,6 +38,7 @@ const (
 	modalFixResult
 	modalFixProgress
 	modalExport
+	modalTheme
 )
 
 type model struct {
@@ -90,6 +91,10 @@ type model struct {
 	// confirm reset
 	confirmReset bool
 
+	// theme
+	themeName string
+	themeIdx  int
+
 	// cached render heights
 	headerH  int
 	metricsH int
@@ -101,6 +106,16 @@ type model struct {
 type tickMsg struct{}
 
 func NewApp(live *domain.ScanProgress, reg *fix.Registry) *model {
+	cfg := LoadConfig()
+	themeName := cfg.Theme
+	themeIdx := 0
+	for i, id := range ThemeIDs() {
+		if id == themeName {
+			themeIdx = i
+			break
+		}
+	}
+
 	s := spinner.New(spinner.WithSpinner(spinner.Dot))
 
 	t := table.New(
@@ -114,7 +129,7 @@ func NewApp(live *domain.ScanProgress, reg *fix.Registry) *model {
 		}),
 		table.WithFocused(true),
 		table.WithHeight(10),
-		table.WithStyles(tableStyles(DefaultTheme())),
+		table.WithStyles(tableStyles(LookupTheme(themeName))),
 	)
 
 	search := textinput.New()
@@ -141,7 +156,9 @@ func NewApp(live *domain.ScanProgress, reg *fix.Registry) *model {
 			sortDir:     "asc",
 			service:     "all",
 		},
-		phase: "loading",
+		phase:     "loading",
+		themeName: themeName,
+		themeIdx:  themeIdx,
 	}
 }
 
@@ -362,7 +379,20 @@ func (m model) View() tea.View {
 }
 
 func (m model) theme() Theme {
-	return DefaultTheme()
+	return LookupTheme(m.themeName)
+}
+
+func (m model) applyTheme(name string) model {
+	m.themeName = NormalizeThemeID(name)
+	for i, id := range ThemeIDs() {
+		if id == m.themeName {
+			m.themeIdx = i
+			break
+		}
+	}
+	m.table.SetStyles(tableStyles(m.theme()))
+	_ = SaveConfig(Config{Theme: m.themeName})
+	return m
 }
 
 func (m model) startRescan() model {

--- a/internal/tui/config.go
+++ b/internal/tui/config.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Config holds persisted TUI preferences.
+type Config struct {
+	Theme string `json:"theme"`
+}
+
+// LoadConfig reads preferences from the hostveil config file.
+func LoadConfig() Config {
+	path, err := configPath()
+	if err != nil {
+		return Config{Theme: ThemeDefault}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{Theme: ThemeDefault}
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{Theme: ThemeDefault}
+	}
+	cfg.Theme = NormalizeThemeID(cfg.Theme)
+	return cfg
+}
+
+// SaveConfig writes preferences to the hostveil config file.
+func SaveConfig(cfg Config) error {
+	cfg.Theme = NormalizeThemeID(cfg.Theme)
+	path, err := configPath()
+	if err != nil {
+		return fmt.Errorf("config path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	return nil
+}
+
+func configPath() (string, error) {
+	if override := os.Getenv("HOSTVEIL_CONFIG_DIR"); override != "" {
+		return filepath.Join(override, "config.json"), nil
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "hostveil", "config.json"), nil
+}

--- a/internal/tui/config_test.go
+++ b/internal/tui/config_test.go
@@ -1,0 +1,41 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSaveAndLoadConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOSTVEIL_CONFIG_DIR", dir)
+
+	if err := SaveConfig(Config{Theme: ThemeCatppuccin}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+	cfg := LoadConfig()
+	if cfg.Theme != ThemeCatppuccin {
+		t.Fatalf("got theme %q want %q", cfg.Theme, ThemeCatppuccin)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(raw), ThemeCatppuccin) {
+		t.Fatalf("config file missing theme: %s", raw)
+	}
+}
+
+func TestLoadConfig_InvalidThemeFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOSTVEIL_CONFIG_DIR", dir)
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"theme":"bogus"}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := LoadConfig()
+	if cfg.Theme != ThemeDefault {
+		t.Fatalf("got theme %q want %q", cfg.Theme, ThemeDefault)
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -148,6 +148,10 @@ func (m model) updateMain(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.exportIdx = 0
 		m.modal = modalExport
 		return m, nil
+	case "t":
+		m.themeIdx = themeIndex(m.themeName)
+		m.modal = modalTheme
+		return m, nil
 	}
 
 	if m.mode == paneDetail {
@@ -286,6 +290,24 @@ func (m model) updateModal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		case "enter", "l":
 			m.modal = modalNone
 			m.exportReport()
+		case "q", "esc":
+			m.modal = modalNone
+		}
+	case modalTheme:
+		switch msg.String() {
+		case "up", "k":
+			if m.themeIdx > 0 {
+				m.themeIdx--
+			}
+		case "down", "j":
+			if m.themeIdx < len(ThemeIDs())-1 {
+				m.themeIdx++
+			}
+		case "enter", "l":
+			m = m.applyTheme(ThemeIDs()[m.themeIdx])
+			m.modal = modalNone
+			m.toast = "Theme: " + ThemeLabel(m.themeName)
+			m.toastUntil = time.Now().Add(3 * time.Second)
 		case "q", "esc":
 			m.modal = modalNone
 		}

--- a/internal/tui/screen.go
+++ b/internal/tui/screen.go
@@ -806,6 +806,8 @@ func (m model) renderWithModal(base string) string {
 		modal = m.renderFixProgressModal()
 	case modalExport:
 		modal = m.renderExportModal()
+	case modalTheme:
+		modal = m.renderThemeModal()
 	default:
 		return base
 	}
@@ -847,6 +849,7 @@ func (m model) renderHelpModal() string {
 			"  O             Toggle sort direction",
 			"  R             Clear all filters",
 			"  e             Export report (JSON/CSV/AI)",
+			"  t             Color scheme",
 			"  ?             This help",
 			"  q             Quit",
 		)
@@ -862,6 +865,7 @@ func (m model) renderHelpModal() string {
 			"  Ctrl+S        Rescan all tools",
 			"  Ctrl+A        Select/deselect all visible",
 			"  ?             This help",
+			"  t             Color scheme",
 			"  q             Quit",
 		)
 	}
@@ -1071,6 +1075,39 @@ func (m model) renderExportModal() string {
 	lines = append(lines,
 		"",
 		lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted)).Render("↑/↓ select · Enter export · Esc cancel"),
+	)
+	return s.Width(m.modalWidth(64)).Render(strings.Join(lines, "\n"))
+}
+
+func (m model) renderThemeModal() string {
+	t := m.theme()
+	s := m.modalStyle()
+
+	var items []string
+	for i, id := range ThemeIDs() {
+		mark := "  "
+		style := lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text))
+		if i == m.themeIdx {
+			mark = "> "
+			style = style.Foreground(lipgloss.Color(t.Accent)).Bold(true)
+		}
+		label := ThemeLabel(id)
+		if id == m.themeName {
+			label += " (current)"
+		}
+		items = append(items, "  "+mark+style.Render(label))
+	}
+
+	lines := []string{
+		lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent)).Bold(true).Render("Color scheme"),
+		"",
+		lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted)).Render("Choose palette:"),
+		"",
+	}
+	lines = append(lines, items...)
+	lines = append(lines,
+		"",
+		lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted)).Render("↑/↓ select · Enter apply · Esc cancel"),
 	)
 	return s.Width(m.modalWidth(64)).Render(strings.Join(lines, "\n"))
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -20,106 +20,210 @@ const (
 	ThemeTokyoNight = "tokyo-night"
 	ThemeCatppuccin = "catppuccin"
 	ThemeNord       = "nord"
+	ThemeDracula    = "dracula"
+	ThemeGruvbox    = "gruvbox"
+	ThemeOneDark    = "one-dark"
+	ThemeSolarized  = "solarized"
+	ThemeMonokai    = "monokai"
+	ThemeEverforest = "everforest"
+	ThemeRosePine   = "rose-pine"
+	ThemeKanagawa   = "kanagawa"
+	ThemeGitHubDark = "github-dark"
+	ThemeAyuDark    = "ayu-dark"
+	ThemeNightOwl   = "night-owl"
 )
 
-var themeCatalog = map[string]Theme{
-	ThemeDefault: {
-		Background: "#090b12",
-		SurfaceAlt: "#171c2b",
-		Border:     "#2f3a52",
-		Text:       "#e7ecf8",
-		TextMuted:  "#8390ad",
-		Critical:   "#ff5573",
-		High:       "#ff9868",
-		Medium:     "#f7c66b",
-		Low:        "#87d978",
-		Accent:     "#64c8ff",
-		Success:    "#87d978",
-	},
-	ThemeTokyoNight: {
-		Background: "#1a1b26",
-		SurfaceAlt: "#24283b",
-		Border:     "#292e42",
-		Text:       "#c0caf5",
-		TextMuted:  "#565f89",
-		Critical:   "#f7768e",
-		High:       "#ff9e64",
-		Medium:     "#e0af68",
-		Low:        "#9ece6a",
-		Accent:     "#7aa2f7",
-		Success:    "#9ece6a",
-	},
-	ThemeCatppuccin: {
-		Background: "#1e1e2e",
-		SurfaceAlt: "#313244",
-		Border:     "#45475a",
-		Text:       "#cdd6f4",
-		TextMuted:  "#6c7086",
-		Critical:   "#f38ba8",
-		High:       "#fab387",
-		Medium:     "#f9e2af",
-		Low:        "#a6e3a1",
-		Accent:     "#89b4fa",
-		Success:    "#a6e3a1",
-	},
-	ThemeNord: {
-		Background: "#2e3440",
-		SurfaceAlt: "#434c5e",
-		Border:     "#4c566a",
-		Text:       "#eceff4",
-		TextMuted:  "#616e88",
-		Critical:   "#bf616a",
-		High:       "#d08770",
-		Medium:     "#ebcb8b",
-		Low:        "#a3be8c",
-		Accent:     "#88c0d0",
-		Success:    "#a3be8c",
-	},
+type themeEntry struct {
+	id    string
+	label string
+	theme Theme
 }
 
-var themeLabels = map[string]string{
-	ThemeDefault:    "Default",
-	ThemeTokyoNight: "Tokyo Night",
-	ThemeCatppuccin: "Catppuccin",
-	ThemeNord:       "Nord",
+var themeRegistry = []themeEntry{
+	{
+		id: ThemeDefault, label: "Default",
+		theme: Theme{
+			Background: "#090b12", SurfaceAlt: "#171c2b", Border: "#2f3a52",
+			Text: "#e7ecf8", TextMuted: "#8390ad",
+			Critical: "#ff5573", High: "#ff9868", Medium: "#f7c66b", Low: "#87d978",
+			Accent: "#64c8ff", Success: "#87d978",
+		},
+	},
+	{
+		id: ThemeTokyoNight, label: "Tokyo Night",
+		theme: Theme{
+			Background: "#1a1b26", SurfaceAlt: "#24283b", Border: "#292e42",
+			Text: "#c0caf5", TextMuted: "#565f89",
+			Critical: "#f7768e", High: "#ff9e64", Medium: "#e0af68", Low: "#9ece6a",
+			Accent: "#7aa2f7", Success: "#9ece6a",
+		},
+	},
+	{
+		id: ThemeCatppuccin, label: "Catppuccin",
+		theme: Theme{
+			Background: "#1e1e2e", SurfaceAlt: "#313244", Border: "#45475a",
+			Text: "#cdd6f4", TextMuted: "#6c7086",
+			Critical: "#f38ba8", High: "#fab387", Medium: "#f9e2af", Low: "#a6e3a1",
+			Accent: "#89b4fa", Success: "#a6e3a1",
+		},
+	},
+	{
+		id: ThemeNord, label: "Nord",
+		theme: Theme{
+			Background: "#2e3440", SurfaceAlt: "#434c5e", Border: "#4c566a",
+			Text: "#eceff4", TextMuted: "#616e88",
+			Critical: "#bf616a", High: "#d08770", Medium: "#ebcb8b", Low: "#a3be8c",
+			Accent: "#88c0d0", Success: "#a3be8c",
+		},
+	},
+	{
+		id: ThemeDracula, label: "Dracula",
+		theme: Theme{
+			Background: "#282a36", SurfaceAlt: "#44475a", Border: "#44475a",
+			Text: "#f8f8f2", TextMuted: "#6272a4",
+			Critical: "#ff5555", High: "#ffb86c", Medium: "#f1fa8c", Low: "#50fa7b",
+			Accent: "#bd93f9", Success: "#50fa7b",
+		},
+	},
+	{
+		id: ThemeGruvbox, label: "Gruvbox",
+		theme: Theme{
+			Background: "#282828", SurfaceAlt: "#3c3836", Border: "#504945",
+			Text: "#ebdbb2", TextMuted: "#928374",
+			Critical: "#fb4934", High: "#fe8019", Medium: "#fabd2f", Low: "#b8bb26",
+			Accent: "#83a598", Success: "#b8bb26",
+		},
+	},
+	{
+		id: ThemeOneDark, label: "One Dark",
+		theme: Theme{
+			Background: "#282c34", SurfaceAlt: "#2c313c", Border: "#3e4451",
+			Text: "#abb2bf", TextMuted: "#5c6370",
+			Critical: "#e06c75", High: "#d19a66", Medium: "#e5c07b", Low: "#98c379",
+			Accent: "#61afef", Success: "#98c379",
+		},
+	},
+	{
+		id: ThemeSolarized, label: "Solarized Dark",
+		theme: Theme{
+			Background: "#002b36", SurfaceAlt: "#073642", Border: "#094352",
+			Text: "#93a1a1", TextMuted: "#657b83",
+			Critical: "#dc322f", High: "#cb4b16", Medium: "#b58900", Low: "#859900",
+			Accent: "#268bd2", Success: "#859900",
+		},
+	},
+	{
+		id: ThemeMonokai, label: "Monokai",
+		theme: Theme{
+			Background: "#272822", SurfaceAlt: "#3e3d32", Border: "#49483e",
+			Text: "#f8f8f2", TextMuted: "#75715e",
+			Critical: "#f92672", High: "#fd971f", Medium: "#e6db74", Low: "#a6e22e",
+			Accent: "#66d9ef", Success: "#a6e22e",
+		},
+	},
+	{
+		id: ThemeEverforest, label: "Everforest",
+		theme: Theme{
+			Background: "#2d353b", SurfaceAlt: "#3d484d", Border: "#475258",
+			Text: "#d3c6aa", TextMuted: "#859289",
+			Critical: "#e67e80", High: "#e69875", Medium: "#dbbc7f", Low: "#a7c080",
+			Accent: "#7fbbb3", Success: "#a7c080",
+		},
+	},
+	{
+		id: ThemeRosePine, label: "Rosé Pine",
+		theme: Theme{
+			Background: "#191724", SurfaceAlt: "#26233a", Border: "#403d52",
+			Text: "#e0def4", TextMuted: "#6e6a86",
+			Critical: "#eb6f92", High: "#f6c177", Medium: "#e0c989", Low: "#9ccfd8",
+			Accent: "#c4a7e7", Success: "#9ccfd8",
+		},
+	},
+	{
+		id: ThemeKanagawa, label: "Kanagawa",
+		theme: Theme{
+			Background: "#1f1f28", SurfaceAlt: "#2a2a37", Border: "#363646",
+			Text: "#dcd7ba", TextMuted: "#727169",
+			Critical: "#c34043", High: "#ffa066", Medium: "#e6c384", Low: "#76946a",
+			Accent: "#7e9cd8", Success: "#76946a",
+		},
+	},
+	{
+		id: ThemeGitHubDark, label: "GitHub Dark",
+		theme: Theme{
+			Background: "#0d1117", SurfaceAlt: "#21262d", Border: "#30363d",
+			Text: "#c9d1d9", TextMuted: "#8b949e",
+			Critical: "#f85149", High: "#f0883e", Medium: "#d29922", Low: "#3fb950",
+			Accent: "#58a6ff", Success: "#3fb950",
+		},
+	},
+	{
+		id: ThemeAyuDark, label: "Ayu Dark",
+		theme: Theme{
+			Background: "#0a0e14", SurfaceAlt: "#151a21", Border: "#242936",
+			Text: "#bfbdb6", TextMuted: "#626a73",
+			Critical: "#f07178", High: "#ffad66", Medium: "#ffd580", Low: "#bae67f",
+			Accent: "#59c2ff", Success: "#bae67f",
+		},
+	},
+	{
+		id: ThemeNightOwl, label: "Night Owl",
+		theme: Theme{
+			Background: "#011627", SurfaceAlt: "#1d3b53", Border: "#234d70",
+			Text: "#d6deeb", TextMuted: "#637777",
+			Critical: "#ef5350", High: "#f78c6c", Medium: "#ffeb95", Low: "#c3e88d",
+			Accent: "#82aaff", Success: "#c3e88d",
+		},
+	},
 }
 
 // ThemeIDs returns the ordered list of selectable theme identifiers.
 func ThemeIDs() []string {
-	return []string{ThemeDefault, ThemeTokyoNight, ThemeCatppuccin, ThemeNord}
+	ids := make([]string, len(themeRegistry))
+	for i, entry := range themeRegistry {
+		ids[i] = entry.id
+	}
+	return ids
 }
 
 // ThemeLabel returns the human-readable name for a theme ID.
 func ThemeLabel(id string) string {
-	if label, ok := themeLabels[id]; ok {
-		return label
+	for _, entry := range themeRegistry {
+		if entry.id == id {
+			return entry.label
+		}
 	}
 	return id
 }
 
 // LookupTheme returns the palette for id, falling back to the default theme.
 func LookupTheme(id string) Theme {
-	if t, ok := themeCatalog[id]; ok {
-		return t
+	for _, entry := range themeRegistry {
+		if entry.id == id {
+			return entry.theme
+		}
 	}
-	return themeCatalog[ThemeDefault]
+	return themeRegistry[0].theme
 }
 
 // DefaultTheme returns the built-in default palette.
-func DefaultTheme() Theme { return themeCatalog[ThemeDefault] }
+func DefaultTheme() Theme { return themeRegistry[0].theme }
 
 // NormalizeThemeID returns id when known, otherwise ThemeDefault.
 func NormalizeThemeID(id string) string {
-	if _, ok := themeCatalog[id]; ok {
-		return id
+	for _, entry := range themeRegistry {
+		if entry.id == id {
+			return id
+		}
 	}
 	return ThemeDefault
 }
 
 // themeIndex returns the selection index for id.
 func themeIndex(id string) int {
+	normalized := NormalizeThemeID(id)
 	for i, themeID := range ThemeIDs() {
-		if themeID == NormalizeThemeID(id) {
+		if themeID == normalized {
 			return i
 		}
 	}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,5 +1,6 @@
 package tui
 
+// Theme holds lipgloss color hex values for the terminal UI.
 type Theme struct {
 	Background string
 	SurfaceAlt string
@@ -14,18 +15,113 @@ type Theme struct {
 	Success    string
 }
 
-func DefaultTheme() Theme { return webTheme }
+const (
+	ThemeDefault    = "default"
+	ThemeTokyoNight = "tokyo-night"
+	ThemeCatppuccin = "catppuccin"
+	ThemeNord       = "nord"
+)
 
-var webTheme = Theme{
-	Background: "#090b12",
-	SurfaceAlt: "#171c2b",
-	Border:     "#2f3a52",
-	Text:       "#e7ecf8",
-	TextMuted:  "#8390ad",
-	Critical:   "#ff5573",
-	High:       "#ff9868",
-	Medium:     "#f7c66b",
-	Low:        "#87d978",
-	Accent:     "#64c8ff",
-	Success:    "#87d978",
+var themeCatalog = map[string]Theme{
+	ThemeDefault: {
+		Background: "#090b12",
+		SurfaceAlt: "#171c2b",
+		Border:     "#2f3a52",
+		Text:       "#e7ecf8",
+		TextMuted:  "#8390ad",
+		Critical:   "#ff5573",
+		High:       "#ff9868",
+		Medium:     "#f7c66b",
+		Low:        "#87d978",
+		Accent:     "#64c8ff",
+		Success:    "#87d978",
+	},
+	ThemeTokyoNight: {
+		Background: "#1a1b26",
+		SurfaceAlt: "#24283b",
+		Border:     "#292e42",
+		Text:       "#c0caf5",
+		TextMuted:  "#565f89",
+		Critical:   "#f7768e",
+		High:       "#ff9e64",
+		Medium:     "#e0af68",
+		Low:        "#9ece6a",
+		Accent:     "#7aa2f7",
+		Success:    "#9ece6a",
+	},
+	ThemeCatppuccin: {
+		Background: "#1e1e2e",
+		SurfaceAlt: "#313244",
+		Border:     "#45475a",
+		Text:       "#cdd6f4",
+		TextMuted:  "#6c7086",
+		Critical:   "#f38ba8",
+		High:       "#fab387",
+		Medium:     "#f9e2af",
+		Low:        "#a6e3a1",
+		Accent:     "#89b4fa",
+		Success:    "#a6e3a1",
+	},
+	ThemeNord: {
+		Background: "#2e3440",
+		SurfaceAlt: "#434c5e",
+		Border:     "#4c566a",
+		Text:       "#eceff4",
+		TextMuted:  "#616e88",
+		Critical:   "#bf616a",
+		High:       "#d08770",
+		Medium:     "#ebcb8b",
+		Low:        "#a3be8c",
+		Accent:     "#88c0d0",
+		Success:    "#a3be8c",
+	},
+}
+
+var themeLabels = map[string]string{
+	ThemeDefault:    "Default",
+	ThemeTokyoNight: "Tokyo Night",
+	ThemeCatppuccin: "Catppuccin",
+	ThemeNord:       "Nord",
+}
+
+// ThemeIDs returns the ordered list of selectable theme identifiers.
+func ThemeIDs() []string {
+	return []string{ThemeDefault, ThemeTokyoNight, ThemeCatppuccin, ThemeNord}
+}
+
+// ThemeLabel returns the human-readable name for a theme ID.
+func ThemeLabel(id string) string {
+	if label, ok := themeLabels[id]; ok {
+		return label
+	}
+	return id
+}
+
+// LookupTheme returns the palette for id, falling back to the default theme.
+func LookupTheme(id string) Theme {
+	if t, ok := themeCatalog[id]; ok {
+		return t
+	}
+	return themeCatalog[ThemeDefault]
+}
+
+// DefaultTheme returns the built-in default palette.
+func DefaultTheme() Theme { return themeCatalog[ThemeDefault] }
+
+// NormalizeThemeID returns id when known, otherwise ThemeDefault.
+func NormalizeThemeID(id string) string {
+	if _, ok := themeCatalog[id]; ok {
+		return id
+	}
+	return ThemeDefault
+}
+
+// themeIndex returns the selection index for id.
+func themeIndex(id string) int {
+	for i, themeID := range ThemeIDs() {
+		if themeID == NormalizeThemeID(id) {
+			return i
+		}
+	}
+	return 0
 }

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -6,6 +6,9 @@ func TestLookupTheme_KnownAndFallback(t *testing.T) {
 	if LookupTheme(ThemeTokyoNight).Accent != "#7aa2f7" {
 		t.Fatalf("tokyo night accent mismatch: %q", LookupTheme(ThemeTokyoNight).Accent)
 	}
+	if LookupTheme(ThemeDracula).Accent != "#bd93f9" {
+		t.Fatalf("dracula accent mismatch: %q", LookupTheme(ThemeDracula).Accent)
+	}
 	if LookupTheme("unknown-theme").Accent != DefaultTheme().Accent {
 		t.Fatalf("unknown theme should fall back to default")
 	}
@@ -20,20 +23,47 @@ func TestNormalizeThemeID(t *testing.T) {
 	}
 }
 
-func TestThemeIDs_IncludesPreferredThemes(t *testing.T) {
+func TestThemeIDs_IncludesPopularThemes(t *testing.T) {
 	ids := ThemeIDs()
-	want := map[string]bool{
-		ThemeDefault:    true,
-		ThemeTokyoNight: true,
-		ThemeCatppuccin: true,
-		ThemeNord:       true,
+	required := []string{
+		ThemeDefault,
+		ThemeTokyoNight,
+		ThemeCatppuccin,
+		ThemeNord,
+		ThemeDracula,
+		ThemeGruvbox,
+		ThemeOneDark,
+		ThemeSolarized,
+		ThemeMonokai,
+		ThemeEverforest,
+		ThemeRosePine,
+		ThemeKanagawa,
+		ThemeGitHubDark,
+		ThemeAyuDark,
+		ThemeNightOwl,
 	}
-	if len(ids) != len(want) {
-		t.Fatalf("expected %d themes, got %d", len(want), len(ids))
+	if len(ids) != len(required) {
+		t.Fatalf("expected %d themes, got %d", len(required), len(ids))
 	}
+	seen := make(map[string]bool, len(ids))
 	for _, id := range ids {
-		if !want[id] {
-			t.Fatalf("unexpected theme id %q", id)
+		if seen[id] {
+			t.Fatalf("duplicate theme id %q", id)
 		}
+		seen[id] = true
+	}
+	for _, id := range required {
+		if !seen[id] {
+			t.Fatalf("missing theme id %q", id)
+		}
+	}
+}
+
+func TestThemeLabel_KnownThemes(t *testing.T) {
+	if got := ThemeLabel(ThemeRosePine); got != "Rosé Pine" {
+		t.Fatalf("got label %q", got)
+	}
+	if got := ThemeLabel("missing"); got != "missing" {
+		t.Fatalf("unknown label should echo id, got %q", got)
 	}
 }

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -1,0 +1,39 @@
+package tui
+
+import "testing"
+
+func TestLookupTheme_KnownAndFallback(t *testing.T) {
+	if LookupTheme(ThemeTokyoNight).Accent != "#7aa2f7" {
+		t.Fatalf("tokyo night accent mismatch: %q", LookupTheme(ThemeTokyoNight).Accent)
+	}
+	if LookupTheme("unknown-theme").Accent != DefaultTheme().Accent {
+		t.Fatalf("unknown theme should fall back to default")
+	}
+}
+
+func TestNormalizeThemeID(t *testing.T) {
+	if got := NormalizeThemeID(ThemeNord); got != ThemeNord {
+		t.Fatalf("got %q want %q", got, ThemeNord)
+	}
+	if got := NormalizeThemeID("not-a-theme"); got != ThemeDefault {
+		t.Fatalf("got %q want %q", got, ThemeDefault)
+	}
+}
+
+func TestThemeIDs_IncludesPreferredThemes(t *testing.T) {
+	ids := ThemeIDs()
+	want := map[string]bool{
+		ThemeDefault:    true,
+		ThemeTokyoNight: true,
+		ThemeCatppuccin: true,
+		ThemeNord:       true,
+	}
+	if len(ids) != len(want) {
+		t.Fatalf("expected %d themes, got %d", len(want), len(ids))
+	}
+	for _, id := range ids {
+		if !want[id] {
+			t.Fatalf("unexpected theme id %q", id)
+		}
+	}
+}

--- a/internal/tui/view_boundary_test.go
+++ b/internal/tui/view_boundary_test.go
@@ -124,7 +124,7 @@ func TestView_MainTooSmall(t *testing.T) {
 // the main view without crashing. The compositor centers the modal.
 func TestView_ModalOverlaysReady(t *testing.T) {
 	findings := makeTestFindings(3)
-	for _, mm := range []modalMode{modalHelp, modalFilter, modalExport, modalFixResult} {
+	for _, mm := range []modalMode{modalHelp, modalFilter, modalExport, modalFixResult, modalTheme} {
 		m := testModelWithFindings(t, findings)
 		m.width = 120
 		m.height = 40

--- a/internal/web/assets/app.css
+++ b/internal/web/assets/app.css
@@ -95,6 +95,270 @@
   --shadow-cut: #242933;
 }
 
+[data-theme="dracula"] {
+  color-scheme: dark;
+  --bg: #282a36;
+  --panel: #21222c;
+  --panel-2: #44475a;
+  --panel-strong: #44475a;
+  --surface-sunken: #191a21;
+  --text-dim: #e2e2dc;
+  --text-section: #f8f8f2;
+  --line: #44475a;
+  --line-strong: #6272a4;
+  --border: #44475a;
+  --text: #f8f8f2;
+  --text-muted: #6272a4;
+  --muted: #6272a4;
+  --critical: #ff5555;
+  --high: #ffb86c;
+  --medium: #f1fa8c;
+  --low: #50fa7b;
+  --accent: #bd93f9;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #191a21;
+}
+
+[data-theme="gruvbox"] {
+  color-scheme: dark;
+  --bg: #282828;
+  --panel: #32302f;
+  --panel-2: #3c3836;
+  --panel-strong: #3c3836;
+  --surface-sunken: #1d2021;
+  --text-dim: #d5c4a1;
+  --text-section: #ebdbb2;
+  --line: #504945;
+  --line-strong: #665c54;
+  --border: #504945;
+  --text: #ebdbb2;
+  --text-muted: #928374;
+  --muted: #928374;
+  --critical: #fb4934;
+  --high: #fe8019;
+  --medium: #fabd2f;
+  --low: #b8bb26;
+  --accent: #83a598;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #1d2021;
+}
+
+[data-theme="one-dark"] {
+  color-scheme: dark;
+  --bg: #282c34;
+  --panel: #21252b;
+  --panel-2: #2c313c;
+  --panel-strong: #2c313c;
+  --surface-sunken: #1e2127;
+  --text-dim: #abb2bf;
+  --text-section: #abb2bf;
+  --line: #3e4451;
+  --line-strong: #4b5263;
+  --border: #3e4451;
+  --text: #abb2bf;
+  --text-muted: #5c6370;
+  --muted: #5c6370;
+  --critical: #e06c75;
+  --high: #d19a66;
+  --medium: #e5c07b;
+  --low: #98c379;
+  --accent: #61afef;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #1e2127;
+}
+
+[data-theme="solarized"] {
+  color-scheme: dark;
+  --bg: #002b36;
+  --panel: #073642;
+  --panel-2: #094352;
+  --panel-strong: #094352;
+  --surface-sunken: #001e26;
+  --text-dim: #839496;
+  --text-section: #93a1a1;
+  --line: #094352;
+  --line-strong: #0b5568;
+  --border: #094352;
+  --text: #93a1a1;
+  --text-muted: #657b83;
+  --muted: #657b83;
+  --critical: #dc322f;
+  --high: #cb4b16;
+  --medium: #b58900;
+  --low: #859900;
+  --accent: #268bd2;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #001e26;
+}
+
+[data-theme="monokai"] {
+  color-scheme: dark;
+  --bg: #272822;
+  --panel: #1e1f1c;
+  --panel-2: #3e3d32;
+  --panel-strong: #3e3d32;
+  --surface-sunken: #181915;
+  --text-dim: #cfcfc7;
+  --text-section: #f8f8f2;
+  --line: #49483e;
+  --line-strong: #75715e;
+  --border: #49483e;
+  --text: #f8f8f2;
+  --text-muted: #75715e;
+  --muted: #75715e;
+  --critical: #f92672;
+  --high: #fd971f;
+  --medium: #e6db74;
+  --low: #a6e22e;
+  --accent: #66d9ef;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #181915;
+}
+
+[data-theme="everforest"] {
+  color-scheme: dark;
+  --bg: #2d353b;
+  --panel: #343f44;
+  --panel-2: #3d484d;
+  --panel-strong: #3d484d;
+  --surface-sunken: #232a2e;
+  --text-dim: #c4b99a;
+  --text-section: #d3c6aa;
+  --line: #475258;
+  --line-strong: #566268;
+  --border: #475258;
+  --text: #d3c6aa;
+  --text-muted: #859289;
+  --muted: #859289;
+  --critical: #e67e80;
+  --high: #e69875;
+  --medium: #dbbc7f;
+  --low: #a7c080;
+  --accent: #7fbbb3;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #232a2e;
+}
+
+[data-theme="rose-pine"] {
+  color-scheme: dark;
+  --bg: #191724;
+  --panel: #1f1d2e;
+  --panel-2: #26233a;
+  --panel-strong: #26233a;
+  --surface-sunken: #11111b;
+  --text-dim: #cdc4e4;
+  --text-section: #e0def4;
+  --line: #403d52;
+  --line-strong: #524f67;
+  --border: #403d52;
+  --text: #e0def4;
+  --text-muted: #6e6a86;
+  --muted: #6e6a86;
+  --critical: #eb6f92;
+  --high: #f6c177;
+  --medium: #e0c989;
+  --low: #9ccfd8;
+  --accent: #c4a7e7;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #11111b;
+}
+
+[data-theme="kanagawa"] {
+  color-scheme: dark;
+  --bg: #1f1f28;
+  --panel: #16161d;
+  --panel-2: #2a2a37;
+  --panel-strong: #2a2a37;
+  --surface-sunken: #121219;
+  --text-dim: #c8c093;
+  --text-section: #dcd7ba;
+  --line: #363646;
+  --line-strong: #54546d;
+  --border: #363646;
+  --text: #dcd7ba;
+  --text-muted: #727169;
+  --muted: #727169;
+  --critical: #c34043;
+  --high: #ffa066;
+  --medium: #e6c384;
+  --low: #76946a;
+  --accent: #7e9cd8;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #121219;
+}
+
+[data-theme="github-dark"] {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --panel: #161b22;
+  --panel-2: #21262d;
+  --panel-strong: #21262d;
+  --surface-sunken: #010409;
+  --text-dim: #b1bac4;
+  --text-section: #c9d1d9;
+  --line: #30363d;
+  --line-strong: #484f58;
+  --border: #30363d;
+  --text: #c9d1d9;
+  --text-muted: #8b949e;
+  --muted: #8b949e;
+  --critical: #f85149;
+  --high: #f0883e;
+  --medium: #d29922;
+  --low: #3fb950;
+  --accent: #58a6ff;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #010409;
+}
+
+[data-theme="ayu-dark"] {
+  color-scheme: dark;
+  --bg: #0a0e14;
+  --panel: #0f131a;
+  --panel-2: #151a21;
+  --panel-strong: #151a21;
+  --surface-sunken: #05070a;
+  --text-dim: #acb0b9;
+  --text-section: #bfbdb6;
+  --line: #242936;
+  --line-strong: #323844;
+  --border: #242936;
+  --text: #bfbdb6;
+  --text-muted: #626a73;
+  --muted: #626a73;
+  --critical: #f07178;
+  --high: #ffad66;
+  --medium: #ffd580;
+  --low: #bae67f;
+  --accent: #59c2ff;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #05070a;
+}
+
+[data-theme="night-owl"] {
+  color-scheme: dark;
+  --bg: #011627;
+  --panel: #0b2942;
+  --panel-2: #1d3b53;
+  --panel-strong: #1d3b53;
+  --surface-sunken: #001122;
+  --text-dim: #b2ccd6;
+  --text-section: #d6deeb;
+  --line: #234d70;
+  --line-strong: #2d6a9f;
+  --border: #234d70;
+  --text: #d6deeb;
+  --text-muted: #637777;
+  --muted: #637777;
+  --critical: #ef5350;
+  --high: #f78c6c;
+  --medium: #ffeb95;
+  --low: #c3e88d;
+  --accent: #82aaff;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #001122;
+}
+
 * { box-sizing: border-box; }
 
 body {

--- a/internal/web/assets/app.css
+++ b/internal/web/assets/app.css
@@ -1,25 +1,98 @@
-:root {
+:root,
+[data-theme="default"] {
   color-scheme: dark;
-  --bg: #07100f;
-  --panel: #101816;
-  --panel-2: #16231f;
-  --panel-strong: #16231f;
-  --surface-sunken: #050a09;
-  --text-dim: #c8bea7;
-  --text-section: #e7dfca;
-  --line: #31413b;
-  --line-strong: #516057;
-  --border: #31413b;
-  --text: #f5ead2;
-  --text-muted: #9aa89f;
-  --muted: #9aa89f;
-  --critical: #e05757;
-  --high: #d8843b;
-  --medium: #d6ae58;
-  --low: #91b987;
-  --accent: #d2bc74;
+  --bg: #090b12;
+  --panel: #111522;
+  --panel-2: #171c2b;
+  --panel-strong: #171c2b;
+  --surface-sunken: #0b0e17;
+  --text-dim: #b9c3dd;
+  --text-section: #dbe3f5;
+  --line: #2f3a52;
+  --line-strong: #3d4a66;
+  --border: #2f3a52;
+  --text: #e7ecf8;
+  --text-muted: #8390ad;
+  --muted: #8390ad;
+  --critical: #ff5573;
+  --high: #ff9868;
+  --medium: #f7c66b;
+  --low: #87d978;
+  --accent: #64c8ff;
   --shadow: rgba(0, 0, 0, 0.45);
-  --shadow-cut: #020504;
+  --shadow-cut: #05070d;
+}
+
+[data-theme="tokyo-night"] {
+  color-scheme: dark;
+  --bg: #1a1b26;
+  --panel: #16161e;
+  --panel-2: #24283b;
+  --panel-strong: #24283b;
+  --surface-sunken: #13131a;
+  --text-dim: #a9b1d6;
+  --text-section: #c0caf5;
+  --line: #292e42;
+  --line-strong: #414868;
+  --border: #292e42;
+  --text: #c0caf5;
+  --text-muted: #565f89;
+  --muted: #565f89;
+  --critical: #f7768e;
+  --high: #ff9e64;
+  --medium: #e0af68;
+  --low: #9ece6a;
+  --accent: #7aa2f7;
+  --shadow: rgba(0, 0, 0, 0.5);
+  --shadow-cut: #0f0f14;
+}
+
+[data-theme="catppuccin"] {
+  color-scheme: dark;
+  --bg: #1e1e2e;
+  --panel: #181825;
+  --panel-2: #313244;
+  --panel-strong: #313244;
+  --surface-sunken: #11111b;
+  --text-dim: #bac2de;
+  --text-section: #cdd6f4;
+  --line: #45475a;
+  --line-strong: #585b70;
+  --border: #45475a;
+  --text: #cdd6f4;
+  --text-muted: #6c7086;
+  --muted: #6c7086;
+  --critical: #f38ba8;
+  --high: #fab387;
+  --medium: #f9e2af;
+  --low: #a6e3a1;
+  --accent: #89b4fa;
+  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow-cut: #11111b;
+}
+
+[data-theme="nord"] {
+  color-scheme: dark;
+  --bg: #2e3440;
+  --panel: #3b4252;
+  --panel-2: #434c5e;
+  --panel-strong: #434c5e;
+  --surface-sunken: #242933;
+  --text-dim: #d8dee9;
+  --text-section: #eceff4;
+  --line: #4c566a;
+  --line-strong: #5e6779;
+  --border: #4c566a;
+  --text: #eceff4;
+  --text-muted: #616e88;
+  --muted: #81a1c1;
+  --critical: #bf616a;
+  --high: #d08770;
+  --medium: #ebcb8b;
+  --low: #a3be8c;
+  --accent: #88c0d0;
+  --shadow: rgba(0, 0, 0, 0.4);
+  --shadow-cut: #242933;
 }
 
 * { box-sizing: border-box; }

--- a/internal/web/assets/app.js
+++ b/internal/web/assets/app.js
@@ -2,7 +2,24 @@ const severityOrder = { critical: 0, high: 1, medium: 2, low: 3 };
 const toolLabels = { trivy: "Trivy", lynis: "Lynis", compose: "Compose", update: "Update" };
 const statusIcons = ["○", "◌", "✓", "−", "✗", "◪"];
 const THEME_STORAGE_KEY = "hostveil-theme";
-const THEME_IDS = ["default", "tokyo-night", "catppuccin", "nord"];
+const THEME_CATALOG = [
+  { id: "default", label: "Default" },
+  { id: "tokyo-night", label: "Tokyo Night" },
+  { id: "catppuccin", label: "Catppuccin" },
+  { id: "nord", label: "Nord" },
+  { id: "dracula", label: "Dracula" },
+  { id: "gruvbox", label: "Gruvbox" },
+  { id: "one-dark", label: "One Dark" },
+  { id: "solarized", label: "Solarized Dark" },
+  { id: "monokai", label: "Monokai" },
+  { id: "everforest", label: "Everforest" },
+  { id: "rose-pine", label: "Rosé Pine" },
+  { id: "kanagawa", label: "Kanagawa" },
+  { id: "github-dark", label: "GitHub Dark" },
+  { id: "ayu-dark", label: "Ayu Dark" },
+  { id: "night-owl", label: "Night Owl" },
+];
+const THEME_IDS = THEME_CATALOG.map((entry) => entry.id);
 
 const state = {
   live: null,
@@ -117,6 +134,15 @@ function applyTheme(id) {
 }
 
 function initTheme() {
+  const select = $("themeSelect");
+  if (select && select.options.length === 0) {
+    for (const entry of THEME_CATALOG) {
+      const option = document.createElement("option");
+      option.value = entry.id;
+      option.textContent = entry.label;
+      select.appendChild(option);
+    }
+  }
   applyTheme(currentThemeId());
 }
 
@@ -128,13 +154,8 @@ function cycleTheme(step) {
 }
 
 function themeLabel(id) {
-  const labels = {
-    default: "Default",
-    "tokyo-night": "Tokyo Night",
-    catppuccin: "Catppuccin",
-    nord: "Nord",
-  };
-  return labels[id] || id;
+  const entry = THEME_CATALOG.find((item) => item.id === id);
+  return entry ? entry.label : id;
 }
 
 function bindVisibilityPause() {

--- a/internal/web/assets/app.js
+++ b/internal/web/assets/app.js
@@ -1,6 +1,8 @@
 const severityOrder = { critical: 0, high: 1, medium: 2, low: 3 };
 const toolLabels = { trivy: "Trivy", lynis: "Lynis", compose: "Compose", update: "Update" };
 const statusIcons = ["○", "◌", "✓", "−", "✗", "◪"];
+const THEME_STORAGE_KEY = "hostveil-theme";
+const THEME_IDS = ["default", "tokyo-night", "catppuccin", "nord"];
 
 const state = {
   live: null,
@@ -83,12 +85,56 @@ function invalidateFindingsCache() {
 }
 
 async function init() {
+  initTheme();
   await fetchResult();
   if (state.phase === "loading") {
     state.pollTimer = setInterval(fetchResult, 2000);
   }
   bindControls();
   bindVisibilityPause();
+}
+
+function normalizeThemeId(id) {
+  return THEME_IDS.includes(id) ? id : "default";
+}
+
+function currentThemeId() {
+  return normalizeThemeId(document.documentElement.dataset.theme || "default");
+}
+
+function applyTheme(id) {
+  const theme = normalizeThemeId(id);
+  document.documentElement.dataset.theme = theme;
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Ignore storage failures (private mode, quota, etc.).
+  }
+  const select = $("themeSelect");
+  if (select && select.value !== theme) {
+    select.value = theme;
+  }
+}
+
+function initTheme() {
+  applyTheme(currentThemeId());
+}
+
+function cycleTheme(step) {
+  const idx = THEME_IDS.indexOf(currentThemeId());
+  const next = (idx + step + THEME_IDS.length) % THEME_IDS.length;
+  applyTheme(THEME_IDS[next]);
+  showToast(`Theme: ${themeLabel(THEME_IDS[next])}`, "toast-info");
+}
+
+function themeLabel(id) {
+  const labels = {
+    default: "Default",
+    "tokyo-night": "Tokyo Night",
+    catppuccin: "Catppuccin",
+    nord: "Nord",
+  };
+  return labels[id] || id;
 }
 
 function bindVisibilityPause() {
@@ -118,6 +164,10 @@ function bindControls() {
   $("sortBy")?.addEventListener("change", (event) => {
     state.sortBy = event.target.value;
     render();
+  });
+  $("themeSelect")?.addEventListener("change", (event) => {
+    applyTheme(event.target.value);
+    showToast(`Theme: ${themeLabel(currentThemeId())}`, "toast-info");
   });
   $("clearFilters")?.addEventListener("click", () => {
     $("clearFilters").blur();
@@ -373,6 +423,13 @@ function bindControls() {
       state.remediation = rems[(idx + 1) % rems.length];
       state.selected = 0;
       render();
+      return;
+    }
+
+    // t: cycle color scheme
+    if (e.key === "t" && !e.shiftKey) {
+      e.preventDefault();
+      cycleTheme(1);
       return;
     }
 
@@ -1452,6 +1509,13 @@ function showHelpModal() {
             <dt><kbd>Ctrl+A</kbd></dt><dd>Select all visible</dd>
             <dt><kbd>Ctrl+R</kbd></dt><dd>Recalculate score</dd>
             <dt><kbd>Ctrl+S</kbd></dt><dd>Rescan all tools</dd>
+          </dl>
+        </div>
+        <div class="help-section">
+          <h3>Appearance</h3>
+          <dl>
+            <dt><kbd>t</kbd></dt><dd>Cycle color scheme</dd>
+            <dt>Sidebar</dt><dd>Use the Color scheme dropdown</dd>
           </dl>
         </div>
         <div class="help-section">

--- a/internal/web/assets/index.html
+++ b/internal/web/assets/index.html
@@ -4,6 +4,15 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>hostveil</title>
+    <script>
+      (function () {
+        var key = "hostveil-theme";
+        var allowed = { default: 1, "tokyo-night": 1, catppuccin: 1, nord: 1 };
+        var saved = localStorage.getItem(key) || "default";
+        if (!allowed[saved]) saved = "default";
+        document.documentElement.dataset.theme = saved;
+      })();
+    </script>
     <link rel="stylesheet" href="/app.css" />
   </head>
   <body>
@@ -63,6 +72,16 @@
           <div class="filter-block">
             <h2>Service</h2>
             <div class="chips" id="serviceFilters"></div>
+          </div>
+
+          <div class="filter-block">
+            <h2>Color scheme</h2>
+            <select id="themeSelect" aria-label="Color scheme">
+              <option value="default">Default</option>
+              <option value="tokyo-night">Tokyo Night</option>
+              <option value="catppuccin">Catppuccin</option>
+              <option value="nord">Nord</option>
+            </select>
           </div>
 
           <div class="filter-block">

--- a/internal/web/assets/index.html
+++ b/internal/web/assets/index.html
@@ -6,11 +6,8 @@
     <title>hostveil</title>
     <script>
       (function () {
-        var key = "hostveil-theme";
-        var allowed = { default: 1, "tokyo-night": 1, catppuccin: 1, nord: 1 };
-        var saved = localStorage.getItem(key) || "default";
-        if (!allowed[saved]) saved = "default";
-        document.documentElement.dataset.theme = saved;
+        var saved = localStorage.getItem("hostveil-theme");
+        if (saved) document.documentElement.dataset.theme = saved;
       })();
     </script>
     <link rel="stylesheet" href="/app.css" />
@@ -76,12 +73,7 @@
 
           <div class="filter-block">
             <h2>Color scheme</h2>
-            <select id="themeSelect" aria-label="Color scheme">
-              <option value="default">Default</option>
-              <option value="tokyo-night">Tokyo Night</option>
-              <option value="catppuccin">Catppuccin</option>
-              <option value="nord">Nord</option>
-            </select>
+            <select id="themeSelect" aria-label="Color scheme"></select>
           </div>
 
           <div class="filter-block">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds selectable color schemes to both the terminal UI and embedded Web UI with **15 popular dark themes**:

| Theme | ID |
|---|---|
| Default (hostveil) | `default` |
| Tokyo Night | `tokyo-night` |
| Catppuccin | `catppuccin` |
| Nord | `nord` |
| Dracula | `dracula` |
| Gruvbox | `gruvbox` |
| One Dark | `one-dark` |
| Solarized Dark | `solarized` |
| Monokai | `monokai` |
| Everforest | `everforest` |
| Rosé Pine | `rose-pine` |
| Kanagawa | `kanagawa` |
| GitHub Dark | `github-dark` |
| Ayu Dark | `ayu-dark` |
| Night Owl | `night-owl` |

Also restores the default Web UI palette (replacing the gold/green anti-slop colors) while keeping the editorial layout from the visual refresh.

## TUI

- Press **`t`** to open a color scheme picker (↑/↓, Enter to apply, Esc to cancel)
- Preference persists to `~/.config/hostveil/config.json`
- Help modal documents the new shortcut

## Web UI

- **Color scheme** dropdown in the filters sidebar (populated from the shared catalog)
- Press **`t`** to cycle themes
- Preference persists in `localStorage` (`hostveil-theme`)
- Inline `<head>` script applies saved theme before first paint (no flash)

## Tests

- `internal/tui/theme_test.go` — full catalog coverage, lookup, labels
- `internal/tui/config_test.go` — save/load round-trip
- `go test -race ./...` passes

## Notes

This branch builds on the anti-slop Web UI layout from #484.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-097e1e77-af98-462a-b1a0-2da22fdf794b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-097e1e77-af98-462a-b1a0-2da22fdf794b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

