### PR TITLE
site: add a light theme reviving the original warm palette

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -14,6 +14,16 @@
     <link rel="canonical" href="https://hostveil.seolcu.com/">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%230b0d10'/%3E%3Crect x='6' y='15' width='4' height='7' fill='%23e7e3d8'/%3E%3Crect x='12' y='11' width='4' height='11' fill='%23e7e3d8'/%3E%3Crect x='18' y='7' width='4' height='15' fill='%2346c69a'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="styles.css">
+    <script>
+      // Set the theme before first paint to avoid a flash.
+      (function () {
+        try {
+          var t = localStorage.getItem("hv-theme") ||
+            (matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
+          document.documentElement.setAttribute("data-theme", t);
+        } catch (e) {}
+      })();
+    </script>
     <script src="script.js" defer></script>
   </head>
   <body>
@@ -31,6 +41,7 @@
           <a href="#screenshots">Screenshots</a>
           <a href="#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch color theme">☀</button>
         </div>
       </nav>
     </header>

--- a/site/script.js
+++ b/site/script.js
@@ -1,6 +1,37 @@
-/* hostveil landing page — copy-to-clipboard + lightbox */
+/* hostveil landing page — theme toggle + copy-to-clipboard + lightbox */
 (function () {
   "use strict";
+
+  /* ── theme toggle ─────────────────────────────────────── */
+
+  var root = document.documentElement;
+  var themeBtn = document.getElementById("theme-toggle");
+  var themeMeta = document.querySelector('meta[name="theme-color"]');
+  var THEME_BG = { dark: "#0b0d10", light: "#e7e0cc" };
+
+  function paintTheme(t) {
+    if (themeBtn) {
+      themeBtn.textContent = t === "dark" ? "☀" : "☾";
+      themeBtn.setAttribute(
+        "aria-label",
+        t === "dark" ? "Switch to light theme" : "Switch to dark theme"
+      );
+    }
+    if (themeMeta) themeMeta.setAttribute("content", THEME_BG[t] || THEME_BG.dark);
+  }
+
+  paintTheme(root.getAttribute("data-theme") === "light" ? "light" : "dark");
+
+  if (themeBtn) {
+    themeBtn.addEventListener("click", function () {
+      var next = root.getAttribute("data-theme") === "light" ? "dark" : "light";
+      root.setAttribute("data-theme", next);
+      try {
+        localStorage.setItem("hv-theme", next);
+      } catch (e) {}
+      paintTheme(next);
+    });
+  }
 
   /* ── copy-to-clipboard ────────────────────────────────── */
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -128,6 +128,22 @@ a { color: inherit; text-decoration: none; }
 .site-footer a:hover,
 .site-footer a:focus-visible { color: var(--bone); border-bottom-color: currentColor; }
 .nav-links a[href*="github"] { color: var(--bone); }
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid var(--line-2);
+  background: transparent;
+  color: var(--slate);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 140ms ease, border-color 140ms ease;
+}
+.theme-toggle:hover, .theme-toggle:focus-visible { color: var(--bone); border-color: var(--bone); }
 
 /* ── shared type ──────────────────────────────────────────────────────── */
 h1, h2, h3, p { margin-top: 0; }
@@ -386,7 +402,7 @@ figcaption span { color: var(--slate); font-size: 0.86rem; }
   position: fixed;
   inset: 0;
   z-index: 100;
-  background: color-mix(in srgb, var(--ink) 92%, transparent);
+  background: rgba(9, 11, 14, 0.9); /* dark scrim in both themes — app shots are dark */
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   align-items: center;
@@ -426,4 +442,45 @@ figcaption span { color: var(--slate); font-size: 0.86rem; }
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   .meter::before { animation: none; }
+}
+
+/* ── light theme: the old warm "paper" identity (gold · deep green · cream) ──
+   Structure is unchanged — only the tokens swap. Dark stays the Instrument
+   look that matches the app; light revives hostveil's original brand. The
+   theme is set on <html data-theme> by an inline script (no flash) and the
+   nav toggle; specificity keeps these ahead of the base rules regardless of
+   source order. */
+:root[data-theme="light"] {
+  color-scheme: light;
+  --ink: #e7e0cc;    /* paper — page background */
+  --ink-2: #f1ecdb;  /* raised — cards, panels, header, code */
+  --ink-3: #dcd2b8;  /* recessed — meter track, code chips */
+  --line: #ccc09e;
+  --line-2: #b0a37b;
+  --bone: #1b241f;   /* deep green ink — primary text */
+  --bone-2: #3c463c; /* secondary text */
+  --slate: #625a40;  /* warm muted labels */
+  --crit: #bf3a2f;   /* severity, retuned for contrast on cream */
+  --high: #ac5f16;
+  --med: #8f7314;
+  --low: #6f6750;
+  --safe: #2f8b60;   /* safety stays green */
+}
+/* Gold/bronze is the returning brand accent. As text on cream it must be a
+   dark bronze for contrast; as the primary button it is solid gold (the old
+   signature) with dark ink text. */
+:root[data-theme="light"] .eyebrow { color: #6e5518; }
+:root[data-theme="light"] .eyebrow::before { border-top-color: #6e5518; }
+:root[data-theme="light"] .brand-mark { color: #6e5518; }
+:root[data-theme="light"] .command-box::before { color: #6e5518; }
+:root[data-theme="light"] .button.primary {
+  background: #c9a94a;
+  border-color: #c9a94a;
+  color: #241d09;
+}
+:root[data-theme="light"] .button.primary:hover,
+:root[data-theme="light"] .button.primary:focus-visible {
+  background: #d8b962;
+  border-color: #d8b962;
+  color: #241d09;
 }


### PR DESCRIPTION
Adds a light theme that brings back hostveil's original brand palette, while the dark theme stays the "Instrument" look that matches the TUI and Web UI.

## What changed
- **Light theme** = the old warm identity: cream paper background, deep-green ink text, and gold/bronze accents — including the original **solid-gold primary button**. Severity colors are retuned for contrast on the light background; safety stays green in both themes.
- **Only tokens swap** — the layout, gauge, heat gutters, and every component are unchanged. A handful of explicit overrides give gold a darker bronze where it's used as text on cream (eyebrows, brand mark, `$` prompt) so it stays readable.
- **Toggle + persistence** — a nav button (☀/☾) switches themes and stores the choice in `localStorage`. An inline `<head>` script applies the stored (or OS `prefers-color-scheme`) theme before first paint, so there's no flash. `theme-color` updates with the theme.
- Lightbox scrim is now a fixed dark tint in both themes so the dark app screenshots pop.

## Verification
Rendered both themes with headless Chrome (desktop + mobile earlier): dark = Instrument monochrome with green accent; light = warm paper with the solid-gold button and bronze accents. Toggle, persistence, and no-flash init confirmed. Site-only change; no Go code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)