### PR TITLE
Drop unnecessary sudo prefix from fixing/interfaces docs

### DIFF
--- a/site/docs/fixing.html
+++ b/site/docs/fixing.html
@@ -105,28 +105,28 @@
             <h2>Applying a fix</h2>
             <p>Preview and apply a single finding by its ID:</p>
             <div class="command-box">
-              <button class="copy-btn" type="button" data-copy="sudo hostveil fix ssh.rootlogin">Copy</button>
-              <pre><code>sudo hostveil fix ssh.rootlogin</code></pre>
+              <button class="copy-btn" type="button" data-copy="hostveil fix ssh.rootlogin">Copy</button>
+              <pre><code>hostveil fix ssh.rootlogin</code></pre>
             </div>
             <p>Applying always: <strong>1)</strong> shows the exact diff or command, <strong>2)</strong> backs up the original file to a checkpoint, then <strong>3)</strong> applies the change. You confirm at a <code>[y/N]</code> prompt unless you pass <code>--yes</code>.</p>
 
             <h3>Choosing a Review alternative</h3>
             <p>Review findings offer independent alternatives. Pass the 0-based index with <code>--action</code>:</p>
-            <div class="code-block"><pre><code>sudo hostveil fix ssh.passwordauth --action 0</code></pre></div>
+            <div class="code-block"><pre><code>hostveil fix ssh.passwordauth --action 0</code></pre></div>
 
             <h3>Disambiguating by service</h3>
             <p>When the same Compose rule fires for more than one service, narrow it with <code>--service</code>:</p>
-            <div class="code-block"><pre><code>sudo hostveil fix compose.ds018 --service db</code></pre></div>
+            <div class="code-block"><pre><code>hostveil fix compose.ds018 --service db</code></pre></div>
 
             <h3>Applying every safe fix</h3>
-            <div class="code-block"><pre><code>sudo hostveil fix --all</code></pre></div>
+            <div class="code-block"><pre><code>hostveil fix --all</code></pre></div>
             <p>Applies each Auto-fix finding, each with its own checkpoint so any of them can be rolled back individually.</p>
 
             <h2>History &amp; rollback</h2>
             <p>Every applied fix is recorded as a checkpoint. List them newest-first:</p>
             <div class="code-block"><pre><code>hostveil history</code></pre></div>
             <p>Each entry shows a timestamp, the finding ID, a label, and the exact rollback command. Undo one by its checkpoint ID:</p>
-            <div class="code-block"><pre><code>sudo hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
+            <div class="code-block"><pre><code>hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
             <div class="callout">
               <span class="callout-label">Reversible everywhere</span>
               <p>Rollback restores the backed-up file byte-for-byte. Because the TUI, web dashboard, and CLI all go through one shared engine, a fix applied in any of them is listed in <code>history</code> and reversible from any of them. (A few actions are inherently not reversible; <code>history</code> marks those <em>not reversible</em>.)</p>

--- a/site/docs/interfaces.html
+++ b/site/docs/interfaces.html
@@ -89,7 +89,7 @@
 
             <h2>TUI — the default</h2>
             <p>Running <code>hostveil</code> with no arguments on an interactive terminal opens the keyboard-driven TUI. You can also launch it explicitly:</p>
-            <div class="code-block"><pre><code>sudo hostveil        # or: sudo hostveil tui</code></pre></div>
+            <div class="code-block"><pre><code>hostveil        # or: hostveil tui</code></pre></div>
             <p>It shows the score and findings with severity and domain <strong>filters</strong>, <strong>multi-select</strong> for batch fixing, plain-language detail, and a fix preview before anything is applied.</p>
             <figure>
               <img src="../assets/tui.png" alt="hostveil terminal UI — findings with severity filters and multi-select" width="1200" height="478" loading="lazy">
@@ -103,8 +103,8 @@
             <h2>Web — localhost dashboard</h2>
             <p>Serve the same scan over HTTP when a browser is better for review:</p>
             <div class="command-box">
