### PR TITLE
site: use extensionless URLs for docs pages

### DIFF
--- a/site/docs.js
+++ b/site/docs.js
@@ -50,13 +50,22 @@
   }
 
   /* ── active link highlight ────────────────────────────── */
-  /* Mark the sidebar link matching the current page. Works even if
-     the authored `.active` class drifts from the served filename. */
+  /* Mark the sidebar link matching the current page. Robust to both
+     extensionless (/docs/installation) and .html (/docs/installation.html)
+     forms, and to the directory index (/docs/ or /docs/index). */
 
-  var here = location.pathname.replace(/\/index\.html$/, "/").split("/").pop() || "index.html";
+  function pageKey(path) {
+    return path
+      .replace(/\/index(\.html)?$/, "/") // treat /docs/index[.html] as the dir
+      .replace(/\.html$/, "")            // drop a trailing .html
+      .split("/")
+      .pop() || "index";                 // "" (dir root) -> "index"
+  }
+
+  var here = pageKey(location.pathname);
   document.querySelectorAll(".docs-nav-group a").forEach(function (a) {
     var href = a.getAttribute("href") || "";
-    var target = href.replace(/\/index\.html$/, "/").split("/").pop() || "index.html";
+    var target = pageKey(href.replace(/\/$/, "/index")); // "./" or "" -> index
     if (target === here) {
       a.classList.add("active");
       a.setAttribute("aria-current", "page");

--- a/site/docs/ai.html
+++ b/site/docs/ai.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="AI explanations — hostveil docs">
     <meta property="og:description" content="Optional, advisory-only, local-first AI second opinions with explain --ai.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://hostveil.seolcu.com/docs/ai.html">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/ai">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
-    <link rel="canonical" href="https://hostveil.seolcu.com/docs/ai.html">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/ai">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html">Introduction</a></li>
-              <li><a href="installation.html">Installation</a></li>
-              <li><a href="quickstart.html">Quick start</a></li>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html">What it checks</a></li>
-              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html">Interfaces</a></li>
-              <li><a href="ai.html" class="active">AI explanations</a></li>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai" class="active">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html">CLI reference</a></li>
-              <li><a href="faq.html">FAQ</a></li>
-              <li><a href="contributing.html">Contributing</a></li>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -111,8 +111,8 @@ hostveil explain ssh.rootlogin --ai</code></pre></div>
             </div>
 
             <div class="docs-pager">
-              <a class="button secondary" href="interfaces.html">← Interfaces</a>
-              <a class="button primary" href="cli.html">CLI reference →</a>
+              <a class="button secondary" href="interfaces">← Interfaces</a>
+              <a class="button primary" href="cli">CLI reference →</a>
             </div>
           </article>
         </main>

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="What it checks — hostveil docs">
     <meta property="og:description" content="Docker/Compose, SSH, firewall, auto-updates, and optional image CVEs — finding IDs, severities, and the score model.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://hostveil.seolcu.com/docs/checks.html">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/checks">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
-    <link rel="canonical" href="https://hostveil.seolcu.com/docs/checks.html">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/checks">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html">Introduction</a></li>
-              <li><a href="installation.html">Installation</a></li>
-              <li><a href="quickstart.html">Quick start</a></li>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html" class="active">What it checks</a></li>
-              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html">Interfaces</a></li>
-              <li><a href="ai.html">AI explanations</a></li>
+              <li><a href="checks" class="active">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html">CLI reference</a></li>
-              <li><a href="faq.html">FAQ</a></li>
-              <li><a href="contributing.html">Contributing</a></li>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -173,8 +173,8 @@
             </div>
 
             <div class="docs-pager">
-              <a class="button secondary" href="quickstart.html">← Quick start</a>
-              <a class="button primary" href="fixing.html">Fixing &amp; rollback →</a>
+              <a class="button secondary" href="quickstart">← Quick start</a>
+              <a class="button primary" href="fixing">Fixing &amp; rollback →</a>
             </div>
           </article>
         </main>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="CLI reference — hostveil docs">
     <meta property="og:description" content="Every hostveil subcommand and flag: scan, fix, rollback, history, explain, serve, tui.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://hostveil.seolcu.com/docs/cli.html">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/cli">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
-    <link rel="canonical" href="https://hostveil.seolcu.com/docs/cli.html">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/cli">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html">Introduction</a></li>
-              <li><a href="installation.html">Installation</a></li>
-              <li><a href="quickstart.html">Quick start</a></li>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html">What it checks</a></li>
-              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html">Interfaces</a></li>
-              <li><a href="ai.html">AI explanations</a></li>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html" class="active">CLI reference</a></li>
-              <li><a href="faq.html">FAQ</a></li>
-              <li><a href="contributing.html">Contributing</a></li>
+              <li><a href="cli" class="active">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -77,7 +77,7 @@
 
             <h2>Synopsis</h2>
             <div class="code-block"><pre><code>hostveil &lt;command&gt; [flags]</code></pre></div>
-            <p>With no command on an interactive terminal, hostveil opens the <a href="interfaces.html">TUI</a>; when stdin/stdout are not a terminal, it runs <code>scan</code> instead. <code>hostveil version</code> (or <code>--version</code>) prints the version; <code>hostveil help</code> (or <code>--help</code>) prints usage.</p>
+            <p>With no command on an interactive terminal, hostveil opens the <a href="interfaces">TUI</a>; when stdin/stdout are not a terminal, it runs <code>scan</code> instead. <code>hostveil version</code> (or <code>--version</code>) prints the version; <code>hostveil help</code> (or <code>--help</code>) prints usage.</p>
 
             <h2 id="scan">scan</h2>
             <p>Scan the host and report security findings.</p>
@@ -110,7 +110,7 @@ hostveil fix --all [flags]</code></pre></div>
                 </tbody>
               </table>
             </div>
-            <p>Applying always shows the diff/command, backs up the original to a checkpoint, then applies. See <a href="fixing.html">Fixing &amp; rollback</a>.</p>
+            <p>Applying always shows the diff/command, backs up the original to a checkpoint, then applies. See <a href="fixing">Fixing &amp; rollback</a>.</p>
 
             <h2 id="rollback">rollback</h2>
             <p>Undo a previously applied fix.</p>
@@ -134,7 +134,7 @@ hostveil fix --all [flags]</code></pre></div>
                 </tbody>
               </table>
             </div>
-            <p>The built-in plain explanation always prints; <code>--ai</code> adds an advisory section. See <a href="ai.html">AI explanations</a>.</p>
+            <p>The built-in plain explanation always prints; <code>--ai</code> adds an advisory section. See <a href="ai">AI explanations</a>.</p>
 
             <h2 id="serve">serve</h2>
             <p>Run the localhost web dashboard. <code>hostveil web</code> is an alias.</p>
@@ -167,8 +167,8 @@ hostveil fix --all [flags]</code></pre></div>
             </div>
 
             <div class="docs-pager">
-              <a class="button secondary" href="ai.html">← AI explanations</a>
-              <a class="button primary" href="faq.html">FAQ →</a>
+              <a class="button secondary" href="ai">← AI explanations</a>
+              <a class="button primary" href="faq">FAQ →</a>
             </div>
           </article>
         </main>

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="Contributing — hostveil docs">
     <meta property="og:description" content="Build from source, run the checks, the repo layout, adding a check, and the demo VM.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://hostveil.seolcu.com/docs/contributing.html">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/contributing">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
-    <link rel="canonical" href="https://hostveil.seolcu.com/docs/contributing.html">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/contributing">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html">Introduction</a></li>
-              <li><a href="installation.html">Installation</a></li>
-              <li><a href="quickstart.html">Quick start</a></li>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html">What it checks</a></li>
-              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html">Interfaces</a></li>
-              <li><a href="ai.html">AI explanations</a></li>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html">CLI reference</a></li>
-              <li><a href="faq.html">FAQ</a></li>
-              <li><a href="contributing.html" class="active">Contributing</a></li>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="contributing" class="active">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -117,7 +117,7 @@ docs/                developer documentation</code></pre></div>
             </div>
 
             <h2>Adding a check</h2>
-            <p>Adding a detection domain means writing one package under <code>internal/check/</code> that implements the <code>Checker</code> interface and registering it. Findings are created with a stable <code>domain.rule</code> ID, a severity, and a remediation kind (see <a href="checks.html">What it checks</a> and <a href="fixing.html">Fixing &amp; rollback</a>).</p>
+            <p>Adding a detection domain means writing one package under <code>internal/check/</code> that implements the <code>Checker</code> interface and registering it. Findings are created with a stable <code>domain.rule</code> ID, a severity, and a remediation kind (see <a href="checks">What it checks</a> and <a href="fixing">Fixing &amp; rollback</a>).</p>
 
             <h2>Running it for real: the demo VM</h2>
             <p><code>demo/</code> is a code-defined, deliberately vulnerable Ubuntu server. hostveil is built from your working tree <em>inside</em> the VM, so it always reflects your current code:</p>
@@ -130,7 +130,7 @@ docs/                developer documentation</code></pre></div>
             <p>The full walkthrough, per-platform provider setup, demo script, and reset workflow live in <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>.</p>
 
             <div class="docs-pager">
-              <a class="button secondary" href="faq.html">← FAQ</a>
+              <a class="button secondary" href="faq">← FAQ</a>
               <a class="button primary" href="https://github.com/seolcu/hostveil">GitHub repository →</a>
             </div>
           </article>

--- a/site/docs/faq.html
+++ b/site/docs/faq.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="FAQ — hostveil docs">
     <meta property="og:description" content="Common questions about hostveil — privacy, safety, tradeoffs, sudo, and optional tooling.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://hostveil.seolcu.com/docs/faq.html">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/faq">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
-    <link rel="canonical" href="https://hostveil.seolcu.com/docs/faq.html">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/faq">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html">Introduction</a></li>
-              <li><a href="installation.html">Installation</a></li>
-              <li><a href="quickstart.html">Quick start</a></li>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html">What it checks</a></li>
-              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html">Interfaces</a></li>
-              <li><a href="ai.html">AI explanations</a></li>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html">CLI reference</a></li>
-              <li><a href="faq.html" class="active">FAQ</a></li>
-              <li><a href="contributing.html">Contributing</a></li>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq" class="active">FAQ</a></li>
+              <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -76,10 +76,10 @@
             <p class="lead">The questions self-hosters ask most before trusting a tool with their server.</p>
 
             <h2>Does it upload my data?</h2>
-            <p>No. hostveil runs entirely locally — no SaaS, no database, no account. Even the optional AI explanations default to a model on your own machine, and only human-readable fields (never raw secrets or paths) are ever sent to it. See <a href="ai.html">AI explanations</a>.</p>
+            <p>No. hostveil runs entirely locally — no SaaS, no database, no account. Even the optional AI explanations default to a model on your own machine, and only human-readable fields (never raw secrets or paths) are ever sent to it. See <a href="ai">AI explanations</a>.</p>
 
             <h2>Will a fix break my server?</h2>
-            <p>You see the exact change before it applies, the original file is backed up to a checkpoint first, and <code>hostveil rollback</code> restores it byte-for-byte. Fixes that can't be automated safely are classified <strong>Manual</strong> and only explained, never applied. See <a href="fixing.html">Fixing &amp; rollback</a>.</p>
+            <p>You see the exact change before it applies, the original file is backed up to a checkpoint first, and <code>hostveil rollback</code> restores it byte-for-byte. Fixes that can't be automated safely are classified <strong>Manual</strong> and only explained, never applied. See <a href="fixing">Fixing &amp; rollback</a>.</p>
 
             <h2>What if a fix has tradeoffs?</h2>
             <p>Then it's a <strong>Review</strong> fix, not Auto-fix. hostveil presents independent alternatives and makes you choose one with <code>--action</code>. <code>fix --all</code> touches only the clearly-safe Auto-fix findings and leaves everything else to you.</p>
@@ -91,17 +91,17 @@
             <p>Some checks read root-owned files such as <code>sshd_config</code>, and applying a fix writes to protected paths. Run scans and fixes with <code>sudo</code> for full coverage; without it, those domains are skipped with a clear message.</p>
 
             <h2>Is the web dashboard exposed to my network?</h2>
-            <p>No — <code>hostveil serve</code> binds to <code>127.0.0.1:8787</code> (loopback only) by default. You can change the bind address with <code>--addr</code>, but pointing it at a non-loopback address prints a warning first. See <a href="interfaces.html">Interfaces</a>.</p>
+            <p>No — <code>hostveil serve</code> binds to <code>127.0.0.1:8787</code> (loopback only) by default. You can change the bind address with <code>--addr</code>, but pointing it at a non-loopback address prints a warning first. See <a href="interfaces">Interfaces</a>.</p>
 
             <h2>What does the 0–100 score mean?</h2>
-            <p>It starts at 100 and subtracts a penalty for each unfixed finding by severity (Critical 8, High 5, Medium 2, Low 1). A host with nothing to flag shows <strong>Clean</strong> rather than a hollow 100, and <code>scan</code> exits non-zero when any unfixed finding is Critical or High. See <a href="checks.html">What it checks</a>.</p>
+            <p>It starts at 100 and subtracts a penalty for each unfixed finding by severity (Critical 8, High 5, Medium 2, Low 1). A host with nothing to flag shows <strong>Clean</strong> rather than a hollow 100, and <code>scan</code> exits non-zero when any unfixed finding is Critical or High. See <a href="checks">What it checks</a>.</p>
 
             <h2>Which platforms are supported?</h2>
             <p>Prebuilt binaries target <strong>Linux</strong> and <strong>macOS</strong> on <code>amd64</code> and <code>arm64</code>. hostveil is built for self-hosted Linux servers.</p>
 
             <div class="docs-pager">
-              <a class="button secondary" href="cli.html">← CLI reference</a>
-              <a class="button primary" href="contributing.html">Contributing →</a>
+              <a class="button secondary" href="cli">← CLI reference</a>
+              <a class="button primary" href="contributing">Contributing →</a>
             </div>
           </article>
         </main>

--- a/site/docs/fixing.html
+++ b/site/docs/fixing.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="Fixing &amp; rollback — hostveil docs">
     <meta property="og:description" content="Auto-fix, Review, and Manual fixes; preview, backup, history, and one-command rollback.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://hostveil.seolcu.com/docs/fixing.html">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/fixing">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
-    <link rel="canonical" href="https://hostveil.seolcu.com/docs/fixing.html">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/fixing">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html">Introduction</a></li>
-              <li><a href="installation.html">Installation</a></li>
-              <li><a href="quickstart.html">Quick start</a></li>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html">What it checks</a></li>
-              <li><a href="fixing.html" class="active">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html">Interfaces</a></li>
-              <li><a href="ai.html">AI explanations</a></li>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing" class="active">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html">CLI reference</a></li>
-              <li><a href="faq.html">FAQ</a></li>
-              <li><a href="contributing.html">Contributing</a></li>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -121,8 +121,8 @@
             </div>
 
             <div class="docs-pager">
-              <a class="button secondary" href="checks.html">← What it checks</a>
-              <a class="button primary" href="interfaces.html">Interfaces →</a>
+              <a class="button secondary" href="checks">← What it checks</a>
+              <a class="button primary" href="interfaces">Interfaces →</a>
             </div>
           </article>
         </main>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html" class="active">Introduction</a></li>
-              <li><a href="installation.html">Installation</a></li>
-              <li><a href="quickstart.html">Quick start</a></li>
+              <li><a href="./" class="active">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html">What it checks</a></li>
-              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html">Interfaces</a></li>
-              <li><a href="ai.html">AI explanations</a></li>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html">CLI reference</a></li>
-              <li><a href="faq.html">FAQ</a></li>
-              <li><a href="contributing.html">Contributing</a></li>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -85,25 +85,25 @@
             <h2>New here? Start with these</h2>
             <ul class="docs-cards">
               <li>
-                <a href="installation.html">
+                <a href="installation">
                   <strong>Installation →</strong>
                   <span>One command to install, plus optional tools (Docker, Trivy, Ollama) and what each unlocks.</span>
                 </a>
               </li>
               <li>
-                <a href="quickstart.html">
+                <a href="quickstart">
                   <strong>Quick start →</strong>
                   <span>Scan, understand a finding, apply a fix, and roll it back — the full loop in a few minutes.</span>
                 </a>
               </li>
               <li>
-                <a href="checks.html">
+                <a href="checks">
                   <strong>What it checks →</strong>
                   <span>Docker/Compose, SSH, firewall, auto-updates, and optional image CVEs — what each looks at.</span>
                 </a>
               </li>
               <li>
-                <a href="fixing.html">
+                <a href="fixing">
                   <strong>Fixing &amp; rollback →</strong>
                   <span>Auto, Review, and Manual fixes; how preview, backup, history, and rollback work.</span>
                 </a>
@@ -113,25 +113,25 @@
             <h2>Reference</h2>
             <ul class="docs-cards">
               <li>
-                <a href="interfaces.html">
+                <a href="interfaces">
                   <strong>Interfaces →</strong>
                   <span>The TUI, the localhost web dashboard, and the scriptable CLI — one shared engine.</span>
                 </a>
               </li>
               <li>
-                <a href="cli.html">
+                <a href="cli">
                   <strong>CLI reference →</strong>
                   <span>Every subcommand and flag: scan, fix, rollback, history, explain, and serve.</span>
                 </a>
               </li>
               <li>
-                <a href="ai.html">
+                <a href="ai">
                   <strong>AI explanations →</strong>
                   <span>Optional, advisory-only, local-first second opinions with <code>explain --ai</code>.</span>
                 </a>
               </li>
               <li>
-                <a href="contributing.html">
+                <a href="contributing">
                   <strong>Contributing →</strong>
                   <span>Build from source, run the checks, the repo layout, and how to add a new check.</span>
                 </a>
@@ -139,7 +139,7 @@
             </ul>
 
             <div class="docs-pager">
-              <a class="button primary" href="installation.html">Install hostveil</a>
+              <a class="button primary" href="installation">Install hostveil</a>
               <a class="button secondary" href="https://github.com/seolcu/hostveil">Source on GitHub</a>
             </div>
           </article>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="Installation — hostveil docs">
     <meta property="og:description" content="Install hostveil with one command, or build from source. Optional Docker, Trivy, and Ollama integrations.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://hostveil.seolcu.com/docs/installation.html">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/installation">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
-    <link rel="canonical" href="https://hostveil.seolcu.com/docs/installation.html">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/installation">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html">Introduction</a></li>
-              <li><a href="installation.html" class="active">Installation</a></li>
-              <li><a href="quickstart.html">Quick start</a></li>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation" class="active">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html">What it checks</a></li>
-              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html">Interfaces</a></li>
-              <li><a href="ai.html">AI explanations</a></li>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html">CLI reference</a></li>
-              <li><a href="faq.html">FAQ</a></li>
-              <li><a href="contributing.html">Contributing</a></li>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -125,7 +125,7 @@
                 <tbody>
                   <tr><td><strong>Docker</strong></td><td>The Docker / Compose audit</td><td>hostveil reads your Compose files to audit services.</td></tr>
                   <tr><td><strong>Trivy</strong></td><td>Image CVE scanning</td><td>Used if present; the installer can set it up for you.</td></tr>
-                  <tr><td><strong>Ollama</strong></td><td>AI explanations (<code>explain --ai</code>)</td><td>Local by default — nothing leaves your host. See <a href="ai.html">AI explanations</a>.</td></tr>
+                  <tr><td><strong>Ollama</strong></td><td>AI explanations (<code>explain --ai</code>)</td><td>Local by default — nothing leaves your host. See <a href="ai">AI explanations</a>.</td></tr>
                 </tbody>
               </table>
             </div>
@@ -136,11 +136,11 @@
 cd hostveil
 go build ./cmd/hostveil
 go test ./...</code></pre></div>
-            <p>See <a href="contributing.html">Contributing</a> for the full development setup, including the reproducible demo VM.</p>
+            <p>See <a href="contributing">Contributing</a> for the full development setup, including the reproducible demo VM.</p>
 
             <div class="docs-pager">
-              <a class="button secondary" href="index.html">← Introduction</a>
-              <a class="button primary" href="quickstart.html">Quick start →</a>
+              <a class="button secondary" href="./">← Introduction</a>
+              <a class="button primary" href="quickstart">Quick start →</a>
             </div>
           </article>
         </main>

--- a/site/docs/interfaces.html
+++ b/site/docs/interfaces.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="Interfaces — hostveil docs">
     <meta property="og:description" content="The TUI, the localhost web dashboard, and the scriptable CLI — one shared engine.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://hostveil.seolcu.com/docs/interfaces.html">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/interfaces">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
-    <link rel="canonical" href="https://hostveil.seolcu.com/docs/interfaces.html">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/interfaces">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html">Introduction</a></li>
-              <li><a href="installation.html">Installation</a></li>
-              <li><a href="quickstart.html">Quick start</a></li>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html">What it checks</a></li>
-              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html" class="active">Interfaces</a></li>
-              <li><a href="ai.html">AI explanations</a></li>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces" class="active">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html">CLI reference</a></li>
-              <li><a href="faq.html">FAQ</a></li>
-              <li><a href="contributing.html">Contributing</a></li>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -104,7 +104,7 @@
             <p>The <code>scan</code>, <code>fix</code>, <code>rollback</code>, and <code>history</code> subcommands work non-interactively. <code>scan --json</code> emits machine-readable output, and <code>scan</code> exits non-zero when any unfixed finding is Critical or High — so it slots into CI or a cron job:</p>
             <div class="code-block"><pre><code>hostveil scan --json &gt; report.json
 sudo hostveil fix --all --yes</code></pre></div>
-            <p>See the <a href="cli.html">CLI reference</a> for every command and flag.</p>
+            <p>See the <a href="cli">CLI reference</a> for every command and flag.</p>
 
             <div class="callout">
               <span class="callout-label">One engine, three faces</span>
@@ -112,8 +112,8 @@ sudo hostveil fix --all --yes</code></pre></div>
             </div>
 
             <div class="docs-pager">
-              <a class="button secondary" href="fixing.html">← Fixing &amp; rollback</a>
-              <a class="button primary" href="ai.html">AI explanations →</a>
+              <a class="button secondary" href="fixing">← Fixing &amp; rollback</a>
+              <a class="button primary" href="ai">AI explanations →</a>
             </div>
           </article>
         </main>

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="Quick start — hostveil docs">
     <meta property="og:description" content="Scan, understand, apply, and roll back — the full hostveil loop in a few minutes.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://hostveil.seolcu.com/docs/quickstart.html">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/quickstart">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
-    <link rel="canonical" href="https://hostveil.seolcu.com/docs/quickstart.html">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/quickstart">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
@@ -45,26 +45,26 @@
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>
-              <li><a href="index.html">Introduction</a></li>
-              <li><a href="installation.html">Installation</a></li>
-              <li><a href="quickstart.html" class="active">Quick start</a></li>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart" class="active">Quick start</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Guide</p>
             <ul>
-              <li><a href="checks.html">What it checks</a></li>
-              <li><a href="fixing.html">Fixing &amp; rollback</a></li>
-              <li><a href="interfaces.html">Interfaces</a></li>
-              <li><a href="ai.html">AI explanations</a></li>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
             </ul>
           </div>
           <div class="docs-nav-group">
             <p>Reference</p>
             <ul>
-              <li><a href="cli.html">CLI reference</a></li>
-              <li><a href="faq.html">FAQ</a></li>
-              <li><a href="contributing.html">Contributing</a></li>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
         </aside>
@@ -84,7 +84,7 @@
             <p>You get a single 0–100 security score and a list of findings ordered by severity. Areas whose tooling is absent (no Docker, no Trivy) are skipped and the score is renormalized — a clean host shows <strong>Clean</strong>, not a hollow 100.</p>
             <div class="callout">
               <span class="callout-label">Tip</span>
-              <p>On an interactive terminal, running <code>hostveil</code> with no arguments opens the <a href="interfaces.html">TUI</a> instead. Piped or redirected, it prints a scan — handy in scripts.</p>
+              <p>On an interactive terminal, running <code>hostveil</code> with no arguments opens the <a href="interfaces">TUI</a> instead. Piped or redirected, it prints a scan — handy in scripts.</p>
             </div>
 
             <h2>2. Understand a finding</h2>
@@ -92,14 +92,14 @@
             <div class="code-block"><pre><code>sudo hostveil scan -v</code></pre></div>
             <p>Or dig into one finding by its ID (for example <code>ssh.rootlogin</code>):</p>
             <div class="code-block"><pre><code>hostveil explain ssh.rootlogin</code></pre></div>
-            <p>Want a second opinion in your own words? Add <code>--ai</code> for an advisory explanation from a local model — see <a href="ai.html">AI explanations</a>. Every finding ID and what it means is listed in <a href="checks.html">What it checks</a>.</p>
+            <p>Want a second opinion in your own words? Add <code>--ai</code> for an advisory explanation from a local model — see <a href="ai">AI explanations</a>. Every finding ID and what it means is listed in <a href="checks">What it checks</a>.</p>
 
             <h2>3. Apply a fix</h2>
             <p>Fixing always shows the exact change first and backs up the original before touching anything. Preview and apply one finding:</p>
             <div class="code-block"><pre><code>sudo hostveil fix ssh.rootlogin</code></pre></div>
             <p>Or apply every clearly-safe (Auto) fix at once — Review and Manual findings are left for you to decide:</p>
             <div class="code-block"><pre><code>sudo hostveil fix --all</code></pre></div>
-            <p>See <a href="fixing.html">Fixing &amp; rollback</a> for how Auto, Review, and Manual differ.</p>
+            <p>See <a href="fixing">Fixing &amp; rollback</a> for how Auto, Review, and Manual differ.</p>
 
             <h2>4. Roll back anytime</h2>
             <p>Every applied fix is a checkpoint. List them, then undo one by its ID:</p>
@@ -108,8 +108,8 @@ sudo hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
             <p>Rollback restores the backed-up file byte-for-byte. Because every interface goes through one shared engine, a fix applied in the TUI or web dashboard is reversible here too.</p>
 
             <div class="docs-pager">
-              <a class="button secondary" href="installation.html">← Installation</a>
-              <a class="button primary" href="checks.html">What it checks →</a>
+              <a class="button secondary" href="installation">← Installation</a>
+              <a class="button primary" href="checks">What it checks →</a>
             </div>
           </article>
         </main>


### PR DESCRIPTION
## Summary

Switches the docs site to clean, **extensionless URLs** as the canonical form. GitHub Pages already serves `foo.html` at `/foo` (verified live), so this is purely about which form is authoritative.

- Internal sidebar, prose, and pager links drop the `.html` suffix; the Introduction link now points at the directory root (`./`).
- Each page's `<link rel="canonical">` and `og:url` lose the `.html` suffix (the index already canonicalizes to `/docs/`).
- `docs.js` active-link matching is now robust to both extensionless and `.html` forms, and to the directory index.

Both `/docs/installation` and `/docs/installation.html` continue to resolve; the canonical now points at the extensionless form, so there's no duplicate-content ambiguity.

## Verification
- `node --check docs.js` passes.
- Every extensionless link resolves to a real `*.html` file.
- All 10 pages pass the tag-nesting well-formedness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)