### PR TITLE
Serve installer at hostveil.seolcu.com/install.sh

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - "site/**"
+      - "scripts/install.sh"
+      - "scripts/install.sh.sha256"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -28,6 +30,11 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v6
+
+      - name: Copy installer into site
+        run: |
+          cp scripts/install.sh site/install.sh
+          cp scripts/install.sh.sha256 site/install.sh.sha256
 
       - name: Upload static site
         uses: actions/upload-pages-artifact@v5

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ renormalized so you are never handed a misleadingly perfect result.
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
+curl -fsSL https://hostveil.seolcu.com/install.sh | bash
 ```
 
 Trivy is optional — install it any time to enable image CVE scanning.

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -85,8 +85,8 @@
             <h2>Quick install</h2>
             <p>The installer detects your OS and architecture, downloads the release binary, verifies its checksum, and installs it to <code>/usr/bin/hostveil</code>:</p>
             <div class="command-box">
-              <button class="copy-btn" type="button" data-copy="curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash">Copy</button>
-              <pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash</code></pre>
+              <button class="copy-btn" type="button" data-copy="curl -fsSL https://hostveil.seolcu.com/install.sh | bash">Copy</button>
+              <pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash</code></pre>
             </div>
             <p>Run the same command any time to update to the latest release. Then verify:</p>
             <div class="code-block"><pre><code>hostveil version</code></pre></div>
@@ -116,7 +116,7 @@
               </table>
             </div>
             <p>Pass options through the pipe with <code>bash -s --</code>, for example:</p>
-            <div class="code-block"><pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --no-trivy</code></pre></div>
+            <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --no-trivy</code></pre></div>
 
             <h2>Elevation is automatic</h2>
             <div class="callout">

--- a/site/index.html
+++ b/site/index.html
@@ -63,8 +63,8 @@
           </div>
         </div>
         <div class="command-box container" aria-label="Install command">
-          <button class="copy-btn" type="button" data-copy="curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash &amp;&amp; hostveil">Copy</button>
-          <pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash &amp;&amp; hostveil</code></pre>
+          <button class="copy-btn" type="button" data-copy="curl -fsSL https://hostveil.seolcu.com/install.sh | bash &amp;&amp; hostveil">Copy</button>
+          <pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash &amp;&amp; hostveil</code></pre>
         </div>
       </section>
 
@@ -181,7 +181,7 @@
           </div>
           <div class="code-block">
             <pre><code># Install or update hostveil
-curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
+curl -fsSL https://hostveil.seolcu.com/install.sh | bash
 
 # Terminal UI (default)
 hostveil


### PR DESCRIPTION
## What

Shortens the installer command from the long raw GitHub URL to the site domain:

```
curl -fsSL https://hostveil.seolcu.com/install.sh | bash
```

## How

- `pages.yml` copies `scripts/install.sh` and `scripts/install.sh.sha256` into the `site/` artifact before upload, so GitHub Pages serves them at the domain root. Single source of truth — no duplicated script committed to the repo.
- Added `scripts/install.sh` / `scripts/install.sh.sha256` to the Pages trigger paths so an installer-only change still redeploys the served copy.
- Updated all 7 link references (`README.md`, `site/index.html`, `site/docs/installation.html`, including the `--no-trivy` variant) to the short URL.

## Notes

- GitHub Pages caches served files ~10 min, so an updated installer propagates slightly slower than the raw-on-`main` URL. Fine for an installer.
- Checksum stays reachable at `https://hostveil.seolcu.com/install.sh.sha256`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)