### PR TITLE
Add Korean (ko) localization for the website

### DIFF
--- a/site/docs.js
+++ b/site/docs.js
@@ -3,6 +3,14 @@
 (function () {
   "use strict";
 
+  var KO = document.documentElement.lang === "ko";
+  var T = {
+    copy: KO ? "복사" : "Copy",
+    copied: KO ? "복사됨" : "Copied",
+    noMatches: KO ? "검색 결과 없음" : "No matches",
+    inSection: KO ? "이 섹션" : "In this section",
+  };
+
   /* ── copy-to-clipboard ────────────────────────────────── */
 
   document.addEventListener("click", function (e) {
@@ -11,10 +19,10 @@
     var text = btn.getAttribute("data-copy");
     if (!text || !navigator.clipboard) return;
     navigator.clipboard.writeText(text).then(function () {
-      btn.textContent = "Copied";
+      btn.textContent = T.copied;
       btn.classList.add("copied");
       setTimeout(function () {
-        btn.textContent = "Copy";
+        btn.textContent = T.copy;
         btn.classList.remove("copied");
       }, 1500);
     });
@@ -183,11 +191,11 @@
       active = -1;
       if (!sInput.value.trim()) { close(); return; }
       if (!items.length) {
-        sResults.innerHTML = '<li class="docs-search-empty">No matches</li>';
+        sResults.innerHTML = '<li class="docs-search-empty">' + T.noMatches + "</li>";
       } else {
         sResults.innerHTML = items.map(function (r, i) {
           var href = r.url + (r.anchor ? "#" + r.anchor : "");
-          var sub = r.heading && r.heading !== r.title ? r.title : "In this section";
+          var sub = r.heading && r.heading !== r.title ? r.title : T.inSection;
           return '<li role="option" id="ds-opt-' + i + '">' +
             '<a href="' + esc(href) + '"><strong>' + esc(r.heading) + "</strong>" +
             "<span>" + esc(sub) + "</span></a></li>";

--- a/site/docs/ai.html
+++ b/site/docs/ai.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/ai">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/ai">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/ai">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/ai">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/ai">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/ai" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/checks">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/checks">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/checks">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/checks">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/checks">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/checks" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/cli">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/cli">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/cli">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/cli">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/cli">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/cli" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/contributing">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/contributing">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/contributing">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/contributing">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/contributing">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/contributing" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/faq.html
+++ b/site/docs/faq.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/faq">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/faq">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/faq">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/faq">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/faq">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/faq" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/fixing.html
+++ b/site/docs/fixing.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/fixing">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/fixing">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/fixing">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/fixing">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/fixing">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/fixing" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/installation">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/installation">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/installation">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/installation">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/installation">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/installation" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/interfaces.html
+++ b/site/docs/interfaces.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/interfaces">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/interfaces">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/interfaces">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/interfaces">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/interfaces">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/interfaces" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -12,10 +12,14 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/docs/quickstart">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/docs/quickstart">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/quickstart">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/quickstart">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/quickstart">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -31,6 +35,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/quickstart" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/index.html
+++ b/site/index.html
@@ -12,9 +12,13 @@
     <meta property="og:url" content="https://hostveil.seolcu.com/">
     <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
     <link rel="canonical" href="https://hostveil.seolcu.com/">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="styles.css">
     <script src="script.js" defer></script>
+    <script src="lang-suggest.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -32,6 +36,7 @@
           <a href="#install">Install</a>
           <a href="/docs/">Docs</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/" lang="ko" hreflang="ko">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/ai.html
+++ b/site/ko/docs/ai.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>AI 설명 — hostveil 문서</title>
+    <meta name="description" content="hostveil의 선택적·조언 전용 AI: 기본값은 로컬 Ollama이며, 절대 변경을 적용하지 않고, 사람이 읽을 수 있는 필드만 전송합니다 — 원본 비밀 값이나 경로는 절대 보내지 않습니다.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="AI 설명 — hostveil 문서">
+    <meta property="og:description" content="explain --ai로 얻는 선택적·조언 전용·로컬 우선 AI second opinion.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/ai">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/ai">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/ai">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/ai">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/ai">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/ai" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai" class="active">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / AI 설명</p>
+            <h1>AI 설명</h1>
+            <p class="lead">hostveil의 AI는 선택 사항이며, 조언 전용이고, 로컬 우선입니다. 쉬운 말로 second opinion을 더해 줄 수 있지만, 절대 변경을 적용하지 않으며, AI 없이도 모든 기능이 그대로 동작합니다.</p>
+
+            <h2>사용 방법</h2>
+            <p>발견 항목에 대한 조언성 설명을 얻으려면 <code>explain</code>에 <code>--ai</code>를 추가하세요:</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="hostveil explain ssh.rootlogin --ai">Copy</button>
+              <pre><code>hostveil explain ssh.rootlogin --ai</code></pre>
+            </div>
+            <p>내장된 쉬운 말 설명은 항상 먼저 출력되며, <code>--ai</code>는 <em>AI 설명(조언)</em> 섹션을 뒤에 덧붙입니다. 모델에 연결할 수 없으면 hostveil은 그 사실을 알리고 계속 진행합니다 — AI를 사용할 수 없다고 해서 명령이 실패하는 일은 없습니다.</p>
+
+            <h2>기본은 로컬</h2>
+            <p>기본 제공자는 <strong>Ollama</strong>이며, 사용자 본인의 머신에서 실행됩니다 — 아무것도 호스트 밖으로 나가지 않습니다. 기본값:</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>설정</th><th>기본값</th><th>재정의</th></tr></thead>
+                <tbody>
+                  <tr><td>호스트</td><td><code>http://127.0.0.1:11434</code></td><td><code>HOSTVEIL_OLLAMA_HOST</code></td></tr>
+                  <tr><td>모델</td><td><code>llama3.2</code></td><td><code>HOSTVEIL_OLLAMA_MODEL</code></td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><a href="https://ollama.com">Ollama</a>를 설치하고 모델을 한 번 내려받으세요:</p>
+            <div class="code-block"><pre><code>ollama pull llama3.2
+hostveil explain ssh.rootlogin --ai</code></pre></div>
+            <p>다른 로컬 모델을 사용하려면:</p>
+            <div class="code-block"><pre><code>HOSTVEIL_OLLAMA_MODEL=llama3.1 hostveil explain ssh.rootlogin --ai</code></pre></div>
+
+            <h2>조언 전용이며, 설계상 비공개</h2>
+            <div class="callout">
+              <span class="callout-label">모델이 할 수 있는 것과 할 수 없는 것</span>
+              <p>AI는 오직 <strong>설명</strong>만 할 수 있습니다 — 어떤 수정도 적용·변경·주도할 능력이 없습니다. 점수, 발견 항목, 수정은 전적으로 AI 없이 계산됩니다.</p>
+            </div>
+            <div class="callout warn">
+              <span class="callout-label">개인정보 보호</span>
+              <p>모델에는 사람이 읽을 수 있는 필드만 전송됩니다 — 발견 항목의 제목, 서비스, 설명, 수정 방법 텍스트뿐입니다. 비밀 값, 포트, 파일 경로 같은 원본 증거 값은 <strong>절대</strong> 프롬프트에 포함되지 않으므로, 선택적으로 참여하더라도 민감한 세부 정보가 호스트 밖으로 나가지 않습니다.</p>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="interfaces">← 인터페이스</a>
+              <a class="button primary" href="cli">CLI 레퍼런스 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>점검 항목 — hostveil 문서</title>
+    <meta name="description" content="hostveil의 점검 범위: Docker/Compose, SSH, 방화벽, 자동 업데이트, 선택적 이미지 CVE — 발견 항목 ID, 심각도, 0–100 점수가 만들어지는 방식.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="점검 항목 — hostveil 문서">
+    <meta property="og:description" content="Docker/Compose, SSH, 방화벽, 자동 업데이트, 선택적 이미지 CVE — 발견 항목 ID, 심각도, 점수 모델.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/checks">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/checks">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/checks">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/checks">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/checks">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/checks" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks" class="active">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 점검 항목</p>
+            <h1>점검 항목</h1>
+            <p class="lead">hostveil은 셀프호스터가 실제로 침해당하는 영향이 가장 큰 경로들을 점검한 뒤, 모든 것을 하나의 0–100 점수로 합칩니다. 각 발견 항목은 <code>domain.rule</code> 형태의 고정된 ID를 가지며, <code>explain</code>, <code>fix</code>, <code>rollback</code>과 함께 사용합니다.</p>
+
+            <h2>영역 한눈에 보기</h2>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>영역</th><th>접두사</th><th>필요 조건</th></tr></thead>
+                <tbody>
+                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker + Compose 파일</td></tr>
+                  <tr><td>SSH</td><td><code>ssh.</code></td><td>—</td></tr>
+                  <tr><td>방화벽</td><td><code>firewall.</code></td><td>—</td></tr>
+                  <tr><td>자동 업데이트</td><td><code>updates.</code></td><td>—</td></tr>
+                  <tr><td>이미지 CVE <em>(선택)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Docker나 Trivy가 없나요? 해당 영역은 깔끔하게 건너뛰어지고 점수가 <strong>재정규화</strong>되므로, 실행되지도 않은 스캔에 대해 오해를 살 만큼 완벽한 결과를 받는 일은 없습니다.</p>
+
+            <h2>심각도와 점수</h2>
+            <p>모든 발견 항목은 네 가지 심각도 중 하나를 가집니다. 점수는 100에서 시작하며, 수정되지 않은 발견 항목마다 심각도별 감점이 적용됩니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>심각도</th><th>감점</th></tr></thead>
+                <tbody>
+                  <tr><td><span class="sev critical">심각</span></td><td>8</td></tr>
+                  <tr><td><span class="sev high">높음</span></td><td>5</td></tr>
+                  <tr><td><span class="sev medium">보통</span></td><td>2</td></tr>
+                  <tr><td><span class="sev low">낮음</span></td><td>1</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><code>hostveil scan</code>은 수정되지 않은 발견 항목 중 <span class="sev critical">심각</span> 또는 <span class="sev high">높음</span>이 하나라도 있으면 0이 아닌 값으로 종료합니다 — CI나 cron 게이트로 유용합니다.</p>
+
+            <h2 id="ssh">SSH <code>ssh.</code></h2>
+            <p><code>sshd_config</code>에서 직접 파싱합니다. 읽으려면 root 권한이 필요하며, <code>hostveil</code>은 <code>sudo</code>로 자동 상승하여 이를 얻습니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>ssh.emptypasswords</code></td><td>빈 비밀번호가 허용됨</td><td><span class="sev critical">심각</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>ssh.rootlogin</code></td><td>비밀번호를 사용한 root 로그인이 허용됨</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
+                  <tr><td><code>ssh.passwordauth</code></td><td>비밀번호 인증이 허용됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>ssh.maxauthtries</code></td><td>연결당 인증 시도 횟수가 너무 많음</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>ssh.x11forwarding</code></td><td>X11 포워딩이 활성화됨</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="compose">Docker / Compose <code>compose.</code></h2>
+            <p>Compose 파일에 대한 네이티브 감사입니다 — 외부 스캐너가 필요 없습니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>compose.ds016</code></td><td>Docker 소켓이 컨테이너에 마운트됨</td><td><span class="sev critical">심각</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.ds018</code></td><td>데이터 저장소가 모든 인터페이스에 노출됨</td><td><span class="sev critical">심각</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.ds001</code></td><td>컨테이너가 특권 모드로 실행됨</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.ds019</code></td><td>관리자 패널이 모든 인터페이스에 노출됨</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.dr001</code></td><td>컨테이너가 호스트 네트워킹 모드를 사용함</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.ds017</code></td><td>민감한 호스트 경로가 읽기-쓰기로 마운트됨</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.ds005</code></td><td>위험한 리눅스 capability를 추가함</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.dr005</code></td><td>환경 변수에 하드코딩된 비밀값</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.ds006</code></td><td>no-new-privileges 강화 설정 누락</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>compose.ds009</code></td><td>컨테이너가 root로 실행됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.dr002</code></td><td>포트가 모든 인터페이스에 게시됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.ds008</code></td><td>재시작 정책이 설정되지 않음</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>compose.ds010</code></td><td>메모리 제한이 설정되지 않음</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
+                  <tr><td><code>compose.ds012</code></td><td>헬스체크가 정의되지 않음</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>compose.dr004</code></td><td>env_file에서 비밀값을 불러옴</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="firewall">방화벽 <code>firewall.</code></h2>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, 또는 nftables)</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="updates">자동 업데이트 <code>updates.</code></h2>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>updates.disabled</code></td><td>자동 보안 업데이트가 활성화되지 않음 (apt unattended-upgrades 또는 dnf-automatic)</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="cve">이미지 CVE <code>cve.</code> <em>(선택)</em></h2>
+            <p>Trivy가 설치되어 있으면, hostveil은 Compose 서비스가 실행하는 이미지를 스캔하여 알려진 심각·높음·보통 등급의 취약점을 찾습니다. 각 고유 취약점은 <code>cve.&lt;vulnerability-id&gt;</code> 형태의 ID를 가진 발견 항목이 되며 (예: <code>cve.cve-2023-1234</code>), 심각도는 Trivy의 등급에서 매핑됩니다.</p>
+            <div class="callout">
+              <span class="callout-label">"아직 패치가 없음"에 대한 솔직함</span>
+              <p>수정된 버전이 존재하면 해당 발견 항목은 <strong>검토</strong> 수정입니다 (이미지 업데이트). 아직 패치가 없다면, hostveil은 이를 고칠 수 있는 척하는 대신 <strong>사용 불가</strong>라는 정식 상태로 모델링합니다 — 스캔이 정직함을 유지하도록.</p>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="quickstart">← 빠른 시작</a>
+              <a class="button primary" href="fixing">수정 및 롤백 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/cli.html
+++ b/site/ko/docs/cli.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CLI 레퍼런스 — hostveil 문서</title>
+    <meta name="description" content="hostveil 명령줄 완전 레퍼런스: scan, fix, rollback, history, explain, serve, tui — 모든 플래그, 기본값, 종료 코드.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="CLI 레퍼런스 — hostveil 문서">
+    <meta property="og:description" content="hostveil의 모든 하위 명령과 플래그: scan, fix, rollback, history, explain, serve, tui.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/cli">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/cli">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/cli">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/cli">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/cli">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/cli" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli" class="active">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / CLI 레퍼런스</p>
+            <h1>CLI 레퍼런스</h1>
+            <p class="lead">모든 하위 명령, 플래그, 기본값입니다. root 소유 파일(SSH, 방화벽)을 읽거나 보호된 경로에 쓰는 명령은 root 권한이 필요하므로, <code>hostveil</code>은 (<code>version</code>/<code>help</code>를 제외하고) <code>sudo</code> 아래에서 자동으로 자신을 다시 실행합니다. 이를 원하지 않으면 <code>HOSTVEIL_NO_SUDO=1</code>을 설정하세요.</p>
+
+            <h2>개요</h2>
+            <div class="code-block"><pre><code>hostveil &lt;command&gt; [flags]</code></pre></div>
+            <p>대화형 터미널에서 명령 없이 실행하면 hostveil은 <a href="interfaces">TUI</a>를 엽니다. stdin/stdout이 터미널이 아니면 대신 <code>scan</code>을 실행합니다. <code>hostveil version</code>(또는 <code>--version</code>)은 버전을 출력하고, <code>hostveil help</code>(또는 <code>--help</code>)는 사용법을 출력합니다.</p>
+
+            <h2 id="scan">scan</h2>
+            <p>호스트를 스캔하고 보안 발견 항목을 보고합니다.</p>
+            <div class="code-block"><pre><code>hostveil scan [flags]</code></pre></div>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>플래그</th><th>기본값</th><th>설명</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--json</code></td><td><code>false</code></td><td>보고서를 JSON으로 출력합니다.</td></tr>
+                  <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>설명과 수정 안내를 표시합니다.</td></tr>
+                  <tr><td><code>--no-color</code></td><td><code>false</code></td><td>색상 출력을 비활성화합니다.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>종료 코드: 수정되지 않은 발견 항목 중 심각 또는 높음이 있으면 <code>1</code>, 그렇지 않으면 <code>0</code>입니다. 색상은 터미널에만 출력되며 <code>NO_COLOR</code>가 설정되면 억제됩니다.</p>
+
+            <h2 id="fix">fix</h2>
+            <p>발견 항목에 대한 수정을 미리 보고 적용합니다.</p>
+            <div class="code-block"><pre><code>hostveil fix &lt;finding-id&gt; [flags]
+hostveil fix --all [flags]</code></pre></div>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>플래그</th><th>기본값</th><th>설명</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--all</code></td><td><code>false</code></td><td>안전한(자동 수정) 발견 항목을 모두 한 번에 적용합니다.</td></tr>
+                  <tr><td><code>--action N</code></td><td><code>-1</code></td><td>검토 수정에서 적용할, 0부터 시작하는 대안의 번호입니다.</td></tr>
+                  <tr><td><code>--service NAME</code></td><td><code>""</code></td><td>서비스 이름으로 발견 항목을 구분합니다.</td></tr>
+                  <tr><td><code>--yes</code></td><td><code>false</code></td><td>대화형 확인 없이 적용합니다.</td></tr>
+                  <tr><td><code>--no-color</code></td><td><code>false</code></td><td>색상 출력을 비활성화합니다.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>적용 시에는 항상 diff/명령을 먼저 보여 주고, 원본을 체크포인트로 백업한 뒤 적용합니다. <a href="fixing">수정 및 롤백</a>을 참고하세요.</p>
+
+            <h2 id="rollback">rollback</h2>
+            <p>이전에 적용한 수정을 되돌립니다.</p>
+            <div class="code-block"><pre><code>hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
+            <p>(<code>hostveil history</code>에서 얻은) 체크포인트 ID 하나를 받아 백업된 파일을 바이트 단위 그대로 복원합니다. 플래그는 없습니다.</p>
+
+            <h2 id="history">history</h2>
+            <p>적용된 수정과 그 롤백 ID를 나열합니다.</p>
+            <div class="code-block"><pre><code>hostveil history</code></pre></div>
+            <p>체크포인트를 최신순으로 나열하며, 타임스탬프, 발견 항목 ID, 레이블, 그리고 정확한 <code>hostveil rollback &lt;id&gt;</code> 명령 또는 <em>되돌릴 수 없음</em> 표시가 함께 나옵니다. 플래그는 없습니다.</p>
+
+            <h2 id="explain">explain</h2>
+            <p>발견 항목을 쉬운 말로 설명합니다.</p>
+            <div class="code-block"><pre><code>hostveil explain &lt;finding-id&gt; [flags]</code></pre></div>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>플래그</th><th>기본값</th><th>설명</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--ai</code></td><td><code>false</code></td><td>로컬 LLM(Ollama)의 조언성 설명을 덧붙입니다.</td></tr>
+                  <tr><td><code>--service NAME</code></td><td><code>""</code></td><td>서비스 이름으로 발견 항목을 구분합니다.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>내장된 쉬운 말 설명은 항상 출력되며, <code>--ai</code>는 조언 섹션을 추가합니다. <a href="ai">AI 설명</a>을 참고하세요.</p>
+
+            <h2 id="serve">serve</h2>
+            <p>localhost 웹 대시보드를 실행합니다. <code>hostveil web</code>은 별칭입니다.</p>
+            <div class="code-block"><pre><code>hostveil serve [--addr ADDR]</code></pre></div>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>플래그</th><th>기본값</th><th>설명</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--addr ADDR</code></td><td><code>127.0.0.1:8787</code></td><td>대시보드를 바인딩할 주소입니다.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>루프백이 아닌 주소에 바인딩하면 대시보드가 네트워크에 노출된다는 경고가 출력됩니다.</p>
+
+            <h2 id="tui">tui</h2>
+            <p>대화형 터미널 UI를 엽니다(터미널에서 명령 없이 실행할 때의 기본값이기도 합니다).</p>
+            <div class="code-block"><pre><code>hostveil tui</code></pre></div>
+            <p>플래그는 없습니다. 대화형 터미널이 필요하며, 그렇지 않으면 <code>hostveil scan</code>을 사용하라고 안내합니다.</p>
+
+            <h2 id="exit-codes">종료 코드</h2>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>코드</th><th>의미</th></tr></thead>
+                <tbody>
+                  <tr><td><code>0</code></td><td>성공(<code>scan</code>의 경우, 수정되지 않은 심각/높음 발견 항목이 없음).</td></tr>
+                  <tr><td><code>1</code></td><td><code>scan</code>이 수정되지 않은 심각 또는 높음 발견 항목을 찾았거나, 명령이 실패했습니다.</td></tr>
+                  <tr><td><code>2</code></td><td>사용법 오류 — 알 수 없는 명령이거나 필수 인자가 누락되었습니다.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="ai">← AI 설명</a>
+              <a class="button primary" href="faq">자주 묻는 질문 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/contributing.html
+++ b/site/ko/docs/contributing.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>기여하기 — hostveil 문서</title>
+    <meta name="description" content="소스에서 hostveil을 빌드하고, CI가 실행하는 점검을 직접 실행하고, 저장소 구조와 아키텍처 규칙을 배우고, 새 점검 항목을 추가하고, 데모 VM을 사용하는 법.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="기여하기 — hostveil 문서">
+    <meta property="og:description" content="소스에서 빌드하기, 점검 실행, 저장소 구조, 점검 항목 추가, 데모 VM.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/contributing">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/contributing">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/contributing">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/contributing">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/contributing">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/contributing" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="contributing" class="active">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 기여하기</p>
+            <h1>기여하기</h1>
+            <p class="lead">hostveil은 Go로 작성되었으며, 의존성 트리가 작고 아키텍처 규칙이 엄격합니다. 이 글은 요약본이며, 정식 개발자 가이드는 <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>docs/DEVELOPMENT.md</code></a>입니다.</p>
+
+            <h2>사전 준비물</h2>
+            <ul>
+              <li><strong>Go</strong> — <code>go.mod</code>에 고정된 버전 이상.</li>
+              <li><strong>git</strong>.</li>
+              <li><em>선택 사항:</em> 데모 VM을 실행하려면 Vagrant와 프로바이더(리눅스는 libvirt, macOS/Windows는 VirtualBox).</li>
+            </ul>
+
+            <h2>빌드 및 테스트</h2>
+            <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil.git
+cd hostveil
+go build ./cmd/hostveil     # produces ./hostveil
+go test ./...               # unit + fuzz + property tests</code></pre></div>
+            <p>변경 사항을 보내기 전에, CI가 실행하는 것과 같은 점검을 실행하세요:</p>
+            <div class="code-block"><pre><code>go build ./...
+go vet ./...
+gofmt -l .                  # must print nothing
+go mod tidy                 # must leave go.mod/go.sum unchanged
+go test -race ./...</code></pre></div>
+            <div class="callout">
+              <span class="callout-label">리눅스 도구, 이식 가능한 테스트</span>
+              <p>hostveil은 <strong>어떤 OS에서도 빌드되고 테스트가 통과</strong>하지만, 바이너리를 의미 있게 실행하려면 관련 도구가 설치된 리눅스가 필요합니다. 본인의 머신에서 직접 실행하기보다 데모 VM을 사용하세요.</p>
+            </div>
+
+            <h2>저장소 구조</h2>
+            <div class="code-block"><pre><code>cmd/hostveil/        entry point + subcommand wiring
+internal/
+  core/              the shared engine — the only thing the UIs call
+  check/             detection domains (compose, ssh, firewall, updates, cve)
+  fix/ compose/ history/   fix registry, YAML editing, backup/rollback
+  model/ platform/   pure value types; the OS/command seam
+  ui/{cli,tui,web}/  thin UIs over the engine
+demo/                the reproducible vulnerable-server VM (Vagrant)
+site/                the marketing site + these docs (static)
+docs/                developer documentation</code></pre></div>
+
+            <h2>아키텍처 규칙</h2>
+            <div class="callout warn">
+              <span class="callout-label">테스트로 강제됨</span>
+              <p>UI는 오직 <code>core</code>에만 의존합니다. import-lint 테스트가 <code>ui/*</code>가 <code>fix</code>, <code>history</code>, <code>check</code>, <code>compose</code>를 절대 import하지 않도록 강제합니다. 이것이 TUI, 웹, CLI가 동일하게 동작하도록 만드는 요인입니다 — 모두 하나의 엔진을 거쳐 갑니다.</p>
+            </div>
+
+            <h2>점검 항목 추가하기</h2>
+            <p>탐지 도메인을 추가한다는 것은 <code>internal/check/</code> 아래에 <code>Checker</code> 인터페이스를 구현하는 패키지 하나를 작성하고 등록하는 것을 의미합니다. 발견 항목은 안정적인 <code>domain.rule</code> ID, 심각도, 그리고 해결 방식(remediation kind)과 함께 생성됩니다(<a href="checks">점검 항목</a>과 <a href="fixing">수정 및 롤백</a>을 참고하세요).</p>
+
+            <h2>실제로 실행해 보기: 데모 VM</h2>
+            <p><code>demo/</code>는 코드로 정의된, 의도적으로 취약하게 만든 Ubuntu 서버입니다. hostveil은 VM <em>내부</em>에서 여러분의 작업 트리로부터 빌드되므로, 항상 현재 코드를 반영합니다:</p>
+            <div class="code-block"><pre><code>cd demo
+./run.sh up        # boot + provision + start the vulnerable stacks
+./run.sh scan      # run hostveil against the server
+./run.sh web       # dashboard at http://localhost:8787
+./run.sh shell     # a shell on the server (then: sudo hostveil ...)
+./run.sh halt      # shut it down</code></pre></div>
+            <p>전체 안내, 플랫폼별 프로바이더 설정, 데모 스크립트, 초기화 절차는 <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>에 있습니다.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="faq">← 자주 묻는 질문</a>
+              <a class="button primary" href="https://github.com/seolcu/hostveil">GitHub 저장소 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/faq.html
+++ b/site/ko/docs/faq.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>자주 묻는 질문 — hostveil 문서</title>
+    <meta name="description" content="hostveil에 대한 흔한 질문들: 데이터 프라이버시, 수정이 서버를 망가뜨릴 수 있는지, 검토(Review) 절충안, sudo, 선택적 Docker/Trivy/AI 도구.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="자주 묻는 질문 — hostveil 문서">
+    <meta property="og:description" content="hostveil에 대한 흔한 질문들 — 프라이버시, 안전성, 절충안, sudo, 선택적 도구.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/faq">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/faq">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/faq">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/faq">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/faq">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/faq" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq" class="active">자주 묻는 질문</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 자주 묻는 질문</p>
+            <h1>자주 묻는 질문</h1>
+            <p class="lead">셀프호스터들이 자신의 서버를 도구에 맡기기 전에 가장 많이 묻는 질문들입니다.</p>
+
+            <h2>내 데이터를 업로드하나요?</h2>
+            <p>아니요. hostveil은 전적으로 로컬에서 동작합니다 — SaaS도, 데이터베이스도, 계정도 없습니다. 선택적인 AI 설명조차 기본값은 사용자 자신의 컴퓨터에 있는 모델이며, 사람이 읽을 수 있는 필드만(원본 비밀값이나 경로는 절대 아님) 전달됩니다. <a href="ai">AI 설명</a>을 참고하세요.</p>
+
+            <h2>수정이 서버를 망가뜨리지는 않나요?</h2>
+            <p>적용되기 전에 정확한 변경 내용을 볼 수 있고, 원본 파일은 먼저 체크포인트로 백업되며, <code>hostveil rollback</code>이 이를 바이트 단위 그대로 복원합니다. 안전하게 자동화할 수 없는 수정은 <strong>수동</strong>으로 분류되어 설명만 되고 절대 적용되지 않습니다. <a href="fixing">수정 및 롤백</a>을 참고하세요.</p>
+
+            <h2>수정에 절충안이 있다면요?</h2>
+            <p>그런 경우는 자동 수정이 아니라 <strong>검토</strong> 수정입니다. hostveil은 독립적인 대안들을 제시하고 <code>--action</code>으로 직접 선택하게 합니다. <code>fix --all</code>은 명백히 안전한 자동 수정 발견 항목만 건드리고 나머지는 모두 사용자에게 맡깁니다.</p>
+
+            <h2>Docker나 Trivy가 필요한가요?</h2>
+            <p>아니요. SSH, 방화벽, 자동 업데이트 점검은 추가 도구 없이 네이티브로 실행됩니다. Docker/Compose 점검은 Docker가, 이미지 CVE 스캔은 Trivy가 필요합니다 — 각각 있으면 사용되고 없으면 깔끔하게 건너뛰어지며, 건너뛴 영역이 결과를 부풀리지 않도록 점수가 재정규화됩니다.</p>
+
+            <h2>왜 sudo를 요구하나요?</h2>
+            <p>일부 점검은 <code>sshd_config</code> 같은 root 소유 파일을 읽어야 하고, 수정을 적용하려면 보호된 경로에 써야 합니다. 그래서 <code>hostveil</code>은 <code>sudo</code>로 자동으로 권한을 상승시킵니다 — 표시되는 프롬프트는 sudo 자체의 것으로 <code>sudo hostveil</code>을 실행할 때와 동일하며, 인증하면 같은 터미널에서 계속 진행됩니다. <code>version</code>과 <code>help</code>는 절대 프롬프트를 띄우지 않습니다. 권한 없이(스크립트·CI에서) 실행하려면 <code>HOSTVEIL_NO_SUDO=1</code>을 설정하세요. 그러면 root 소유 영역은 명확한 메시지와 함께 건너뛰어집니다.</p>
+
+            <h2>웹 대시보드가 네트워크에 노출되나요?</h2>
+            <p>아니요 — <code>hostveil serve</code>는 기본적으로 <code>127.0.0.1:8787</code>(루프백 전용)에 바인딩됩니다. <code>--addr</code>로 바인드 주소를 바꿀 수 있지만, 루프백이 아닌 주소를 지정하면 먼저 경고가 표시됩니다. <a href="interfaces">인터페이스</a>를 참고하세요.</p>
+
+            <h2>0–100 점수는 무엇을 의미하나요?</h2>
+            <p>100점에서 시작해 수정되지 않은 발견 항목마다 심각도에 따라 점수를 뺍니다(심각 8, 높음 5, 보통 2, 낮음 1). 지적할 것이 없는 호스트는 속 빈 100점이 아니라 <strong>Clean</strong>으로 표시되며, 수정되지 않은 발견 항목 중 심각 또는 높음이 하나라도 있으면 <code>scan</code>은 0이 아닌 값으로 종료됩니다. <a href="checks">점검 항목</a>을 참고하세요.</p>
+
+            <h2>어떤 플랫폼을 지원하나요?</h2>
+            <p>사전 빌드 바이너리는 <strong>Linux</strong>와 <strong>macOS</strong>의 <code>amd64</code>·<code>arm64</code>를 대상으로 합니다. hostveil은 셀프호스팅 리눅스 서버를 위해 만들어졌습니다.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="cli">← CLI 레퍼런스</a>
+              <a class="button primary" href="contributing">기여하기 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/fixing.html
+++ b/site/ko/docs/fixing.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>수정 및 롤백 — hostveil 문서</title>
+    <meta name="description" content="hostveil이 발견 항목을 고치는 방식: 자동 수정, 검토, 수동 분류; 미리보기 우선, 체크포인트 백업, 이력, 한 번의 명령 롤백.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="수정 및 롤백 — hostveil 문서">
+    <meta property="og:description" content="자동 수정, 검토, 수동 수정; 미리보기, 백업, 이력, 한 번의 명령 롤백.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/fixing">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/fixing">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/fixing">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/fixing">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/fixing">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/fixing" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing" class="active">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 수정 및 롤백</p>
+            <h1>수정 및 롤백</h1>
+            <p class="lead">hostveil은 절대 눈감고 변경하지 않습니다. 모든 수정은 얼마나 안전하게 자동화할 수 있는지에 따라 분류되고, 항상 정확한 변경 내용을 먼저 보여 주고, 원본을 체크포인트로 백업하며, 명령 한 줄로 되돌릴 수 있습니다.</p>
+
+            <h2>발견 항목은 어떻게 분류되는가</h2>
+            <p>각 발견 항목에는 얼마나 자동화가 적절한지를 결정하는 수정 종류가 태그로 붙습니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>종류</th><th>의미</th><th>수정 가능?</th></tr></thead>
+                <tbody>
+                  <tr><td><strong>자동 수정</strong></td><td>명백히 올바른 하나의 변경. 적용되기 전에 여전히 확인할 수 있습니다.</td><td>예</td></tr>
+                  <tr><td><strong>검토</strong></td><td>여러 유효한 대안이 있으며, 어느 것을 적용할지 직접 선택합니다.</td><td>예</td></tr>
+                  <tr><td><strong>수동</strong></td><td>안전한 자동화가 없음 — hostveil이 대신 무엇을 해야 하는지 설명합니다.</td><td>아니오</td></tr>
+                  <tr><td><strong>사용 불가</strong></td><td>아직 수정 방법이 없는 알려진 문제 (예: 패치가 없는 CVE).</td><td>아니오</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><strong>자동 수정</strong>과 <strong>검토</strong> 발견 항목만 hostveil이 적용할 수 있습니다. <code>fix --all</code>은 자동 수정 항목만 적용하고, 판단이 필요한 것은 사용자에게 남깁니다.</p>
+
+            <h2>수정 적용하기</h2>
+            <p>단일 발견 항목을 ID로 미리보고 적용합니다.</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="sudo hostveil fix ssh.rootlogin">Copy</button>
+              <pre><code>sudo hostveil fix ssh.rootlogin</code></pre>
+            </div>
+            <p>적용은 항상 <strong>1)</strong> 정확한 diff나 명령을 보여 주고, <strong>2)</strong> 원본 파일을 체크포인트로 백업한 뒤, <strong>3)</strong> 변경을 적용합니다. <code>--yes</code>를 넘기지 않는 한 <code>[y/N]</code> 프롬프트에서 확인합니다.</p>
+
+            <h3>검토 대안 선택하기</h3>
+            <p>검토 발견 항목은 독립적인 대안을 제공합니다. 0부터 시작하는 인덱스를 <code>--action</code>으로 넘깁니다.</p>
+            <div class="code-block"><pre><code>sudo hostveil fix ssh.passwordauth --action 0</code></pre></div>
+
+            <h3>서비스별로 구분하기</h3>
+            <p>동일한 Compose 규칙이 둘 이상의 서비스에서 발생하면, <code>--service</code>로 범위를 좁힙니다.</p>
+            <div class="code-block"><pre><code>sudo hostveil fix compose.ds018 --service db</code></pre></div>
+
+            <h3>안전한 모든 수정 적용하기</h3>
+            <div class="code-block"><pre><code>sudo hostveil fix --all</code></pre></div>
+            <p>각 자동 수정 발견 항목을 적용하며, 각각 자체 체크포인트를 가지므로 개별적으로 롤백할 수 있습니다.</p>
+
+            <h2>이력 및 롤백</h2>
+            <p>적용된 모든 수정은 체크포인트로 기록됩니다. 최신순으로 나열합니다.</p>
+            <div class="code-block"><pre><code>hostveil history</code></pre></div>
+            <p>각 항목은 타임스탬프, 발견 항목 ID, 레이블, 정확한 롤백 명령을 보여 줍니다. 체크포인트 ID로 하나를 되돌립니다.</p>
+            <div class="code-block"><pre><code>sudo hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
+            <div class="callout">
+              <span class="callout-label">어디서나 되돌릴 수 있음</span>
+              <p>롤백은 백업된 파일을 바이트 단위 그대로 복원합니다. TUI, 웹 대시보드, CLI가 모두 하나의 공유 엔진을 거치기 때문에, 어느 곳에서 적용한 수정이든 <code>history</code>에 나열되고 어디서나 되돌릴 수 있습니다. (일부 작업은 본질적으로 되돌릴 수 없으며, <code>history</code>는 이를 <em>되돌릴 수 없음</em>으로 표시합니다.)</p>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="checks">← 점검 항목</a>
+              <a class="button primary" href="interfaces">인터페이스 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/index.html
+++ b/site/ko/docs/index.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>hostveil 문서 — 셀프호스팅 리눅스를 위한 가이드형 보안 강화</title>
+    <meta name="description" content="hostveil 공식 문서: 설치하고, 스캔을 실행하고, 발견 항목을 이해하고, 미리보기·백업·한 번의 명령 롤백으로 안전하게 고치세요.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="hostveil 문서">
+    <meta property="og:description" content="셀프호스팅 리눅스 서버의 잘못된 보안 설정을 설치·스캔·이해하고 안전하게 고치세요.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./" aria-current="page">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./" class="active">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / 문서</p>
+            <h1>hostveil 문서</h1>
+            <p class="lead">hostveil은 셀프호스팅 리눅스 서버의 보안 실수를 찾아, 쉬운 말로 설명하고, 미리보기·백업·한 번의 명령 롤백과 함께 안전하게 고쳐 줍니다. 바이너리 하나, 설정 파일 없음, 클라우드 계정 없음.</p>
+
+            <p>셀프호스팅이 빠르게 늘고 있지만, Jellyfin·Nextcloud·게임 서버·로컬 LLM을 돌리는 대부분의 사람은 보안 전문가가 아닙니다 — 그리고 단 하나의 잘못된 설정이 심각한 침해로 이어질 수 있습니다. hostveil은 바로 그런 사람들을 위한 <strong>가이드형 보안 강화 도구</strong>입니다. 리눅스 서버를 가리키면, 영향이 가장 큰 영역들을 스캔하고, 모든 것을 하나의 0–100 점수로 합치고, 각 발견 항목을 전문 용어 없이 설명하고, 고치는 과정을 안내합니다 — 정확한 변경 내용을 보여 주고, 원본을 먼저 백업하고, 어떤 수정이든 명령 한 줄로 되돌릴 수 있게 하면서.</p>
+
+            <div class="callout">
+              <span class="callout-label">안전 모델</span>
+              <p>아무것도 눈감고 바꾸지 않습니다. 모든 수정은 실행 전에 <strong>미리보기</strong>되고, 원본 파일은 <strong>체크포인트로 백업</strong>되며, <code>hostveil rollback</code>이 바이트 단위 그대로 복원합니다. 모든 인터페이스가 같은 엔진을 구동하므로, 어디서 적용한 수정이든 어디서나 되돌릴 수 있습니다.</p>
+            </div>
+
+            <h2>처음이신가요? 여기서 시작하세요</h2>
+            <ul class="docs-cards">
+              <li>
+                <a href="installation">
+                  <strong>설치 →</strong>
+                  <span>설치 명령 한 줄과, 선택 도구(Docker, Trivy, Ollama) 및 각각이 무엇을 열어 주는지.</span>
+                </a>
+              </li>
+              <li>
+                <a href="quickstart">
+                  <strong>빠른 시작 →</strong>
+                  <span>스캔하고, 발견 항목을 이해하고, 수정을 적용하고, 되돌리기 — 전체 흐름을 몇 분 만에.</span>
+                </a>
+              </li>
+              <li>
+                <a href="checks">
+                  <strong>점검 항목 →</strong>
+                  <span>Docker/Compose, SSH, 방화벽, 자동 업데이트, 선택적 이미지 CVE — 각각이 무엇을 보는지.</span>
+                </a>
+              </li>
+              <li>
+                <a href="fixing">
+                  <strong>수정 및 롤백 →</strong>
+                  <span>자동·검토·수동 수정과, 미리보기·백업·이력·롤백이 어떻게 동작하는지.</span>
+                </a>
+              </li>
+            </ul>
+
+            <h2>레퍼런스</h2>
+            <ul class="docs-cards">
+              <li>
+                <a href="interfaces">
+                  <strong>인터페이스 →</strong>
+                  <span>TUI, localhost 웹 대시보드, 스크립트로 다루는 CLI — 하나의 공유 엔진.</span>
+                </a>
+              </li>
+              <li>
+                <a href="cli">
+                  <strong>CLI 레퍼런스 →</strong>
+                  <span>모든 하위 명령과 플래그: scan, fix, rollback, history, explain, serve.</span>
+                </a>
+              </li>
+              <li>
+                <a href="ai">
+                  <strong>AI 설명 →</strong>
+                  <span><code>explain --ai</code>로 얻는 선택적·조언 전용·로컬 우선의 second opinion.</span>
+                </a>
+              </li>
+              <li>
+                <a href="contributing">
+                  <strong>기여하기 →</strong>
+                  <span>소스에서 빌드하기, 점검 실행, 저장소 구조, 새 점검 항목 추가하는 법.</span>
+                </a>
+              </li>
+            </ul>
+
+            <div class="docs-pager">
+              <a class="button primary" href="installation">hostveil 설치</a>
+              <a class="button secondary" href="https://github.com/seolcu/hostveil">GitHub에서 소스 보기</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/installation.html
+++ b/site/ko/docs/installation.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>설치 — hostveil 문서</title>
+    <meta name="description" content="한 줄 명령으로 hostveil을 설치하거나 소스에서 빌드하세요. 선택 도구인 Docker, Trivy, Ollama가 각각 무엇을 열어 주는지 알아보세요.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="설치 — hostveil 문서">
+    <meta property="og:description" content="한 줄 명령으로 hostveil을 설치하거나 소스에서 빌드하세요. 선택적인 Docker, Trivy, Ollama 연동.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/installation">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/installation">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/installation">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/installation">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/installation">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/installation" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation" class="active">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 설치</p>
+            <h1>설치</h1>
+            <p class="lead">한 줄 명령이면 바이너리 하나가 설치됩니다. 작성해야 할 설정 파일도, 만들어야 할 계정도 없습니다 — 설치 후 바로 스캔할 수 있습니다.</p>
+
+            <h2>빠른 설치</h2>
+            <p>설치 스크립트는 OS와 아키텍처를 감지하고, 릴리스 바이너리를 내려받아 체크섬을 검증한 뒤 <code>/usr/bin/hostveil</code>에 설치합니다:</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash">Copy</button>
+              <pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash</code></pre>
+            </div>
+            <p>같은 명령을 언제든 다시 실행하면 최신 릴리스로 업데이트됩니다. 그런 다음 확인하세요:</p>
+            <div class="code-block"><pre><code>hostveil version</code></pre></div>
+
+            <div class="callout">
+              <span class="callout-label">지원 플랫폼</span>
+              <p><strong>Linux</strong>와 <strong>macOS</strong>의 <code>amd64</code>·<code>arm64</code> 아키텍처용 사전 빌드 바이너리가 제공됩니다. hostveil은 셀프호스팅 리눅스 서버를 위해 설계되었으며, SSH·방화벽·자동 업데이트 점검은 리눅스를 대상으로 합니다.</p>
+            </div>
+
+            <h2>설치 스크립트가 하는 일</h2>
+            <ul>
+              <li>OS(<code>linux</code>/<code>darwin</code>)와 아키텍처(<code>amd64</code>/<code>arm64</code>)를 감지합니다.</li>
+              <li>릴리스 tarball과 <code>hostveil-checksums.txt</code>를 내려받은 뒤 SHA-256 체크섬을 검증합니다. 일치하지 않으면 중단합니다.</li>
+              <li><code>sudo</code>로 바이너리를 <code>/usr/bin/hostveil</code>에 설치(권한 0755)하고, <code>hostveil --version</code>을 실행해 정상 동작을 확인합니다.</li>
+              <li>선택적 이미지 CVE 스캔을 위한 <strong>Trivy</strong> 설치를 제안합니다. 거절해도 hostveil 설치를 막지 않습니다.</li>
+            </ul>
+
+            <h3>설치 스크립트 옵션</h3>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>옵션</th><th>효과</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--version vX.Y.Z</code></td><td>최신 대신 특정 릴리스를 설치합니다.</td></tr>
+                  <tr><td><code>--no-trivy</code></td><td>선택적 Trivy 안내를 아예 건너뜁니다.</td></tr>
+                  <tr><td><code>--yes</code> / <code>-y</code></td><td>비대화형으로 실행합니다(모든 확인을 수락).</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>파이프를 통해 옵션을 전달하려면 <code>bash -s --</code>를 사용하세요. 예:</p>
+            <div class="code-block"><pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --no-trivy</code></pre></div>
+
+            <h2>권한 상승은 자동입니다</h2>
+            <div class="callout">
+              <span class="callout-label">참고</span>
+              <p>SSH와 방화벽 점검은 <code>sshd_config</code> 같은 root 소유 파일을 읽어야 하고, 수정을 적용하려면 보호된 경로에 써야 합니다. 그래서 <code>hostveil</code>은 <code>sudo</code> 아래에서 자동으로 자신을 다시 실행합니다 — <code>sudo hostveil</code>과 동일한 sudo 비밀번호 프롬프트가 표시되며, 인증 후 같은 터미널에서 계속 진행됩니다. <code>version</code>과 <code>help</code>는 절대 프롬프트를 띄우지 않습니다. 권한 없이(스크립트·CI에서) 실행하려면 <code>HOSTVEIL_NO_SUDO=1</code>을 설정하세요. 그러면 root 소유 영역은 명확한 메시지와 함께 건너뛰어지고, 점수는 오해를 부르는 완벽한 결과를 주지 않도록 재정규화됩니다.</p>
+            </div>
+
+            <h2>선택 도구</h2>
+            <p>해당 도구가 없으면 각 영역은 깔끔하게 건너뛰어집니다. 추가 범위를 원한다면 다음을 추가하세요:</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>도구</th><th>열어 주는 기능</th><th>참고</th></tr></thead>
+                <tbody>
+                  <tr><td><strong>Docker</strong></td><td>Docker / Compose 점검</td><td>hostveil은 Compose 파일을 읽어 서비스를 점검합니다.</td></tr>
+                  <tr><td><strong>Trivy</strong></td><td>이미지 CVE 스캔</td><td>있으면 사용되며, 설치 스크립트가 대신 설정해 줄 수 있습니다.</td></tr>
+                  <tr><td><strong>Ollama</strong></td><td>AI 설명(<code>explain --ai</code>)</td><td>기본적으로 로컬에서 동작하며 — 호스트 밖으로 아무것도 나가지 않습니다. <a href="ai">AI 설명</a>을 참고하세요.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2>소스에서 빌드하기</h2>
+            <p>최신 Go 툴체인이 설치되어 있다면:</p>
+            <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil
+cd hostveil
+go build ./cmd/hostveil
+go test ./...</code></pre></div>
+            <p>재현 가능한 데모 VM을 포함한 전체 개발 환경 설정은 <a href="contributing">기여하기</a>를 참고하세요.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="./">← 소개</a>
+              <a class="button primary" href="quickstart">빠른 시작 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/interfaces.html
+++ b/site/ko/docs/interfaces.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>인터페이스 — hostveil 문서</title>
+    <meta name="description" content="hostveil의 세 가지 인터페이스 — 키보드 기반 TUI, localhost 웹 대시보드, 스크립트로 다루는 CLI — 모두 하나의 공유 수정·롤백 엔진을 구동합니다.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="인터페이스 — hostveil 문서">
+    <meta property="og:description" content="TUI, localhost 웹 대시보드, 스크립트로 다루는 CLI — 하나의 공유 엔진.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/interfaces">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/interfaces">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/interfaces">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/interfaces">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/interfaces">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/interfaces" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces" class="active">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 인터페이스</p>
+            <h1>인터페이스</h1>
+            <p class="lead">hostveil에는 세 가지 얼굴이 있습니다 — 터미널 UI, localhost 웹 대시보드, 스크립트로 다루는 CLI — 그리고 셋 모두 하나의 공유 엔진 위의 얇은 계층입니다. 어느 하나에서 스캔하거나, 고치거나, 되돌리든 다른 곳에도 반영됩니다.</p>
+
+            <h2>TUI — 기본값</h2>
+            <p>인수 없이 대화형 터미널에서 <code>hostveil</code>을 실행하면 키보드 기반 TUI가 열립니다. 명시적으로 실행할 수도 있습니다.</p>
+            <div class="code-block"><pre><code>sudo hostveil        # or: sudo hostveil tui</code></pre></div>
+            <p>점수와 발견 항목을 심각도·영역 <strong>필터</strong>, 일괄 수정을 위한 <strong>다중 선택</strong>, 쉬운 말 상세 설명, 그리고 적용 전 수정 미리보기와 함께 보여 줍니다.</p>
+            <figure>
+              <img src="../../assets/tui.png" alt="hostveil 터미널 UI — 심각도 필터와 다중 선택이 있는 발견 항목" width="1200" height="478" loading="lazy">
+              <figcaption><strong>TUI</strong><span>심각도·영역 필터, 다중 선택, 쉬운 말 상세 설명, 수정 미리보기를 갖춘 키보드 기반 발견 항목.</span></figcaption>
+            </figure>
+            <div class="callout">
+              <span class="callout-label">터미널이 필요함</span>
+              <p>TUI는 대화형 터미널이 필요합니다. stdin/stdout이 파이프되거나 리다이렉트된 경우, 대신 <code>hostveil scan</code>을 사용하세요 — 일반 텍스트 보고서를 출력합니다.</p>
+            </div>
+
+            <h2>웹 — localhost 대시보드</h2>
+            <p>브라우저로 검토하는 편이 나을 때 동일한 스캔을 HTTP로 제공합니다.</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="sudo hostveil serve">Copy</button>
+              <pre><code>sudo hostveil serve</code></pre>
+            </div>
+            <p>기본적으로 <code>127.0.0.1:8787</code>에 바인딩됩니다 — loopback 전용입니다. <code>--addr</code>로 변경할 수 있으며, non-loopback 주소를 지정하면 hostveil이 대시보드 노출에 관한 경고를 출력합니다. (<code>hostveil web</code>은 <code>serve</code>의 별칭입니다.)</p>
+            <figure>
+              <img src="../../assets/web.png" alt="hostveil 웹 대시보드 — 필터 칩, 다중 선택, 수정 상세" width="1200" height="456" loading="lazy">
+              <figcaption><strong>웹 UI</strong><span>localhost 대시보드: 점수, 필터 가능한 발견 항목, 다중 선택 일괄 수정, 미리보기, 롤백.</span></figcaption>
+            </figure>
+
+            <h2>CLI — 스크립트 가능</h2>
+            <p><code>scan</code>, <code>fix</code>, <code>rollback</code>, <code>history</code> 하위 명령은 비대화형으로 동작합니다. <code>scan --json</code>은 기계가 읽을 수 있는 출력을 내보내며, <code>scan</code>은 수정되지 않은 발견 항목 중 심각 또는 높음이 하나라도 있으면 0이 아닌 값으로 종료합니다 — 그래서 CI나 cron 작업에 그대로 들어갑니다.</p>
+            <div class="code-block"><pre><code>hostveil scan --json &gt; report.json
+sudo hostveil fix --all --yes</code></pre></div>
+            <p>모든 명령과 플래그는 <a href="cli">CLI 레퍼런스</a>를 참고하세요.</p>
+
+            <div class="callout">
+              <span class="callout-label">엔진 하나, 얼굴 셋</span>
+              <p>인터페이스들이 하나의 수정·롤백 엔진을 공유하기 때문에, 동작은 어디서나 동일합니다 — 브라우저에서 적용한 수정은 <code>hostveil history</code>에 나타나고 터미널에서 되돌릴 수 있으며, 그 반대도 마찬가지입니다.</p>
+            </div>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="fixing">← 수정 및 롤백</a>
+              <a class="button primary" href="ai">AI 설명 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/quickstart.html
+++ b/site/ko/docs/quickstart.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>빠른 시작 — hostveil 문서</title>
+    <meta name="description" content="서버를 스캔하고, 발견 항목을 이해하고, 미리보기와 백업으로 수정을 적용한 뒤 되돌리세요 — 몇 분 만에 익히는 hostveil의 전체 흐름.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="빠른 시작 — hostveil 문서">
+    <meta property="og:description" content="스캔, 이해, 적용, 롤백 — 몇 분 만에 익히는 hostveil의 전체 흐름.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/quickstart">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/quickstart">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/quickstart">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/quickstart">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/quickstart">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/quickstart" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart" class="active">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 빠른 시작</p>
+            <h1>빠른 시작</h1>
+            <p class="lead">스캔하고, 이해하고, 적용하고, 복구하기. 여기서는 명령줄로 전체 흐름을 따라가지만, 원한다면 TUI와 웹 대시보드도 정확히 같은 엔진으로 동작합니다.</p>
+
+            <h2>1. 로컬에서 스캔하기</h2>
+            <p>스캔을 실행하기만 하면 됩니다 — <code>hostveil</code>은 SSH와 방화벽 점검이 root 소유 파일을 읽을 수 있도록 <code>sudo</code>로 자동으로 권한을 상승시킵니다. <code>sudo hostveil</code>과 동일한 sudo 비밀번호 프롬프트가 표시됩니다:</p>
+            <div class="command-box">
+              <button class="copy-btn" type="button" data-copy="hostveil scan">Copy</button>
+              <pre><code>hostveil scan</code></pre>
+            </div>
+            <p>0–100 사이의 단일 보안 점수와 심각도순으로 정렬된 발견 항목 목록을 받게 됩니다. 도구가 없는 영역(Docker 없음, Trivy 없음)은 건너뛰어지고 점수가 재정규화됩니다 — 깨끗한 호스트는 속 빈 100점이 아니라 <strong>Clean</strong>으로 표시됩니다.</p>
+            <div class="callout">
+              <span class="callout-label">팁</span>
+              <p>대화형 터미널에서는 인자 없이 <code>hostveil</code>을 실행하면 대신 <a href="interfaces">TUI</a>가 열립니다. 파이프되거나 리디렉션된 경우에는 스캔 결과를 출력합니다 — 스크립트에서 유용합니다.</p>
+            </div>
+
+            <h2>2. 발견 항목 이해하기</h2>
+            <p><code>-v</code>를 추가하면 각 발견 항목의 쉬운 말 설명과 수정 안내를 바로 볼 수 있습니다:</p>
+            <div class="code-block"><pre><code>hostveil scan -v</code></pre></div>
+            <p>또는 ID로 하나의 발견 항목을 자세히 살펴볼 수 있습니다(예: <code>ssh.rootlogin</code>):</p>
+            <div class="code-block"><pre><code>hostveil explain ssh.rootlogin</code></pre></div>
+            <p>내 방식으로 된 second opinion이 필요하신가요? <code>--ai</code>를 추가하면 로컬 모델의 조언성 설명을 받을 수 있습니다 — <a href="ai">AI 설명</a>을 참고하세요. 모든 발견 항목 ID와 그 의미는 <a href="checks">점검 항목</a>에 정리되어 있습니다.</p>
+
+            <h2>3. 수정 적용하기</h2>
+            <p>수정은 항상 무엇이든 건드리기 전에 정확한 변경 내용을 먼저 보여 주고 원본을 백업합니다. 하나의 발견 항목을 미리 보고 적용하려면:</p>
+            <div class="code-block"><pre><code>hostveil fix ssh.rootlogin</code></pre></div>
+            <p>또는 명백히 안전한(자동) 수정을 한 번에 모두 적용할 수도 있습니다 — 검토와 수동 발견 항목은 직접 결정하도록 남겨집니다:</p>
+            <div class="code-block"><pre><code>hostveil fix --all</code></pre></div>
+            <p>자동·검토·수동이 어떻게 다른지는 <a href="fixing">수정 및 롤백</a>을 참고하세요.</p>
+
+            <h2>4. 언제든 롤백하기</h2>
+            <p>적용된 모든 수정은 체크포인트가 됩니다. 목록을 확인한 뒤 ID로 하나를 되돌리세요:</p>
+            <div class="code-block"><pre><code>hostveil history
+hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
+            <p>롤백은 백업된 파일을 바이트 단위 그대로 복원합니다. 모든 인터페이스가 하나의 공유 엔진을 거치므로, TUI나 웹 대시보드에서 적용한 수정도 여기서 되돌릴 수 있습니다.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="installation">← 설치</a>
+              <a class="button primary" href="checks">점검 항목 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/index.html
+++ b/site/ko/index.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>hostveil — 셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화</title>
+    <meta name="description" content="hostveil은 셀프호스터가 해킹당하는 보안 실수 — Docker Compose, SSH, 방화벽, 자동 업데이트 — 를 리눅스 홈 서버에서 찾아, 쉬운 말로 설명하고, 미리보기·백업·한 번의 명령으로 되돌리는 롤백과 함께 고쳐 줍니다.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="hostveil — 셀프호스터를 위한 가이드형 보안 강화">
+    <meta property="og:description" content="리눅스 홈 서버의 보안 실수를 찾아 쉽게 설명하고 안전하게 고치는 로컬 바이너리 하나 — 미리보기, 백업, 롤백. 선택적 CVE 스캔과 로컬 AI 지원.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <script src="../script.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="#top" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="#features">기능</a>
+          <a href="#checks">점검</a>
+          <a href="#screenshots">스크린샷</a>
+          <a href="#install">설치</a>
+          <a href="/ko/docs/">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <main id="main">
+      <section class="hero" id="top">
+        <div class="container hero-grid">
+          <div class="hero-copy">
+            <p class="eyebrow">셀프호스터를 위한 가이드형 보안 강화</p>
+            <h1>당신의 홈 서버에 숨은 보안 실수, 찾아서 고쳐 드립니다.</h1>
+            <p class="lede">리눅스에서 셀프호스팅을 하지만 보안 전문가는 아니시죠. hostveil은 사람들이 해킹당하는 잘못된 설정을 찾아 쉬운 말로 설명하고 — 미리보기, 백업, 한 번의 명령으로 되돌리는 롤백과 함께 — 고쳐 줍니다.</p>
+            <div class="hero-actions" aria-label="주요 동작">
+              <a class="button primary" href="#install">설치</a>
+              <a class="button secondary" href="https://github.com/seolcu/hostveil">소스</a>
+            </div>
+          </div>
+
+          <div class="hero-panel" aria-label="hostveil 제품 요약">
+            <div class="score-card">
+              <span>보안 점수</span>
+              <strong>68/100</strong>
+              <small>수정할 때마다 점수가 즉시 오릅니다</small>
+            </div>
+            <div class="finding-list" aria-label="예시 발견 항목">
+              <div class="finding critical"><span>심각</span><strong>데이터베이스가 인터넷에 노출됨</strong><small>compose.ds018</small></div>
+              <div class="finding high"><span>높음</span><strong>SSH가 root 로그인을 허용함</strong><small>ssh.rootlogin</small></div>
+              <div class="finding medium"><span>보통</span><strong>자동 업데이트가 꺼져 있음</strong><small>updates.disabled</small></div>
+            </div>
+          </div>
+        </div>
+        <div class="command-box container" aria-label="설치 명령">
+          <button class="copy-btn" type="button" data-copy="curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash &amp;&amp; hostveil">복사</button>
+          <pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash &amp;&amp; hostveil</code></pre>
+        </div>
+      </section>
+
+      <section class="trust-strip" aria-label="프로젝트 사실">
+        <div class="container stats-grid">
+          <div><strong>바이너리 1개</strong><span>SaaS도, 데이터베이스도, 프런트엔드 빌드도 없음</span></div>
+          <div><strong>네이티브 점검</strong><span>추가 도구 없이 SSH·방화벽·업데이트 점검</span></div>
+          <div><strong>클라우드 계정 0개</strong><span>모든 것이 당신이 통제하는 호스트에서 실행됨</span></div>
+          <div><strong>롤백 준비 완료</strong><span>모든 수정은 먼저 백업하고 되돌릴 수 있음</span></div>
+        </div>
+      </section>
+
+      <section class="section" id="features">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">왜 hostveil인가</p>
+            <h2>또 하나의 보고서가 아니라, 안내자입니다.</h2>
+            <p>hostveil은 알기 어려운 호스트 상태를, 비전문가도 이해할 수 있는 구체적 문제의 우선순위 목록으로 바꾸고 — 안전하게 고치는 과정을 하나씩 안내합니다.</p>
+          </div>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <span class="card-kicker">쉬운 언어</span>
+              <h3>전문 용어 없이 위험을 이해하세요.</h3>
+              <p>각 발견 항목은 무엇이 잘못됐고, 왜 중요하며, 어떻게 고치는지 알려 줍니다 — 점검한 모든 영역을 0–100 점수로 담은 하나의 스냅샷으로.</p>
+            </article>
+            <article class="feature-card">
+              <span class="card-kicker">안전장치와 함께 수정</span>
+              <h3>미리보기, 백업, 적용, 롤백.</h3>
+              <p>모든 자동 수정은 정확한 변경 내용을 먼저 보여 주고, 파일을 건드리기 전에 백업합니다. 마음이 바뀌었나요? <code>hostveil rollback</code>이 원본을 복원합니다.</p>
+            </article>
+            <article class="feature-card">
+              <span class="card-kicker">설계부터 셀프호스팅</span>
+              <h3>에이전트도, 클라우드 업로드도, 계정도 없음.</h3>
+              <p>Compose 파일과 호스트 설정을 로컬에서 읽습니다. 네이티브 점검 덕분에 SSH·방화벽·업데이트 강화를 위해 따로 설치할 것이 없습니다.</p>
+            </article>
+            <article class="feature-card accent-card">
+              <span class="card-kicker">원할 때만, 당신의 방식으로</span>
+              <h3>원하면 CVE 스캔과 로컬 AI를 추가하세요.</h3>
+              <p>Trivy 이미지 스캔은 설치돼 있으면 사용하고, 없으면 깔끔히 건너뜁니다. AI 설명은 선택 사항이며 기본값이 로컬 모델이라 — 무엇도 호스트를 떠나지 않습니다.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section split-section" id="checks">
+        <div class="container split-grid">
+          <div>
+            <p class="eyebrow">점검 범위</p>
+            <h2>실제로 당신을 해킹당하게 만드는 홈 서버 실수들.</h2>
+            <p>노출된 데이터베이스, 컨테이너에 넘겨진 Docker 소켓, root SSH 로그인, 방화벽 부재, 패치되지 않은 패키지 — hostveil은 영향이 가장 큰 경로들을 함께, 깊이 점검합니다.</p>
+          </div>
+          <div class="check-stack">
+            <article>
+              <strong>Docker &amp; Compose</strong>
+              <p>특권 모드, 호스트 네트워킹, Docker 소켓 마운트, 노출된 데이터 저장소와 관리자 패널, 누락된 no-new-privileges, 안전하지 않은 바인드 마운트, 하드코딩된 비밀값 — Compose 파일에 대한 네이티브 감사로 점검합니다.</p>
+            </article>
+            <article>
+              <strong>SSH, 방화벽 &amp; 업데이트</strong>
+              <p>sshd_config의 root 로그인과 비밀번호 인증, 방화벽이 실제로 활성화돼 있는지, 자동 보안 업데이트가 켜져 있는지를 네이티브로 점검합니다. 외부 감사 도구가 필요 없습니다.</p>
+            </article>
+            <article>
+              <strong>이미지 CVE (선택)</strong>
+              <p>Trivy가 설치돼 있으면, hostveil은 Compose 서비스가 실행하는 이미지를 스캔하고 “아직 패치 없음”을 정식 상태로 다룹니다 — 스캔이 실행되지 않았는데도 오해를 주는 만점은 주지 않습니다.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section dark-section" id="screenshots">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">제품</p>
+            <h2>터미널 우선, 브라우저도 친화적.</h2>
+            <p>기본은 TUI로 실행하고, 브라우저로 검토하는 편이 나을 때는 같은 스캔을 localhost로 제공하세요. 둘 다 완전히 동일한 수정·롤백 엔진을 구동합니다.</p>
+          </div>
+          <div class="screens-grid">
+            <figure class="screenshot-card" data-lightbox="tui" role="button" tabindex="0" aria-label="TUI 스크린샷 확대">
+              <img src="../assets/tui.png" alt="hostveil 터미널 UI — 심각도 필터와 다중 선택이 있는 발견 항목" width="1200" height="478" loading="lazy">
+              <figcaption><strong>TUI</strong><span>키보드로 다루는 발견 항목 — 심각도·영역 필터, 다중 선택, 쉬운 말 상세 설명, 수정 미리보기.</span></figcaption>
+            </figure>
+            <figure class="screenshot-card" data-lightbox="web" role="button" tabindex="0" aria-label="웹 UI 스크린샷 확대">
+              <img src="../assets/web.png" alt="hostveil 웹 대시보드 — 필터 칩, 다중 선택, 수정 상세" width="1200" height="456" loading="lazy">
+              <figcaption><strong>웹 UI</strong><span>Localhost 대시보드: 점수, 필터 가능한 발견 항목, 다중 선택 일괄 수정, 미리보기, 롤백.</span></figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section class="section flow-section">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">작업 흐름</p>
+            <h2>스캔하고, 이해하고, 적용하고, 복구하기.</h2>
+          </div>
+          <ol class="flow-list">
+            <li><div class="flow-step-head"><span>01</span><strong>로컬에서 스캔</strong></div><p>리눅스 서버에서 <code>hostveil</code>을 실행하세요. Docker나 Trivy가 없나요? 해당 영역은 깔끔히 건너뜁니다.</p></li>
+            <li><div class="flow-step-head"><span>02</span><strong>이해하기</strong></div><p>발견 항목은 심각도순으로 정렬되며 무엇이·왜 문제인지 쉬운 말로 설명됩니다. 깨끗한 호스트는 속 빈 100점이 아니라 ‘깨끗함’으로 표시됩니다.</p></li>
+            <li><div class="flow-step-head"><span>03</span><strong>수정 적용</strong></div><p>명백히 안전한 수정은 자동, 실질적 대안이 있을 때는 검토, 도구가 직접 바꾸기보다 안내해야 할 때는 수동으로.</p></li>
+            <li><div class="flow-step-head"><span>04</span><strong>언제든 롤백</strong></div><p>적용된 모든 수정은 먼저 백업되며 <code>hostveil rollback</code>으로<br>되돌릴 수 있습니다.</p></li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="section install-section" id="install">
+        <div class="container install-grid">
+          <div>
+            <p class="eyebrow">설치</p>
+            <h2>명령 한 줄, 그리고 스캔.</h2>
+            <p>설치 스크립트는 릴리스 바이너리를 내려받아 체크섬을 검증하고 hostveil을 설치합니다. Trivy는 선택 사항입니다 — 이미지 CVE 스캔을 원하면 나중에 설치하세요.</p>
+            <div class="button-row">
+              <a class="button primary" href="https://github.com/seolcu/hostveil/releases/latest">최신 릴리스</a>
+              <a class="button secondary" href="/ko/docs/">문서</a>
+            </div>
+          </div>
+          <div class="code-block">
+            <pre><code># hostveil 설치 또는 업데이트
+curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
+
+# 터미널 UI (기본)
+hostveil
+
+# localhost 웹 UI
+hostveil serve
+
+# 스캔한 뒤 안전한 것 모두 수정
+hostveil scan
+hostveil fix --all</code></pre>
+          </div>
+        </div>
+      </section>
+
+      <section class="section faq-section" id="faq">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">자주 묻는 질문</p>
+            <h2>자주 묻는 질문들.</h2>
+          </div>
+          <div class="faq-grid">
+            <article>
+              <h3>제 데이터를 업로드하나요?</h3>
+              <p>아니요. hostveil은 로컬에서 실행됩니다. 선택적 AI<br>설명조차 기본값이 당신의 컴퓨터에 있는 모델입니다.</p>
+            </article>
+            <article>
+              <h3>수정이 서버를 망가뜨리진 않나요?</h3>
+              <p>적용 전에 정확한 변경 내용을 확인하고, 원본은 먼저<br>백업되며, <code>hostveil rollback</code>으로 되돌립니다.</p>
+            </article>
+            <article>
+              <h3>수정에 절충점이 있으면 어떻게 되나요?</h3>
+              <p>그건 자동이 아니라 검토 수정입니다. hostveil이 독립적인<br>대안을 보여 주고 당신이 선택하게 합니다.</p>
+            </article>
+            <article>
+              <h3>Docker나 Trivy가 필요한가요?</h3>
+              <p>아니요. SSH·방화벽·업데이트 점검은 네이티브로 실행됩니다. Docker와<br>Trivy 점검은 있으면 사용하고 없으면 건너뜁니다.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <div class="lightbox-overlay" id="lightbox" role="dialog" aria-label="확대된 스크린샷" aria-hidden="true">
+      <div class="lightbox-content">
+        <img alt="" id="lightbox-img">
+        <div class="lightbox-caption" id="lightbox-caption"></div>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="#top"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="/ko/docs/">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/lang-suggest.js
+++ b/site/lang-suggest.js
@@ -1,0 +1,57 @@
+/* hostveil — suggest the Korean version to Korean-locale visitors.
+   Non-intrusive banner, no forced redirect. Loaded on English pages only. */
+(function () {
+  "use strict";
+
+  var DISMISS_KEY = "hv-lang-suggest-dismissed";
+
+  // Already on a /ko/ page? Nothing to suggest.
+  if (location.pathname.indexOf("/ko/") === 0) return;
+
+  // Does the visitor prefer Korean?
+  var langs = navigator.languages || [navigator.language || ""];
+  var prefersKo = langs.some(function (l) {
+    return /^ko\b/i.test(l || "");
+  });
+  if (!prefersKo) return;
+
+  // Respect a prior dismissal.
+  try {
+    if (localStorage.getItem(DISMISS_KEY) === "1") return;
+  } catch (e) { /* ignore */ }
+
+  // Korean counterpart of the current page.
+  var koHref = "/ko" + location.pathname + location.search + location.hash;
+
+  function dismiss() {
+    try { localStorage.setItem(DISMISS_KEY, "1"); } catch (e) { /* ignore */ }
+    if (banner.parentNode) banner.parentNode.removeChild(banner);
+  }
+
+  var banner = document.createElement("div");
+  banner.className = "lang-suggest";
+  banner.setAttribute("role", "region");
+  banner.setAttribute("aria-label", "언어 안내");
+
+  var msg = document.createElement("span");
+  msg.textContent = "이 페이지는 한국어로도 볼 수 있습니다.";
+
+  var link = document.createElement("a");
+  link.href = koHref;
+  link.textContent = "한국어로 보기 →";
+  link.addEventListener("click", function () {
+    try { localStorage.setItem(DISMISS_KEY, "1"); } catch (e) { /* ignore */ }
+  });
+
+  var close = document.createElement("button");
+  close.type = "button";
+  close.textContent = "✕";
+  close.setAttribute("aria-label", "닫기");
+  close.addEventListener("click", dismiss);
+
+  banner.appendChild(msg);
+  banner.appendChild(link);
+  banner.appendChild(close);
+
+  document.body.insertBefore(banner, document.body.firstChild);
+})();

--- a/site/script.js
+++ b/site/script.js
@@ -2,6 +2,12 @@
 (function () {
   "use strict";
 
+  var KO = document.documentElement.lang === "ko";
+  var T = {
+    copy: KO ? "복사" : "Copy",
+    copied: KO ? "복사됨" : "Copied",
+  };
+
   /* ── copy-to-clipboard ────────────────────────────────── */
 
   document.addEventListener("click", function (e) {
@@ -10,10 +16,10 @@
     var text = btn.getAttribute("data-copy");
     if (!text) return;
     navigator.clipboard.writeText(text).then(function () {
-      btn.textContent = "Copied";
+      btn.textContent = T.copied;
       btn.classList.add("copied");
       setTimeout(function () {
-        btn.textContent = "Copy";
+        btn.textContent = T.copy;
         btn.classList.remove("copied");
       }, 1500);
     });

--- a/site/styles.css
+++ b/site/styles.css
@@ -17,8 +17,8 @@
   --warning: #d6ae58;
   --shadow-cut: #020504;
   --max: 1080px;
-  --font-body: Georgia, "Iowan Old Style", "Palatino Linotype", Palatino, serif;
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --font-body: Georgia, "Iowan Old Style", "Palatino Linotype", Palatino, "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "맑은 고딕", serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "맑은 고딕", monospace;
 }
 
 * {
@@ -926,4 +926,65 @@ figcaption strong {
   margin-bottom: 4px;
   color: var(--paper);
   font-size: 1.1rem;
+}
+
+/* ── language switch (header) ─────────────────────────── */
+
+.nav-links a.lang-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px;
+  border: 1px solid var(--line-strong);
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.nav-links a.lang-switch::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  background: var(--accent);
+}
+
+.nav-links a.lang-switch:hover,
+.nav-links a.lang-switch:focus-visible {
+  border-color: var(--accent);
+}
+
+/* ── language suggestion banner ───────────────────────── */
+
+.lang-suggest {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--accent);
+  background: var(--panel-strong);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.lang-suggest a {
+  color: var(--accent);
+  font-weight: 700;
+  border-bottom: 1px solid currentColor;
+}
+
+.lang-suggest button {
+  padding: 2px 8px;
+  border: 1px solid var(--line-strong);
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  cursor: pointer;
+}
+
+.lang-suggest button:hover,
+.lang-suggest button:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
 }


### PR DESCRIPTION
## 개요

hostveil.seolcu.com 웹사이트에 **한국어(ko) 지원**을 추가합니다. 프레임워크 없는 정적 사이트 특성에 맞춰, 영어 원본은 그대로 두고 `site/ko/` 아래에 한국어 미러를 만드는 SEO 친화적·JS 불필요 방식으로 구현했습니다.

## 변경 내용

**한국어 페이지 (신규 11개)** — `site/ko/`
- `ko/index.html` (랜딩) + `ko/docs/*.html` (문서 10개 전부 번역)
- 각 페이지 `lang="ko"`, `/ko/` canonical, `og:locale=ko_KR`
- 코드·명령어·플래그·finding ID(예: `compose.ds018`)는 번역하지 않고 원문 유지

**다국어 인프라**
- **hreflang** (en/ko/x-default): 모든 EN↔KO 페이지 쌍 상호 연결, 영어가 기본(x-default)
- **언어 전환기**: 모든 헤더에 한국어/English 링크 (각자 대응 페이지로 연결)
- **자동 감지 배너** (`site/lang-suggest.js`): 한국어 브라우저 방문자에게 영어 페이지에서만 "한국어로 보기" 안내. 강제 리다이렉트 없음, ✕로 닫으면 재노출 안 함
- **공유 JS 언어 인식**: `script.js`/`docs.js`가 `documentElement.lang` 기준으로 "복사/복사됨/검색 결과 없음" 등 UI 문자열 분기 (파일은 여전히 하나로 공유)
- **CSS**: `styles.css`에 한글 글리프 폰트 폴백 + `.lang-switch`/`.lang-suggest` 스타일

## 검증

- 구조 검증 스크립트 통과: lang·hreflang·canonical·자산 경로·전환기 타깃·사이드바 active 링크 정확
- HTML well-formedness 통과, 문서 코드 블록은 영어 원본과 바이트 단위 동일
- 로컬 서버로 주요 URL·자산 200 응답 확인

## 배포

`.github/workflows/pages.yml`의 `site/**` 트리거가 새 파일을 자동 포함하므로 워크플로 수정은 불필요합니다. main 머지 시 `/ko/` 경로가 그대로 배포됩니다.

> 참고: 로컬 `python http.server`는 확장자 없는 URL(`/ko/docs/checks`)을 `.html`로 해석하지 않아 문서 내부 링크 클릭 검증은 GitHub Pages 프로덕션에서 최종 확인이 필요합니다(프로덕션은 정상 해석).

🤖 Generated with [Claude Code](https://claude.com/claude-code)