### PR TITLE
feat: polish TUI visuals and add visual e2e tests

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -116,7 +116,11 @@ func NewApp(live *domain.ScanProgress, reg *fix.Registry) *model {
 		}
 	}
 
-	s := spinner.New(spinner.WithSpinner(spinner.Dot))
+	theme := LookupTheme(themeName)
+	s := spinner.New(
+		spinner.WithSpinner(spinner.Dot),
+		spinner.WithStyle(lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Accent))),
+	)
 
 	t := table.New(
 		table.WithColumns([]table.Column{
@@ -129,12 +133,13 @@ func NewApp(live *domain.ScanProgress, reg *fix.Registry) *model {
 		}),
 		table.WithFocused(true),
 		table.WithHeight(10),
-		table.WithStyles(tableStyles(LookupTheme(themeName))),
+		table.WithStyles(tableStyles(theme)),
 	)
 
 	search := textinput.New()
 	search.Placeholder = "Search findings..."
 	search.CharLimit = 64
+	search.SetStyles(inputStyles(theme))
 
 	vp := viewport.New()
 	vp.SoftWrap = true
@@ -390,7 +395,10 @@ func (m model) applyTheme(name string) model {
 			break
 		}
 	}
-	m.table.SetStyles(tableStyles(m.theme()))
+	t := m.theme()
+	m.table.SetStyles(tableStyles(t))
+	m.searchBox.SetStyles(inputStyles(t))
+	m.spinner.Style = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent))
 	_ = SaveConfig(Config{Theme: m.themeName})
 	return m
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -1,9 +1,8 @@
 package tui
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/table"
+	"charm.land/lipgloss/v2"
 )
 
 func (m *model) rebuildTable() {
@@ -14,6 +13,7 @@ func (m *model) rebuildTable() {
 	rows := make([]table.Row, len(visible))
 	layout := m.tableLayout()
 	cursor := m.table.Cursor()
+	t := m.theme()
 	for i, f := range visible {
 		checkbox := "◇"
 		if !isBatchFixableFinding(f) {
@@ -21,24 +21,22 @@ func (m *model) rebuildTable() {
 		} else if m.selectedSet[f.ID] {
 			checkbox = "◆"
 		}
-		sevText := strings.ToUpper(f.Severity.String())
+		sevText := styledTableSeverity(t, f)
 		src := f.Source.String()
 		id := shortID(f.ID)
-		title := findingTitle(f)
+		title := styledTableTitle(t, f, m.findingColumnWidth(layout))
 		fixLabel := remediationShortLabel(f.Remediation)
 		if f.Fixed {
-			sevText = "✓"
 			src = ""
-			title = "✓ " + title
-			fixLabel = "Fixed"
+			fixLabel = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Success)).Render("Fixed")
 		}
 		switch layout {
 		case "compact":
-			rows[i] = table.Row{checkbox, sevText, fit(title, m.findingColumnWidth(layout))}
+			rows[i] = table.Row{checkbox, sevText, title}
 		case "medium":
-			rows[i] = table.Row{checkbox, sevText, id, fit(title, m.findingColumnWidth(layout)), fixLabel}
+			rows[i] = table.Row{checkbox, sevText, id, title, fixLabel}
 		default:
-			rows[i] = table.Row{checkbox, sevText, src, id, fit(title, m.findingColumnWidth(layout)), fixLabel}
+			rows[i] = table.Row{checkbox, sevText, src, id, title, fixLabel}
 		}
 	}
 	m.table.SetRows(nil)

--- a/internal/tui/render_regression_test.go
+++ b/internal/tui/render_regression_test.go
@@ -73,7 +73,7 @@ func TestView_BoundaryDimensionsPreserveVisibleStateAndWidth(t *testing.T) {
 				{ID: "fixed.001", Title: "Fixed SSH hardening", Severity: domain.SeverityCritical, Source: domain.SourceLynis, Remediation: domain.RemediationAuto, Fixed: true},
 				{ID: "fixed.002", Title: "Fixed compose hardening", Severity: domain.SeverityHigh, Source: domain.SourceCompose, Remediation: domain.RemediationReview, Fixed: true},
 			},
-			want: []string{"SEARCH FINDINGS", "Fixed", "✓ Fixed SSH hardening"},
+			want: []string{"SEARCH FINDINGS", "Fixed", "Fixed SSH hardening"},
 		},
 	}
 

