### PR TITLE
ui: findings filtering + multi-select batch fix (TUI & Web)

### DIFF
--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -7,6 +7,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -28,7 +29,10 @@ const (
 type appModel struct {
 	engine *core.Engine
 	report model.Report
-	active []model.Finding
+	active []model.Finding // report findings after m.filter
+
+	filter   model.Filter    // classification/narrowing (empty = all active)
+	selected map[string]bool // finding.Key() → picked for a batch fix
 
 	cursor        int
 	offset        int // first visible finding index (list scrolling)
@@ -42,7 +46,15 @@ type appModel struct {
 
 // New builds the TUI model around an engine.
 func New(engine *core.Engine) tea.Model {
-	return &appModel{engine: engine, mode: modeScanning, status: "Scanning…"}
+	return &appModel{engine: engine, mode: modeScanning, status: "Scanning…", selected: map[string]bool{}}
+}
+
+// rebuildActive re-derives the visible list from the current report and
+// filter, keeping the cursor in range. The single place both scan and fix
+// refresh the list through.
+func (m *appModel) rebuildActive() {
+	m.active = m.report.Select(m.filter)
+	m.cursor = clamp(m.cursor, 0, len(m.active)-1)
 }
 
 // Run starts the TUI event loop.
@@ -81,6 +93,14 @@ func applyCmd(e *core.Engine, f model.Finding, action int) tea.Cmd {
 	}
 }
 
+type batchAppliedMsg struct{ outcome model.BatchOutcome }
+
+func batchCmd(e *core.Engine, fs []model.Finding) tea.Cmd {
+	return func() tea.Msg {
+		return batchAppliedMsg{outcome: e.ApplyBatch(context.Background(), fs)}
+	}
+}
+
 // --- tea.Model ---
 
 func (m *appModel) Init() tea.Cmd { return scanCmd(m.engine) }
@@ -93,8 +113,8 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case scannedMsg:
 		m.report = msg.report
-		m.active = m.report.Select(model.Filter{})
-		m.cursor = clamp(m.cursor, 0, len(m.active)-1)
+		m.selected = map[string]bool{} // a fresh scan invalidates old picks
+		m.rebuildActive()
 		m.offset = 0
 		m.mode = modeList
 		return m, nil
@@ -118,10 +138,19 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Refresh from the engine's authoritative state.
 			if cur, ok := m.engine.Current(); ok {
 				m.report = cur
-				m.active = m.report.Select(model.Filter{})
-				m.cursor = clamp(m.cursor, 0, len(m.active)-1)
+				m.rebuildActive()
 			}
 		}
+		m.mode = modeMessage
+		return m, nil
+
+	case batchAppliedMsg:
+		m.status = batchSummary(msg.outcome)
+		if cur, ok := m.engine.Current(); ok {
+			m.report = cur
+			m.rebuildActive()
+		}
+		m.selected = map[string]bool{}
 		m.mode = modeMessage
 		return m, nil
 
@@ -169,12 +198,127 @@ func (m *appModel) keyList(key string) (tea.Model, tea.Cmd) {
 		}
 	case "f":
 		return m, m.startPreview()
+	case " ", "space":
+		m.toggleSelect()
+	case "a":
+		return m, m.startBatch()
+	case "esc":
+		m.selected = map[string]bool{}
+	case "s":
+		m.filter.MinSeverity = cycleSeverity(m.filter.MinSeverity)
+		m.rebuildActive()
+	case "d":
+		m.filter.Source = cycleSource(m.filter.Source, m.presentSources())
+		m.rebuildActive()
+	case "x":
+		m.filter.FixableOnly = !m.filter.FixableOnly
+		m.rebuildActive()
+	case "c":
+		m.filter = model.Filter{}
+		m.rebuildActive()
 	case "r":
 		m.mode = modeScanning
 		m.status = "Rescanning…"
 		return m, scanCmd(m.engine)
 	}
 	return m, nil
