### PR TITLE
site: add official docs website at /docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ One binary, no config file, no cloud account.
 [![Go Version](https://img.shields.io/github/go-mod/go-version/seolcu/hostveil)](go.mod)
 [![License: GPL-3.0](https://img.shields.io/github/license/seolcu/hostveil)](LICENSE)
 
-[Website](https://hostveil.seolcu.com/) · [Latest release](https://github.com/seolcu/hostveil/releases/latest)
+[Website](https://hostveil.seolcu.com/) · [Docs](https://hostveil.seolcu.com/docs/) · [Latest release](https://github.com/seolcu/hostveil/releases/latest)
 
 ---
 

--- a/site/docs.css
+++ b/site/docs.css
@@ -1,0 +1,404 @@
+/* hostveil docs — layout + long-form prose.
+   Loaded AFTER styles.css; inherits all :root custom properties. */
+
+:root {
+  --docs-max: 1240px;
+  --sidebar-w: 244px;
+  --toc-w: 200px;
+}
+
+/* ── shell ────────────────────────────────────────────── */
+
+.docs-container {
+  width: min(100% - 40px, var(--docs-max));
+  margin-inline: auto;
+}
+
+.docs-layout {
+  display: grid;
+  grid-template-columns: var(--sidebar-w) minmax(0, 1fr);
+  gap: clamp(28px, 4vw, 56px);
+  align-items: start;
+  padding: clamp(32px, 5vw, 56px) 0 96px;
+}
+
+/* ── sidebar ──────────────────────────────────────────── */
+
+.docs-sidebar {
+  position: sticky;
+  top: 88px;
+  max-height: calc(100vh - 108px);
+  overflow-y: auto;
+  padding-right: 8px;
+  font-family: var(--font-mono);
+}
+
+.docs-nav-group {
+  margin-bottom: 22px;
+}
+
+.docs-nav-group > p {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.docs-nav-group ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1px;
+}
+
+.docs-nav-group a {
+  display: block;
+  padding: 7px 12px;
+  border-left: 2px solid var(--line);
+  color: var(--muted);
+  font-size: 0.86rem;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.docs-nav-group a:hover,
+.docs-nav-group a:focus-visible {
+  color: var(--text);
+  border-left-color: var(--line-strong);
+  background: var(--panel);
+}
+
+.docs-nav-group a.active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+  background: var(--panel);
+  font-weight: 700;
+}
+
+/* ── mobile sidebar toggle (hidden on desktop) ────────── */
+
+.docs-sidebar-toggle {
+  display: none;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 16px;
+  border: 1px solid var(--line-strong);
+  background: var(--panel);
+  color: var(--text);
+  font: 800 0.78rem/1 var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+.docs-sidebar-toggle::after {
+  content: "▾";
+  color: var(--accent);
+  transition: transform 150ms ease;
+}
+
+.docs-sidebar-toggle[aria-expanded="true"]::after {
+  transform: rotate(180deg);
+}
+
+/* ── content column ───────────────────────────────────── */
+
+.docs-content {
+  min-width: 0;
+}
+
+.docs-breadcrumb {
+  margin: 0 0 14px;
+  color: var(--muted);
+  font: 700 0.72rem/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.docs-breadcrumb a:hover {
+  color: var(--accent);
+}
+
+/* ── prose typography ─────────────────────────────────── */
+
+.docs-prose {
+  max-width: 760px;
+}
+
+.docs-prose > h1 {
+  font-size: clamp(2rem, 4.5vw, 2.9rem);
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+  margin-bottom: 14px;
+}
+
+.docs-prose .lead {
+  color: var(--paper-muted);
+  font-size: 1.14rem;
+  margin-bottom: 34px;
+}
+
+.docs-prose h2 {
+  margin: 46px 0 14px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  font-size: clamp(1.5rem, 3vw, 1.95rem);
+  letter-spacing: -0.02em;
+  scroll-margin-top: 88px;
+}
+
+.docs-prose h3 {
+  margin: 30px 0 10px;
+  font-family: var(--font-mono);
+  font-size: 1.02rem;
+  color: var(--paper);
+  scroll-margin-top: 88px;
+}
+
+.docs-prose p {
+  margin: 0 0 16px;
+  color: var(--paper-muted);
+}
+
+.docs-prose strong {
+  color: var(--text);
+}
+
+.docs-prose a:not(.button) {
+  color: var(--accent);
+  border-bottom: 1px solid var(--line-strong);
+}
+
+.docs-prose a:not(.button):hover {
+  border-bottom-color: var(--accent);
+}
+
+.docs-prose ul,
+.docs-prose ol {
+  margin: 0 0 18px;
+  padding-left: 22px;
+  color: var(--paper-muted);
+}
+
+.docs-prose li {
+  margin-bottom: 8px;
+}
+
+.docs-prose li::marker {
+  color: var(--accent);
+}
+
+.docs-prose code {
+  font-family: var(--font-mono);
+  font-size: 0.86em;
+  color: var(--text);
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  padding: 0.08rem 0.36rem;
+}
+
+.docs-prose pre code {
+  border: 0;
+  background: none;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+/* code blocks reuse .command-box / .code-block from styles.css */
+.docs-prose .command-box,
+.docs-prose .code-block {
+  margin: 0 0 22px;
+}
+
+.docs-prose .code-block pre {
+  white-space: pre;
+}
+
+/* ── callout / note boxes ─────────────────────────────── */
+
+.callout {
+  margin: 0 0 22px;
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  background: var(--panel);
+}
+
+.callout p:last-child {
+  margin-bottom: 0;
+}
+
+.callout .callout-label {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--accent);
+  font: 800 0.72rem/1 var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.callout.warn {
+  border-left-color: var(--orange);
+}
+
+.callout.warn .callout-label {
+  color: var(--orange);
+}
+
+/* ── tables ───────────────────────────────────────────── */
+
+.docs-table-wrap {
+  overflow-x: auto;
+  margin: 0 0 22px;
+  border: 1px solid var(--line);
+}
+
+.docs-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.docs-prose thead th {
+  text-align: left;
+  padding: 12px 14px;
+  background: var(--panel-strong);
+  border-bottom: 1px solid var(--line-strong);
+  color: var(--paper);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.docs-prose tbody td {
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--line);
+  color: var(--paper-muted);
+  vertical-align: top;
+}
+
+.docs-prose tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.docs-prose tbody code {
+  white-space: nowrap;
+}
+
+/* ── doc-map grid (index page) ────────────────────────── */
+
+.docs-cards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin: 0 0 26px;
+  padding: 0;
+  list-style: none;
+}
+
+.docs-cards li {
+  margin: 0;
+}
+
+.docs-cards a {
+  display: block;
+  height: 100%;
+  padding: 20px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  box-shadow: 6px 6px 0 var(--shadow-cut);
+  transition: box-shadow 150ms ease, border-color 150ms ease;
+}
+
+.docs-cards a:hover {
+  border-color: var(--line-strong);
+  box-shadow: 3px 3px 0 var(--shadow-cut);
+}
+
+.docs-cards strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+}
+
+.docs-cards span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+/* ── page footer nav (prev / next-ish) ────────────────── */
+
+.docs-pager {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 48px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+}
+
+/* ── severity chips (reuse .finding look inline) ──────── */
+
+.sev {
+  display: inline-block;
+  padding: 2px 8px;
+  font: 800 0.72rem/1.5 var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border: 1px solid var(--line-strong);
+  color: var(--muted);
+}
+
+.sev.critical { color: var(--danger); border-color: var(--danger); }
+.sev.high { color: var(--orange); border-color: var(--orange); }
+.sev.medium { color: var(--warning); border-color: var(--warning); }
+.sev.low { color: var(--signal); border-color: var(--signal); }
+
+/* ── responsive ───────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .docs-layout {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .docs-sidebar-toggle {
+    display: flex;
+  }
+
+  .docs-sidebar {
+    position: static;
+    max-height: none;
+    overflow: visible;
+    padding: 16px;
+    border: 1px solid var(--line);
+    background: var(--bg-alt);
+  }
+
+  .docs-sidebar[hidden] {
+    display: none;
+  }
+
+  .docs-prose {
+    max-width: none;
+  }
+}
+
+@media (max-width: 620px) {
+  .docs-container {
+    width: min(100% - 28px, var(--docs-max));
+  }
+
+  .docs-cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/site/docs.js
+++ b/site/docs.js
@@ -1,0 +1,67 @@
+/* hostveil docs — copy-to-clipboard, mobile sidebar, active link.
+   Standalone (does NOT touch the landing-page lightbox). */
+(function () {
+  "use strict";
+
+  /* ── copy-to-clipboard ────────────────────────────────── */
+
+  document.addEventListener("click", function (e) {
+    var btn = e.target.closest(".copy-btn");
+    if (!btn) return;
+    var text = btn.getAttribute("data-copy");
+    if (!text || !navigator.clipboard) return;
+    navigator.clipboard.writeText(text).then(function () {
+      btn.textContent = "Copied";
+      btn.classList.add("copied");
+      setTimeout(function () {
+        btn.textContent = "Copy";
+        btn.classList.remove("copied");
+      }, 1500);
+    });
+  });
+
+  /* ── mobile sidebar toggle ────────────────────────────── */
+
+  var toggle = document.querySelector(".docs-sidebar-toggle");
+  var sidebar = document.getElementById("docs-sidebar");
+
+  function isMobile() {
+    return window.matchMedia("(max-width: 900px)").matches;
+  }
+
+  function syncSidebar() {
+    if (!toggle || !sidebar) return;
+    if (isMobile()) {
+      var open = toggle.getAttribute("aria-expanded") === "true";
+      sidebar.hidden = !open;
+    } else {
+      sidebar.hidden = false;
+    }
+  }
+
+  if (toggle && sidebar) {
+    toggle.addEventListener("click", function () {
+      var open = toggle.getAttribute("aria-expanded") === "true";
+      toggle.setAttribute("aria-expanded", String(!open));
+      sidebar.hidden = open;
+    });
+    window.addEventListener("resize", syncSidebar);
+    syncSidebar();
+  }
+
+  /* ── active link highlight ────────────────────────────── */
+  /* Mark the sidebar link matching the current page. Works even if
+     the authored `.active` class drifts from the served filename. */
+
+  var here = location.pathname.replace(/\/index\.html$/, "/").split("/").pop() || "index.html";
+  document.querySelectorAll(".docs-nav-group a").forEach(function (a) {
+    var href = a.getAttribute("href") || "";
+    var target = href.replace(/\/index\.html$/, "/").split("/").pop() || "index.html";
+    if (target === here) {
+      a.classList.add("active");
+      a.setAttribute("aria-current", "page");
+    } else {
+      a.classList.remove("active");
+    }
+  });
+})();

--- a/site/docs/ai.html
+++ b/site/docs/ai.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>AI explanations — hostveil docs</title>
+    <meta name="description" content="hostveil's optional, advisory-only AI: local Ollama by default, never applies changes, and sends only human-readable fields — never raw secrets or paths.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="AI explanations — hostveil docs">
+    <meta property="og:description" content="Optional, advisory-only, local-first AI second opinions with explain --ai.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/ai.html">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/ai.html">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html">Introduction</a></li>
+              <li><a href="installation.html">Installation</a></li>
+              <li><a href="quickstart.html">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html">What it checks</a></li>
+              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html">Interfaces</a></li>
+              <li><a href="ai.html" class="active">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html">CLI reference</a></li>
+              <li><a href="faq.html">FAQ</a></li>
+              <li><a href="contributing.html">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / AI explanations</p>
+            <h1>AI explanations</h1>
+            <p class="lead">AI in hostveil is optional, advisory-only, and local-first. It can add a second opinion in plain words — but it never applies changes, and everything works with no AI at all.</p>
+
+            <h2>Using it</h2>
+            <p>Add <code>--ai</code> to <code>explain</code> for an advisory explanation of a finding:</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="hostveil explain ssh.rootlogin --ai">Copy</button>
+              <pre><code>hostveil explain ssh.rootlogin --ai</code></pre>
+            </div>
+            <p>The built-in plain explanation always prints first; <code>--ai</code> appends an <em>AI explanation (advisory)</em> section. If the model is not reachable, hostveil says so and continues — the command never fails because AI is unavailable.</p>
+
+            <h2>Local by default</h2>
+            <p>The default provider is <strong>Ollama</strong>, running on your own machine — nothing leaves the host. Defaults:</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Setting</th><th>Default</th><th>Override</th></tr></thead>
+                <tbody>
+                  <tr><td>Host</td><td><code>http://127.0.0.1:11434</code></td><td><code>HOSTVEIL_OLLAMA_HOST</code></td></tr>
+                  <tr><td>Model</td><td><code>llama3.2</code></td><td><code>HOSTVEIL_OLLAMA_MODEL</code></td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Install <a href="https://ollama.com">Ollama</a> and pull the model once:</p>
+            <div class="code-block"><pre><code>ollama pull llama3.2
+hostveil explain ssh.rootlogin --ai</code></pre></div>
+            <p>To use a different local model:</p>
+            <div class="code-block"><pre><code>HOSTVEIL_OLLAMA_MODEL=llama3.1 hostveil explain ssh.rootlogin --ai</code></pre></div>
+
+            <h2>Advisory only, and private by design</h2>
+            <div class="callout">
+              <span class="callout-label">What the model can and can't do</span>
+              <p>The AI can only <strong>explain</strong> — it has no ability to apply, change, or drive any fix. Scores, findings, and fixes are computed entirely without it.</p>
+            </div>
+            <div class="callout warn">
+              <span class="callout-label">Privacy</span>
+              <p>Only human-readable fields are sent to the model — a finding's title, service, description, and how-to-fix text. Raw evidence values such as secrets, ports, and file paths are <strong>never</strong> included in the prompt, so sensitive detail does not leave the host even when you opt in.</p>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="interfaces.html">← Interfaces</a>
+              <a class="button primary" href="cli.html">CLI reference →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>What it checks — hostveil docs</title>
+    <meta name="description" content="hostveil's coverage: Docker/Compose, SSH, firewall, auto-updates, and optional image CVEs — the finding IDs, severities, and how the 0–100 score is built.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="What it checks — hostveil docs">
+    <meta property="og:description" content="Docker/Compose, SSH, firewall, auto-updates, and optional image CVEs — finding IDs, severities, and the score model.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/checks.html">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/checks.html">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html">Introduction</a></li>
+              <li><a href="installation.html">Installation</a></li>
+              <li><a href="quickstart.html">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html" class="active">What it checks</a></li>
+              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html">Interfaces</a></li>
+              <li><a href="ai.html">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html">CLI reference</a></li>
+              <li><a href="faq.html">FAQ</a></li>
+              <li><a href="contributing.html">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / What it checks</p>
+            <h1>What it checks</h1>
+            <p class="lead">hostveil checks the highest-impact paths that actually get self-hosters breached, then merges everything into one 0–100 score. Each finding has a stable ID of the form <code>domain.rule</code> — use it with <code>explain</code>, <code>fix</code>, and <code>rollback</code>.</p>
+
+            <h2>Domains at a glance</h2>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Domain</th><th>Prefix</th><th>Needs</th></tr></thead>
+                <tbody>
+                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker + Compose files</td></tr>
+                  <tr><td>SSH</td><td><code>ssh.</code></td><td>—</td></tr>
+                  <tr><td>Firewall</td><td><code>firewall.</code></td><td>—</td></tr>
+                  <tr><td>Auto-updates</td><td><code>updates.</code></td><td>—</td></tr>
+                  <tr><td>Image CVEs <em>(optional)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Missing Docker or Trivy? Those domains are skipped cleanly and the score is <strong>renormalized</strong>, so you are never handed a misleadingly perfect result for a scan that did not run.</p>
+
+            <h2>Severity &amp; the score</h2>
+            <p>Every finding carries one of four severities. The score starts at 100 and each unfixed finding subtracts a penalty by severity:</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Severity</th><th>Penalty</th></tr></thead>
+                <tbody>
+                  <tr><td><span class="sev critical">Critical</span></td><td>8</td></tr>
+                  <tr><td><span class="sev high">High</span></td><td>5</td></tr>
+                  <tr><td><span class="sev medium">Medium</span></td><td>2</td></tr>
+                  <tr><td><span class="sev low">Low</span></td><td>1</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><code>hostveil scan</code> exits non-zero when any unfixed finding is <span class="sev critical">Critical</span> or <span class="sev high">High</span> — useful as a CI or cron gate.</p>
+
+            <h2 id="ssh">SSH <code>ssh.</code></h2>
+            <p>Parsed natively from <code>sshd_config</code>. Run with <code>sudo</code> to read it.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>ssh.emptypasswords</code></td><td>Empty passwords are permitted</td><td><span class="sev critical">Critical</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>ssh.rootlogin</code></td><td>Root login with a password is allowed</td><td><span class="sev high">High</span></td><td>Review</td></tr>
+                  <tr><td><code>ssh.passwordauth</code></td><td>Password authentication is allowed</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>ssh.maxauthtries</code></td><td>Too many auth attempts per connection</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>ssh.x11forwarding</code></td><td>X11 forwarding is enabled</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="compose">Docker / Compose <code>compose.</code></h2>
+            <p>A native audit of your Compose files — no external scanner required.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>compose.ds016</code></td><td>Docker socket mounted into a container</td><td><span class="sev critical">Critical</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.ds018</code></td><td>Datastore exposed on all interfaces</td><td><span class="sev critical">Critical</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.ds001</code></td><td>Container runs in privileged mode</td><td><span class="sev high">High</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.ds019</code></td><td>Admin panel exposed on all interfaces</td><td><span class="sev high">High</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.dr001</code></td><td>Container uses host network mode</td><td><span class="sev high">High</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.ds017</code></td><td>Sensitive host path mounted read-write</td><td><span class="sev high">High</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.ds005</code></td><td>Adds a dangerous Linux capability</td><td><span class="sev high">High</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.dr005</code></td><td>Hardcoded secret in the environment</td><td><span class="sev high">High</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.ds006</code></td><td>Missing no-new-privileges hardening</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>compose.ds009</code></td><td>Container runs as root</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.dr002</code></td><td>Port published on all interfaces</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.ds008</code></td><td>No restart policy set</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>compose.ds010</code></td><td>No memory limit set</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
+                  <tr><td><code>compose.ds012</code></td><td>No healthcheck defined</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>compose.dr004</code></td><td>Loads secrets from an env_file</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="firewall">Firewall <code>firewall.</code></h2>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, or nftables)</td><td><span class="sev high">High</span></td><td>Review</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="updates">Auto-updates <code>updates.</code></h2>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>updates.disabled</code></td><td>Automatic security updates are not enabled (apt unattended-upgrades or dnf-automatic)</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="cve">Image CVEs <code>cve.</code> <em>(optional)</em></h2>
+            <p>When Trivy is installed, hostveil scans the images your Compose services run for known Critical, High, and Medium vulnerabilities. Each unique vulnerability becomes a finding whose ID is <code>cve.&lt;vulnerability-id&gt;</code> (for example <code>cve.cve-2023-1234</code>), with severity mapped from Trivy's rating.</p>
+            <div class="callout">
+              <span class="callout-label">Honest about "no patch yet"</span>
+              <p>If a fixed version exists, the finding is a <strong>Review</strong> fix (update the image). If there is no patch available yet, hostveil models that as a first-class <strong>Unavailable</strong> state rather than pretending it can be fixed — so the scan stays truthful.</p>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="quickstart.html">← Quick start</a>
+              <a class="button primary" href="fixing.html">Fixing &amp; rollback →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CLI reference — hostveil docs</title>
+    <meta name="description" content="Complete hostveil command-line reference: scan, fix, rollback, history, explain, serve, and tui — every flag, default, and exit code.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="CLI reference — hostveil docs">
+    <meta property="og:description" content="Every hostveil subcommand and flag: scan, fix, rollback, history, explain, serve, tui.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/cli.html">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/cli.html">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html">Introduction</a></li>
+              <li><a href="installation.html">Installation</a></li>
+              <li><a href="quickstart.html">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html">What it checks</a></li>
+              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html">Interfaces</a></li>
+              <li><a href="ai.html">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html" class="active">CLI reference</a></li>
+              <li><a href="faq.html">FAQ</a></li>
+              <li><a href="contributing.html">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / CLI reference</p>
+            <h1>CLI reference</h1>
+            <p class="lead">Every subcommand, flag, and default. Commands that read root-owned files (SSH, firewall) or write to protected paths need <code>sudo</code>.</p>
+
+            <h2>Synopsis</h2>
+            <div class="code-block"><pre><code>hostveil &lt;command&gt; [flags]</code></pre></div>
+            <p>With no command on an interactive terminal, hostveil opens the <a href="interfaces.html">TUI</a>; when stdin/stdout are not a terminal, it runs <code>scan</code> instead. <code>hostveil version</code> (or <code>--version</code>) prints the version; <code>hostveil help</code> (or <code>--help</code>) prints usage.</p>
+
+            <h2 id="scan">scan</h2>
+            <p>Scan the host and report security findings.</p>
+            <div class="code-block"><pre><code>hostveil scan [flags]</code></pre></div>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--json</code></td><td><code>false</code></td><td>Output the report as JSON.</td></tr>
+                  <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>Show descriptions and fix guidance.</td></tr>
+                  <tr><td><code>--no-color</code></td><td><code>false</code></td><td>Disable colored output.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Exit code: <code>1</code> if any unfixed finding is Critical or High, otherwise <code>0</code>. Color is emitted only to a terminal and is suppressed when <code>NO_COLOR</code> is set.</p>
+
+            <h2 id="fix">fix</h2>
+            <p>Preview and apply the fix for a finding.</p>
+            <div class="code-block"><pre><code>hostveil fix &lt;finding-id&gt; [flags]
+hostveil fix --all [flags]</code></pre></div>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--all</code></td><td><code>false</code></td><td>Apply every safe (Auto-fix) finding at once.</td></tr>
+                  <tr><td><code>--action N</code></td><td><code>-1</code></td><td>For a Review fix, the 0-based alternative to apply.</td></tr>
+                  <tr><td><code>--service NAME</code></td><td><code>""</code></td><td>Disambiguate a finding by service name.</td></tr>
+                  <tr><td><code>--yes</code></td><td><code>false</code></td><td>Apply without the interactive confirmation.</td></tr>
+                  <tr><td><code>--no-color</code></td><td><code>false</code></td><td>Disable colored output.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Applying always shows the diff/command, backs up the original to a checkpoint, then applies. See <a href="fixing.html">Fixing &amp; rollback</a>.</p>
+
+            <h2 id="rollback">rollback</h2>
+            <p>Undo a previously applied fix.</p>
+            <div class="code-block"><pre><code>hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
+            <p>Takes one checkpoint ID (from <code>hostveil history</code>) and restores the backed-up file byte-for-byte. No flags.</p>
+
+            <h2 id="history">history</h2>
+            <p>List applied fixes and their rollback IDs.</p>
+            <div class="code-block"><pre><code>hostveil history</code></pre></div>
+            <p>Lists checkpoints newest-first with a timestamp, the finding ID, a label, and either the exact <code>hostveil rollback &lt;id&gt;</code> command or <em>not reversible</em>. No flags.</p>
+
+            <h2 id="explain">explain</h2>
+            <p>Explain a finding in plain language.</p>
+            <div class="code-block"><pre><code>hostveil explain &lt;finding-id&gt; [flags]</code></pre></div>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--ai</code></td><td><code>false</code></td><td>Append an advisory explanation from a local LLM (Ollama).</td></tr>
+                  <tr><td><code>--service NAME</code></td><td><code>""</code></td><td>Disambiguate a finding by service name.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>The built-in plain explanation always prints; <code>--ai</code> adds an advisory section. See <a href="ai.html">AI explanations</a>.</p>
+
+            <h2 id="serve">serve</h2>
+            <p>Run the localhost web dashboard. <code>hostveil web</code> is an alias.</p>
+            <div class="code-block"><pre><code>hostveil serve [--addr ADDR]</code></pre></div>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--addr ADDR</code></td><td><code>127.0.0.1:8787</code></td><td>Address to bind the dashboard to.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Binding to a non-loopback address prints a warning about exposing the dashboard on the network.</p>
+
+            <h2 id="tui">tui</h2>
+            <p>Open the interactive terminal UI (also the default with no command on a terminal).</p>
+            <div class="code-block"><pre><code>hostveil tui</code></pre></div>
+            <p>No flags. Requires an interactive terminal; otherwise it tells you to use <code>hostveil scan</code>.</p>
+
+            <h2 id="exit-codes">Exit codes</h2>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Code</th><th>Meaning</th></tr></thead>
+                <tbody>
+                  <tr><td><code>0</code></td><td>Success (and, for <code>scan</code>, no unfixed Critical/High findings).</td></tr>
+                  <tr><td><code>1</code></td><td><code>scan</code> found unfixed Critical or High findings, or a command failed.</td></tr>
+                  <tr><td><code>2</code></td><td>Usage error — unknown command or missing required argument.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="ai.html">← AI explanations</a>
+              <a class="button primary" href="faq.html">FAQ →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Contributing — hostveil docs</title>
+    <meta name="description" content="Build hostveil from source, run the checks CI runs, learn the repository layout and architecture rule, add a new check, and use the demo VM.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="Contributing — hostveil docs">
+    <meta property="og:description" content="Build from source, run the checks, the repo layout, adding a check, and the demo VM.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/contributing.html">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/contributing.html">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html">Introduction</a></li>
+              <li><a href="installation.html">Installation</a></li>
+              <li><a href="quickstart.html">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html">What it checks</a></li>
+              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html">Interfaces</a></li>
+              <li><a href="ai.html">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html">CLI reference</a></li>
+              <li><a href="faq.html">FAQ</a></li>
+              <li><a href="contributing.html" class="active">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / Contributing</p>
+            <h1>Contributing</h1>
+            <p class="lead">hostveil is Go, with a small dependency tree and a strict architecture. This is the short version; the canonical developer guide is <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>docs/DEVELOPMENT.md</code></a>.</p>
+
+            <h2>Prerequisites</h2>
+            <ul>
+              <li><strong>Go</strong> — the version pinned in <code>go.mod</code> or newer.</li>
+              <li><strong>git</strong>.</li>
+              <li><em>Optional:</em> Vagrant + a provider (libvirt on Linux, VirtualBox on macOS/Windows) to run the demo VM.</li>
+            </ul>
+
+            <h2>Build &amp; test</h2>
+            <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil.git
+cd hostveil
+go build ./cmd/hostveil     # produces ./hostveil
+go test ./...               # unit + fuzz + property tests</code></pre></div>
+            <p>Before sending a change, run the same checks CI runs:</p>
+            <div class="code-block"><pre><code>go build ./...
+go vet ./...
+gofmt -l .                  # must print nothing
+go mod tidy                 # must leave go.mod/go.sum unchanged
+go test -race ./...</code></pre></div>
+            <div class="callout">
+              <span class="callout-label">Linux tool, portable tests</span>
+              <p>hostveil <strong>builds and its tests pass on any OS</strong>, but running the binary meaningfully needs Linux with the relevant tools present. Use the demo VM rather than running it against your own machine.</p>
+            </div>
+
+            <h2>Repository layout</h2>
+            <div class="code-block"><pre><code>cmd/hostveil/        entry point + subcommand wiring
+internal/
+  core/              the shared engine — the only thing the UIs call
+  check/             detection domains (compose, ssh, firewall, updates, cve)
+  fix/ compose/ history/   fix registry, YAML editing, backup/rollback
+  model/ platform/   pure value types; the OS/command seam
+  ui/{cli,tui,web}/  thin UIs over the engine
+demo/                the reproducible vulnerable-server VM (Vagrant)
+site/                the marketing site + these docs (static)
+docs/                developer documentation</code></pre></div>
+
+            <h2>Architecture rule</h2>
+            <div class="callout warn">
+              <span class="callout-label">Enforced by a test</span>
+              <p>UIs depend only on <code>core</code>. An import-lint test enforces that <code>ui/*</code> never imports <code>fix</code>, <code>history</code>, <code>check</code>, or <code>compose</code>. This is what keeps the TUI, web, and CLI behaving identically — they all go through the one engine.</p>
+            </div>
+
+            <h2>Adding a check</h2>
+            <p>Adding a detection domain means writing one package under <code>internal/check/</code> that implements the <code>Checker</code> interface and registering it. Findings are created with a stable <code>domain.rule</code> ID, a severity, and a remediation kind (see <a href="checks.html">What it checks</a> and <a href="fixing.html">Fixing &amp; rollback</a>).</p>
+
+            <h2>Running it for real: the demo VM</h2>
+            <p><code>demo/</code> is a code-defined, deliberately vulnerable Ubuntu server. hostveil is built from your working tree <em>inside</em> the VM, so it always reflects your current code:</p>
+            <div class="code-block"><pre><code>cd demo
+./run.sh up        # boot + provision + start the vulnerable stacks
+./run.sh scan      # run hostveil against the server
+./run.sh web       # dashboard at http://localhost:8787
+./run.sh shell     # a shell on the server (then: sudo hostveil ...)
+./run.sh halt      # shut it down</code></pre></div>
+            <p>The full walkthrough, per-platform provider setup, demo script, and reset workflow live in <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="faq.html">← FAQ</a>
+              <a class="button primary" href="https://github.com/seolcu/hostveil">GitHub repository →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/docs/faq.html
+++ b/site/docs/faq.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>FAQ — hostveil docs</title>
+    <meta name="description" content="Common questions about hostveil: data privacy, whether fixes can break your server, Review tradeoffs, sudo, and optional Docker/Trivy/AI tooling.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="FAQ — hostveil docs">
+    <meta property="og:description" content="Common questions about hostveil — privacy, safety, tradeoffs, sudo, and optional tooling.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/faq.html">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/faq.html">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html">Introduction</a></li>
+              <li><a href="installation.html">Installation</a></li>
+              <li><a href="quickstart.html">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html">What it checks</a></li>
+              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html">Interfaces</a></li>
+              <li><a href="ai.html">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html">CLI reference</a></li>
+              <li><a href="faq.html" class="active">FAQ</a></li>
+              <li><a href="contributing.html">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / FAQ</p>
+            <h1>Frequently asked questions</h1>
+            <p class="lead">The questions self-hosters ask most before trusting a tool with their server.</p>
+
+            <h2>Does it upload my data?</h2>
+            <p>No. hostveil runs entirely locally — no SaaS, no database, no account. Even the optional AI explanations default to a model on your own machine, and only human-readable fields (never raw secrets or paths) are ever sent to it. See <a href="ai.html">AI explanations</a>.</p>
+
+            <h2>Will a fix break my server?</h2>
+            <p>You see the exact change before it applies, the original file is backed up to a checkpoint first, and <code>hostveil rollback</code> restores it byte-for-byte. Fixes that can't be automated safely are classified <strong>Manual</strong> and only explained, never applied. See <a href="fixing.html">Fixing &amp; rollback</a>.</p>
+
+            <h2>What if a fix has tradeoffs?</h2>
+            <p>Then it's a <strong>Review</strong> fix, not Auto-fix. hostveil presents independent alternatives and makes you choose one with <code>--action</code>. <code>fix --all</code> touches only the clearly-safe Auto-fix findings and leaves everything else to you.</p>
+
+            <h2>Do I need Docker or Trivy?</h2>
+            <p>No. The SSH, firewall, and auto-update checks run natively with no extra tooling. The Docker/Compose audit needs Docker, and image CVE scanning needs Trivy — each is used when present and skipped cleanly when not, with the score renormalized so a skipped domain doesn't inflate your result.</p>
+
+            <h2>Why does it ask for sudo?</h2>
+            <p>Some checks read root-owned files such as <code>sshd_config</code>, and applying a fix writes to protected paths. Run scans and fixes with <code>sudo</code> for full coverage; without it, those domains are skipped with a clear message.</p>
+
+            <h2>Is the web dashboard exposed to my network?</h2>
+            <p>No — <code>hostveil serve</code> binds to <code>127.0.0.1:8787</code> (loopback only) by default. You can change the bind address with <code>--addr</code>, but pointing it at a non-loopback address prints a warning first. See <a href="interfaces.html">Interfaces</a>.</p>
+
+            <h2>What does the 0–100 score mean?</h2>
+            <p>It starts at 100 and subtracts a penalty for each unfixed finding by severity (Critical 8, High 5, Medium 2, Low 1). A host with nothing to flag shows <strong>Clean</strong> rather than a hollow 100, and <code>scan</code> exits non-zero when any unfixed finding is Critical or High. See <a href="checks.html">What it checks</a>.</p>
+
+            <h2>Which platforms are supported?</h2>
+            <p>Prebuilt binaries target <strong>Linux</strong> and <strong>macOS</strong> on <code>amd64</code> and <code>arm64</code>. hostveil is built for self-hosted Linux servers.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="cli.html">← CLI reference</a>
+              <a class="button primary" href="contributing.html">Contributing →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/docs/fixing.html
+++ b/site/docs/fixing.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Fixing &amp; rollback — hostveil docs</title>
+    <meta name="description" content="How hostveil fixes findings: Auto-fix, Review, and Manual classifications; preview-first, checkpoint backups, history, and one-command rollback.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="Fixing &amp; rollback — hostveil docs">
+    <meta property="og:description" content="Auto-fix, Review, and Manual fixes; preview, backup, history, and one-command rollback.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/fixing.html">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/fixing.html">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html">Introduction</a></li>
+              <li><a href="installation.html">Installation</a></li>
+              <li><a href="quickstart.html">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html">What it checks</a></li>
+              <li><a href="fixing.html" class="active">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html">Interfaces</a></li>
+              <li><a href="ai.html">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html">CLI reference</a></li>
+              <li><a href="faq.html">FAQ</a></li>
+              <li><a href="contributing.html">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / Fixing &amp; rollback</p>
+            <h1>Fixing &amp; rollback</h1>
+            <p class="lead">hostveil never mutates blindly. Every fix is classified by how safely it can be automated, always shows the exact change first, backs up the original to a checkpoint, and can be undone with one command.</p>
+
+            <h2>How a finding is classified</h2>
+            <p>Each finding is tagged with a remediation kind that decides how much automation is appropriate:</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Kind</th><th>Meaning</th><th>Fixable?</th></tr></thead>
+                <tbody>
+                  <tr><td><strong>Auto-fix</strong></td><td>One clearly-correct change. You still see it before it applies.</td><td>Yes</td></tr>
+                  <tr><td><strong>Review</strong></td><td>Several valid alternatives; you choose which one to apply.</td><td>Yes</td></tr>
+                  <tr><td><strong>Manual</strong></td><td>No safe automation — hostveil explains what to do instead.</td><td>No</td></tr>
+                  <tr><td><strong>Unavailable</strong></td><td>Known issue with no fix yet (e.g. a CVE with no patch).</td><td>No</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Only <strong>Auto-fix</strong> and <strong>Review</strong> findings can be applied by hostveil. <code>fix --all</code> applies only the Auto-fix ones, leaving anything that needs a decision to you.</p>
+
+            <h2>Applying a fix</h2>
+            <p>Preview and apply a single finding by its ID:</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="sudo hostveil fix ssh.rootlogin">Copy</button>
+              <pre><code>sudo hostveil fix ssh.rootlogin</code></pre>
+            </div>
+            <p>Applying always: <strong>1)</strong> shows the exact diff or command, <strong>2)</strong> backs up the original file to a checkpoint, then <strong>3)</strong> applies the change. You confirm at a <code>[y/N]</code> prompt unless you pass <code>--yes</code>.</p>
+
+            <h3>Choosing a Review alternative</h3>
+            <p>Review findings offer independent alternatives. Pass the 0-based index with <code>--action</code>:</p>
+            <div class="code-block"><pre><code>sudo hostveil fix ssh.passwordauth --action 0</code></pre></div>
+
+            <h3>Disambiguating by service</h3>
+            <p>When the same Compose rule fires for more than one service, narrow it with <code>--service</code>:</p>
+            <div class="code-block"><pre><code>sudo hostveil fix compose.ds018 --service db</code></pre></div>
+
+            <h3>Applying every safe fix</h3>
+            <div class="code-block"><pre><code>sudo hostveil fix --all</code></pre></div>
+            <p>Applies each Auto-fix finding, each with its own checkpoint so any of them can be rolled back individually.</p>
+
+            <h2>History &amp; rollback</h2>
+            <p>Every applied fix is recorded as a checkpoint. List them newest-first:</p>
+            <div class="code-block"><pre><code>hostveil history</code></pre></div>
+            <p>Each entry shows a timestamp, the finding ID, a label, and the exact rollback command. Undo one by its checkpoint ID:</p>
+            <div class="code-block"><pre><code>sudo hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
+            <div class="callout">
+              <span class="callout-label">Reversible everywhere</span>
+              <p>Rollback restores the backed-up file byte-for-byte. Because the TUI, web dashboard, and CLI all go through one shared engine, a fix applied in any of them is listed in <code>history</code> and reversible from any of them. (A few actions are inherently not reversible; <code>history</code> marks those <em>not reversible</em>.)</p>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="checks.html">← What it checks</a>
+              <a class="button primary" href="interfaces.html">Interfaces →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>hostveil docs — guided security hardening for self-hosted Linux</title>
+    <meta name="description" content="Official documentation for hostveil: install it, run a scan, understand the findings, and fix them safely with preview, backup, and one-command rollback.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="hostveil documentation">
+    <meta property="og:description" content="Install, scan, understand, and safely fix the security misconfigurations on your self-hosted Linux server.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./" aria-current="page">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html" class="active">Introduction</a></li>
+              <li><a href="installation.html">Installation</a></li>
+              <li><a href="quickstart.html">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html">What it checks</a></li>
+              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html">Interfaces</a></li>
+              <li><a href="ai.html">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html">CLI reference</a></li>
+              <li><a href="faq.html">FAQ</a></li>
+              <li><a href="contributing.html">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / Docs</p>
+            <h1>hostveil documentation</h1>
+            <p class="lead">hostveil finds the security mistakes on your self-hosted Linux server, explains them in plain language, and fixes them safely — with a preview, a backup, and one-command rollback. One binary, no config file, no cloud account.</p>
+
+            <p>Self-hosting is booming, but most people running Jellyfin, Nextcloud, a game server, or a local LLM are not security experts — and a single misconfiguration can turn into a serious breach. hostveil is a <strong>guided hardening tool</strong> for exactly those people. Point it at a Linux server: it scans the highest-impact areas, merges everything into one 0–100 score, explains each finding without jargon, and walks you through fixing it — showing the exact change, backing up the original first, and letting you undo any fix with one command.</p>
+
+            <div class="callout">
+              <span class="callout-label">The safety model</span>
+              <p>Nothing is changed blindly. Every fix is <strong>previewed</strong> before it runs, the original file is <strong>backed up to a checkpoint</strong>, and <code>hostveil rollback</code> restores it byte-for-byte. Every interface drives the same engine, so a fix applied anywhere is reversible everywhere.</p>
+            </div>
+
+            <h2>New here? Start with these</h2>
+            <ul class="docs-cards">
+              <li>
+                <a href="installation.html">
+                  <strong>Installation →</strong>
+                  <span>One command to install, plus optional tools (Docker, Trivy, Ollama) and what each unlocks.</span>
+                </a>
+              </li>
+              <li>
+                <a href="quickstart.html">
+                  <strong>Quick start →</strong>
+                  <span>Scan, understand a finding, apply a fix, and roll it back — the full loop in a few minutes.</span>
+                </a>
+              </li>
+              <li>
+                <a href="checks.html">
+                  <strong>What it checks →</strong>
+                  <span>Docker/Compose, SSH, firewall, auto-updates, and optional image CVEs — what each looks at.</span>
+                </a>
+              </li>
+              <li>
+                <a href="fixing.html">
+                  <strong>Fixing &amp; rollback →</strong>
+                  <span>Auto, Review, and Manual fixes; how preview, backup, history, and rollback work.</span>
+                </a>
+              </li>
+            </ul>
+
+            <h2>Reference</h2>
+            <ul class="docs-cards">
+              <li>
+                <a href="interfaces.html">
+                  <strong>Interfaces →</strong>
+                  <span>The TUI, the localhost web dashboard, and the scriptable CLI — one shared engine.</span>
+                </a>
+              </li>
+              <li>
+                <a href="cli.html">
+                  <strong>CLI reference →</strong>
+                  <span>Every subcommand and flag: scan, fix, rollback, history, explain, and serve.</span>
+                </a>
+              </li>
+              <li>
+                <a href="ai.html">
+                  <strong>AI explanations →</strong>
+                  <span>Optional, advisory-only, local-first second opinions with <code>explain --ai</code>.</span>
+                </a>
+              </li>
+              <li>
+                <a href="contributing.html">
+                  <strong>Contributing →</strong>
+                  <span>Build from source, run the checks, the repo layout, and how to add a new check.</span>
+                </a>
+              </li>
+            </ul>
+
+            <div class="docs-pager">
+              <a class="button primary" href="installation.html">Install hostveil</a>
+              <a class="button secondary" href="https://github.com/seolcu/hostveil">Source on GitHub</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Installation — hostveil docs</title>
+    <meta name="description" content="Install hostveil with one command, or build from source. Optional tools — Docker, Trivy, and Ollama — and what each one unlocks.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="Installation — hostveil docs">
+    <meta property="og:description" content="Install hostveil with one command, or build from source. Optional Docker, Trivy, and Ollama integrations.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/installation.html">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/installation.html">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html">Introduction</a></li>
+              <li><a href="installation.html" class="active">Installation</a></li>
+              <li><a href="quickstart.html">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html">What it checks</a></li>
+              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html">Interfaces</a></li>
+              <li><a href="ai.html">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html">CLI reference</a></li>
+              <li><a href="faq.html">FAQ</a></li>
+              <li><a href="contributing.html">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / Installation</p>
+            <h1>Installation</h1>
+            <p class="lead">One command installs a single binary. There is no config file to write and no account to create — after installing, you can scan immediately.</p>
+
+            <h2>Quick install</h2>
+            <p>The installer detects your OS and architecture, downloads the release binary, verifies its checksum, and installs it to <code>/usr/bin/hostveil</code>:</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash">Copy</button>
+              <pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash</code></pre>
+            </div>
+            <p>Run the same command any time to update to the latest release. Then verify:</p>
+            <div class="code-block"><pre><code>hostveil version</code></pre></div>
+
+            <div class="callout">
+              <span class="callout-label">Supported platforms</span>
+              <p>Prebuilt binaries are published for <strong>Linux</strong> and <strong>macOS</strong> on <code>amd64</code> and <code>arm64</code>. hostveil is designed for self-hosted Linux servers; the SSH, firewall, and auto-update checks target Linux.</p>
+            </div>
+
+            <h2>What the installer does</h2>
+            <ul>
+              <li>Detects your OS (<code>linux</code>/<code>darwin</code>) and architecture (<code>amd64</code>/<code>arm64</code>).</li>
+              <li>Downloads the release tarball and <code>hostveil-checksums.txt</code>, then verifies the SHA-256 checksum. On a mismatch it aborts.</li>
+              <li>Installs the binary to <code>/usr/bin/hostveil</code> with <code>sudo</code> (mode 0755) and runs <code>hostveil --version</code> as a sanity check.</li>
+              <li>Offers to install <strong>Trivy</strong> for optional image CVE scanning. Declining never blocks the hostveil install.</li>
+            </ul>
+
+            <h3>Installer options</h3>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Option</th><th>Effect</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--version vX.Y.Z</code></td><td>Install a specific release instead of the latest.</td></tr>
+                  <tr><td><code>--no-trivy</code></td><td>Skip the optional Trivy prompt entirely.</td></tr>
+                  <tr><td><code>--yes</code> / <code>-y</code></td><td>Run non-interactively (accept prompts).</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Pass options through the pipe with <code>bash -s --</code>, for example:</p>
+            <div class="code-block"><pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --no-trivy</code></pre></div>
+
+            <h2>Run with sudo for full coverage</h2>
+            <div class="callout warn">
+              <span class="callout-label">Heads up</span>
+              <p>The SSH and firewall checks read root-owned files (such as <code>sshd_config</code>). Run scans with <code>sudo</code> for complete coverage — without it, those domains are skipped with a clear message and the score is renormalized so you are not handed a misleadingly perfect result.</p>
+            </div>
+
+            <h2>Optional tools</h2>
+            <p>Every domain is skipped cleanly if its tooling is absent. Add these when you want the extra coverage:</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Tool</th><th>Unlocks</th><th>Notes</th></tr></thead>
+                <tbody>
+                  <tr><td><strong>Docker</strong></td><td>The Docker / Compose audit</td><td>hostveil reads your Compose files to audit services.</td></tr>
+                  <tr><td><strong>Trivy</strong></td><td>Image CVE scanning</td><td>Used if present; the installer can set it up for you.</td></tr>
+                  <tr><td><strong>Ollama</strong></td><td>AI explanations (<code>explain --ai</code>)</td><td>Local by default — nothing leaves your host. See <a href="ai.html">AI explanations</a>.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2>Build from source</h2>
+            <p>With a recent Go toolchain installed:</p>
+            <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil
+cd hostveil
+go build ./cmd/hostveil
+go test ./...</code></pre></div>
+            <p>See <a href="contributing.html">Contributing</a> for the full development setup, including the reproducible demo VM.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="index.html">← Introduction</a>
+              <a class="button primary" href="quickstart.html">Quick start →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/docs/interfaces.html
+++ b/site/docs/interfaces.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Interfaces — hostveil docs</title>
+    <meta name="description" content="hostveil's three interfaces — the keyboard-driven TUI, the localhost web dashboard, and the scriptable CLI — all drive one shared fix-and-rollback engine.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="Interfaces — hostveil docs">
+    <meta property="og:description" content="The TUI, the localhost web dashboard, and the scriptable CLI — one shared engine.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/interfaces.html">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/interfaces.html">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html">Introduction</a></li>
+              <li><a href="installation.html">Installation</a></li>
+              <li><a href="quickstart.html">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html">What it checks</a></li>
+              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html" class="active">Interfaces</a></li>
+              <li><a href="ai.html">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html">CLI reference</a></li>
+              <li><a href="faq.html">FAQ</a></li>
+              <li><a href="contributing.html">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / Interfaces</p>
+            <h1>Interfaces</h1>
+            <p class="lead">hostveil has three faces — a terminal UI, a localhost web dashboard, and a scriptable CLI — and all three are thin layers over one shared engine. Whatever you scan, fix, or roll back in one is reflected in the others.</p>
+
+            <h2>TUI — the default</h2>
+            <p>Running <code>hostveil</code> with no arguments on an interactive terminal opens the keyboard-driven TUI. You can also launch it explicitly:</p>
+            <div class="code-block"><pre><code>sudo hostveil        # or: sudo hostveil tui</code></pre></div>
+            <p>It shows the score and findings with severity and domain <strong>filters</strong>, <strong>multi-select</strong> for batch fixing, plain-language detail, and a fix preview before anything is applied.</p>
+            <figure>
+              <img src="../assets/tui.png" alt="hostveil terminal UI — findings with severity filters and multi-select" width="1200" height="478" loading="lazy">
+              <figcaption><strong>TUI</strong><span>Keyboard-driven findings with severity and domain filters, multi-select, plain-language detail, and fix preview.</span></figcaption>
+            </figure>
+            <div class="callout">
+              <span class="callout-label">Needs a terminal</span>
+              <p>The TUI requires an interactive terminal. If stdin/stdout are piped or redirected, use <code>hostveil scan</code> instead — it prints a plain report.</p>
+            </div>
+
+            <h2>Web — localhost dashboard</h2>
+            <p>Serve the same scan over HTTP when a browser is better for review:</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="sudo hostveil serve">Copy</button>
+              <pre><code>sudo hostveil serve</code></pre>
+            </div>
+            <p>By default it binds to <code>127.0.0.1:8787</code> — loopback only. Change it with <code>--addr</code>; if you point it at a non-loopback address, hostveil prints a warning about exposing the dashboard. (<code>hostveil web</code> is an alias for <code>serve</code>.)</p>
+            <figure>
+              <img src="../assets/web.png" alt="hostveil web dashboard — filter chips, multi-select, and fix detail" width="1200" height="456" loading="lazy">
+              <figcaption><strong>Web UI</strong><span>Localhost dashboard: score, filterable findings, multi-select batch fixes, preview, and rollback.</span></figcaption>
+            </figure>
+
+            <h2>CLI — scriptable</h2>
+            <p>The <code>scan</code>, <code>fix</code>, <code>rollback</code>, and <code>history</code> subcommands work non-interactively. <code>scan --json</code> emits machine-readable output, and <code>scan</code> exits non-zero when any unfixed finding is Critical or High — so it slots into CI or a cron job:</p>
+            <div class="code-block"><pre><code>hostveil scan --json &gt; report.json
+sudo hostveil fix --all --yes</code></pre></div>
+            <p>See the <a href="cli.html">CLI reference</a> for every command and flag.</p>
+
+            <div class="callout">
+              <span class="callout-label">One engine, three faces</span>
+              <p>Because the interfaces share a single fix-and-rollback engine, behavior is identical across them: a fix applied in the browser shows up in <code>hostveil history</code> and is reversible from the terminal, and vice versa.</p>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="fixing.html">← Fixing &amp; rollback</a>
+              <a class="button primary" href="ai.html">AI explanations →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Quick start — hostveil docs</title>
+    <meta name="description" content="Scan your server, understand a finding, apply a fix with preview and backup, then roll it back — the full hostveil loop in a few minutes.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="Quick start — hostveil docs">
+    <meta property="og:description" content="Scan, understand, apply, and roll back — the full hostveil loop in a few minutes.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/quickstart.html">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/quickstart.html">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="index.html">Introduction</a></li>
+              <li><a href="installation.html">Installation</a></li>
+              <li><a href="quickstart.html" class="active">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks.html">What it checks</a></li>
+              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces.html">Interfaces</a></li>
+              <li><a href="ai.html">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli.html">CLI reference</a></li>
+              <li><a href="faq.html">FAQ</a></li>
+              <li><a href="contributing.html">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / Quick start</p>
+            <h1>Quick start</h1>
+            <p class="lead">Scan, understand, apply, recover. This walks the whole loop on the command line; the TUI and web dashboard drive the exact same engine if you prefer them.</p>
+
+            <h2>1. Scan locally</h2>
+            <p>Run a scan with <code>sudo</code> so the SSH and firewall checks have access to root-owned files:</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="sudo hostveil scan">Copy</button>
+              <pre><code>sudo hostveil scan</code></pre>
+            </div>
+            <p>You get a single 0–100 security score and a list of findings ordered by severity. Areas whose tooling is absent (no Docker, no Trivy) are skipped and the score is renormalized — a clean host shows <strong>Clean</strong>, not a hollow 100.</p>
+            <div class="callout">
+              <span class="callout-label">Tip</span>
+              <p>On an interactive terminal, running <code>hostveil</code> with no arguments opens the <a href="interfaces.html">TUI</a> instead. Piped or redirected, it prints a scan — handy in scripts.</p>
+            </div>
+
+            <h2>2. Understand a finding</h2>
+            <p>Add <code>-v</code> to see each finding's plain-language description and fix guidance inline:</p>
+            <div class="code-block"><pre><code>sudo hostveil scan -v</code></pre></div>
+            <p>Or dig into one finding by its ID (for example <code>ssh.rootlogin</code>):</p>
+            <div class="code-block"><pre><code>hostveil explain ssh.rootlogin</code></pre></div>
+            <p>Want a second opinion in your own words? Add <code>--ai</code> for an advisory explanation from a local model — see <a href="ai.html">AI explanations</a>. Every finding ID and what it means is listed in <a href="checks.html">What it checks</a>.</p>
+
+            <h2>3. Apply a fix</h2>
+            <p>Fixing always shows the exact change first and backs up the original before touching anything. Preview and apply one finding:</p>
+            <div class="code-block"><pre><code>sudo hostveil fix ssh.rootlogin</code></pre></div>
+            <p>Or apply every clearly-safe (Auto) fix at once — Review and Manual findings are left for you to decide:</p>
+            <div class="code-block"><pre><code>sudo hostveil fix --all</code></pre></div>
+            <p>See <a href="fixing.html">Fixing &amp; rollback</a> for how Auto, Review, and Manual differ.</p>
+
+            <h2>4. Roll back anytime</h2>
+            <p>Every applied fix is a checkpoint. List them, then undo one by its ID:</p>
+            <div class="code-block"><pre><code>hostveil history
+sudo hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
+            <p>Rollback restores the backed-up file byte-for-byte. Because every interface goes through one shared engine, a fix applied in the TUI or web dashboard is reversible here too.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="installation.html">← Installation</a>
+              <a class="button primary" href="checks.html">What it checks →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -30,6 +30,7 @@
           <a href="#checks">Checks</a>
           <a href="#screenshots">Screenshots</a>
           <a href="#install">Install</a>
+          <a href="/docs/">Docs</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
         </div>
       </nav>
@@ -175,7 +176,7 @@
             <p>The installer downloads the release binary, verifies checksums, and installs hostveil. Trivy is optional — install it later if you want image CVE scanning.</p>
             <div class="button-row">
               <a class="button primary" href="https://github.com/seolcu/hostveil/releases/latest">Latest release</a>
-              <a class="button secondary" href="https://github.com/seolcu/hostveil#readme">Docs</a>
+              <a class="button secondary" href="/docs/">Docs</a>
             </div>
           </div>
           <div class="code-block">
@@ -237,9 +238,9 @@ hostveil fix --all</code></pre>
           <p>Guided security hardening for self-hosted Linux servers.</p>
         </div>
         <nav aria-label="Footer links">
+          <a href="/docs/">Docs</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
           <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
-          <a href="https://github.com/seolcu/hostveil#readme">Docs</a>
         </nav>
       </div>
     </footer>


### PR DESCRIPTION
## Summary

Adds an **official documentation website** at `hostveil.seolcu.com/docs/` — plain multi-page static HTML that reuses the existing landing page's design system and its "no frontend build" philosophy. It deploys through the current GitHub Pages workflow (`pages.yml` already uploads all of `site/`) with **no CI changes**.

### Pages (`site/docs/`)
Introduction, Installation, Quick start, What it checks, Fixing & rollback, Interfaces, AI explanations, CLI reference, FAQ, Contributing — with a shared header, grouped sidebar, and footer.

### New assets
- **`site/docs.css`** — docs-only layout (sticky sidebar, long-form prose, tables, callouts, severity chips), inheriting the `:root` variables already defined in `styles.css`.
- **`site/docs.js`** — copy-to-clipboard, mobile sidebar toggle, active-link highlighting. Standalone by design: it does **not** reuse `script.js`, whose unconditional `getElementById("lightbox")` would throw on pages without a lightbox.

### Integration
- Added a **Docs** link to the landing page nav and footer.
- Repointed the two existing "Docs" links (which went to the GitHub README) to `/docs/`.
- Added a **Docs** link to the README top line.

## Accuracy
Content was cross-checked against the source rather than guessed — CLI flags/defaults, the four severities and penalties, fix kinds (Auto-fix / Review / Manual / Unavailable), per-domain finding IDs, the serve default `127.0.0.1:8787`, and the Ollama defaults (`llama3.2`, `HOSTVEIL_OLLAMA_HOST/MODEL`) all come from reading `cmd/hostveil/*.go`, `internal/check/`, `internal/model/`, `internal/ai/`, and `scripts/install.sh`.

## Verification
- All docs URLs return **200** locally; `/docs/` resolves to the index.
- Every internal link, screenshot asset, and CSS/JS reference resolves.
- All 11 HTML pages pass a tag-nesting well-formedness check.

Preview locally: `python3 -m http.server -d site 8000` → open `http://localhost:8000/docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)