--- a/internal/tui/screen.go
+++ b/internal/tui/screen.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/table"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/seolcu/hostveil/internal/domain"
 )
@@ -97,6 +99,7 @@ func (m model) renderLoading() string {
 	panel := lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(lipgloss.Color(t.Border)).
+		Background(lipgloss.Color(t.SurfaceAlt)).
 		Padding(1, 2).
 		Width(panelW).
 		Render(content)
@@ -263,6 +266,7 @@ func (m model) renderFilterPanel(width int) string {
 	return lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(lipgloss.Color(t.Border)).
+		Background(lipgloss.Color(t.SurfaceAlt)).
 		Width(width).
 		Height(m.bodyHeight()).
 		Padding(1, 2).
@@ -365,9 +369,13 @@ func (m model) renderScorePlate() string {
 				penalty = axis.MaxPenalty
 			}
 			meta := fmt.Sprintf("%d/%d", penalty, axis.MaxPenalty)
-			line := fmt.Sprintf("%s %3d  %s",
+			scoreStyled := lipgloss.NewStyle().
+				Foreground(lipgloss.Color(scoreColor(uint8(axis.Score), t))).
+				Bold(true).
+				Render(fmt.Sprintf("%3d", axis.Score))
+			line := fmt.Sprintf("%s %s  %s",
 				lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted)).Render(axisLabel),
-				axis.Score,
+				scoreStyled,
 				lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted)).Render(meta),
 			)
 			lines = append(lines, line)
