### PR TITLE
ui: unified "Instrument" redesign (TUI + Web share one look)

### DIFF
--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -126,7 +126,7 @@ func TestListRenders(t *testing.T) {
 	if !strings.Contains(view, "compose.ds018") || !strings.Contains(view, "compose.ds001") {
 		t.Errorf("list view missing findings:\n%s", view)
 	}
-	if !strings.Contains(view, "Security score") {
+	if !strings.Contains(view, "SECURITY") {
 		t.Error("list view missing score header")
 	}
 }

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"image/color"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -10,32 +11,71 @@ import (
 	"github.com/seolcu/hostveil/internal/model"
 )
 
+// Palette — identical hex to the web UI ("Instrument" system). lipgloss v2
+// renders these as truecolor and degrades gracefully on limited terminals.
 var (
-	styleBold   = lipgloss.NewStyle().Bold(true)
-	styleDim    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	styleGreen  = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	styleSel    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("0")).Background(lipgloss.Color("45"))
-	styleHeader = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("45"))
+	cLine  = lipgloss.Color("#333b46")
+	cBone  = lipgloss.Color("#e7e3d8")
+	cSlate = lipgloss.Color("#7c8692")
+	cCrit  = lipgloss.Color("#e5484d")
+	cHigh  = lipgloss.Color("#e8843c")
+	cMed   = lipgloss.Color("#e6c14a")
+	cLow   = lipgloss.Color("#6b7480")
+	cSafe  = lipgloss.Color("#46c69a")
 )
 
