### PR TITLE
readme: drop retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 One binary, no config file, no cloud account.
 
 [![CI](https://github.com/seolcu/hostveil/actions/workflows/ci.yml/badge.svg)](https://github.com/seolcu/hostveil/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/seolcu/hostveil)](https://goreportcard.com/report/github.com/seolcu/hostveil)
 [![Release](https://img.shields.io/github/v/release/seolcu/hostveil)](https://github.com/seolcu/hostveil/releases/latest)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/seolcu/hostveil)](go.mod)
 [![License: GPL-3.0](https://img.shields.io/github/license/seolcu/hostveil)](LICENSE)


### PR DESCRIPTION
## What

Removes the Go Report Card badge from the README.

## Why

The badge currently renders **`go report: retired`**. This is not a problem with this repository — [goreportcard.com](https://goreportcard.com) has been sunset, and its badge endpoint now returns `retired` for every repo. There is no way to restore a real grade.

Verified the four remaining badges still render correctly (CI, release `v3.0.0`, Go `v1.26.3`, GPL-3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)