@@ -392,6 +400,7 @@ func (m model) renderScorePlate() string {
 	return lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(lipgloss.Color(t.Border)).
+		Background(lipgloss.Color(t.SurfaceAlt)).
 		Padding(vPad, 2).
 		Width(28).
 		Height(height).
@@ -480,6 +489,7 @@ func (m model) renderMetrics() string {
 		card := lipgloss.NewStyle().
 			Border(border).
 			BorderForeground(lipgloss.Color(borderColor)).
+			Background(lipgloss.Color(t.SurfaceAlt)).
 			Width(cardW).
 			Padding(1, 2).
 			Render(
@@ -597,6 +607,7 @@ func (m model) renderListPane() string {
 	return lipgloss.NewStyle().
 		Width(headW).
 		Height(m.bodyHeight()).
+		Background(lipgloss.Color(t.SurfaceAlt)).
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(lipgloss.Color(borderColor)).
 		Render(body)
@@ -686,6 +697,7 @@ func (m model) renderDetailPane() string {
 	return lipgloss.NewStyle().
 		Width(m.detailWidth()).
 		Height(m.bodyHeight()).
+		Background(lipgloss.Color(t.SurfaceAlt)).
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(lipgloss.Color(borderColor)).
 		Render(body)
@@ -730,6 +742,7 @@ func renderDetailContent(t Theme, f *domain.Finding, width int) string {
 	meta := lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(lipgloss.Color(t.Border)).
+		Background(lipgloss.Color(t.Background)).
 		Padding(1, 2).
 		Width(width).
 		Render(strings.Join(metaRows, "\n"))
@@ -757,6 +770,7 @@ func renderDetailContent(t Theme, f *domain.Finding, width int) string {
 			block := lipgloss.NewStyle().
 				Border(lipgloss.NormalBorder()).
 				BorderForeground(lipgloss.Color(t.Border)).
+				Background(lipgloss.Color(t.Background)).
 				Padding(0, 1).
 				Width(width).
 				Render(muted.Render(fit(k, blockInnerW)) + "\n" + text.Render(lipgloss.Wrap(f.Evidence[k], blockInnerW, " ")))
@@ -775,6 +789,7 @@ func renderDetailContent(t Theme, f *domain.Finding, width int) string {
 			block := lipgloss.NewStyle().
 				Border(lipgloss.NormalBorder()).
 				BorderForeground(lipgloss.Color(t.Border)).
+				Background(lipgloss.Color(t.Background)).
 				Padding(0, 1).
 				Width(width).
 				Render(muted.Render(fit(k, blockInnerW)) + "\n" + text.Render(lipgloss.Wrap(f.Metadata[k], blockInnerW, " ")))
@@ -815,8 +830,9 @@ func (m model) renderWithModal(base string) string {
 	mw, mh := lipgloss.Size(modal)
 	x := max(0, (m.width-mw)/2)
 	y := max(0, (m.height-mh)/2)
+	dimmed := lipgloss.NewStyle().Faint(true).Render(base)
 	return lipgloss.NewCompositor(
-		lipgloss.NewLayer(base).X(0).Y(0).Z(0),
+		lipgloss.NewLayer(dimmed).X(0).Y(0).Z(0),
 		lipgloss.NewLayer(modal).X(x).Y(y).Z(10),
 	).Render()
 }
@@ -901,7 +917,7 @@ func (m model) renderFixDryRunModal() string {
 	lines := []string{
 		lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent)).Bold(true).Render(title),
 		"",
-		lipgloss.NewStyle().Bold(true).Render(label),
+		lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text)).Bold(true).Render(label),
 		"",
 	}
 
@@ -917,7 +933,7 @@ func (m model) renderFixDryRunModal() string {
 		}
 		actionLine := fmt.Sprintf("%s%s%s%s", prefix, info.label, typeTag, warn)
 		if !multi || i == m.dryRunApplyIdx {
-			style := lipgloss.NewStyle()
+			style := lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text))
 			if multi && i == m.dryRunApplyIdx {
 				style = style.Foreground(lipgloss.Color(t.Accent)).Bold(true)
 			}
@@ -960,7 +976,7 @@ func (m model) renderFixConfirmModal() string {
 		"",
 	}
 	if m.fixTarget != nil && len(m.fixTarget.Actions) > 0 {
-		lines = append(lines, lipgloss.NewStyle().Bold(true).Render(m.fixTarget.Label))
+		lines = append(lines, lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text)).Bold(true).Render(m.fixTarget.Label))
 
 		// Clamp the action index so a stale value (e.g. left over from a
 		// previous multi-action fix) cannot index past the end.
@@ -979,14 +995,16 @@ func (m model) renderFixConfirmModal() string {
 			lines = append(lines, lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted)).Render("Actions:"))
 			for i, a := range m.fixTarget.Actions {
 				mark := "  "
-				if i == m.fixActionIdx {
+				style := lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text))
+				if i == idx {
 					mark = "> "
+					style = style.Foreground(lipgloss.Color(t.Accent)).Bold(true)
 				}
 				warn := ""
 				if a.Warning != "" {
 					warn = " ⚠"
 				}
-				lines = append(lines, fmt.Sprintf("  %s%s%s", mark, a.Label, warn))
+				lines = append(lines, style.Render(fmt.Sprintf("%s%s%s", mark, a.Label, warn)))
 			}
 		}
 	}
@@ -999,10 +1017,27 @@ func (m model) renderFixResultModal() string {
 	t := m.theme()
 	s := m.modalStyle()
 
+	resultBody := m.fixResult
+	if strings.HasPrefix(m.fixResult, "✓") {
+		resultBody = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Success)).Render(m.fixResult)
+	} else if strings.HasPrefix(m.fixResult, "✗") {
+		resultBody = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Critical)).Render(m.fixResult)
+	} else if strings.Contains(m.fixResult, "\n\n") {
+		parts := strings.SplitN(m.fixResult, "\n\n", 2)
+		head := parts[0]
+		diff := parts[1]
+		headStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(t.Success))
+		if strings.HasPrefix(head, "✗") {
+			headStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Critical))
+		}
+		diffStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted))
+		resultBody = headStyle.Render(head) + "\n\n" + diffStyle.Render(diff)
+	}
+
 	lines := []string{
 		lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent)).Bold(true).Render("Fix result"),
 		"",
