### PR TITLE
Auto-elevate with sudo when a root-benefiting command runs without root

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,13 @@ hostveil explain <id>    # explain a finding (add --ai for a local-LLM second op
 hostveil serve           # web dashboard on 127.0.0.1:8787
 ```
 
-Some checks (SSH, firewall) read root-owned files. Run with `sudo` for full
-coverage; without it, those domains are skipped with a clear message.
+Some checks (SSH, firewall) read root-owned files, and applying fixes needs
+root too. So `hostveil` **elevates itself with `sudo` automatically** — you'll
+see the same sudo password prompt as `sudo hostveil`, and after authenticating
+it continues in the same terminal. `version` and `help` never prompt.
+
+To run unprivileged (scripts/CI), set `HOSTVEIL_NO_SUDO=1`; the root-owned
+domains are then skipped with a clear message.
 
 ## How fixing works
 

--- a/cmd/hostveil/elevate.go
+++ b/cmd/hostveil/elevate.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// needsRoot reports whether a subcommand should auto-elevate. version/help
+// and unknown commands do not.
+func needsRoot(cmd string) bool {
+	switch cmd {
+	case "scan", "tui", "fix", "serve", "web", "explain", "rollback", "history":
+		return true
+	}
+	return false
+}
+
+// maybeElevate re-executes hostveil under sudo when a root-benefiting command
+// is run without root, so plain `hostveil` behaves like `sudo hostveil` — the
+// sudo password prompt is sudo's own and appears identically. On success it
+// replaces the current process (execve) and does not return. It degrades to
+// running unprivileged when it cannot elevate (no sudo, opt-out env, or sudo
+// failure) so existing non-root partial scans still work.
+func maybeElevate(cmd string) {
+	if os.Geteuid() == 0 {
+		return // already root (includes the re-executed sudo child)
+	}
+	if os.Getenv("HOSTVEIL_NO_SUDO") != "" {
+		return // explicit opt-out for scripts/CI
+	}
+	if os.Getenv("HOSTVEIL_ELEVATED") != "" {
+		return // re-exec loop guard (e.g. sudo target is not root)
+	}
+	if !needsRoot(cmd) {
+		return
+	}
+	sudo, err := exec.LookPath("sudo")
+	if err != nil {
+		return // no sudo available — run unprivileged, checks degrade gracefully
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	argv := append([]string{"sudo", exe}, os.Args[1:]...)
+	env := append(os.Environ(), "HOSTVEIL_ELEVATED=1")
+	_ = syscall.Exec(sudo, argv, env)
+	// If Exec returns, it failed; fall through and run unprivileged.
+}

--- a/cmd/hostveil/elevate_test.go
+++ b/cmd/hostveil/elevate_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestNeedsRoot(t *testing.T) {
+	cases := map[string]bool{
+		"scan":     true,
+		"tui":      true,
+		"fix":      true,
+		"serve":    true,
+		"web":      true,
+		"explain":  true,
+		"rollback": true,
+		"history":  true,
+		"version":  false,
+		"help":     false,
+		"":         false,
+		"bogus":    false,
+	}
+	for cmd, want := range cases {
+		if got := needsRoot(cmd); got != want {
+			t.Errorf("needsRoot(%q) = %v, want %v", cmd, got, want)
+		}
+	}
+}

--- a/cmd/hostveil/main.go
+++ b/cmd/hostveil/main.go
@@ -29,6 +29,8 @@ func run(args []string) int {
 		cmd = "tui"
 	}
 
+	maybeElevate(cmd) // on success the process is replaced by sudo and does not return
+
 	switch cmd {
 	case "scan":
 		return cmdScan(args)

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -113,7 +113,7 @@
             <p><code>hostveil scan</code> exits non-zero when any unfixed finding is <span class="sev critical">Critical</span> or <span class="sev high">High</span> — useful as a CI or cron gate.</p>
 
             <h2 id="ssh">SSH <code>ssh.</code></h2>
-            <p>Parsed natively from <code>sshd_config</code>. Run with <code>sudo</code> to read it.</p>
+            <p>Parsed natively from <code>sshd_config</code>. Reading it needs root, which <code>hostveil</code> obtains by auto-elevating with <code>sudo</code>.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -80,7 +80,7 @@
           <article class="docs-prose">
             <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / CLI reference</p>
             <h1>CLI reference</h1>
-            <p class="lead">Every subcommand, flag, and default. Commands that read root-owned files (SSH, firewall) or write to protected paths need <code>sudo</code>.</p>
+            <p class="lead">Every subcommand, flag, and default. Commands that read root-owned files (SSH, firewall) or write to protected paths need root, so <code>hostveil</code> re-runs itself under <code>sudo</code> automatically (except <code>version</code>/<code>help</code>); set <code>HOSTVEIL_NO_SUDO=1</code> to opt out.</p>
 
             <h2>Synopsis</h2>
             <div class="code-block"><pre><code>hostveil &lt;command&gt; [flags]</code></pre></div>

--- a/site/docs/faq.html
+++ b/site/docs/faq.html
@@ -95,7 +95,7 @@
             <p>No. The SSH, firewall, and auto-update checks run natively with no extra tooling. The Docker/Compose audit needs Docker, and image CVE scanning needs Trivy — each is used when present and skipped cleanly when not, with the score renormalized so a skipped domain doesn't inflate your result.</p>
 
             <h2>Why does it ask for sudo?</h2>
-            <p>Some checks read root-owned files such as <code>sshd_config</code>, and applying a fix writes to protected paths. Run scans and fixes with <code>sudo</code> for full coverage; without it, those domains are skipped with a clear message.</p>
+            <p>Some checks read root-owned files such as <code>sshd_config</code>, and applying a fix writes to protected paths. So <code>hostveil</code> elevates itself with <code>sudo</code> automatically — the prompt you see is sudo's own, identical to running <code>sudo hostveil</code>, and it continues in the same terminal once you authenticate. <code>version</code> and <code>help</code> never prompt. To run unprivileged (scripts/CI), set <code>HOSTVEIL_NO_SUDO=1</code>; the root-owned domains are then skipped with a clear message.</p>
 
             <h2>Is the web dashboard exposed to my network?</h2>
             <p>No — <code>hostveil serve</code> binds to <code>127.0.0.1:8787</code> (loopback only) by default. You can change the bind address with <code>--addr</code>, but pointing it at a non-loopback address prints a warning first. See <a href="interfaces">Interfaces</a>.</p>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -118,10 +118,10 @@
             <p>Pass options through the pipe with <code>bash -s --</code>, for example:</p>
             <div class="code-block"><pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --no-trivy</code></pre></div>
 
-            <h2>Run with sudo for full coverage</h2>
-            <div class="callout warn">
+            <h2>Elevation is automatic</h2>
+            <div class="callout">
               <span class="callout-label">Heads up</span>
-              <p>The SSH and firewall checks read root-owned files (such as <code>sshd_config</code>). Run scans with <code>sudo</code> for complete coverage — without it, those domains are skipped with a clear message and the score is renormalized so you are not handed a misleadingly perfect result.</p>
+              <p>The SSH and firewall checks read root-owned files (such as <code>sshd_config</code>), and applying fixes writes to protected paths. So <code>hostveil</code> re-runs itself under <code>sudo</code> automatically — you'll see the same sudo password prompt as <code>sudo hostveil</code>, and after authenticating it continues in the same terminal. <code>version</code> and <code>help</code> never prompt. To run unprivileged (scripts/CI), set <code>HOSTVEIL_NO_SUDO=1</code>; the root-owned domains are then skipped with a clear message and the score is renormalized so you are not handed a misleadingly perfect result.</p>
             </div>
 
             <h2>Optional tools</h2>

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -83,10 +83,10 @@
             <p class="lead">Scan, understand, apply, recover. This walks the whole loop on the command line; the TUI and web dashboard drive the exact same engine if you prefer them.</p>
 
             <h2>1. Scan locally</h2>
-            <p>Run a scan with <code>sudo</code> so the SSH and firewall checks have access to root-owned files:</p>
+            <p>Just run a scan — <code>hostveil</code> elevates itself with <code>sudo</code> automatically so the SSH and firewall checks can read root-owned files. You'll see the same sudo password prompt as <code>sudo hostveil</code>:</p>
             <div class="command-box">
-              <button class="copy-btn" type="button" data-copy="sudo hostveil scan">Copy</button>
-              <pre><code>sudo hostveil scan</code></pre>
+              <button class="copy-btn" type="button" data-copy="hostveil scan">Copy</button>
+              <pre><code>hostveil scan</code></pre>
             </div>
             <p>You get a single 0–100 security score and a list of findings ordered by severity. Areas whose tooling is absent (no Docker, no Trivy) are skipped and the score is renormalized — a clean host shows <strong>Clean</strong>, not a hollow 100.</p>
             <div class="callout">
@@ -96,22 +96,22 @@
 
             <h2>2. Understand a finding</h2>
             <p>Add <code>-v</code> to see each finding's plain-language description and fix guidance inline:</p>
-            <div class="code-block"><pre><code>sudo hostveil scan -v</code></pre></div>
+            <div class="code-block"><pre><code>hostveil scan -v</code></pre></div>
             <p>Or dig into one finding by its ID (for example <code>ssh.rootlogin</code>):</p>
             <div class="code-block"><pre><code>hostveil explain ssh.rootlogin</code></pre></div>
             <p>Want a second opinion in your own words? Add <code>--ai</code> for an advisory explanation from a local model — see <a href="ai">AI explanations</a>. Every finding ID and what it means is listed in <a href="checks">What it checks</a>.</p>
 
             <h2>3. Apply a fix</h2>
             <p>Fixing always shows the exact change first and backs up the original before touching anything. Preview and apply one finding:</p>
-            <div class="code-block"><pre><code>sudo hostveil fix ssh.rootlogin</code></pre></div>
+            <div class="code-block"><pre><code>hostveil fix ssh.rootlogin</code></pre></div>
             <p>Or apply every clearly-safe (Auto) fix at once — Review and Manual findings are left for you to decide:</p>
-            <div class="code-block"><pre><code>sudo hostveil fix --all</code></pre></div>
+            <div class="code-block"><pre><code>hostveil fix --all</code></pre></div>
             <p>See <a href="fixing">Fixing &amp; rollback</a> for how Auto, Review, and Manual differ.</p>
 
             <h2>4. Roll back anytime</h2>
             <p>Every applied fix is a checkpoint. List them, then undo one by its ID:</p>
             <div class="code-block"><pre><code>hostveil history
-sudo hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
+hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
             <p>Rollback restores the backed-up file byte-for-byte. Because every interface goes through one shared engine, a fix applied in the TUI or web dashboard is reversible here too.</p>
 
             <div class="docs-pager">


### PR DESCRIPTION
## What & why

Running plain `hostveil` (no `sudo`) now behaves like `sudo hostveil`: for commands that need or benefit from root, it re-executes itself under `sudo` and you see the **same sudo password prompt**, then execution continues in the same terminal — TUI included.

Previously users had to remember to prefix `sudo`, or root-owned domains (SSH, firewall) were silently skipped and fixes couldn't be applied.

## How

New `cmd/hostveil/elevate.go` with `maybeElevate(cmd)`, called in `run()` right before command dispatch. It uses `syscall.Exec` (execve) to **replace** the current process with `sudo <self> <original args>`, so tty, signals, and the password prompt are handled exactly as `sudo hostveil` would.

- **Scope**: elevates `scan`, `tui`, `fix`, `serve`/`web`, `explain`, `rollback`, `history`. `version`/`help` never prompt.
- **Opt-out**: `HOSTVEIL_NO_SUDO=1` skips elevation (scripts/CI non-root partial scans still work).
- **Graceful**: no-op when already root, when `sudo` is absent, or if `exec` fails (falls through to unprivileged, matching the existing degrade-gracefully behavior).
- **Loop guard**: `HOSTVEIL_ELEVATED` prevents re-exec loops if sudo's target isn't root.

Side effect (intended): `rollback`/`history` now read `/var/lib/hostveil`, where root-applied `fix` checkpoints actually live — so this is the correct behavior.

## Docs

README and site docs (installation, quickstart, faq, cli, checks) updated to describe auto-elevation and the `HOSTVEIL_NO_SUDO` opt-out; quickstart commands drop the now-unnecessary `sudo` prefix.

## Verification

- `go build ./...`, `go vet ./cmd/...`, `go test ./cmd/hostveil`, `gofmt` — all clean.
- `hostveil version` / `help` → no prompt.
- `HOSTVEIL_NO_SUDO=1 hostveil scan` → no prompt, SSH skipped with a clear message.
- Fake-`sudo` shim confirms non-root `hostveil scan --json` invokes `sudo <exe> scan --json` (flags preserved); `HOSTVEIL_ELEVATED=1` does not re-invoke sudo.
- Added `needsRoot` unit test covering the whitelist and the version/help/unknown exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)