### PR TITLE
Deduplicate contributing docs; refresh demo docs for auto-elevation

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -12,7 +12,7 @@ from a `git clone`.
 cd demo
 vagrant up            # boots + provisions the vulnerable server (first run: a few minutes)
 vagrant ssh           # you're now on the "home server"
-  sudo hostveil scan  # see the findings
+  hostveil scan       # see the findings (auto-elevates with sudo)
 ```
 
 Everything is **real** — real Docker with real running stacks, real weak SSH
@@ -55,7 +55,7 @@ cd demo
 ./run.sh up        # boot the VM + start the vulnerable stacks (first run downloads the box + images)
 ./run.sh scan      # scored report across all domains
 ./run.sh web       # dashboard at http://localhost:8787 (Ctrl-C to stop)
-./run.sh shell     # a shell on the demo server — then e.g. `sudo hostveil`
+./run.sh shell     # a shell on the demo server — then e.g. `hostveil`
 ./run.sh halt      # shut the VM down; nothing keeps running
 ```
 
@@ -63,9 +63,12 @@ Prefer raw Vagrant? `vagrant up` / `vagrant ssh` work too (run
 `./run.sh up` once after a boot to start the stacks — they intentionally
 have no restart policy, so they don't come back on their own).
 
-> Run hostveil with **sudo** inside the VM so it can read root-owned config
-> (`/etc/ssh/sshd_config`) and apply fixes. Without sudo, those domains are
-> skipped with a clear message — which is itself a nice thing to show.
+> Inside the VM, plain `hostveil` re-executes itself under **sudo**
+> automatically so it can read root-owned config (`/etc/ssh/sshd_config`) and
+> apply fixes — the prompt you see is sudo's own. To instead show the graceful
+> non-root behaviour, run `HOSTVEIL_NO_SUDO=1 hostveil scan`: the root-owned
+> domains are skipped with a clear message and the score is renormalized —
+> itself a nice thing to demo.
 
 **Web dashboard**: port 8787 is forwarded to the host, so while
 `./run.sh web` is running, open **<http://localhost:8787>** in your browser.
@@ -78,18 +81,18 @@ rebuild inside: `cd /hostveil && sudo /usr/local/go/bin/go build -o /usr/local/b
 
 ## Suggested demo script (5 minutes)
 
-1. **Scan** — `sudo hostveil scan`
+1. **Scan** — `hostveil scan`
    Score is low; findings are grouped by severity with plain-language
    descriptions across Docker/Compose, SSH, firewall, auto-updates, and CVEs.
-2. **Explain one** — `sudo hostveil explain compose.ds018 --service redis`
+2. **Explain one** — `hostveil explain compose.ds018 --service redis`
    ("a database exposed to the whole internet").
-3. **Fix with a preview** — `sudo hostveil fix ssh.rootlogin`
+3. **Fix with a preview** — `hostveil fix ssh.rootlogin`
    Shows the exact diff, backs up the file, applies it. Then
-   `sudo hostveil rollback <id>` restores it byte-for-byte.
-4. **Fix everything safe** — `sudo hostveil fix --all`
+   `hostveil rollback <id>` restores it byte-for-byte.
+4. **Fix everything safe** — `hostveil fix --all`
    Watch the score jump.
-5. **Re-scan** — `sudo hostveil scan` shows what's now *resolved*.
-6. **(Optional) Web** — `sudo hostveil serve --addr 0.0.0.0:8787`, open
+5. **Re-scan** — `hostveil scan` shows what's now *resolved*.
+6. **(Optional) Web** — `hostveil serve --addr 0.0.0.0:8787`, open
    <http://localhost:8787>, click a finding, preview + apply from the browser.
 
 Judges can poke around and see it's a real server: `docker ps`,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -70,7 +70,7 @@ cd demo
 ./run.sh up        # boot + provision + start the vulnerable stacks
 ./run.sh scan      # run hostveil against the server
 ./run.sh web       # dashboard at http://localhost:8787
-./run.sh shell     # a shell on the server (then: sudo hostveil ...)
+./run.sh shell     # a shell on the server (then: hostveil ...)
 ./run.sh halt      # shut it down — nothing keeps running
 ```
 

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -85,61 +85,24 @@
           <article class="docs-prose">
             <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / Contributing</p>
             <h1>Contributing</h1>
-            <p class="lead">hostveil is Go, with a small dependency tree and a strict architecture. This is the short version; the canonical developer guide is <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>docs/DEVELOPMENT.md</code></a>.</p>
+            <p class="lead">hostveil is Go, with a small dependency tree and a strict architecture. This page is a quick orientation — the canonical developer guide is <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>docs/DEVELOPMENT.md</code></a>, and the demo VM is documented in <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>.</p>
 
-            <h2>Prerequisites</h2>
-            <ul>
-              <li><strong>Go</strong> — the version pinned in <code>go.mod</code> or newer.</li>
-              <li><strong>git</strong>.</li>
-              <li><em>Optional:</em> Vagrant + a provider (libvirt on Linux, VirtualBox on macOS/Windows) to run the demo VM.</li>
-            </ul>
-
-            <h2>Build &amp; test</h2>
+            <h2>Start here</h2>
             <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil.git
 cd hostveil
 go build ./cmd/hostveil     # produces ./hostveil
-go test ./...               # unit + fuzz + property tests</code></pre></div>
-            <p>Before sending a change, run the same checks CI runs:</p>
-            <div class="code-block"><pre><code>go build ./...
-go vet ./...
-gofmt -l .                  # must print nothing
-go mod tidy                 # must leave go.mod/go.sum unchanged
-go test -race ./...</code></pre></div>
+go test ./...</code></pre></div>
+            <p>Before opening a PR, run the full suite CI runs — <code>go build ./...</code>, <code>go vet</code>, <code>gofmt -l .</code>, <code>go mod tidy</code>, and <code>go test -race ./...</code>. The exact commands and the pinned Go version are in <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>DEVELOPMENT.md</code></a>.</p>
             <div class="callout">
               <span class="callout-label">Linux tool, portable tests</span>
-              <p>hostveil <strong>builds and its tests pass on any OS</strong>, but running the binary meaningfully needs Linux with the relevant tools present. Use the demo VM rather than running it against your own machine.</p>
+              <p>hostveil <strong>builds and its tests pass on any OS</strong>, but running the binary meaningfully needs Linux with the relevant tools present — use the demo VM rather than your own machine.</p>
             </div>
 
-            <h2>Repository layout</h2>
-            <div class="code-block"><pre><code>cmd/hostveil/        entry point + subcommand wiring
-internal/
-  core/              the shared engine — the only thing the UIs call
-  check/             detection domains (compose, ssh, firewall, updates, cve)
-  fix/ compose/ history/   fix registry, YAML editing, backup/rollback
-  model/ platform/   pure value types; the OS/command seam
-  ui/{cli,tui,web}/  thin UIs over the engine
-demo/                the reproducible vulnerable-server VM (Vagrant)
-site/                the marketing site + these docs (static)
-docs/                developer documentation</code></pre></div>
-
-            <h2>Architecture rule</h2>
-            <div class="callout warn">
-              <span class="callout-label">Enforced by a test</span>
-              <p>UIs depend only on <code>core</code>. An import-lint test enforces that <code>ui/*</code> never imports <code>fix</code>, <code>history</code>, <code>check</code>, or <code>compose</code>. This is what keeps the TUI, web, and CLI behaving identically — they all go through the one engine.</p>
-            </div>
-
-            <h2>Adding a check</h2>
-            <p>Adding a detection domain means writing one package under <code>internal/check/</code> that implements the <code>Checker</code> interface and registering it. Findings are created with a stable <code>domain.rule</code> ID, a severity, and a remediation kind (see <a href="checks">What it checks</a> and <a href="fixing">Fixing &amp; rollback</a>).</p>
+            <h2>How it's built</h2>
+            <p>The engine lives in <code>internal/core</code>; the CLI, TUI, and web UIs are thin layers over it. An import-lint <strong>test</strong> enforces that <code>ui/*</code> never imports <code>fix</code>, <code>history</code>, <code>check</code>, or <code>compose</code> — that is what keeps the three interfaces behaving identically. Adding a detection domain means writing one package under <code>internal/check/</code> that implements the <code>Checker</code> interface and registering it (see <a href="checks">What it checks</a> and <a href="fixing">Fixing &amp; rollback</a>). The full repository layout and architecture notes are in <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>DEVELOPMENT.md</code></a>.</p>
 
             <h2>Running it for real: the demo VM</h2>
-            <p><code>demo/</code> is a code-defined, deliberately vulnerable Ubuntu server. hostveil is built from your working tree <em>inside</em> the VM, so it always reflects your current code:</p>
-            <div class="code-block"><pre><code>cd demo
-./run.sh up        # boot + provision + start the vulnerable stacks
-./run.sh scan      # run hostveil against the server
-./run.sh web       # dashboard at http://localhost:8787
-./run.sh shell     # a shell on the server (then: sudo hostveil ...)
-./run.sh halt      # shut it down</code></pre></div>
-            <p>The full walkthrough, per-platform provider setup, demo script, and reset workflow live in <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>.</p>
+            <p><code>demo/</code> is a code-defined, deliberately vulnerable Ubuntu server; hostveil is built from your working tree <em>inside</em> the VM, so it always reflects your current code. Bring it up with <code>./run.sh up</code> and scan with <code>./run.sh scan</code>. Per-platform provider setup, the 5-minute demo script, the reset workflow, and troubleshooting all live in <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>.</p>
 
             <div class="docs-pager">
               <a class="button secondary" href="faq">← FAQ</a>

--- a/site/ko/docs/contributing.html
+++ b/site/ko/docs/contributing.html
@@ -85,61 +85,24 @@
           <article class="docs-prose">
             <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 기여하기</p>
             <h1>기여하기</h1>
-            <p class="lead">hostveil은 Go로 작성되었으며, 의존성 트리가 작고 아키텍처 규칙이 엄격합니다. 이 글은 요약본이며, 정식 개발자 가이드는 <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>docs/DEVELOPMENT.md</code></a>입니다.</p>
+            <p class="lead">hostveil은 Go로 작성되었으며, 의존성 트리가 작고 아키텍처 규칙이 엄격합니다. 이 페이지는 빠른 안내이며, 정식 개발자 가이드는 <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>docs/DEVELOPMENT.md</code></a>, 데모 VM은 <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>에 정리되어 있습니다.</p>
 
-            <h2>사전 준비물</h2>
-            <ul>
-              <li><strong>Go</strong> — <code>go.mod</code>에 고정된 버전 이상.</li>
-              <li><strong>git</strong>.</li>
-              <li><em>선택 사항:</em> 데모 VM을 실행하려면 Vagrant와 프로바이더(리눅스는 libvirt, macOS/Windows는 VirtualBox).</li>
-            </ul>
-
-            <h2>빌드 및 테스트</h2>
+            <h2>시작하기</h2>
             <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil.git
 cd hostveil
 go build ./cmd/hostveil     # produces ./hostveil
-go test ./...               # unit + fuzz + property tests</code></pre></div>
-            <p>변경 사항을 보내기 전에, CI가 실행하는 것과 같은 점검을 실행하세요:</p>
-            <div class="code-block"><pre><code>go build ./...
-go vet ./...
-gofmt -l .                  # must print nothing
-go mod tidy                 # must leave go.mod/go.sum unchanged
-go test -race ./...</code></pre></div>
+go test ./...</code></pre></div>
+            <p>PR를 열기 전에 CI가 실행하는 전체 점검을 돌리세요 — <code>go build ./...</code>, <code>go vet</code>, <code>gofmt -l .</code>, <code>go mod tidy</code>, 그리고 <code>go test -race ./...</code>입니다. 정확한 명령과 고정된 Go 버전은 <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>DEVELOPMENT.md</code></a>에 있습니다.</p>
             <div class="callout">
               <span class="callout-label">리눅스 도구, 이식 가능한 테스트</span>
-              <p>hostveil은 <strong>어떤 OS에서도 빌드되고 테스트가 통과</strong>하지만, 바이너리를 의미 있게 실행하려면 관련 도구가 설치된 리눅스가 필요합니다. 본인의 머신에서 직접 실행하기보다 데모 VM을 사용하세요.</p>
+              <p>hostveil은 <strong>어떤 OS에서도 빌드되고 테스트가 통과</strong>하지만, 바이너리를 의미 있게 실행하려면 관련 도구가 설치된 리눅스가 필요합니다 — 본인의 머신 대신 데모 VM을 사용하세요.</p>
             </div>
 
-            <h2>저장소 구조</h2>
-            <div class="code-block"><pre><code>cmd/hostveil/        entry point + subcommand wiring
-internal/
-  core/              the shared engine — the only thing the UIs call
-  check/             detection domains (compose, ssh, firewall, updates, cve)
-  fix/ compose/ history/   fix registry, YAML editing, backup/rollback
-  model/ platform/   pure value types; the OS/command seam
-  ui/{cli,tui,web}/  thin UIs over the engine
-demo/                the reproducible vulnerable-server VM (Vagrant)
-site/                the marketing site + these docs (static)
-docs/                developer documentation</code></pre></div>
-
-            <h2>아키텍처 규칙</h2>
-            <div class="callout warn">
-              <span class="callout-label">테스트로 강제됨</span>
-              <p>UI는 오직 <code>core</code>에만 의존합니다. import-lint 테스트가 <code>ui/*</code>가 <code>fix</code>, <code>history</code>, <code>check</code>, <code>compose</code>를 절대 import하지 않도록 강제합니다. 이것이 TUI, 웹, CLI가 동일하게 동작하도록 만드는 요인입니다 — 모두 하나의 엔진을 거쳐 갑니다.</p>
-            </div>
-
-            <h2>점검 항목 추가하기</h2>
-            <p>탐지 도메인을 추가한다는 것은 <code>internal/check/</code> 아래에 <code>Checker</code> 인터페이스를 구현하는 패키지 하나를 작성하고 등록하는 것을 의미합니다. 발견 항목은 안정적인 <code>domain.rule</code> ID, 심각도, 그리고 해결 방식(remediation kind)과 함께 생성됩니다(<a href="checks">점검 항목</a>과 <a href="fixing">수정 및 롤백</a>을 참고하세요).</p>
+            <h2>구조</h2>
+            <p>엔진은 <code>internal/core</code>에 있고, CLI·TUI·웹 UI는 그 위의 얇은 계층입니다. import-lint <strong>테스트</strong>가 <code>ui/*</code>가 <code>fix</code>, <code>history</code>, <code>check</code>, <code>compose</code>를 절대 import하지 않도록 강제하며, 이것이 세 인터페이스를 동일하게 동작하게 만듭니다. 탐지 도메인을 추가하려면 <code>internal/check/</code> 아래에 <code>Checker</code> 인터페이스를 구현하는 패키지 하나를 작성해 등록하면 됩니다(<a href="checks">점검 항목</a>과 <a href="fixing">수정 및 롤백</a> 참고). 전체 저장소 구조와 아키텍처 설명은 <a href="https://github.com/seolcu/hostveil/blob/main/docs/DEVELOPMENT.md"><code>DEVELOPMENT.md</code></a>에 있습니다.</p>
 
             <h2>실제로 실행해 보기: 데모 VM</h2>
-            <p><code>demo/</code>는 코드로 정의된, 의도적으로 취약하게 만든 Ubuntu 서버입니다. hostveil은 VM <em>내부</em>에서 여러분의 작업 트리로부터 빌드되므로, 항상 현재 코드를 반영합니다:</p>
-            <div class="code-block"><pre><code>cd demo
-./run.sh up        # boot + provision + start the vulnerable stacks
-./run.sh scan      # run hostveil against the server
-./run.sh web       # dashboard at http://localhost:8787
-./run.sh shell     # a shell on the server (then: sudo hostveil ...)
-./run.sh halt      # shut it down</code></pre></div>
-            <p>전체 안내, 플랫폼별 프로바이더 설정, 데모 스크립트, 초기화 절차는 <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>에 있습니다.</p>
+            <p><code>demo/</code>는 코드로 정의된, 의도적으로 취약하게 만든 Ubuntu 서버입니다. hostveil은 VM <em>내부</em>에서 여러분의 작업 트리로부터 빌드되므로 항상 현재 코드를 반영합니다. <code>./run.sh up</code>으로 띄우고 <code>./run.sh scan</code>으로 스캔하세요. 플랫폼별 프로바이더 설정, 5분 데모 스크립트, 초기화 절차, 문제 해결은 모두 <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>에 있습니다.</p>
 
             <div class="docs-pager">
               <a class="button secondary" href="faq">← 자주 묻는 질문</a>


### PR DESCRIPTION
## What

**Tighten duplication.** `site/docs/contributing.html` (EN + KO) had become a near-verbatim copy of `docs/DEVELOPMENT.md` — identical Prerequisites, build/test + CI-check blocks, the repository-layout tree, the architecture-rule callout, and the demo `run.sh` block. Trimmed each page back to a real summary that **links to the canonical docs** instead of restating them:

- a minimal `clone` / `build` / `test`
- one prose line naming the full CI suite → links to `DEVELOPMENT.md`
- a short "How it's built" paragraph (engine/UI split + import-lint rule + adding a check) → links to `DEVELOPMENT.md`
- a demo pointer → links to `demo/README.md`

Result: canonical facts live in one place (`DEVELOPMENT.md` for dev setup, `demo/README.md` for the VM), ~53 lines removed per page.

**Update stale content.** The demo docs' sudo guidance predated auto-elevation (`ed3f6ad`) — plain `hostveil` now re-execs under `sudo` itself. So:
- demo commands drop the now-unnecessary `sudo` prefix
- the "run with sudo / else domains are skipped" note is rewritten to describe auto-elevation, with `HOSTVEIL_NO_SUDO=1` for the non-root demo
- genuine `sudo` commands (`ufw`, `dnf`, `systemctl`, `firewall-cmd`, `go build`) left intact

## Notes

- README stays as-is (already a clean build/test + link).
- Docs search index is built client-side from page headings, so it reflects the new structure automatically — no stale index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)