+}
+
+// toggleSelect marks/unmarks the current finding for a batch fix. Only
+// auto-fixable findings can be batched, so others are left alone.
+func (m *appModel) toggleSelect() {
+	if len(m.active) == 0 {
+		return
+	}
+	f := m.active[m.cursor]
+	if f.Remediation != model.RemediationAuto {
+		return
+	}
+	k := f.Key()
+	if m.selected[k] {
+		delete(m.selected, k)
+	} else {
+		m.selected[k] = true
+	}
+}
+
+// startBatch applies the marked findings, or every active auto-fix when
+// nothing is marked (the TUI's "fix all safe").
+func (m *appModel) startBatch() tea.Cmd {
+	var sel []model.Finding
+	if len(m.selected) > 0 {
+		for _, f := range m.active {
+			if m.selected[f.Key()] {
+				sel = append(sel, f)
+			}
+		}
+	} else {
+		for _, f := range m.active {
+			if f.Remediation == model.RemediationAuto {
+				sel = append(sel, f)
+			}
+		}
+	}
+	if len(sel) == 0 {
+		m.status = "No auto-fixable findings to apply."
+		m.mode = modeMessage
+		return nil
+	}
+	return batchCmd(m.engine, sel)
+}
+
+// presentSources lists the distinct sources among active findings, sorted,
+// so the domain filter only cycles through domains that actually appear.
+func (m *appModel) presentSources() []model.Source {
+	seen := map[model.Source]bool{}
+	var out []model.Source
+	for _, f := range m.report.Findings {
+		if f.Fixed || seen[f.Source] {
+			continue
+		}
+		seen[f.Source] = true
+		out = append(out, f.Source)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// cycleSeverity advances the minimum-severity filter: off → Critical → High
+// → Medium → Low → off.
+func cycleSeverity(cur *model.Severity) *model.Severity {
+	next := func(s model.Severity) *model.Severity { return &s }
+	switch {
+	case cur == nil:
+		return next(model.SeverityCritical)
+	case *cur == model.SeverityCritical:
+		return next(model.SeverityHigh)
+	case *cur == model.SeverityHigh:
+		return next(model.SeverityMedium)
+	case *cur == model.SeverityMedium:
+		return next(model.SeverityLow)
+	default:
+		return nil
+	}
+}
+
+// cycleSource advances the domain filter through the present sources and
+// back to "all" (SourceUnset).
+func cycleSource(cur model.Source, present []model.Source) model.Source {
+	if cur == model.SourceUnset {
+		if len(present) > 0 {
+			return present[0]
+		}
+		return model.SourceUnset
+	}
+	for i, s := range present {
+		if s == cur {
+			if i+1 < len(present) {
+				return present[i+1]
+			}
+			return model.SourceUnset
+		}
+	}
+	return model.SourceUnset
 }
 
 func (m *appModel) keyPreview(key string) (tea.Model, tea.Cmd) {
@@ -233,5 +377,18 @@ func applySummary(o model.FixOutcome) string {
 	if o.RestartHint != "" {
 		fmt.Fprintf(&b, " You may need to restart '%s'.", o.RestartHint)
 	}
+	return b.String()
+}
+
+func batchSummary(o model.BatchOutcome) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "✓ Applied %d", len(o.Applied))
+	if len(o.Skipped) > 0 {
+		fmt.Fprintf(&b, " · skipped %d", len(o.Skipped))
+	}
+	if len(o.Failed) > 0 {
+		fmt.Fprintf(&b, " · failed %d", len(o.Failed))
+	}
+	fmt.Fprintf(&b, ". New score: %d/100.", o.NewScore.Overall)
 	return b.String()
 }

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -117,6 +117,121 @@ func TestListScrolls(t *testing.T) {
 	}
 }
 
