### PR TITLE
Add Korean (ko) localization for the website

### DIFF
--- a/site/ko/docs/installation.html
+++ b/site/ko/docs/installation.html
@@ -90,8 +90,8 @@
             <h2>빠른 설치</h2>
             <p>설치 스크립트는 OS와 아키텍처를 감지하고, 릴리스 바이너리를 내려받아 체크섬을 검증한 뒤 <code>/usr/bin/hostveil</code>에 설치합니다:</p>
             <div class="command-box">
-              <button class="copy-btn" type="button" data-copy="curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash">Copy</button>
-              <pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash</code></pre>
+              <button class="copy-btn" type="button" data-copy="curl -fsSL https://hostveil.seolcu.com/install.sh | bash">Copy</button>
+              <pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash</code></pre>
             </div>
             <p>같은 명령을 언제든 다시 실행하면 최신 릴리스로 업데이트됩니다. 그런 다음 확인하세요:</p>
             <div class="code-block"><pre><code>hostveil version</code></pre></div>
@@ -121,7 +121,7 @@
               </table>
             </div>
             <p>파이프를 통해 옵션을 전달하려면 <code>bash -s --</code>를 사용하세요. 예:</p>
-            <div class="code-block"><pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash -s -- --no-trivy</code></pre></div>
+            <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --no-trivy</code></pre></div>
 
             <h2>권한 상승은 자동입니다</h2>
             <div class="callout">

--- a/site/ko/index.html
+++ b/site/ko/index.html
@@ -68,8 +68,8 @@
           </div>
         </div>
         <div class="command-box container" aria-label="설치 명령">
-          <button class="copy-btn" type="button" data-copy="curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash &amp;&amp; hostveil">복사</button>
-          <pre><code>curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash &amp;&amp; hostveil</code></pre>
+          <button class="copy-btn" type="button" data-copy="curl -fsSL https://hostveil.seolcu.com/install.sh | bash &amp;&amp; hostveil">복사</button>
+          <pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash &amp;&amp; hostveil</code></pre>
         </div>
       </section>
 
@@ -186,7 +186,7 @@
           </div>
           <div class="code-block">
             <pre><code># hostveil 설치 또는 업데이트
-curl -fsSL https://raw.githubusercontent.com/seolcu/hostveil/main/scripts/install.sh | bash
+curl -fsSL https://hostveil.seolcu.com/install.sh | bash
 
 # 터미널 UI (기본)
 hostveil


### PR DESCRIPTION
## What

Adds a full Korean (`ko`) localization of the website under `/ko/`, plus a language switcher across the existing English pages.

- New `site/ko/` mirror: landing page + all docs pages.
- Language switcher links added to each English page; `lang-suggest.js` suggests the Korean site to Korean-locale visitors.
- Supporting `docs.js`, `script.js`, `styles.css` updates.

## Installer URL

Korean install docs point at the short domain URL `https://hostveil.seolcu.com/install.sh`, consistent with the English site (#511). The merge auto-combines cleanly with #511's changes on `site/index.html` and `site/docs/installation.html` — no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)