-		m.fixResult,
+		resultBody,
 		"",
 		lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted)).Render("Press any key to close"),
 	}
@@ -1019,18 +1054,15 @@ func (m model) renderFixProgressModal() string {
 	}
 	modalW := m.modalWidth(64)
 	barW := min(30, max(10, modalContentWidth(modalW)-6))
-	filled := barW * pct / 100
-	if filled > barW {
-		filled = barW
+	bar := renderProgressBar(float64(pct)/100.0, barW)
+	if bar == "" {
+		bar = strings.Repeat("░", barW)
 	}
-	bar := strings.Repeat("█", filled) + strings.Repeat("░", barW-filled)
 
 	title := lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent)).Bold(true).Render("Applying fixes")
 	header := fmt.Sprintf("%d / %d", m.fixProgress, m.fixProgressTotal)
-	pctStr := fmt.Sprintf("%d%%", pct)
 
 	barLine := lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent)).Render(bar)
-	pctLine := lipgloss.JoinHorizontal(lipgloss.Top, " ", barLine, " ", pctStr)
 
 	var labelLine string
 	if m.fixProgressLabel != "" {
@@ -1041,7 +1073,7 @@ func (m model) renderFixProgressModal() string {
 		title,
 		"",
 		header,
-		pctLine,
+		barLine,
 	}
 	if labelLine != "" {
 		lines = append(lines, labelLine)
@@ -1056,13 +1088,7 @@ func (m model) renderExportModal() string {
 
 	var items []string
 	for i, f := range exportFormats {
-		mark := "  "
-		style := lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text))
-		if i == m.exportIdx {
-			mark = "> "
-			style = style.Foreground(lipgloss.Color(t.Accent)).Bold(true)
-		}
-		items = append(items, "  "+mark+style.Render(f.label))
+		items = append(items, renderSelectableItem(t, f.label, i == m.exportIdx))
 	}
 
 	lines := []string{
@@ -1085,17 +1111,11 @@ func (m model) renderThemeModal() string {
 
 	var items []string
 	for i, id := range ThemeIDs() {
-		mark := "  "
-		style := lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text))
-		if i == m.themeIdx {
-			mark = "> "
-			style = style.Foreground(lipgloss.Color(t.Accent)).Bold(true)
-		}
 		label := ThemeLabel(id)
 		if id == m.themeName {
 			label += " (current)"
 		}
-		items = append(items, "  "+mark+style.Render(label))
+		items = append(items, renderSelectableItem(t, label, i == m.themeIdx))
 	}
 
 	lines := []string{
@@ -1117,6 +1137,7 @@ func (m model) modalStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(t.Border)).
+		Background(lipgloss.Color(t.SurfaceAlt)).
 		Padding(1, 2)
 }
 
@@ -1144,6 +1165,60 @@ func severityBadgeStr(label, color string) string {
 		Foreground(lipgloss.Color(color)).
 		Bold(true).
 		Render("[" + label + "]")
+}
+
+// inputStyles returns themed textinput styles for the search modal.
+func inputStyles(t Theme) textinput.Styles {
+	state := textinput.StyleState{
+		Text:        lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text)),
+		Placeholder: lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted)),
+		Suggestion:  lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextMuted)),
+		Prompt:      lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent)),
+	}
+	return textinput.Styles{
+		Focused: state,
+		Blurred: state,
+		Cursor: textinput.CursorStyle{
+			Color: lipgloss.Color(t.Accent),
+			Shape: tea.CursorBlock,
+			Blink: true,
+		},
+	}
+}
+
+// styledTableSeverity returns a color-coded severity cell for the findings table.
+func styledTableSeverity(t Theme, f domain.Finding) string {
+	if f.Fixed {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(t.Success)).Bold(true).Render("✓")
+	}
+	sev := strings.ToUpper(f.Severity.String())
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color(severityColor(f.Severity, t))).
+		Bold(true).
+		Render(fit(sev, 8))
+}
+
+// styledTableTitle returns a table title cell, dimming and striking through fixed findings.
+func styledTableTitle(t Theme, f domain.Finding, maxWidth int) string {
+	title := findingTitle(f)
+	if f.Fixed {
+		title = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(t.TextMuted)).
+			Strikethrough(true).
+			Render(title)
+	}
+	return fit(title, maxWidth)
+}
+
+// renderSelectableItem renders one highlighted option row for export/theme modals.
+func renderSelectableItem(t Theme, label string, selected bool) string {
+	mark := "  "
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text))
+	if selected {
+		mark = "> "
+		style = style.Foreground(lipgloss.Color(t.Accent)).Bold(true)
+	}
+	return mark + style.Render(label)
 }
 
 // ── Utility functions ──

