### PR TITLE
demo: fix media redis host-port 6379 collision with native redis

### DIFF
--- a/demo/stacks/media/docker-compose.yml
+++ b/demo/stacks/media/docker-compose.yml
@@ -13,4 +13,7 @@ services:
   redis:
     image: redis:6.0                   # intentionally old → image CVEs
     ports:
-      - "6379:6379"                    # datastore on 0.0.0.0 → compose.ds018 (Critical)
+      # Host port 6380 (not 6379) so it doesn't clash with the native
+      # redis-server provision.sh binds on 6379; still published on 0.0.0.0
+      # → compose.ds018 (Critical) fires all the same.
+      - "6380:6379"                    # datastore on 0.0.0.0 → compose.ds018 (Critical)


### PR DESCRIPTION
## What

Publishes the demo `media` stack's redis container on host port **6380** instead of 6379.

## Why

`provision.sh` step `[7/9]` installs a **native** `redis-server` bound to `0.0.0.0:6379` (to seed `ports.exposed-datastore`), while `demo/stacks/media/docker-compose.yml` also published its redis **container** on host `6379`. Both wanted the same host port, so the outcome depended on boot ordering:

| path | media-redis-1 | 6379 owner | error surfaced? |
|---|---|---|---|
| fresh `vagrant up` | `Created` (never started) | native redis | yes — `address already in use` |
| `vagrant reload --provision` | `running`, but port unpublished (`NetworkSettings.Ports={}`) | native redis | **no** (silent) |

## Fix

`- "6380:6379"` — still bound to `0.0.0.0` (HostIP empty). `compose.ds018` keys off the redis **image** + all-interfaces exposure, not the specific host port, so the Critical finding still fires exactly as before. The native redis keeps 6379 (and its `ports.exposed-datastore` finding), so both intended findings remain, with no collision on either boot path.

## Verification

- Unit-checked that `auditService` still emits `compose.ds018` for the demo redis with host-port evidence `6380`.
- Verified live in the demo VM: `media-redis-1` now starts cleanly, the native redis still owns 6379, and both findings still fire.

Fixes #522