-func severityStyle(s model.Severity) lipgloss.Style {
+var (
+	styleBone  = lipgloss.NewStyle().Foreground(cBone)
+	styleDim   = lipgloss.NewStyle().Foreground(cSlate)
+	styleSafe  = lipgloss.NewStyle().Foreground(cSafe)
+	styleBrand = lipgloss.NewStyle().Foreground(cBone).Bold(true)
+	styleSel   = lipgloss.NewStyle().Foreground(cBone).Background(cLine).Bold(true)
+	styleTrack = lipgloss.NewStyle().Foreground(cLine)
+)
+
+func severityColor(s model.Severity) color.Color {
 	switch s {
 	case model.SeverityCritical:
-		return lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("196"))
+		return cCrit
 	case model.SeverityHigh:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
+		return cHigh
 	case model.SeverityMedium:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+		return cMed
 	default:
-		return styleDim
+		return cLow
 	}
+}
+
+// band maps a 0-100 health score to its meter color (safe→crit heat).
+func band(v uint8) color.Color {
+	switch {
+	case v >= 80:
+		return cSafe
+	case v >= 50:
+		return cMed
+	case v >= 25:
+		return cHigh
+	default:
+		return cCrit
+	}
+}
+
+// meter renders a segmented bar: filled blocks in c, empty in the track.
+func meter(pct uint8, width int, c color.Color) string {
+	filled := int(pct) * width / 100
+	if filled > width {
+		filled = width
+	}
+	on := lipgloss.NewStyle().Foreground(c).Render(strings.Repeat("█", filled))
+	off := styleTrack.Render(strings.Repeat("░", width-filled))
+	return on + off
 }
 
 func (m *appModel) View() tea.View {
 	var content string
 	switch m.mode {
 	case modeScanning:
-		content = "\n  " + m.status + "\n"
+		content = "\n  " + styleDim.Render(m.status) + "\n"
 	case modeList:
 		content = m.viewList()
 	case modeDetail:
@@ -48,40 +88,53 @@ func (m *appModel) View() tea.View {
 	return tea.View{Content: content, AltScreen: true}
 }
 
-func (m *appModel) header() string {
-	score := m.report.Score.Overall
-	return styleHeader.Render("hostveil") + "   " +
-		styleBold.Render(fmt.Sprintf("Security score: %d/100", score)) + "\n" +
-		styleDim.Render(m.scoreAxes()) + "\n"
+func (m *appModel) rule() string {
+	w := m.width
+	if w < 1 {
+		w = 1
+	}
+	return styleTrack.Render(strings.Repeat("─", w))
 }
 
-func (m *appModel) scoreAxes() string {
+// header renders the status bar: brand + the exposure gauge (SECURITY
+// meter + score), then the per-axis bars.
+func (m *appModel) header() string {
+	var b strings.Builder
+	sc := m.report.Score.Overall
+	b.WriteString(styleDim.Render("▚ ") + styleBrand.Render("hostveil"))
+	b.WriteString("   " + styleDim.Render("SECURITY ") + meter(sc, 18, band(sc)) +
+		styleBone.Render(fmt.Sprintf(" %d", sc)) + styleDim.Render("/100"))
+	b.WriteString("\n")
+	b.WriteString(m.axesLine())
+	b.WriteString("\n")
+	return b.String()
+}
+
+func (m *appModel) axesLine() string {
 	var parts []string
 	for _, ax := range m.report.Score.Axes {
-		if !ax.Applicable {
-			parts = append(parts, ax.Label+": N/A")
-			continue
+		label := styleDim.Render(fmt.Sprintf("%-9s", ax.ID))
+		if ax.Applicable {
+			parts = append(parts, label+meter(ax.Score, 8, band(ax.Score))+styleBone.Render(fmt.Sprintf(" %-3d", ax.Score)))
+		} else {
+			parts = append(parts, label+styleTrack.Render(strings.Repeat("░", 8))+styleDim.Render(" N/A"))
 		}
-		parts = append(parts, fmt.Sprintf("%s: %d", ax.Label, ax.Score))
 	}
-	return strings.Join(parts, "  ·  ")
+	return strings.Join(parts, styleDim.Render("   "))
 }
 
 func (m *appModel) viewList() string {
 	var b strings.Builder
 	b.WriteString(m.header())
-	b.WriteString("\n")
+	b.WriteString(m.rule() + "\n")
 
 	if len(m.active) == 0 {
-		b.WriteString(styleGreen.Render("  No problems found. Clean.") + "\n")
+		b.WriteString("\n" + styleSafe.Render("  No problems found. Clean.") + "\n")
 		b.WriteString(m.footer("r rescan   q quit"))
 		return b.String()
 	}
 
-	// Scroll a window of the list so the cursor stays visible even when
-	// there are more findings than fit on screen. The overhead is the
-	// header (2), the blank line, the title, and the footer (2).
-	visible := m.height - 6
+	visible := m.height - 7
 	if visible < 1 {
 		visible = 1
 	}
@@ -91,26 +144,137 @@ func (m *appModel) viewList() string {
 		end = len(m.active)
 	}
 
-	title := styleBold.Render(fmt.Sprintf("Findings (%d)", len(m.active)))
+	head := styleDim.Render(fmt.Sprintf("FINDINGS · %d", len(m.active)))
 	if len(m.active) > visible {
-		title += styleDim.Render(fmt.Sprintf("   showing %d–%d", m.offset+1, end))
+		head += styleDim.Render(fmt.Sprintf("      %d–%d", m.offset+1, end))
 	}
-	fmt.Fprintf(&b, "%s\n", title)
+	b.WriteString(head + "\n")
 
 	for i := m.offset; i < end; i++ {
-		f := m.active[i]
-		row := fmt.Sprintf("%-9s %-11s %-13s %s",
-			strings.ToUpper(f.Severity.String()), f.ID, f.Remediation.Label(), truncate(f.Title, m.width-40))
-		if f.Service != "" {
-			row += " (" + f.Service + ")"
-		}
-		if i == m.cursor {
-			b.WriteString(styleSel.Render("› "+row) + "\n")
-		} else {
-			b.WriteString("  " + severityStyle(f.Severity).Render(row) + "\n")
-		}
+		b.WriteString(m.findingRow(m.active[i], i == m.cursor) + "\n")
 	}
 	b.WriteString(m.footer("↑/↓ move   enter details   f fix   r rescan   q quit"))
+	return b.String()
+}
+
+// findingRow renders one heat-gutter row: severity gutter + label + id +
+// title + service. The selected row is inverse-video.
+func (m *appModel) findingRow(f model.Finding, selected bool) string {
+	sevC := severityColor(f.Severity)
+	gutter := lipgloss.NewStyle().Foreground(sevC).Render("▌")
+	sev := sevAbbr(f.Severity)
+	title := truncate(f.Title, m.width-42)
+	if selected {
+		return gutter + styleSel.Render(" "+padRight(fmt.Sprintf("%-4s %-13s %s", sev, f.ID, title), m.width-3))
+	}
+	return gutter + " " + lipgloss.NewStyle().Foreground(sevC).Render(sev) +
+		styleDim.Render(fmt.Sprintf(" %-13s ", f.ID)) + styleBone.Render(title) + serviceSuffixTUI(f)
+}
+
+func sevAbbr(s model.Severity) string {
+	switch s {
+	case model.SeverityCritical:
+		return "CRIT"
+	case model.SeverityHigh:
+		return "HIGH"
+	case model.SeverityMedium:
+		return "MED"
+	default:
+		return "LOW"
+	}
+}
+
+func serviceSuffixTUI(f model.Finding) string {
+	if f.Service == "" {
+		return ""
+	}
+	return styleDim.Render("  (" + f.Service + ")")
+}
+
+func (m *appModel) viewDetail() string {
+	f := m.active[m.cursor]
+	var b strings.Builder
+	b.WriteString(m.header())
+	b.WriteString(m.rule() + "\n\n")
+	b.WriteString(lipgloss.NewStyle().Foreground(severityColor(f.Severity)).Bold(true).Render(strings.ToUpper(f.Severity.String())) +
+		"  " + styleBrand.Render(f.Title) + "\n")
+	meta := strings.ToUpper(f.ID + "  ·  " + f.Remediation.String())
+	if f.Service != "" {
+		meta += "  ·  SERVICE: " + f.Service
+	}
+	b.WriteString(styleDim.Render(meta) + "\n\n")
+	b.WriteString(styleBone.Render(wrap(f.Description, min(m.width-4, 78))) + "\n\n")
+	if f.HowToFix != "" {
+		b.WriteString(styleDim.Render("HOW TO FIX") + "\n")
+		b.WriteString(styleBone.Render(wrap(f.HowToFix, min(m.width-4, 78))) + "\n")
+	}
+	hint := "esc back   q list"
+	if f.IsFixable() {
+		hint = "f apply fix   " + hint
+	}
+	b.WriteString(m.footer(hint))
+	return b.String()
+}
+
+func (m *appModel) viewPreview() string {
+	var b strings.Builder
+	b.WriteString(styleDim.Render("FIX PREVIEW") + "\n")
+	b.WriteString(styleBrand.Render(m.preview.Label) + "\n")
+	b.WriteString(m.rule() + "\n\n")
+
+	if len(m.preview.Actions) > 1 {
+		b.WriteString(styleDim.Render("Alternatives (press a number):") + "\n")
+		for _, a := range m.preview.Actions {
+			marker := "  "
+			if a.Index == m.previewAction {
+				marker = lipgloss.NewStyle().Foreground(cBone).Render("› ")
+			}
+			b.WriteString(marker + styleBone.Render(fmt.Sprintf("[%d] %s", a.Index, a.Label)) + "\n")
+		}
+		b.WriteString("\n")
+	}
+
+	a := m.preview.Actions[m.previewAction]
+	if a.Warning != "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(cHigh).Render("⚠  "+a.Warning) + "\n\n")
+	}
+	switch a.Type {
+	case "edit":
+		b.WriteString(renderDiff(a.Diff))
+	case "exec":
+		b.WriteString(styleDim.Render("These commands will run:") + "\n")
+		for _, cmd := range a.Commands {
+			b.WriteString(styleDim.Render("  $ "+strings.Join(cmd, " ")) + "\n")
+		}
+	}
+	b.WriteString(m.footer("y apply   n cancel"))
+	return b.String()
+}
+
+func (m *appModel) viewMessage() string {
+	var b strings.Builder
+	b.WriteString(m.header())
+	b.WriteString(m.rule() + "\n\n  " + styleBone.Render(m.status) + "\n")
+	b.WriteString(m.footer("press any key to continue"))
+	return b.String()
+}
+
+func (m *appModel) footer(hint string) string {
+	return "\n" + m.rule() + "\n" + styleDim.Render(hint)
+}
+
+func renderDiff(diff string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(strings.TrimRight(diff, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
+			b.WriteString(styleSafe.Render(line) + "\n")
+		case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---"):
+			b.WriteString(lipgloss.NewStyle().Foreground(cCrit).Render(line) + "\n")
+		default:
+			b.WriteString(styleDim.Render(line) + "\n")
+		}
+	}
 	return b.String()
 }
 
@@ -132,99 +296,18 @@ func scrollOffset(cursor, total, visible, offset int) int {
 	return offset
 }
 
-func (m *appModel) viewDetail() string {
-	f := m.active[m.cursor]
-	var b strings.Builder
-	b.WriteString(m.header())
-	b.WriteString("\n")
-	fmt.Fprintf(&b, "%s %s\n", severityStyle(f.Severity).Render("["+strings.ToUpper(f.Severity.String())+"]"), styleBold.Render(f.Title))
-	fmt.Fprintf(&b, "%s\n\n", styleDim.Render(f.ID+"   "+f.Remediation.Label()+serviceTag(f)))
-	b.WriteString(wrap(f.Description, min(m.width-4, 76)) + "\n\n")
-	if f.HowToFix != "" {
-		b.WriteString(styleGreen.Render("How to fix:") + "\n")
-		b.WriteString(wrap(f.HowToFix, min(m.width-4, 76)) + "\n")
-	}
-	hint := "esc back   q list"
-	if f.IsFixable() {
-		hint = "f apply fix   " + hint
-	}
-	b.WriteString(m.footer(hint))
-	return b.String()
-}
-
-func (m *appModel) viewPreview() string {
-	var b strings.Builder
-	b.WriteString(styleHeader.Render("Fix preview") + "\n")
-	fmt.Fprintf(&b, "%s\n\n", styleBold.Render(m.preview.Label))
-
-	if len(m.preview.Actions) > 1 {
-		b.WriteString(styleDim.Render("Alternatives (press a number to choose):") + "\n")
-		for _, a := range m.preview.Actions {
-			marker := "  "
-			if a.Index == m.previewAction {
-				marker = "› "
-			}
-			fmt.Fprintf(&b, "%s[%d] %s\n", marker, a.Index, a.Label)
-		}
-		b.WriteString("\n")
-	}
-
-	a := m.preview.Actions[m.previewAction]
-	if a.Warning != "" {
-		b.WriteString(severityStyle(model.SeverityHigh).Render("⚠  "+a.Warning) + "\n\n")
-	}
-	switch a.Type {
-	case "edit":
-		b.WriteString(renderDiff(a.Diff))
-	case "exec":
-		b.WriteString(styleDim.Render("These commands will run:") + "\n")
-		for _, cmd := range a.Commands {
-			b.WriteString("  $ " + strings.Join(cmd, " ") + "\n")
-		}
-	}
-	b.WriteString(m.footer("y apply   n cancel"))
-	return b.String()
-}
-
-func (m *appModel) viewMessage() string {
-	var b strings.Builder
-	b.WriteString(m.header())
-	b.WriteString("\n  " + m.status + "\n")
-	b.WriteString(m.footer("press any key to continue"))
-	return b.String()
-}
-
-func (m *appModel) footer(hint string) string {
-	return "\n" + styleDim.Render(hint)
-}
-
-func renderDiff(diff string) string {
-	var b strings.Builder
-	for _, line := range strings.Split(strings.TrimRight(diff, "\n"), "\n") {
-		switch {
-		case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
-			b.WriteString(styleGreen.Render(line) + "\n")
-		case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---"):
-			b.WriteString(severityStyle(model.SeverityCritical).Render(line) + "\n")
-		default:
-			b.WriteString(styleDim.Render(line) + "\n")
-		}
-	}
-	return b.String()
-}
-
-func serviceTag(f model.Finding) string {
-	if f.Service == "" {
-		return ""
-	}
-	return "   service: " + f.Service
-}
-
 func truncate(s string, max int) string {
 	if max < 4 || len(s) <= max {
 		return s
 	}
 	return s[:max-1] + "…"
+}
+
+func padRight(s string, n int) string {
+	if lipgloss.Width(s) >= n || n < 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", n-lipgloss.Width(s))
 }
 
 func wrap(s string, width int) string {
@@ -246,4 +329,11 @@ func wrap(s string, width int) string {
 		ll += len(w)
 	}
 	return b.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/internal/ui/web/assets/app.css
+++ b/internal/ui/web/assets/app.css
@@ -1,66 +1,141 @@
+/* hostveil — "Instrument" design system.
+   Monochrome console: bone text on ink, all-monospace, dense. The ONLY
+   things that carry color are risk (severity) and safety. Shared, to the
+   hex, with the TUI. */
 :root {
-  --bg: #0f1115; --panel: #171a21; --line: #262b36; --text: #e6e9ef;
-  --dim: #8a92a6; --crit: #ff5c5c; --high: #ff9f43; --med: #ffd34e;
-  --low: #6b7280; --ok: #35d07f; --accent: #4aa3ff;
+  --ink: #0b0d10; --ink-2: #12151b; --ink-3: #171b22;
+  --line: #222831; --line-2: #333b46;
+  --bone: #e7e3d8; --slate: #7c8692;
+  --crit: #e5484d; --high: #e8843c; --med: #e6c14a; --low: #6b7480;
+  --safe: #46c69a;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, "Liberation Mono", monospace;
 }
 * { box-sizing: border-box; }
 html, body { height: 100%; }
 body {
-  margin: 0; background: var(--bg); color: var(--text);
-  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
-  /* Fixed header/axes; the two panels below scroll independently. */
+  margin: 0; background: var(--ink); color: var(--bone);
+  font: 13px/1.55 var(--mono);
   display: flex; flex-direction: column; height: 100vh; overflow: hidden;
+  -webkit-font-smoothing: antialiased;
 }
-header {
-  flex: 0 0 auto;
-  display: flex; align-items: center; gap: 20px;
-  padding: 14px 22px; border-bottom: 1px solid var(--line); background: var(--panel);
+::selection { background: var(--bone); color: var(--ink); }
+
+/* ── status bar ── */
+.statusbar {
+  flex: 0 0 auto; display: flex; align-items: center; gap: 26px;
+  padding: 11px 18px; border-bottom: 1px solid var(--line); background: var(--ink-2);
 }
-.brand { font-weight: 700; font-size: 18px; letter-spacing: .5px; color: var(--accent); }
-.score { font-weight: 700; font-size: 20px; }
-.score small { color: var(--dim); font-weight: 400; font-size: 13px; }
-.actions { margin-left: auto; display: flex; gap: 10px; }
+.brand { font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; white-space: nowrap; }
+.brand b { color: var(--bone); }
+.brand::before { content: "▚"; color: var(--slate); margin-right: 8px; }
+.actions { margin-left: auto; display: flex; gap: 8px; }
+
 button {
-  background: var(--panel); color: var(--text); border: 1px solid var(--line);
-  border-radius: 6px; padding: 7px 12px; cursor: pointer; font-size: 13px;
+  font: 600 11px/1 var(--mono); letter-spacing: .8px; text-transform: uppercase;
+  background: transparent; color: var(--bone); border: 1px solid var(--line-2);
+  border-radius: 0; padding: 8px 12px; cursor: pointer;
 }
-button:hover { border-color: var(--accent); }
-button.primary { background: var(--accent); color: #06101f; border-color: var(--accent); font-weight: 600; }
-button:disabled { opacity: .5; cursor: default; }
-.axes { flex: 0 0 auto; display: flex; flex-wrap: wrap; gap: 8px 18px; padding: 12px 22px; color: var(--dim); border-bottom: 1px solid var(--line); }
-.axes .na { opacity: .55; }
-.status { flex: 0 0 auto; margin: 12px 22px 0; padding: 10px 14px; border-radius: 6px; background: #10261b; border: 1px solid #1f4d36; color: var(--ok); }
-main { flex: 1 1 auto; min-height: 0; display: grid; grid-template-columns: minmax(340px, 1.2fr) 1.4fr; gap: 0; overflow: hidden; }
-.findings { border-right: 1px solid var(--line); padding: 10px 0; overflow-y: auto; min-height: 0; }
-.detail { overflow-y: auto; min-height: 0; }
-@media (max-width: 800px) {
-  /* On narrow screens stack the panels and let the page scroll normally. */
+button:hover { border-color: var(--bone); }
+button:focus-visible { outline: 2px solid var(--safe); outline-offset: 1px; }
+button.primary { border-color: var(--safe); color: var(--safe); }
+button.primary:hover { background: var(--safe); color: var(--ink); }
+button:disabled { opacity: .45; cursor: default; }
+
+/* ── exposure gauge (the signature) ── */
+.gauge { display: flex; align-items: center; gap: 12px; }
+.gauge-label { font-size: 10px; letter-spacing: 1.5px; color: var(--slate); text-transform: uppercase; }
+.gauge-score { font-weight: 700; font-size: 19px; letter-spacing: .5px; min-width: 74px; }
+.gauge-score small { color: var(--slate); font-size: 12px; font-weight: 400; }
+.meter {
+  --w: 0%; --c: var(--slate);
+  position: relative; width: 150px; height: 10px;
+  background: repeating-linear-gradient(90deg, var(--ink-3) 0 6px, transparent 6px 8px);
+  border: 1px solid var(--line);
+}
+.meter::before {
+  content: ""; position: absolute; inset: 0; width: var(--w);
+  background: repeating-linear-gradient(90deg, var(--c) 0 6px, transparent 6px 8px);
+}
+.b-safe { --c: var(--safe); } .b-med { --c: var(--med); }
+.b-high { --c: var(--high); } .b-crit { --c: var(--crit); } .b-na { --c: var(--line-2); }
+
+/* ── axes strip ── */
+.axes {
+  flex: 0 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 5px 26px; padding: 9px 18px; border-bottom: 1px solid var(--line);
+}
+.axis { display: flex; align-items: center; gap: 10px; }
+.axis-label { color: var(--slate); text-transform: uppercase; font-size: 10px; letter-spacing: 1px;
+  width: 72px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 0 0 auto; }
+.axis .meter { width: 92px; height: 8px; flex: 0 0 auto; }
+.axis-val { font-size: 11px; min-width: 30px; }
+.axis.na .axis-val { color: var(--slate); }
+
+/* ── transient status line ── */
+.status { flex: 0 0 auto; margin: 0; padding: 9px 18px; border-bottom: 1px solid var(--line);
+  color: var(--safe); font-size: 12px; }
+.status.err { color: var(--crit); }
+
+/* ── body: two panes, independent scroll ── */
+main { flex: 1 1 auto; min-height: 0; display: grid;
+  grid-template-columns: minmax(360px, 1.1fr) 1.5fr; overflow: hidden; }
+.findings { border-right: 1px solid var(--line); overflow-y: auto; min-height: 0; }
+.detail { overflow-y: auto; min-height: 0; padding: 16px 22px; }
+
+.pane-head { position: sticky; top: 0; background: var(--ink);
+  padding: 10px 18px; border-bottom: 1px solid var(--line);
+  font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--slate); }
+ul { list-style: none; margin: 0; padding: 0; }
+
+/* ── finding row: heat gutter + dense mono ── */
+.finding { display: grid; grid-template-columns: auto 1fr auto; gap: 12px; align-items: baseline;
+  padding: 9px 18px 9px 15px; border-left: 3px solid transparent; cursor: pointer;
+  border-bottom: 1px solid var(--ink-2); }
+.finding:hover { background: var(--ink-2); }
+.finding.active { background: var(--ink-2); border-left-color: var(--bone); }
+.sev { font-size: 10px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; white-space: nowrap; }
+.finding.crit { border-left-color: var(--crit); } .finding.crit .sev { color: var(--crit); }
+.finding.high { border-left-color: var(--high); } .finding.high .sev { color: var(--high); }
+.finding.medium { border-left-color: var(--med); } .finding.medium .sev { color: var(--med); }
+.finding.low { border-left-color: var(--low); } .finding.low .sev { color: var(--low); }
+.finding .title { min-width: 0; }
+.finding .title .name { color: var(--bone); }
+.finding .title .rem { color: var(--slate); font-size: 11px; }
+.finding .svc { color: var(--slate); font-size: 11px; white-space: nowrap; }
+.clean { padding: 22px 18px; color: var(--safe); }
+
+/* ── detail / console ── */
+.detail .empty { color: var(--slate); }
+.detail h3 { margin: 0 0 6px; font-size: 16px; font-weight: 700; letter-spacing: .2px; }
+.detail .meta { color: var(--slate); font-size: 11px; text-transform: uppercase; letter-spacing: .8px;
+  margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px solid var(--line); }
+.detail p { max-width: 74ch; margin: 0 0 12px; }
+.detail .howto { color: var(--slate); text-transform: uppercase; font-size: 10px; letter-spacing: 1.5px; }
+
+/* ── fix preview ── */
+.fixbox { margin-top: 18px; border: 1px solid var(--line); background: var(--ink-2); }
+.fixbox-head { padding: 10px 14px; border-bottom: 1px solid var(--line);
+  font-size: 11px; letter-spacing: .5px; }
+.fixbox-body { padding: 12px 14px; }
+.warn { color: var(--high); margin: 0 0 10px; font-size: 12px; }
+.alts { margin: 0 0 12px; }
+.alts label { display: block; margin: 3px 0; cursor: pointer; }
+.alts input { accent-color: var(--safe); }
+pre.diff { margin: 0 0 12px; background: var(--ink); border: 1px solid var(--line);
+  padding: 10px; overflow-x: auto; font-size: 12px; line-height: 1.5; }
+pre.diff .add { color: var(--safe); }
+pre.diff .del { color: var(--crit); }
+pre.diff .ctx { color: var(--slate); }
+.fixbox .row { display: flex; gap: 8px; }
+
+/* scrollbars — quiet */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: var(--line-2); }
+::-webkit-scrollbar-track { background: transparent; }
+
+@media (max-width: 820px) {
   body { height: auto; overflow: visible; }
   main { grid-template-columns: 1fr; overflow: visible; }
   .findings, .detail { overflow: visible; }
+  .axes { grid-template-columns: 1fr 1fr; }
 }
-.findings h2, .detail h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .6px; color: var(--dim); margin: 8px 22px; }
-ul { list-style: none; margin: 0; padding: 0; }
-.finding { padding: 10px 22px; border-left: 3px solid transparent; cursor: pointer; display: flex; gap: 10px; align-items: baseline; }
-.finding:hover { background: #12151c; }
-.finding.active { background: #12151c; border-left-color: var(--accent); }
-.badge { font-size: 10px; font-weight: 700; text-transform: uppercase; padding: 2px 6px; border-radius: 4px; white-space: nowrap; }
-.badge.critical { background: #3a1416; color: var(--crit); }
-.badge.high { background: #3a2410; color: var(--high); }
-.badge.medium { background: #3a3410; color: var(--med); }
-.badge.low { background: #22262f; color: var(--low); }
-.finding .title { flex: 1; }
-.finding .svc { color: var(--dim); font-size: 12px; }
-.rem { font-size: 11px; color: var(--dim); }
-.detail { padding: 14px 24px; }
-.detail .empty { color: var(--dim); }
-.detail h3 { margin: 4px 0; }
-.detail .meta { color: var(--dim); font-size: 12px; margin-bottom: 14px; }
-.detail p { max-width: 68ch; }
-.fixbox { margin-top: 16px; border: 1px solid var(--line); border-radius: 8px; padding: 14px; background: var(--panel); }
-.warn { color: var(--high); margin: 6px 0 10px; }
-pre.diff { background: #0b0d12; border: 1px solid var(--line); border-radius: 6px; padding: 10px; overflow-x: auto; font-size: 12px; }
-pre.diff .add { color: var(--ok); }
-pre.diff .del { color: var(--crit); }
-.alts label { display: block; margin: 4px 0; }
-.clean { color: var(--ok); font-weight: 600; padding: 20px 22px; }

--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -16,47 +16,70 @@ function el(tag, attrs = {}, ...kids) {
   for (const [k, v] of Object.entries(attrs)) {
     if (k === "class") e.className = v;
     else if (k === "onclick") e.onclick = v;
+    else if (k === "html") e.innerHTML = v;
     else e.setAttribute(k, v);
   }
-  for (const kid of kids) e.append(kid);
+  for (const kid of kids) if (kid) e.append(kid);
   return e;
 }
 
-function active(findings) {
-  return findings.filter((f) => !f.fixed);
+function sevName(f) { return SEV[f.severity] || "low"; }
+function sevAbbr(f) { return ["crit", "high", "med", "low"][f.severity] || "low"; }
+function remLabel(r) { return ["Unclassified", "Auto-fix", "Review", "Manual", "Unavailable"][r] || "?"; }
+function isFixable(f) { return f.remediation === 1 || f.remediation === 2; }
+function active(findings) { return findings.filter((x) => !x.fixed); }
+
+// A finding row's grid class → the severity class also used for the gutter.
+function rowSevClass(f) { return ["crit", "high", "medium", "low"][f.severity] || "low"; }
+
+// Score/axis health band → meter fill color.
+function band(v) { return v >= 80 ? "b-safe" : v >= 50 ? "b-med" : v >= 25 ? "b-high" : "b-crit"; }
+
+function meter(pct, bandClass) {
+  const m = el("div", { class: "meter " + bandClass });
+  m.style.setProperty("--w", Math.max(0, Math.min(100, pct)) + "%");
+  return m;
 }
 
 function render() {
   const score = report.score;
-  document.getElementById("score").innerHTML =
-    `${score.overall}<small>/100</small>`;
 
-  const axes = document.getElementById("axes");
-  axes.replaceChildren(
+  // Exposure gauge (the signature): SECURITY meter + score.
+  document.getElementById("gauge").replaceChildren(
+    el("span", { class: "gauge-label" }, "Security"),
+    meter(score.overall, band(score.overall)),
+    el("span", { class: "gauge-score", html: `${score.overall}<small>/100</small>` })
+  );
+
+  // Per-axis bars (short labels so they never crowd the meter).
+  const AX = { container: "Container", ssh: "SSH", firewall: "Firewall", updates: "Updates", cve: "CVEs" };
+  document.getElementById("axes").replaceChildren(
     ...score.axes.map((ax) =>
-      el("span", { class: ax.applicable ? "" : "na" },
-        ax.applicable ? `${ax.label}: ${ax.score}` : `${ax.label}: N/A`)
+      el("div", { class: "axis" + (ax.applicable ? "" : " na") },
+        el("span", { class: "axis-label" }, AX[ax.id] || ax.label),
+        ax.applicable ? meter(ax.score, band(ax.score)) : meter(0, "b-na"),
+        el("span", { class: "axis-val" }, ax.applicable ? String(ax.score) : "N/A")
+      )
     )
   );
 
+  // Findings list.
   const list = document.getElementById("findings");
   const items = active(report.findings);
-  document.getElementById("findings-title").textContent = `Findings (${items.length})`;
+  document.getElementById("findings-title").textContent = `Findings · ${items.length}`;
   if (items.length === 0) {
     list.replaceChildren(el("li", { class: "clean" }, "No problems found. Clean."));
-    document.getElementById("detail").replaceChildren(
-      el("p", { class: "empty" }, "Nothing to fix.")
-    );
+    document.getElementById("detail").replaceChildren(el("p", { class: "empty" }, "Nothing to fix."));
     return;
   }
-  items.sort((a, b) => SEV.indexOf(a.severity_s || sevName(a)) - SEV.indexOf(b.severity_s || sevName(b)));
+  items.sort((a, b) => a.severity - b.severity);
   list.replaceChildren(
     ...items.map((f) => {
-      const li = el("li", { class: "finding" },
-        el("span", { class: "badge " + sevName(f) }, sevName(f)),
+      const li = el("li", { class: "finding " + rowSevClass(f) },
+        el("span", { class: "sev" }, sevAbbr(f)),
         el("div", { class: "title" },
-          el("div", {}, f.title),
-          el("div", { class: "rem" }, f.id + " · " + remLabel(f.remediation))
+          el("div", { class: "name" }, f.title),
+          el("div", { class: "rem" }, f.id + "  ·  " + remLabel(f.remediation))
         ),
         f.service ? el("span", { class: "svc" }, f.service) : ""
       );
@@ -67,20 +90,19 @@ function render() {
   );
 }
 
-function sevName(f) { return SEV[f.severity] || "low"; }
-function remLabel(r) { return ["Unclassified", "Auto-fix", "Review", "Manual", "Unavailable"][r] || "?"; }
-function isFixable(f) { return f.remediation === 1 || f.remediation === 2; }
-
 function selectFinding(f, li) {
   selected = { id: f.id, service: f.service };
   document.querySelectorAll(".finding").forEach((n) => n.classList.remove("active"));
-  li.classList.add("active");
+  if (li) li.classList.add("active");
+  const meta = [f.id, sevName(f), remLabel(f.remediation)];
+  if (f.service) meta.push("service: " + f.service);
   const d = document.getElementById("detail");
   d.replaceChildren(
     el("h3", {}, f.title),
-    el("div", { class: "meta" }, `${f.id}   ${remLabel(f.remediation)}${f.service ? "   service: " + f.service : ""}`),
-    el("p", {}, f.description || ""),
-    f.how_to_fix ? el("p", {}, el("strong", {}, "How to fix: "), f.how_to_fix) : ""
+    el("div", { class: "meta" }, meta.join("  ·  ")),
+    f.description ? el("p", {}, f.description) : "",
+    f.how_to_fix ? el("div", { class: "howto" }, "How to fix") : "",
+    f.how_to_fix ? el("p", {}, f.how_to_fix) : ""
   );
   if (isFixable(f)) {
     d.append(el("button", { class: "primary", onclick: () => preview(f) }, "Preview fix"));
@@ -97,34 +119,33 @@ async function preview(f) {
 function showPreview(f, p) {
   let chosen = 0;
   const box = el("div", { class: "fixbox" });
-  const render = () => {
+  const head = el("div", { class: "fixbox-head" });
+  const body = el("div", { class: "fixbox-body" });
+  box.append(head, body);
+  const draw = () => {
     const a = p.actions[chosen];
-    box.replaceChildren(
-      el("strong", {}, p.label),
-      p.actions.length > 1 ? altPicker(p, chosen, (i) => { chosen = i; render(); }) : "",
-      a.warning ? el("div", { class: "warn" }, "⚠ " + a.warning) : "",
+    head.textContent = p.label;
+    body.replaceChildren(
+      p.actions.length > 1 ? altPicker(p, chosen, (i) => { chosen = i; draw(); }) : "",
+      a.warning ? el("div", { class: "warn" }, "⚠  " + a.warning) : "",
       a.type === "edit" ? diffPre(a.diff) : cmdList(a.commands),
-      el("div", {},
+      el("div", { class: "row" },
         el("button", { class: "primary", onclick: () => applyFix(f, chosen) }, "Apply"),
-        " ",
         el("button", { onclick: () => selectFinding(f, document.querySelector(".finding.active")) }, "Cancel")
       )
     );
   };
-  render();
+  draw();
   document.getElementById("detail").append(box);
 }
 
 function altPicker(p, chosen, onpick) {
   return el("div", { class: "alts" },
     ...p.actions.map((a, i) => {
-      const l = el("label", {},
-        Object.assign(document.createElement("input"), {
-          type: "radio", name: "alt", checked: i === chosen, onchange: () => onpick(i),
-        }),
-        " " + a.label
-      );
-      return l;
+      const input = Object.assign(document.createElement("input"),
+        { type: "radio", name: "alt", checked: i === chosen });
+      input.onchange = () => onpick(i);
+      return el("label", {}, input, " " + a.label);
     })
   );
 }
@@ -132,7 +153,7 @@ function altPicker(p, chosen, onpick) {
 function diffPre(diff) {
   const pre = el("pre", { class: "diff" });
   (diff || "").split("\n").forEach((line) => {
-    let cls = "";
+    let cls = "ctx";
     if (line.startsWith("+") && !line.startsWith("+++")) cls = "add";
     else if (line.startsWith("-") && !line.startsWith("---")) cls = "del";
     pre.append(el("span", { class: cls }, line + "\n"));
@@ -142,34 +163,31 @@ function diffPre(diff) {
 
 function cmdList(cmds) {
   const pre = el("pre", { class: "diff" });
-  (cmds || []).forEach((c) => pre.append("$ " + c.join(" ") + "\n"));
+  (cmds || []).forEach((c) => pre.append(el("span", { class: "ctx" }, "$ " + c.join(" ") + "\n")));
   return pre;
 }
 
 async function applyFix(f, action) {
   try {
     const o = await api("/api/fix", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: f.id, service: f.service || "", action }),
     });
-    flash(`Fix applied. New score ${o.new_score.overall}/100.` +
-      (o.checkpoint_id ? ` Rollback id: ${o.checkpoint_id}` : ""));
+    flash(`Fix applied. Score ${o.new_score.overall}/100.` +
+      (o.checkpoint_id ? `  Rollback: ${o.checkpoint_id}` : ""));
     await refresh();
   } catch (e) { flash("Fix failed: " + e.message, true); }
 }
 
-async function refresh() {
-  report = await api("/api/result");
-  render();
-}
+async function refresh() { report = await api("/api/result"); render(); }
 
 function flash(msg, isErr) {
   const s = document.getElementById("status");
   s.textContent = msg;
-  s.style.color = isErr ? "var(--crit)" : "var(--ok)";
+  s.className = "status" + (isErr ? " err" : "");
   s.hidden = false;
-  setTimeout(() => (s.hidden = true), 6000);
+  clearTimeout(flash._t);
+  flash._t = setTimeout(() => (s.hidden = true), 6000);
 }
 
 document.getElementById("rescan").onclick = async () => {
@@ -183,7 +201,7 @@ document.getElementById("fixall").onclick = async () => {
   if (!confirm("Apply every safe (Auto) fix now?")) return;
   try {
     const o = await api("/api/fix/all", { method: "POST", headers: { "Content-Type": "application/json" } });
-    flash(`Applied ${o.applied ? o.applied.length : 0} fixes. New score ${o.new_score.overall}/100.`);
+    flash(`Applied ${o.applied ? o.applied.length : 0} fixes. Score ${o.new_score.overall}/100.`);
     await refresh();
   } catch (e) { flash("Batch fix failed: " + e.message, true); }
 };

--- a/internal/ui/web/assets/index.html
+++ b/internal/ui/web/assets/index.html
@@ -7,25 +7,25 @@
   <link rel="stylesheet" href="/app.css">
 </head>
 <body>
-  <header>
-    <div class="brand">hostveil</div>
-    <div class="score" id="score">—</div>
+  <div class="statusbar">
+    <div class="brand"><b>hostveil</b></div>
+    <div class="gauge" id="gauge"></div>
     <div class="actions">
       <button id="rescan">Rescan</button>
       <button id="fixall" class="primary">Fix all safe</button>
     </div>
-  </header>
+  </div>
 
-  <div id="axes" class="axes"></div>
-  <div id="status" class="status" hidden></div>
+  <div class="axes" id="axes"></div>
+  <div class="status" id="status" hidden></div>
 
   <main>
     <section class="findings">
-      <h2 id="findings-title">Findings</h2>
+      <div class="pane-head" id="findings-title">Findings</div>
       <ul id="findings"></ul>
     </section>
     <section class="detail" id="detail">
-      <p class="empty">Select a finding to see details.</p>
+      <p class="empty">Select a finding to inspect it.</p>
     </section>
   </main>
 


### PR DESCRIPTION
The two product UIs were visually weak and shared no design language — the Web was blue/system-sans/rounded, the TUI cyan/plain-text, and neither matched the other. This redesigns both into **one system** so they read as the same instrument.

**Thesis: a security tool is an instrument, not a webpage — color means risk.**
- Monochrome console: warm bone text on ink, all-monospace, dense (dividers over whitespace). The only things that carry color are **severity** (a red→slate heat scale) and **safety** (mint). No decorative accent.
- Signature **exposure gauge**: the score as a segmented meter with per-axis bars, in the status bar of both UIs.
- Findings as a fault-log with a **severity heat gutter**; detail/preview as a console readout; diff add=mint, del=red, warning=amber.
- **Shared to the exact hex:** the web CSS variables and the TUI's lipgloss v2 colors use the same values (lipgloss v2 renders truecolor, degrading gracefully), so the two match hue-for-hue.

Web: full `app.css` rewrite + restructured `index.html`/`app.js` (gauge, axis bars, heat-gutter rows). TUI: `view.go` rewritten (same palette, gauge blocks, heat gutters, console rules). Both stay thin (engine-only); scroll + layering tests still pass. Verified with headless screenshots of both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)