--- a/internal/tui/screen_test.go
+++ b/internal/tui/screen_test.go
@@ -267,7 +267,7 @@ func TestUpdate_SpaceTogglesSelectionInRenderedTable(t *testing.T) {
 	}
 }
 
-func TestRebuildTable_RowsArePlainStrings(t *testing.T) {
+func TestRebuildTable_SeverityColumnIsColorCoded(t *testing.T) {
 	live := domain.NewScanProgress(true)
 	live.AddFindings([]domain.Finding{
 		{ID: "a", Title: "Plain finding", Severity: domain.SeverityCritical, Source: domain.SourceTrivy},
@@ -283,12 +283,15 @@ func TestRebuildTable_RowsArePlainStrings(t *testing.T) {
 	m.selectedSet["a"] = true
 	m.rebuildTable()
 
-	for rowIdx, row := range m.table.Rows() {
-		for colIdx, cell := range row {
-			if strings.Contains(cell, "\x1b[") {
-				t.Fatalf("row %d col %d contains ANSI styling: %q", rowIdx, colIdx, cell)
-			}
-		}
+	row := m.table.Rows()[0]
+	if !strings.Contains(row[1], "CRITICAL") {
+		t.Fatalf("severity column should include label, got %q", row[1])
+	}
+	if !strings.Contains(row[1], "\x1b[") {
+		t.Fatalf("severity column should be color-coded, got %q", row[1])
+	}
+	if strings.Contains(row[0], "\x1b[") {
+		t.Fatalf("checkbox column should stay unstyled, got %q", row[0])
 	}
 }
 

--- a/internal/tui/visual_test.go
+++ b/internal/tui/visual_test.go
@@ -1,0 +1,94 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/seolcu/hostveil/internal/domain"
+)
+
+func TestStyledTableSeverity_ColorsActiveAndFixedFindings(t *testing.T) {
+	t.Parallel()
+	theme := DefaultTheme()
+
+	active := styledTableSeverity(theme, domain.Finding{
+		Severity: domain.SeverityCritical,
+	})
+	if !strings.Contains(active, "CRITICAL") {
+		t.Fatalf("active severity should render label, got %q", active)
+	}
+	if lipgloss.Width(active) == 0 {
+		t.Fatal("active severity should include styling")
+	}
+
+	fixed := styledTableSeverity(theme, domain.Finding{
+		Severity: domain.SeverityHigh,
+		Fixed:    true,
+	})
+	if !strings.Contains(fixed, "✓") {
+		t.Fatalf("fixed severity should render checkmark, got %q", fixed)
+	}
+}
+
+func TestStyledTableTitle_StrikesThroughFixedFindings(t *testing.T) {
+	t.Parallel()
+	theme := DefaultTheme()
+
+	active := styledTableTitle(theme, domain.Finding{Title: "Open finding"}, 40)
+	if active != "Open finding" {
+		t.Fatalf("active title should render plainly, got %q", active)
+	}
+
+	fixed := styledTableTitle(theme, domain.Finding{Title: "Resolved finding", Fixed: true}, 40)
+	if fixed == active || !strings.Contains(fixed, ";9m") {
+		t.Fatalf("fixed title should be struck through, got %q", fixed)
+	}
+}
+
+func TestRenderSelectableItem_HighlightsSelection(t *testing.T) {
+	t.Parallel()
+	theme := DefaultTheme()
+
+	unselected := renderSelectableItem(theme, "JSON (full data)", false)
+	if !strings.Contains(unselected, "JSON (full data)") || !strings.HasPrefix(unselected, "  ") {
+		t.Fatalf("unselected item should be indented with label, got %q", unselected)
+	}
+
+	selected := renderSelectableItem(theme, "CSV (spreadsheet)", true)
+	if !strings.Contains(selected, "CSV (spreadsheet)") || !strings.HasPrefix(selected, "> ") {
+		t.Fatalf("selected item should use cursor prefix, got %q", selected)
+	}
+}
+
+func TestRenderFixResultModal_ColorsSuccessAndFailure(t *testing.T) {
+	t.Parallel()
+	m := readyModelForRenderRegression(t, nil, 120, 32)
+
+	m.fixResult = "✓ Hardened SSH"
+	success := m.renderFixResultModal()
+	if !strings.Contains(success, "✓ Hardened SSH") {
+		t.Fatalf("success modal should include result text:\n%s", success)
+	}
+
+	m.fixResult = "✗ permission denied"
+	failure := m.renderFixResultModal()
+	if !strings.Contains(failure, "permission denied") {
+		t.Fatalf("failure modal should include error text:\n%s", failure)
+	}
+}
+
+func TestView_ModalOverlayDimsUnderlyingContent(t *testing.T) {
+	t.Parallel()
+	m := readyModelForRenderRegression(t, makeTestFindings(1), 120, 32)
+	m.modal = modalHelp
+
+	base := m.renderMain()
+	overlay := m.renderWithModal(base)
+	if overlay == base {
+		t.Fatal("modal overlay should change rendered output")
+	}
+	if !strings.Contains(overlay, "Help") {
+		t.Fatalf("overlay should still include modal content:\n%s", overlay)
+	}
+}

--- a/internal/web/assets/app.css
+++ b/internal/web/assets/app.css
@@ -945,6 +945,7 @@ th.sortable.desc::after {
 }
 
 .fixed td { opacity: 0.65; }
+.fixed-title { text-decoration: line-through; }
 
 .fix-warning { color: var(--high); }
 

--- a/internal/web/assets/app.js
+++ b/internal/web/assets/app.js
@@ -810,7 +810,7 @@ function renderTable(visible) {
     const sevDisplay = f.fixed ? "&#10003;" : `<span class="badge ${severity(f)}">${severity(f)}</span>`;
     const srcDisplay = f.fixed ? "" : `<span class="muted">${source(f)}</span>`;
     const fixDisplay = f.fixed ? "Fixed" : label(remediation(f));
-    const titleDisplay = f.fixed ? `<span style="opacity:0.5;text-decoration:line-through">${escapeHTML(title(f))}</span>` : escapeHTML(title(f));
+    const titleDisplay = f.fixed ? `<span class="fixed-title">${escapeHTML(title(f))}</span>` : escapeHTML(title(f));
     const checked = selectableRow && state.selectedSet.has(f.id) ? "checked" : "";
     const disabledAttr = !selectableRow ? "disabled" : "";
     const sevAttr = f.fixed ? "" : ` data-severity="${severity(f)}"`;

--- a/test/e2e/specs/export.spec.ts
+++ b/test/e2e/specs/export.spec.ts
@@ -106,10 +106,10 @@ test.describe("Export", () => {
     const sevCell = fixedRow.first().locator("td:nth-child(2)");
     await expect(sevCell).toContainText("✓");
 
-    // The title should have line-through styling (opacity:0.5 + text-decoration:line-through)
-    const titleCell = fixedRow.first().locator("td.title");
-    const titleHtml = await titleCell.innerHTML();
-    expect(titleHtml).toContain("line-through");
+    // The title should use the shared fixed-title styling.
+    const titleCell = fixedRow.first().locator("td.title .fixed-title");
+    await expect(titleCell).toBeVisible();
+    await expect(titleCell).toHaveCSS("text-decoration-line", "line-through");
   });
 
   test("JSON export contains all required Snapshot fields", async ({

--- a/test/e2e/specs/responsive-visual-regressions.spec.ts
+++ b/test/e2e/specs/responsive-visual-regressions.spec.ts
@@ -207,6 +207,61 @@ test.describe("Responsive visual regressions", () => {
     await expect(page.locator("#fixSelectedBtn")).not.toContainText("14");
   });
 
+  test("severity badges use severity classes on visible rows", async ({ page }) => {
+    await gotoReady(page, { width: 1280, height: 720 });
+
+    const rows = page.locator("#findings tr[data-id]:not(.fixed)");
+    const count = await rows.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < Math.min(count, 6); i++) {
+      const badge = rows.nth(i).locator("td:nth-child(2) .badge");
+      await expect(badge).toBeVisible();
+      const className = await badge.getAttribute("class");
+      expect(className).toMatch(/\b(critical|high|medium|low)\b/);
+    }
+  });
+
+  test("fix modal stays inside a short viewport", async ({ page }) => {
+    await gotoReady(page, { width: 640, height: 360 });
+
+    const fixableRow = page.locator('#findings tr[data-id="lynis.AUTH-9286"]');
+    await fixableRow.click();
+    await page.keyboard.press("f");
+    const modal = page.locator(".modal-overlay .modal-content");
+    await expect(modal).toBeVisible();
+
+    const metrics = await modal.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+        right: rect.right,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    expect(metrics.left).toBeGreaterThanOrEqual(0);
+    expect(metrics.right).toBeLessThanOrEqual(metrics.viewportWidth + 1);
+    expect(metrics.top).toBeGreaterThanOrEqual(0);
+    expect(metrics.bottom).toBeLessThanOrEqual(metrics.viewportHeight + 1);
+  });
+
+  test("fixed findings use shared title styling instead of inline opacity", async ({
+    page,
+  }) => {
+    await gotoReady(page, { width: 1280, height: 720 });
+
+    const fixedTitle = page.locator('#findings tr[data-id="trivy.cve-2024-0003"] td.title .fixed-title');
+    await expect(fixedTitle).toBeVisible();
+    await expect(fixedTitle).toHaveCSS("text-decoration-line", "line-through");
+
+    const inlineOpacity = await fixedTitle.evaluate((el) => el.getAttribute("style"));
+    expect(inlineOpacity).toBeNull();
+  });
+
   test("rescan button stays in loading state while the rescan request is pending", async ({
     page,
   }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves hostveil's terminal UI visual consistency with the Web UI and adds regression coverage for visual behavior.

### TUI visual polish
- **Severity colors in the findings table** — critical/high/medium/low are now color-coded (matching Web badge colors)
- **Panel depth** — list, detail, filter, metrics, score plate, loading, and modals use `SurfaceAlt` backgrounds
- **Fixed findings** — strikethrough + muted titles; green checkmark in severity column; green "Fixed" label
- **Score plate** — per-axis scores tinted by tier (same thresholds as overall score)
- **Modals** — faint backdrop behind overlays; success/error coloring in fix-result modal; accent highlight for review-action selection; unified bracketed progress bar
- **Search input** — themed textinput (prompt, text, placeholder, cursor) synced with active palette
- **Spinner** — accent-colored during loading

### Web UI bug fix
- **Fixed row double-dimming** — removed inline `opacity:0.5` on fixed titles (row already uses `.fixed td { opacity: 0.65 }`); replaced with `.fixed-title` class for line-through only

### Tests
- New TUI unit tests in `internal/tui/visual_test.go` (severity styling, selectable items, fix-result colors, modal dimming)
- Updated `TestRebuildTable_SeverityColumnIsColorCoded` (replaces plain-string assertion)
- 3 new Playwright visual regression tests (severity badges, fix modal viewport bounds, fixed-title styling)
- Updated `export.spec.ts` to assert CSS class instead of inline style

## Test plan
- [x] `gofmt -l .` (clean)
- [x] `go build ./...` && `go vet ./...`
- [x] `go test -race ./...`
- [x] `npx playwright test` (123 passed, 2 skipped)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e1631ac-18b9-466a-a033-85a3e8c7bda6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e1631ac-18b9-466a-a033-85a3e8c7bda6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

