### PR TITLE
site: add client-side search to the docs

### DIFF
--- a/site/docs.css
+++ b/site/docs.css
@@ -77,6 +77,85 @@
   font-weight: 700;
 }
 
+/* ── search ───────────────────────────────────────────── */
+
+.docs-search {
+  position: relative;
+  margin: 0 0 24px;
+}
+
+.docs-search-input {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--line-strong);
+  background: var(--panel);
+  color: var(--text);
+  font: 0.86rem/1.2 var(--font-mono);
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.docs-search-input::placeholder {
+  color: var(--muted);
+}
+
+.docs-search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 3px 3px 0 var(--shadow-cut);
+}
+
+.docs-search-results {
+  margin: 6px 0 0;
+  padding: 0;
+  list-style: none;
+  max-height: 60vh;
+  overflow-y: auto;
+  border: 1px solid var(--line-strong);
+  background: var(--panel-strong);
+  box-shadow: 6px 6px 0 var(--shadow-cut);
+}
+
+.docs-search-results li {
+  margin: 0;
+}
+
+.docs-search-results a {
+  display: block;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.docs-search-results li:last-child a {
+  border-bottom: 0;
+}
+
+.docs-search-results a:hover,
+.docs-search-results li.active a {
+  background: var(--panel);
+}
+
+.docs-search-results strong {
+  display: block;
+  color: var(--text);
+  font: 700 0.85rem/1.3 var(--font-mono);
+}
+
+.docs-search-results span {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.docs-search-empty {
+  padding: 10px 12px;
+  color: var(--muted);
+  font: 0.82rem/1.4 var(--font-mono);
+}
+
 /* ── mobile sidebar toggle (hidden on desktop) ────────── */
 
 .docs-sidebar-toggle {

--- a/site/docs.js
+++ b/site/docs.js
@@ -73,4 +73,166 @@
       a.classList.remove("active");
     }
   });
