### PR TITLE
Fix version injection so releases report their real tag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ builds:
     binary: hostveil
     ldflags:
       - -s -w
-      - -X github.com/seolcu/hostveil/internal/tui.Version=v{{.Version}}
+      - -X main.version=v{{.Version}}
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
## Problem

Released binaries print `v3-dev` from `hostveil version`, not the release tag.

The goreleaser ldflag pointed at a symbol that doesn't exist:

```yaml
-X github.com/seolcu/hostveil/internal/tui.Version=v{{.Version}}
```

The TUI package is `internal/ui/tui` (not `internal/tui`) and has **no** `Version` variable. The linker silently ignores `-X` for missing symbols, so the injection has always been a no-op — every release shipped the hardcoded `main.version = "v3-dev"`.

## Fix

Point the ldflag at the variable `hostveil version` actually prints:

```yaml
-X main.version=v{{.Version}}
```

`main.version` is goreleaser's standard convention for a `main` package.

## Verification

Reproducing goreleaser's exact release ldflag for tag `v3.0.0` (`{{.Version}}` = `3.0.0`):

```
$ go build -ldflags "-s -w -X main.version=v3.0.0" -o hv ./cmd/hostveil
$ hv version
hostveil v3.0.0        # was: hostveil v3-dev
```

A plain `go build` (no ldflags) still reports `v3-dev`, so local/dev builds are unchanged.

## Note

This corrects **future** releases. The already-published `v3.0.0` binaries were built with the broken ldflag and still print `v3-dev`; re-cutting `v3.0.0` after merge would rebuild them correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)