-              <button class="copy-btn" type="button" data-copy="sudo hostveil serve">Copy</button>
-              <pre><code>sudo hostveil serve</code></pre>
+              <button class="copy-btn" type="button" data-copy="hostveil serve">Copy</button>
+              <pre><code>hostveil serve</code></pre>
             </div>
             <p>By default it binds to <code>127.0.0.1:8787</code> — loopback only. Change it with <code>--addr</code>; if you point it at a non-loopback address, hostveil prints a warning about exposing the dashboard. (<code>hostveil web</code> is an alias for <code>serve</code>.)</p>
             <figure>
@@ -115,7 +115,7 @@
             <h2>CLI — scriptable</h2>
             <p>The <code>scan</code>, <code>fix</code>, <code>rollback</code>, and <code>history</code> subcommands work non-interactively. <code>scan --json</code> emits machine-readable output, and <code>scan</code> exits non-zero when any unfixed finding is Critical or High — so it slots into CI or a cron job:</p>
             <div class="code-block"><pre><code>hostveil scan --json &gt; report.json
-sudo hostveil fix --all --yes</code></pre></div>
+hostveil fix --all --yes</code></pre></div>
             <p>See the <a href="cli">CLI reference</a> for every command and flag.</p>
 
             <div class="callout">

--- a/site/ko/docs/fixing.html
+++ b/site/ko/docs/fixing.html
@@ -105,28 +105,28 @@
             <h2>수정 적용하기</h2>
             <p>단일 발견 항목을 ID로 미리보고 적용합니다.</p>
             <div class="command-box">
-              <button class="copy-btn" type="button" data-copy="sudo hostveil fix ssh.rootlogin">Copy</button>
-              <pre><code>sudo hostveil fix ssh.rootlogin</code></pre>
+              <button class="copy-btn" type="button" data-copy="hostveil fix ssh.rootlogin">Copy</button>
+              <pre><code>hostveil fix ssh.rootlogin</code></pre>
             </div>
             <p>적용은 항상 <strong>1)</strong> 정확한 diff나 명령을 보여 주고, <strong>2)</strong> 원본 파일을 체크포인트로 백업한 뒤, <strong>3)</strong> 변경을 적용합니다. <code>--yes</code>를 넘기지 않는 한 <code>[y/N]</code> 프롬프트에서 확인합니다.</p>
 
             <h3>검토 대안 선택하기</h3>
             <p>검토 발견 항목은 독립적인 대안을 제공합니다. 0부터 시작하는 인덱스를 <code>--action</code>으로 넘깁니다.</p>
-            <div class="code-block"><pre><code>sudo hostveil fix ssh.passwordauth --action 0</code></pre></div>
+            <div class="code-block"><pre><code>hostveil fix ssh.passwordauth --action 0</code></pre></div>
 
             <h3>서비스별로 구분하기</h3>
             <p>동일한 Compose 규칙이 둘 이상의 서비스에서 발생하면, <code>--service</code>로 범위를 좁힙니다.</p>
-            <div class="code-block"><pre><code>sudo hostveil fix compose.ds018 --service db</code></pre></div>
+            <div class="code-block"><pre><code>hostveil fix compose.ds018 --service db</code></pre></div>
 
             <h3>안전한 모든 수정 적용하기</h3>
-            <div class="code-block"><pre><code>sudo hostveil fix --all</code></pre></div>
+            <div class="code-block"><pre><code>hostveil fix --all</code></pre></div>
             <p>각 자동 수정 발견 항목을 적용하며, 각각 자체 체크포인트를 가지므로 개별적으로 롤백할 수 있습니다.</p>
 
             <h2>이력 및 롤백</h2>
             <p>적용된 모든 수정은 체크포인트로 기록됩니다. 최신순으로 나열합니다.</p>
             <div class="code-block"><pre><code>hostveil history</code></pre></div>
             <p>각 항목은 타임스탬프, 발견 항목 ID, 레이블, 정확한 롤백 명령을 보여 줍니다. 체크포인트 ID로 하나를 되돌립니다.</p>
-            <div class="code-block"><pre><code>sudo hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
+            <div class="code-block"><pre><code>hostveil rollback &lt;checkpoint-id&gt;</code></pre></div>
             <div class="callout">
               <span class="callout-label">어디서나 되돌릴 수 있음</span>
               <p>롤백은 백업된 파일을 바이트 단위 그대로 복원합니다. TUI, 웹 대시보드, CLI가 모두 하나의 공유 엔진을 거치기 때문에, 어느 곳에서 적용한 수정이든 <code>history</code>에 나열되고 어디서나 되돌릴 수 있습니다. (일부 작업은 본질적으로 되돌릴 수 없으며, <code>history</code>는 이를 <em>되돌릴 수 없음</em>으로 표시합니다.)</p>