+
+  /* ── search ───────────────────────────────────────────── */
+  /* Index is built at runtime from the pages listed in the sidebar
+     (fetched once, cached in sessionStorage) so it never goes stale. */
+
+  var sInput = document.getElementById("docs-search-input");
+  var sResults = document.getElementById("docs-search-results");
+
+  if (sInput && sResults) {
+    var INDEX = null;
+    var building = null;
+    var active = -1;
+
+    function pages() {
+      var seen = {};
+      var out = [];
+      document.querySelectorAll(".docs-nav-group a").forEach(function (a) {
+        var url = a.getAttribute("href") || "";
+        var key = pageKey(url.replace(/\/$/, "/index"));
+        if (seen[key]) return;
+        seen[key] = true;
+        out.push({ url: url, title: a.textContent.trim(), current: key === here });
+      });
+      return out;
+    }
+
+    function records(doc, page) {
+      var prose = doc.querySelector(".docs-prose");
+      if (!prose) return [];
+      var recs = [];
+      var cur = null;
+      Array.prototype.forEach.call(prose.children, function (node) {
+        var tag = (node.tagName || "").toLowerCase();
+        if (tag === "h1" || tag === "h2" || tag === "h3") {
+          if (cur) recs.push(cur);
+          cur = { title: page.title, url: page.url, heading: node.textContent.trim(), anchor: node.id || "", text: "" };
+        } else {
+          if (!cur) cur = { title: page.title, url: page.url, heading: page.title, anchor: "", text: "" };
+          cur.text += " " + (node.textContent || "");
+        }
+      });
+      if (cur) recs.push(cur);
+      return recs;
+    }
+
+    function build() {
+      if (INDEX) return Promise.resolve(INDEX);
+      if (building) return building;
+      try {
+        var cached = sessionStorage.getItem("hv-docs-index");
+        if (cached) {
+          INDEX = JSON.parse(cached);
+          return Promise.resolve(INDEX);
+        }
+      } catch (e) { /* ignore */ }
+      building = Promise.all(pages().map(function (p) {
+        if (p.current) return Promise.resolve(records(document, p));
+        return fetch(p.url)
+          .then(function (r) { return r.ok ? r.text() : ""; })
+          .then(function (html) {
+            return html ? records(new DOMParser().parseFromString(html, "text/html"), p) : [];
+          })
+          .catch(function () { return []; });
+      })).then(function (all) {
+        INDEX = all.reduce(function (a, b) { return a.concat(b); }, []);
+        try { sessionStorage.setItem("hv-docs-index", JSON.stringify(INDEX)); } catch (e) { /* ignore */ }
+        return INDEX;
+      });
+      return building;
+    }
+
+    function esc(s) {
+      return String(s).replace(/[&<>"]/g, function (c) {
+        return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+      });
+    }
+
+    function query(q) {
+      var terms = q.toLowerCase().split(/\s+/).filter(Boolean);
+      if (!terms.length || !INDEX) return [];
+      var out = [];
+      INDEX.forEach(function (r) {
+        var hay = (r.title + " " + r.heading + " " + r.text).toLowerCase();
+        if (!terms.every(function (t) { return hay.indexOf(t) >= 0; })) return;
+        var score = 0;
+        terms.forEach(function (t) {
+          if (r.title.toLowerCase().indexOf(t) >= 0) score += 3;
+          if (r.heading.toLowerCase().indexOf(t) >= 0) score += 5;
+          if (r.text.toLowerCase().indexOf(t) >= 0) score += 1;
+        });
+        out.push({ r: r, score: score });
+      });
+      return out
+        .sort(function (a, b) { return b.score - a.score; })
+        .slice(0, 8)
+        .map(function (x) { return x.r; });
+    }
+
+    function close() {
+      sResults.hidden = true;
+      sResults.innerHTML = "";
+      sInput.setAttribute("aria-expanded", "false");
+      sInput.removeAttribute("aria-activedescendant");
+      active = -1;
+    }
+
+    function render(items) {
+      active = -1;
+      if (!sInput.value.trim()) { close(); return; }
+      if (!items.length) {
+        sResults.innerHTML = '<li class="docs-search-empty">No matches</li>';
+      } else {
+        sResults.innerHTML = items.map(function (r, i) {
+          var href = r.url + (r.anchor ? "#" + r.anchor : "");
+          var sub = r.heading && r.heading !== r.title ? r.title : "In this section";
+          return '<li role="option" id="ds-opt-' + i + '">' +
+            '<a href="' + esc(href) + '"><strong>' + esc(r.heading) + "</strong>" +
+            "<span>" + esc(sub) + "</span></a></li>";
+        }).join("");
+      }
+      sResults.hidden = false;
+      sInput.setAttribute("aria-expanded", "true");
+    }
+
+    function move(delta) {
+      var opts = sResults.querySelectorAll('li[role="option"]');
+      if (!opts.length) return;
+      Array.prototype.forEach.call(opts, function (o) { o.classList.remove("active"); });
+      active = (active + delta + opts.length) % opts.length;
+      var el = opts[active];
+      el.classList.add("active");
+      sInput.setAttribute("aria-activedescendant", el.id);
+      el.scrollIntoView({ block: "nearest" });
+    }
+
+    sInput.addEventListener("focus", build);
+
+    sInput.addEventListener("input", function () {
+      var q = sInput.value;
+      if (!q.trim()) { close(); return; }
+      build().then(function () {
+        if (sInput.value === q) render(query(q));
+      });
+    });
+
+    sInput.addEventListener("keydown", function (e) {
+      if (e.key === "ArrowDown") { e.preventDefault(); move(1); }
+      else if (e.key === "ArrowUp") { e.preventDefault(); move(-1); }
+      else if (e.key === "Enter") {
+        var links = sResults.querySelectorAll('li[role="option"] a');
+        var pick = active >= 0 ? links[active] : links[0];
+        if (pick) { e.preventDefault(); window.location.href = pick.getAttribute("href"); }
+      } else if (e.key === "Escape") {
+        if (!sResults.hidden) { e.preventDefault(); close(); }
+        else { sInput.value = ""; }
+      }
+    });
+
+    document.addEventListener("click", function (e) {
+      if (!e.target.closest(".docs-search")) close();
+    });
+  }
 })();

--- a/site/docs/ai.html
+++ b/site/docs/ai.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>

--- a/site/docs/faq.html
+++ b/site/docs/faq.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>

--- a/site/docs/fixing.html
+++ b/site/docs/fixing.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>

--- a/site/docs/interfaces.html
+++ b/site/docs/interfaces.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -42,6 +42,13 @@
 
       <div class="docs-layout">
         <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
           <div class="docs-nav-group">
             <p>Getting started</p>
             <ul>


### PR DESCRIPTION
## Summary

Adds a **search box** at the top of the docs sidebar with a live results list — no build step, consistent with the rest of the static docs site.

- The search index is **built at runtime in the browser** from the pages listed in the sidebar: fetched once, parsed with `DOMParser`, and cached in `sessionStorage`. It can never drift out of sync with the content because there's nothing to regenerate.
- Each page is indexed **per heading section**, scoring title/heading/body matches and requiring all query terms to be present. Results link to the page, plus the heading anchor when one exists.
- Full **keyboard support** (↑/↓, Enter, Esc) and an ARIA combobox/listbox pairing.

It relies on GitHub Pages' extensionless serving (already the canonical URL form for these docs) for the sibling-page fetches — verified live that `/docs/<page>` returns 200 with indexable content.

## Verification
- `node --check docs.js` passes.
- All 10 pages carry the search markup and pass the tag-nesting well-formedness check.
- Live check: extensionless doc URLs return 200 with `.docs-prose`, so the runtime index builds in the browser.

Note: local `python -m http.server` 404s on extensionless paths (it lacks the `.html` fallback), so test search on the deployed Pages site rather than that dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)