### PR TITLE
ui: independent scrolling (Web panels + TUI list)

### DIFF
--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -31,6 +31,7 @@ type appModel struct {
 	active []model.Finding
 
 	cursor        int
+	offset        int // first visible finding index (list scrolling)
 	width, height int
 	mode          mode
 
@@ -94,6 +95,7 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.report = msg.report
 		m.active = m.report.Select(model.Filter{})
 		m.cursor = clamp(m.cursor, 0, len(m.active)-1)
+		m.offset = 0
 		m.mode = modeList
 		return m, nil
 

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,6 +87,33 @@ func TestSnapshotDump(t *testing.T) {
 	m = send(m, scannedMsg{report: rep})
 	if err := os.WriteFile(path, []byte(m.(*appModel).View().Content), 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestListScrolls verifies the list viewport follows the cursor when there
+// are more findings than fit on screen.
+func TestListScrolls(t *testing.T) {
+	var fs []model.Finding
+	for i := 0; i < 20; i++ {
+		fs = append(fs, model.NewFinding(fmt.Sprintf("compose.d%03d", i),
+			fmt.Sprintf("finding number %d", i), model.SeverityMedium,
+			model.SourceCompose, model.RemediationManual))
+	}
+	rep := model.Report{Findings: fs, Score: model.ScoreReport(fs, nil)}
+
+	m := tea.Model(&appModel{mode: modeList})
+	m = send(m, tea.WindowSizeMsg{Width: 100, Height: 12}) // only a few rows fit
+	m = send(m, scannedMsg{report: rep})
+	for i := 0; i < 19; i++ { // move to the last finding
+		m = send(m, tea.KeyPressMsg(tea.Key{Text: "j"}))
+	}
+
+	view := m.(*appModel).View().Content
+	if !strings.Contains(view, "compose.d019") {
+		t.Error("the cursor's (last) finding should be visible after scrolling")
+	}
+	if strings.Contains(view, "compose.d000") {
+		t.Error("the first finding should have scrolled out of view")
 	}
 }
 

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -78,8 +78,27 @@ func (m *appModel) viewList() string {
 		return b.String()
 	}
 
-	fmt.Fprintf(&b, "%s\n", styleBold.Render(fmt.Sprintf("Findings (%d)", len(m.active))))
-	for i, f := range m.active {
+	// Scroll a window of the list so the cursor stays visible even when
+	// there are more findings than fit on screen. The overhead is the
+	// header (2), the blank line, the title, and the footer (2).
+	visible := m.height - 6
+	if visible < 1 {
+		visible = 1
+	}
+	m.offset = scrollOffset(m.cursor, len(m.active), visible, m.offset)
+	end := m.offset + visible
+	if end > len(m.active) {
+		end = len(m.active)
+	}
+
+	title := styleBold.Render(fmt.Sprintf("Findings (%d)", len(m.active)))
+	if len(m.active) > visible {
+		title += styleDim.Render(fmt.Sprintf("   showing %d–%d", m.offset+1, end))
+	}
+	fmt.Fprintf(&b, "%s\n", title)
+
+	for i := m.offset; i < end; i++ {
+		f := m.active[i]
 		row := fmt.Sprintf("%-9s %-11s %-13s %s",
 			strings.ToUpper(f.Severity.String()), f.ID, f.Remediation.Label(), truncate(f.Title, m.width-40))
 		if f.Service != "" {
@@ -93,6 +112,24 @@ func (m *appModel) viewList() string {
 	}
 	b.WriteString(m.footer("↑/↓ move   enter details   f fix   r rescan   q quit"))
 	return b.String()
+}
+
+// scrollOffset returns a new window start that keeps cursor within the
+// visible rows, clamped to the list bounds.
+func scrollOffset(cursor, total, visible, offset int) int {
+	if cursor < offset {
+		offset = cursor
+	}
+	if cursor >= offset+visible {
+		offset = cursor - visible + 1
+	}
+	if max := total - visible; offset > max {
+		offset = max
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return offset
 }
 
 func (m *appModel) viewDetail() string {

--- a/internal/ui/web/assets/app.css
+++ b/internal/ui/web/assets/app.css
@@ -4,14 +4,17 @@
   --low: #6b7280; --ok: #35d07f; --accent: #4aa3ff;
 }
 * { box-sizing: border-box; }
+html, body { height: 100%; }
 body {
   margin: 0; background: var(--bg); color: var(--text);
   font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
+  /* Fixed header/axes; the two panels below scroll independently. */
+  display: flex; flex-direction: column; height: 100vh; overflow: hidden;
 }
 header {
+  flex: 0 0 auto;
   display: flex; align-items: center; gap: 20px;
   padding: 14px 22px; border-bottom: 1px solid var(--line); background: var(--panel);
-  position: sticky; top: 0; z-index: 5;
 }
 .brand { font-weight: 700; font-size: 18px; letter-spacing: .5px; color: var(--accent); }
 .score { font-weight: 700; font-size: 20px; }
@@ -24,12 +27,18 @@ button {
 button:hover { border-color: var(--accent); }
 button.primary { background: var(--accent); color: #06101f; border-color: var(--accent); font-weight: 600; }
 button:disabled { opacity: .5; cursor: default; }
-.axes { display: flex; flex-wrap: wrap; gap: 8px 18px; padding: 12px 22px; color: var(--dim); border-bottom: 1px solid var(--line); }
+.axes { flex: 0 0 auto; display: flex; flex-wrap: wrap; gap: 8px 18px; padding: 12px 22px; color: var(--dim); border-bottom: 1px solid var(--line); }
 .axes .na { opacity: .55; }
-.status { margin: 12px 22px 0; padding: 10px 14px; border-radius: 6px; background: #10261b; border: 1px solid #1f4d36; color: var(--ok); }
-main { display: grid; grid-template-columns: minmax(340px, 1.2fr) 1.4fr; gap: 0; min-height: calc(100vh - 120px); }
-@media (max-width: 800px) { main { grid-template-columns: 1fr; } }
-.findings { border-right: 1px solid var(--line); padding: 10px 0; overflow-x: auto; }
+.status { flex: 0 0 auto; margin: 12px 22px 0; padding: 10px 14px; border-radius: 6px; background: #10261b; border: 1px solid #1f4d36; color: var(--ok); }
+main { flex: 1 1 auto; min-height: 0; display: grid; grid-template-columns: minmax(340px, 1.2fr) 1.4fr; gap: 0; overflow: hidden; }
+.findings { border-right: 1px solid var(--line); padding: 10px 0; overflow-y: auto; min-height: 0; }
+.detail { overflow-y: auto; min-height: 0; }
+@media (max-width: 800px) {
+  /* On narrow screens stack the panels and let the page scroll normally. */
+  body { height: auto; overflow: visible; }
+  main { grid-template-columns: 1fr; overflow: visible; }
+  .findings, .detail { overflow: visible; }
+}
 .findings h2, .detail h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .6px; color: var(--dim); margin: 8px 22px; }
 ul { list-style: none; margin: 0; padding: 0; }
 .finding { padding: 10px 22px; border-left: 3px solid transparent; cursor: pointer; display: flex; gap: 10px; align-items: baseline; }


### PR DESCRIPTION
Two UI bugs found by actually using the tool:

- **Web** — the whole page scrolled together, so scrolling the findings list dragged the detail panel out of view. Now the header + score axes are fixed and the findings list and the detail panel each have their own scroll region (they move independently). Narrow screens fall back to normal page scrolling.
- **TUI** — pressing ↓ past the last visible row didn't scroll, so the rest of a long findings list was unreachable. Added a viewport that renders only the rows that fit the terminal and scrolls to keep the cursor visible, with a "showing X–Y" indicator.

Verified: web left panel scrolls to the bottom while the selected finding's detail + fix preview stay put; TUI follows the cursor through 20 findings in a 12-row terminal (regression test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)