### PR TITLE
cmd/hostveil: fix top-level --help/--version leaking into the scan subcommand

### DIFF
--- a/cmd/hostveil/main.go
+++ b/cmd/hostveil/main.go
@@ -18,6 +18,22 @@ func main() {
 }
 
 func run(args []string) int {
+	// Top-level help/version flags are handled before subcommand dispatch so
+	// they behave like the bare-word `help`/`version` subcommands. Otherwise a
+	// leading dash-flag is never promoted to a command and leaks into the
+	// default `scan` flag set — `hostveil --help` would print scan's usage and
+	// `hostveil --version` would error with "flag provided but not defined".
+	if len(args) > 0 {
+		switch args[0] {
+		case "-h", "--help":
+			printUsage(os.Stdout)
+			return 0
+		case "-V", "--version":
+			fmt.Println("hostveil", version)
+			return 0
+		}
+	}
+
 	// With an explicit subcommand, dispatch to it. With none, open the TUI
 	// on an interactive terminal, otherwise print a scan (script-friendly).
 	explicit := len(args) > 0 && !strings.HasPrefix(args[0], "-")
@@ -46,10 +62,10 @@ func run(args []string) int {
 		return cmdRollback(args)
 	case "history":
 		return cmdHistory(args)
-	case "version", "--version", "-v":
+	case "version":
 		fmt.Println("hostveil", version)
 		return 0
-	case "help", "--help", "-h":
+	case "help":
 		printUsage(os.Stdout)
 		return 0
 	default:
@@ -71,8 +87,8 @@ Usage:
   hostveil serve [--addr]        Serve the localhost web dashboard
   hostveil rollback <id>         Undo a previously applied fix
   hostveil history               List applied fixes and their rollback IDs
-  hostveil version               Print the version
-  hostveil help                  Show this help
+  hostveil version               Print the version (also: --version, -V)
+  hostveil help                  Show this help (also: --help, -h)
 
 Scan flags:
   -v, --verbose   Show each finding's description and fix guidance

--- a/cmd/hostveil/main_test.go
+++ b/cmd/hostveil/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what
+// it wrote.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				b.Write(buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- b.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// TestTopLevelHelpFlags guards issue #520: `--help`/`-h` must print the
+// top-level usage, not the scan subcommand's flag usage.
+func TestTopLevelHelpFlags(t *testing.T) {
+	for _, arg := range []string{"help", "--help", "-h"} {
+		var code int
+		out := captureStdout(t, func() { code = run([]string{arg}) })
+		if code != 0 {
+			t.Errorf("run(%q) exit = %d, want 0", arg, code)
+		}
+		if strings.Contains(out, "Usage of scan") {
+			t.Errorf("run(%q) leaked scan flag usage:\n%s", arg, out)
+		}
+		if !strings.Contains(out, "guided hardening") {
+			t.Errorf("run(%q) did not print top-level usage:\n%s", arg, out)
+		}
+	}
+}
+
+// TestTopLevelVersionFlags guards issue #520: `--version`/`-V` must print the
+// version, not error out inside the scan flag set.
+func TestTopLevelVersionFlags(t *testing.T) {
+	for _, arg := range []string{"version", "--version", "-V"} {
+		var code int
+		out := captureStdout(t, func() { code = run([]string{arg}) })
+		if code != 0 {
+			t.Errorf("run(%q) exit = %d, want 0", arg, code)
+		}
+		if !strings.Contains(out, "hostveil "+version) {
+			t.Errorf("run(%q) = %q, want it to contain version %q", arg, out, version)
+		}
+	}
+}


### PR DESCRIPTION
## What

Handles `-h`/`--help`/`--version`/`-V` at the top level before subcommand dispatch.

## Why

A first argument starting with `-` was never promoted to a command:

```go
explicit := len(args) > 0 && !strings.HasPrefix(args[0], "-")
```

so it fell through to the default `scan` subcommand and was parsed against scan's flag set. Observed before this change:

```console
$ hostveil --help
Usage of scan:            # ← scan's flags, not the top-level usage
  -json
  ...
$ hostveil --version
flag provided but not defined: -version
Usage of scan:
```

The `case "help", "--help", "-h"` / `case "version", "--version", "-v"` arms in the dispatch switch were effectively dead — a dash-prefixed arg can never become `cmd`.

## Fix

- Handle `-h`/`--help` (→ top-level usage) and `--version`/`-V` (→ version) before dispatch.
- Drop the dead dash aliases from the switch.
- `-v` stays `scan`'s verbose flag, as the usage text already documents; version's short form is `-V`.
- Usage text now notes the flag forms.

## Tests

`cmd/hostveil/main_test.go` asserts `help`/`--help`/`-h` all print the top-level usage (never `Usage of scan`) and `version`/`--version`/`-V` all print the version.

```
$ hostveil --help      # top-level usage
$ hostveil -h          # top-level usage
$ hostveil --version   # hostveil v3-dev
$ hostveil -V          # hostveil v3-dev
```

Fixes #520