--- a/site/ko/docs/interfaces.html
+++ b/site/ko/docs/interfaces.html
@@ -89,7 +89,7 @@
 
             <h2>TUI — 기본값</h2>
             <p>인수 없이 대화형 터미널에서 <code>hostveil</code>을 실행하면 키보드 기반 TUI가 열립니다. 명시적으로 실행할 수도 있습니다.</p>
-            <div class="code-block"><pre><code>sudo hostveil        # or: sudo hostveil tui</code></pre></div>
+            <div class="code-block"><pre><code>hostveil        # or: hostveil tui</code></pre></div>
             <p>점수와 발견 항목을 심각도·영역 <strong>필터</strong>, 일괄 수정을 위한 <strong>다중 선택</strong>, 쉬운 말 상세 설명, 그리고 적용 전 수정 미리보기와 함께 보여 줍니다.</p>
             <figure>
               <img src="../../assets/tui.png" alt="hostveil 터미널 UI — 심각도 필터와 다중 선택이 있는 발견 항목" width="1200" height="478" loading="lazy">
@@ -103,8 +103,8 @@
             <h2>웹 — localhost 대시보드</h2>
             <p>브라우저로 검토하는 편이 나을 때 동일한 스캔을 HTTP로 제공합니다.</p>
             <div class="command-box">
-              <button class="copy-btn" type="button" data-copy="sudo hostveil serve">Copy</button>
-              <pre><code>sudo hostveil serve</code></pre>
+              <button class="copy-btn" type="button" data-copy="hostveil serve">Copy</button>
+              <pre><code>hostveil serve</code></pre>
             </div>
             <p>기본적으로 <code>127.0.0.1:8787</code>에 바인딩됩니다 — loopback 전용입니다. <code>--addr</code>로 변경할 수 있으며, non-loopback 주소를 지정하면 hostveil이 대시보드 노출에 관한 경고를 출력합니다. (<code>hostveil web</code>은 <code>serve</code>의 별칭입니다.)</p>
             <figure>
@@ -115,7 +115,7 @@
             <h2>CLI — 스크립트 가능</h2>
             <p><code>scan</code>, <code>fix</code>, <code>rollback</code>, <code>history</code> 하위 명령은 비대화형으로 동작합니다. <code>scan --json</code>은 기계가 읽을 수 있는 출력을 내보내며, <code>scan</code>은 수정되지 않은 발견 항목 중 심각 또는 높음이 하나라도 있으면 0이 아닌 값으로 종료합니다 — 그래서 CI나 cron 작업에 그대로 들어갑니다.</p>
             <div class="code-block"><pre><code>hostveil scan --json &gt; report.json
-sudo hostveil fix --all --yes</code></pre></div>
+hostveil fix --all --yes</code></pre></div>
             <p>모든 명령과 플래그는 <a href="cli">CLI 레퍼런스</a>를 참고하세요.</p>
 
             <div class="callout">


### PR DESCRIPTION
## What

Auto-elevation (`ed3f6ad`) made plain `hostveil` re-exec itself under `sudo` for root-benefiting commands (`scan`, `tui`, `fix`, `serve`, `explain`, `rollback`, `history`). That commit dropped the `sudo` prefix from quickstart/cli/faq/installation/checks — but **missed `fixing.html` and `interfaces.html`**, which still instructed users to type `sudo hostveil …`.

This drops the now-unnecessary prefix on those command blocks, in both the **English** and **Korean** pages:

- `site/docs/fixing.html` + `site/ko/docs/fixing.html` — `fix` / `rollback` examples
- `site/docs/interfaces.html` + `site/ko/docs/interfaces.html` — bare `hostveil` / `tui` / `serve` / `fix --all` examples

## Left unchanged

- Prose that references `sudo hostveil` to explain the *identical* password prompt (installation/faq/quickstart/README) — correct as-is.
- Contributor/demo-container docs (`demo/README.md`, `docs/DEVELOPMENT.md`, `contributing.html` shell-flow comment) — a matched set describing the demo shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)