### PR TITLE
site: fix unresolved #493 landing-page feedback (hero heading + severity labels)

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -218,11 +218,11 @@ h3 {
 }
 
 h1 {
-  max-width: 790px;
+  max-width: 620px;
   margin-bottom: 22px;
-  font-size: clamp(2.4rem, 5.5vw, 4.2rem);
-  line-height: 1.05;
-  letter-spacing: -0.06em;
+  font-size: clamp(2rem, 3.7vw, 3rem);
+  line-height: 1.12;
+  letter-spacing: -0.04em;
   text-wrap: balance;
 }
 
@@ -379,8 +379,13 @@ pre {
 }
 
 .finding span {
-  margin-bottom: 2px;
+  margin-bottom: 3px;
+  font-size: 0.92rem;
 }
+
+.finding.critical span { color: var(--danger); }
+.finding.high span { color: var(--orange); }
+.finding.medium span { color: var(--warning); }
 
 .score-card strong {
   display: block;


### PR DESCRIPTION
Follow-up to #493 / #494. Colleague **gkdms04** reviewed the landing page again and two of their original points were still not satisfied on the live site (they had regressed through the later redesign + sitegen migration):

## What was still wrong
1. **Hero heading** — issue #493 explicitly asked: the serif tagline is *too big and takes 5 lines, feels cramped — shrink the font and get it to ~3 lines*. The redesigned `<h1>` was again a large serif line wrapping to **5 lines**.
2. **Severity labels** — issue #493 asked to make `CRITICAL/HIGH/MEDIUM` *more prominent*. In the SCAN SHEET they were small, muted grey, and smaller than the finding titles.

## Fix (CSS-only, `site/styles.css`)
- `h1`: smaller `font-size` clamp + tighter `max-width` + looser `line-height` → now **3 lines (en) / 2 lines (ko)**, less stuffy.
- `.finding span`: larger size (matches the title) and per-severity color (red/orange/yellow) echoing the left border, so severity reads at a glance.

`styles.css` is a static asset — `go run ./cmd/sitegen` leaves all generated HTML byte-identical (CI git-status check stays green).

## Verification
Rendered with a headless browser and eyeballed across **en + ko desktop and mobile**: hero now wraps cleanly, severity labels are prominent and colored, and no other section regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)