+func TestFilterNarrowsList(t *testing.T) {
+	fs := []model.Finding{
+		model.NewFinding("compose.ds018", "Datastore exposed", model.SeverityCritical, model.SourceCompose, model.RemediationAuto, model.WithService("cache")),
+		model.NewFinding("compose.ds001", "Privileged", model.SeverityHigh, model.SourceCompose, model.RemediationManual, model.WithService("app")),
+		model.NewFinding("updates.disabled", "Auto-updates off", model.SeverityMedium, model.SourceUpdates, model.RemediationReview),
+	}
+	rep := model.Report{Findings: fs, Score: model.ScoreReport(fs, nil)}
+
+	m := tea.Model(&appModel{mode: modeList, selected: map[string]bool{}})
+	m = send(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = send(m, scannedMsg{report: rep})
+	if got := len(m.(*appModel).active); got != 3 {
+		t.Fatalf("want 3 active, got %d", got)
+	}
+
+	// s once → minimum severity Critical → only the crit finding.
+	m = send(m, tea.KeyPressMsg(tea.Key{Text: "s"}))
+	if got := len(m.(*appModel).active); got != 1 {
+		t.Errorf("severity filter: want 1, got %d", got)
+	}
+	// c → clear.
+	m = send(m, tea.KeyPressMsg(tea.Key{Text: "c"}))
+	if got := len(m.(*appModel).active); got != 3 {
+		t.Errorf("clear: want 3, got %d", got)
+	}
+	// d once → first present domain (compose) → 2 compose findings.
+	m = send(m, tea.KeyPressMsg(tea.Key{Text: "d"}))
+	if got := len(m.(*appModel).active); got != 2 {
+		t.Errorf("domain filter: want 2 compose, got %d", got)
+	}
+	// x → fixable-only, on top of compose → only the Auto ds018.
+	m = send(m, tea.KeyPressMsg(tea.Key{Text: "x"}))
+	am := m.(*appModel)
+	if len(am.active) != 1 || am.active[0].ID != "compose.ds018" {
+		t.Errorf("fixable filter: want [compose.ds018], got %d findings", len(am.active))
+	}
+}
+
+// TestMultiSelectBatchApply marks two auto-fixable findings and applies them
+// as a batch through a real engine, confirming both files are edited.
+func TestMultiSelectBatchApply(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yml")
+	yaml := "services:\n" +
+		"  cache:\n    image: redis\n    ports:\n      - \"6379:6379\"\n" +
+		"  store:\n    image: redis\n    ports:\n      - \"6380:6380\"\n"
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	engine := core.New(core.Config{
+		Registry: check.NewRegistry(composecheck.New()),
+		Fixes:    fix.Default(),
+		Store:    history.NewStore(t.TempDir()),
+		Runner:   fakeRunner{present: map[string]bool{"docker": true}, lsJSON: `[{"Name":"demo","ConfigFiles":"` + path + `"}]`},
+	})
+	rep := engine.Scan(context.Background(), nil)
+
+	m := tea.Model(&appModel{engine: engine, mode: modeList, selected: map[string]bool{}})
+	m = send(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = send(m, scannedMsg{report: rep})
+
+	// Mark every auto-fixable exposed-datastore finding.
+	am := m.(*appModel)
+	marked := 0
+	for _, f := range am.active {
+		if f.ID == "compose.ds018" && f.Remediation == model.RemediationAuto {
+			am.selected[f.Key()] = true
+			marked++
+		}
+	}
+	if marked != 2 {
+		t.Fatalf("expected 2 exposed datastores to mark, got %d", marked)
+	}
+
+	// a → batch command; run it and feed the result back.
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Text: "a"}))
+	if cmd == nil {
+		t.Fatal("a should issue a batch command")
+	}
+	m = send(m, cmd())
+	am = m.(*appModel)
+	if !strings.Contains(am.status, "Applied 2") {
+		t.Errorf("expected 'Applied 2' status, got %q", am.status)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "127.0.0.1:6379:6379") || !strings.Contains(string(data), "127.0.0.1:6380:6380") {
+		t.Errorf("both datastores should be bound to loopback:\n%s", data)
+	}
+	for _, f := range am.active {
+		if f.ID == "compose.ds018" {
+			t.Error("fixed datastores should be gone from the refreshed list")
+		}
+	}
+	if len(am.selected) != 0 {
+		t.Error("selection should be cleared after a batch apply")
+	}
+}
+
+// TestSpaceTogglesOnlyAuto verifies space marks auto rows and ignores others.
+func TestSpaceTogglesOnlyAuto(t *testing.T) {
+	m := tea.Model(&appModel{mode: modeList, selected: map[string]bool{}})
+	m = send(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = send(m, scannedMsg{report: sampleReport()}) // ds018 Auto (cursor 0), ds001 Manual
+
+	m = send(m, tea.KeyPressMsg(tea.Key{Code: tea.KeySpace})) // mark the Auto finding
+	if got := len(m.(*appModel).selected); got != 1 {
+		t.Fatalf("space on auto row: want 1 marked, got %d", got)
+	}
+	m = send(m, tea.KeyPressMsg(tea.Key{Text: "j"}))          // to the Manual finding
+	m = send(m, tea.KeyPressMsg(tea.Key{Code: tea.KeySpace})) // should be a no-op
+	if got := len(m.(*appModel).selected); got != 1 {
+		t.Errorf("space on manual row must not mark: want 1, got %d", got)
+	}
+}
+
 func TestListRenders(t *testing.T) {
 	m := &appModel{engine: nil, mode: modeList}
 	m = send(m, tea.WindowSizeMsg{Width: 100, Height: 40}).(*appModel)

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -123,18 +123,33 @@ func (m *appModel) axesLine() string {
 	return strings.Join(parts, styleDim.Render("   "))
 }
 
+const listHint = "↑/↓ move   enter details   f fix   space select   a fix marked\n" +
+	"s severity   d domain   x fixable   c clear   r rescan   q quit"
+
 func (m *appModel) viewList() string {
 	var b strings.Builder
 	b.WriteString(m.header())
 	b.WriteString(m.rule() + "\n")
 
+	fl := m.filterLine()
+
+	// Empty list: distinguish a clean host from a too-narrow filter.
 	if len(m.active) == 0 {
-		b.WriteString("\n" + styleSafe.Render("  No problems found. Clean.") + "\n")
-		b.WriteString(m.footer("r rescan   q quit"))
+		if fl != "" {
+			b.WriteString(fl + "\n")
+			b.WriteString("\n" + styleDim.Render("  No findings match the filter.") + "\n")
+		} else {
+			b.WriteString("\n" + styleSafe.Render("  No problems found. Clean.") + "\n")
+		}
+		b.WriteString(m.footer("c clear   r rescan   q quit"))
 		return b.String()
 	}
 
-	visible := m.height - 7
+	reserved := 8
+	if fl != "" {
+		reserved++
+	}
+	visible := m.height - reserved
 	if visible < 1 {
 		visible = 1
 	}
@@ -144,31 +159,101 @@ func (m *appModel) viewList() string {
 		end = len(m.active)
 	}
 
-	head := styleDim.Render(fmt.Sprintf("FINDINGS · %d", len(m.active)))
+	// Head: shown[/total] · selected · scroll range.
+	count := fmt.Sprintf("FINDINGS · %d", len(m.active))
+	if total := m.activeTotal(); total != len(m.active) {
+		count = fmt.Sprintf("FINDINGS · %d/%d", len(m.active), total)
+	}
+	head := styleDim.Render(count)
+	if n := len(m.selected); n > 0 {
+		head += styleSafe.Render(fmt.Sprintf("   ✓ %d marked", n))
+	}
 	if len(m.active) > visible {
 		head += styleDim.Render(fmt.Sprintf("      %d–%d", m.offset+1, end))
 	}
 	b.WriteString(head + "\n")
+	if fl != "" {
+		b.WriteString(fl + "\n")
+	}
 
 	for i := m.offset; i < end; i++ {
 		b.WriteString(m.findingRow(m.active[i], i == m.cursor) + "\n")
 	}
-	b.WriteString(m.footer("↑/↓ move   enter details   f fix   r rescan   q quit"))
+	b.WriteString(m.footer(listHint))
 	return b.String()
 }
 
-// findingRow renders one heat-gutter row: severity gutter + label + id +
-// title + service. The selected row is inverse-video.
-func (m *appModel) findingRow(f model.Finding, selected bool) string {
+// activeTotal counts findings that are not fixed, ignoring the filter — the
+// denominator for the "shown/total" indicator.
+func (m *appModel) activeTotal() int {
+	n := 0
+	for _, f := range m.report.Findings {
+		if !f.Fixed {
+			n++
+		}
+	}
+	return n
+}
+
+// findingRow renders one heat-gutter row: pick marker + severity gutter +
+// label + id + title + service. The cursor row is inverse-video. The pick
+// marker (✓ / ·) is only shown on auto-fixable rows, since only those can be
+// batch-selected.
+func (m *appModel) findingRow(f model.Finding, cursor bool) string {
 	sevC := severityColor(f.Severity)
 	gutter := lipgloss.NewStyle().Foreground(sevC).Render("▌")
-	sev := sevAbbr(f.Severity)
-	title := truncate(f.Title, m.width-42)
-	if selected {
-		return gutter + styleSel.Render(" "+padRight(fmt.Sprintf("%-4s %-13s %s", sev, f.ID, title), m.width-3))
+	mark := "  "
+	if f.Remediation == model.RemediationAuto {
+		if m.selected[f.Key()] {
+			mark = styleSafe.Render("✓ ")
+		} else {
+			mark = styleDim.Render("· ")
+		}
 	}
-	return gutter + " " + lipgloss.NewStyle().Foreground(sevC).Render(sev) +
+	sev := sevAbbr(f.Severity)
+	title := truncate(f.Title, m.width-46)
+	if cursor {
+		return gutter + mark + styleSel.Render(padRight(fmt.Sprintf("%-4s %-13s %s", sev, f.ID, title), m.width-3))
+	}
+	return gutter + mark + lipgloss.NewStyle().Foreground(sevC).Render(sev) +
 		styleDim.Render(fmt.Sprintf(" %-13s ", f.ID)) + styleBone.Render(title) + serviceSuffixTUI(f)
+}
+
+// sourceLabel is the short domain name shown in the filter line, matching
+// the score axis labels.
+func sourceLabel(s model.Source) string {
+	switch s {
+	case model.SourceCompose:
+		return "Container"
+	case model.SourceSSH:
+		return "SSH"
+	case model.SourceFirewall:
+		return "Firewall"
+	case model.SourceUpdates:
+		return "Updates"
+	case model.SourceCVE:
+		return "CVEs"
+	default:
+		return s.String()
+	}
+}
+
+// filterLine describes the active filter, or "" when nothing is filtered.
+func (m *appModel) filterLine() string {
+	var parts []string
+	if m.filter.MinSeverity != nil {
+		parts = append(parts, "sev≥"+strings.ToUpper(m.filter.MinSeverity.String()))
+	}
+	if m.filter.Source != model.SourceUnset {
+		parts = append(parts, sourceLabel(m.filter.Source))
+	}
+	if m.filter.FixableOnly {
+		parts = append(parts, "fixable")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return styleDim.Render("FILTER  ") + styleBone.Render(strings.Join(parts, " · "))
 }
 
 func sevAbbr(s model.Severity) string {

--- a/internal/ui/web/assets/app.css
+++ b/internal/ui/web/assets/app.css
@@ -79,18 +79,41 @@ button:disabled { opacity: .45; cursor: default; }
 /* ── body: two panes, independent scroll ── */
 main { flex: 1 1 auto; min-height: 0; display: grid;
   grid-template-columns: minmax(360px, 1.1fr) 1.5fr; overflow: hidden; }
-.findings { border-right: 1px solid var(--line); overflow-y: auto; min-height: 0; }
+.findings { border-right: 1px solid var(--line); display: flex; flex-direction: column;
+  min-height: 0; overflow: hidden; }
 .detail { overflow-y: auto; min-height: 0; padding: 16px 22px; }
 
-.pane-head { position: sticky; top: 0; background: var(--ink);
-  padding: 10px 18px; border-bottom: 1px solid var(--line);
+.pane-head { background: var(--ink); padding: 10px 18px; border-bottom: 1px solid var(--line);
   font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--slate); }
+#findings { flex: 1 1 auto; overflow-y: auto; min-height: 0; }
 ul { list-style: none; margin: 0; padding: 0; }
 
+/* ── filter chips ── */
+.filterbar { display: flex; flex-wrap: wrap; gap: 6px; padding: 9px 14px; border-bottom: 1px solid var(--line); }
+.filterbar:empty { display: none; }
+.chip { font: 600 10px/1 var(--mono); letter-spacing: .6px; text-transform: uppercase;
+  color: var(--slate); background: transparent; border: 1px solid var(--line-2); border-radius: 0;
+  padding: 5px 9px; cursor: pointer; }
+.chip:hover { border-color: var(--bone); color: var(--bone); }
+.chip.on { color: var(--ink); background: var(--slate); border-color: var(--slate); }
+.chip.c-crit { color: var(--crit); } .chip.c-high { color: var(--high); }
+.chip.c-med { color: var(--med); } .chip.c-low { color: var(--low); }
+.chip.c-crit.on { background: var(--crit); border-color: var(--crit); color: var(--ink); }
+.chip.c-high.on { background: var(--high); border-color: var(--high); color: var(--ink); }
+.chip.c-med.on { background: var(--med); border-color: var(--med); color: var(--ink); }
+.chip.c-low.on { background: var(--low); border-color: var(--low); color: var(--ink); }
+
+/* ── batch action bar ── */
+.batchbar { display: flex; flex-wrap: wrap; gap: 8px; padding: 9px 14px;
+  border-bottom: 1px solid var(--line); background: var(--ink-3); }
+.batchbar[hidden] { display: none; }
+
 /* ── finding row: heat gutter + dense mono ── */
-.finding { display: grid; grid-template-columns: auto 1fr auto; gap: 12px; align-items: baseline;
+.finding { display: grid; grid-template-columns: auto auto 1fr auto; gap: 12px; align-items: baseline;
   padding: 9px 18px 9px 15px; border-left: 3px solid transparent; cursor: pointer;
   border-bottom: 1px solid var(--ink-2); }
+.pick { accent-color: var(--safe); width: 14px; height: 14px; cursor: pointer; align-self: center; margin: 0; }
+.pick-spacer { display: inline-block; width: 14px; }
 .finding:hover { background: var(--ink-2); }
 .finding.active { background: var(--ink-2); border-left-color: var(--bone); }
 .sev { font-size: 10px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; white-space: nowrap; }
@@ -103,6 +126,7 @@ ul { list-style: none; margin: 0; padding: 0; }
 .finding .title .rem { color: var(--slate); font-size: 11px; }
 .finding .svc { color: var(--slate); font-size: 11px; white-space: nowrap; }
 .clean { padding: 22px 18px; color: var(--safe); }
+.clean.muted { color: var(--slate); }
 
 /* ── detail / console ── */
 .detail .empty { color: var(--slate); }

--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -1,8 +1,18 @@
 "use strict";
 
 const SEV = ["critical", "high", "medium", "low"];
+// Finding.source (int) -> short domain label, mirrors the score axes.
+const SRC = { 1: "Container", 2: "SSH", 3: "Firewall", 4: "Updates", 5: "CVEs" };
+const REM_AUTO = 1;
+
 let report = null;
-let selected = null; // {id, service}
+let selected = null; // {id, service} — the inspected finding (single-select)
+
+// Filter + multi-select state.
+const filters = { sev: new Set(), domain: new Set(), fixable: false };
+const marked = new Set(); // keys of findings picked for a batch fix
+
+function fkey(f) { return f.id + "|" + (f.service || ""); }
 
 async function api(path, opts) {
   const res = await fetch(path, opts);
@@ -27,6 +37,7 @@ function sevName(f) { return SEV[f.severity] || "low"; }
 function sevAbbr(f) { return ["crit", "high", "med", "low"][f.severity] || "low"; }
 function remLabel(r) { return ["Unclassified", "Auto-fix", "Review", "Manual", "Unavailable"][r] || "?"; }
 function isFixable(f) { return f.remediation === 1 || f.remediation === 2; }
+function isAuto(f) { return f.remediation === REM_AUTO; }
 function active(findings) { return findings.filter((x) => !x.fixed); }
 
 // A finding row's grid class → the severity class also used for the gutter.
@@ -41,6 +52,109 @@ function meter(pct, bandClass) {
   return m;
 }
 
+// ── filtering ──────────────────────────────────────────────────────────
+function applyFilters(items) {
+  return items.filter((f) => {
+    if (filters.sev.size && !filters.sev.has(f.severity)) return false;
+    if (filters.domain.size && !filters.domain.has(f.source)) return false;
+    if (filters.fixable && !isFixable(f)) return false;
+    return true;
+  });
+}
+
+function filterActive() {
+  return filters.sev.size || filters.domain.size || filters.fixable;
+}
+
+function chip(label, on, onclick, sevClass) {
+  return el("button", { class: "chip" + (on ? " on" : "") + (sevClass ? " " + sevClass : ""), onclick }, label);
+}
+
+function renderFilterbar(all) {
+  const bar = document.getElementById("filterbar");
+  const kids = [];
+
+  // Severity chips (only those present), each with a live count.
+  const sevCounts = [0, 0, 0, 0];
+  all.forEach((f) => { if (f.severity >= 0 && f.severity < 4) sevCounts[f.severity]++; });
+  ["crit", "high", "med", "low"].forEach((abbr, i) => {
+    if (!sevCounts[i]) return;
+    kids.push(chip(`${abbr.toUpperCase()} ${sevCounts[i]}`, filters.sev.has(i), () => {
+      filters.sev.has(i) ? filters.sev.delete(i) : filters.sev.add(i);
+      render();
+    }, "c-" + abbr));
+  });
+
+  // Domain chips (only sources present in the report).
+  const domains = [...new Set(all.map((f) => f.source))].filter((s) => SRC[s]).sort((a, b) => a - b);
+  domains.forEach((s) => {
+    kids.push(chip(SRC[s], filters.domain.has(s), () => {
+      filters.domain.has(s) ? filters.domain.delete(s) : filters.domain.add(s);
+      render();
+    }));
+  });
+
+  // Fixable-only toggle + clear.
+  kids.push(chip("Fixable", filters.fixable, () => { filters.fixable = !filters.fixable; render(); }));
+  if (filterActive()) {
+    kids.push(chip("Clear", false, () => {
+      filters.sev.clear(); filters.domain.clear(); filters.fixable = false; render();
+    }));
+  }
+  bar.replaceChildren(...kids);
+}
+
+// ── multi-select ───────────────────────────────────────────────────────
+function checkbox(f) {
+  const box = Object.assign(document.createElement("input"), { type: "checkbox", checked: marked.has(fkey(f)) });
+  box.className = "pick";
+  box.setAttribute("aria-label", "Select for batch fix");
+  box.onclick = (e) => e.stopPropagation();
+  box.onchange = () => {
+    box.checked ? marked.add(fkey(f)) : marked.delete(fkey(f));
+    renderBatchbar();
+  };
+  return box;
+}
+
+function renderBatchbar() {
+  const bar = document.getElementById("batchbar");
+  if (marked.size === 0) { bar.hidden = true; bar.replaceChildren(); return; }
+  bar.hidden = false;
+  bar.replaceChildren(
+    el("button", { class: "primary", onclick: applyBatch }, `Fix selected (${marked.size})`),
+    el("button", { onclick: selectAllAuto }, "Select all auto"),
+    el("button", { onclick: clearMarked }, "Clear")
+  );
+}
+
+function selectAllAuto() {
+  applyFilters(active(report.findings)).forEach((f) => { if (isAuto(f)) marked.add(fkey(f)); });
+  render();
+}
+
+function clearMarked() { marked.clear(); render(); }
+
+async function applyBatch() {
+  const findings = active(report.findings)
+    .filter((f) => marked.has(fkey(f)))
+    .map((f) => ({ id: f.id, service: f.service || "" }));
+  if (!findings.length) return;
+  try {
+    const o = await api("/api/fix/batch", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ findings }),
+    });
+    const parts = [`Applied ${o.applied ? o.applied.length : 0}`];
+    if (o.skipped && o.skipped.length) parts.push(`skipped ${o.skipped.length}`);
+    if (o.failed && Object.keys(o.failed).length) parts.push(`failed ${Object.keys(o.failed).length}`);
+    flash(parts.join(" · ") + `. Score ${o.new_score.overall}/100.`);
+    marked.clear();
+    await refresh();
+  } catch (e) { flash("Batch fix failed: " + e.message, true); }
+}
+
+// ── main render ────────────────────────────────────────────────────────
 function render() {
   const score = report.score;
 
@@ -65,17 +179,29 @@ function render() {
 
   // Findings list.
   const list = document.getElementById("findings");
-  const items = active(report.findings);
-  document.getElementById("findings-title").textContent = `Findings · ${items.length}`;
-  if (items.length === 0) {
+  const all = active(report.findings);
+  renderFilterbar(all);
+  const items = applyFilters(all).sort((a, b) => a.severity - b.severity);
+  document.getElementById("findings-title").textContent =
+    filterActive() ? `Findings · ${items.length}/${all.length}` : `Findings · ${all.length}`;
+
+  if (all.length === 0) {
+    marked.clear();
+    renderBatchbar();
     list.replaceChildren(el("li", { class: "clean" }, "No problems found. Clean."));
     document.getElementById("detail").replaceChildren(el("p", { class: "empty" }, "Nothing to fix."));
     return;
   }
-  items.sort((a, b) => a.severity - b.severity);
+  if (items.length === 0) {
+    renderBatchbar();
+    list.replaceChildren(el("li", { class: "clean muted" }, "No findings match the filter."));
+    return;
+  }
+
   list.replaceChildren(
     ...items.map((f) => {
-      const li = el("li", { class: "finding " + rowSevClass(f) },
+      const li = el("li", { class: "finding " + rowSevClass(f) + (isAuto(f) ? " pickable" : "") },
+        isAuto(f) ? checkbox(f) : el("span", { class: "pick-spacer" }),
         el("span", { class: "sev" }, sevAbbr(f)),
         el("div", { class: "title" },
           el("div", { class: "name" }, f.title),
@@ -88,6 +214,7 @@ function render() {
       return li;
     })
   );
+  renderBatchbar();
 }
 
 function selectFinding(f, li) {
@@ -192,6 +319,7 @@ function flash(msg, isErr) {
 
 document.getElementById("rescan").onclick = async () => {
   flash("Rescanning…");
+  marked.clear();
   report = await api("/api/rescan", { method: "POST", headers: { "Content-Type": "application/json" } });
   render();
   flash("Rescan complete.");
@@ -202,6 +330,7 @@ document.getElementById("fixall").onclick = async () => {
   try {
     const o = await api("/api/fix/all", { method: "POST", headers: { "Content-Type": "application/json" } });
     flash(`Applied ${o.applied ? o.applied.length : 0} fixes. Score ${o.new_score.overall}/100.`);
+    marked.clear();
     await refresh();
   } catch (e) { flash("Batch fix failed: " + e.message, true); }
 };

--- a/internal/ui/web/assets/index.html
+++ b/internal/ui/web/assets/index.html
@@ -22,6 +22,8 @@
   <main>
     <section class="findings">
       <div class="pane-head" id="findings-title">Findings</div>
+      <div class="filterbar" id="filterbar"></div>
+      <div class="batchbar" id="batchbar" hidden></div>
       <ul id="findings"></ul>
     </section>
     <section class="detail" id="detail">

--- a/internal/ui/web/server.go
+++ b/internal/ui/web/server.go
@@ -43,6 +43,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/preview", s.handlePreview)
 	mux.HandleFunc("/api/fix", s.handleFix)
 	mux.HandleFunc("/api/fix/all", s.handleFixAll)
+	mux.HandleFunc("/api/fix/batch", s.handleFixBatch)
 	mux.HandleFunc("/api/rescan", s.handleRescan)
 	mux.HandleFunc("/api/history", s.handleHistory)
 	mux.HandleFunc("/api/rollback", s.handleRollback)
@@ -183,6 +184,33 @@ func (s *Server) handleFixAll(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, s.engine.ApplyBatch(r.Context(), auto))
+}
+
+type fixRef struct {
+	ID      string `json:"id"`
+	Service string `json:"service"`
+}
+
+type batchRequest struct {
+	Findings []fixRef `json:"findings"`
+}
+
+// handleFixBatch applies exactly the findings the client selected. Each is
+// resolved against the current report; ApplyBatch itself skips anything that
+// is not a single-action Auto fix, reporting it under Skipped.
+func (s *Server) handleFixBatch(w http.ResponseWriter, r *http.Request) {
+	var req batchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	var sel []model.Finding
+	for _, ref := range req.Findings {
+		if f, ok := s.lookup(ref.ID, ref.Service); ok {
+			sel = append(sel, f)
+		}
+	}
+	writeJSON(w, s.engine.ApplyBatch(r.Context(), sel))
 }
 
 func (s *Server) handleHistory(w http.ResponseWriter, _ *http.Request) {

--- a/internal/ui/web/server_test.go
+++ b/internal/ui/web/server_test.go
@@ -124,6 +124,34 @@ func TestFixThroughAPI(t *testing.T) {
 	}
 }
 
+func TestFixBatchThroughAPI(t *testing.T) {
+	s, path := testServer(t)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	body := strings.NewReader(`{"findings":[{"id":"compose.ds018","service":"cache"}]}`)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/fix/batch", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", srv.URL)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("batch fix returned %d", resp.StatusCode)
+	}
+	var outcome model.BatchOutcome
+	_ = json.NewDecoder(resp.Body).Decode(&outcome)
+	if len(outcome.Applied) != 1 || outcome.Applied[0] != "compose.ds018" {
+		t.Errorf("expected ds018 applied, got %+v", outcome)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "127.0.0.1:6379:6379") {
+		t.Errorf("batch fix not applied to file:\n%s", data)
+	}
+}
+
 func TestDashboardServed(t *testing.T) {
 	s, _ := testServer(t)
 	srv := httptest.NewServer(s.Handler())


### PR DESCRIPTION
Addresses two usability gaps the user hit: the findings view had no way to classify/filter, and fixes could only be applied one at a time or "all auto" — never a chosen subset.

Both UIs get the same two capabilities, wired to primitives the engine already exposed (`model.Filter`/`Report.Select` and `Engine.ApplyBatch`) — **no model or engine changes**.

## Filtering
- Axes: **severity · domain (source) · fixable-only**. Display-only — never changes the score.
- **Web**: a filter-chip bar with live per-severity counts; only domains present in the report get a chip; a Clear chip; the pane title shows `shown/total`.
- **TUI**: `s` cycles minimum severity, `d` cycles the present domains, `x` toggles fixable-only, `c` clears; a `FILTER` line + `shown/total` in the header.

## Multi-select batch fix
- Only **auto-fixable** rows are selectable (Review fixes need a per-finding choice). The batch reports **Applied / Skipped / Failed**.
- **Web**: a checkbox on each Auto row + a batch bar (`Fix selected (N)`, `Select all auto`, `Clear`), backed by a new `POST /api/fix/batch` that applies exactly the selected findings.
- **TUI**: `space` marks the current Auto row, `a` applies the marked set (or every active auto-fix when nothing is marked — the TUI's first "fix all"), `esc` clears.

The two duplicated `report.Select(Filter{})` rebuilds in the TUI are unified into one `rebuildActive()` helper.

## Verification
- `go build`, `go vet`, `go test ./...` all green.
- New tests: `/api/fix/batch` endpoint; TUI filter cycling, space-marks-auto-only, and a **real-engine multi-select batch** that edits two fixture files and refreshes the list.
- Manual E2E: served the real dashboard against a deterministic 33-finding / 2-domain / 14-auto report and drove it via CDP — filter chips (`6/33`, colored active), checkboxes only on Auto rows, batch bar, and an end-to-end `Fix selected` that rewrote both datastore ports to loopback. TUI frame rendered with a filter + marks showing the `FILTER` line, `shown/total`, `✓` markers, and the two-line key footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)