### PR TITLE
compose: render fixes as minimal text edits instead of a whole-file re-encode

### DIFF
--- a/internal/compose/edit.go
+++ b/internal/compose/edit.go
@@ -1,6 +1,7 @@
 package compose
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -11,8 +12,34 @@ import (
 // fixes. Every mutation operates in memory; callers render back to bytes
 // with Bytes() and decide when (or whether) to write. This is what lets
 // fix previews compute an exact diff without ever touching the live file.
+//
+// Rendering favours a *minimal* text edit against the original source so a
+// one-line change stays a one-line diff: re-encoding the whole document
+// through yaml.v3 would otherwise reflow untouched lines (collapse aligned
+// inline comments, drop blank lines between services). Each mutation records
+// the text edit it makes; Bytes() applies those edits to the original bytes
+// and only trusts the result when it is byte-for-byte equivalent to the
+// encoder's output after a round-trip — otherwise it falls back to the
+// full re-encode, so correctness never depends on the text surgery.
 type Doc struct {
-	root *yaml.Node // document node
+	root       *yaml.Node // document node
+	src        []byte     // original source, for minimal-diff rendering
+	edits      []edit     // recorded text edits, in application order
+	minimalOff bool       // a mutation could not be expressed as a text edit
+}
+
+type editKind int
+
+const (
+	editReplace editKind = iota // replace a scalar value in place on one line
+	editInsert                  // insert whole line(s) after an anchor line
+)
+
+type edit struct {
+	kind editKind
+	line int    // 1-based anchor line in the original source
+	col  int    // 1-based start column of the value (editReplace only)
+	text string // replacement token (editReplace) or lines to insert (editInsert)
 }
 
 // Load parses compose bytes into an editable Doc, preserving comments and
@@ -28,21 +55,131 @@ func Load(data []byte) (*Doc, error) {
 	if root.Content[0].Kind != yaml.MappingNode {
 		return nil, fmt.Errorf("compose file is not a YAML mapping")
 	}
-	return &Doc{root: &root}, nil
+	return &Doc{root: &root, src: append([]byte(nil), data...)}, nil
 }
 
-// Bytes renders the (possibly mutated) document back to YAML.
+// Bytes renders the (possibly mutated) document back to YAML. It prefers a
+// minimal text edit of the original source and falls back to a full re-encode
+// whenever the minimal result is not provably equivalent.
 func (d *Doc) Bytes() ([]byte, error) {
+	full, err := encodeNode(d.root)
+	if err != nil {
+		return nil, err
+	}
+	if d.minimalOff || len(d.edits) == 0 {
+		return full, nil
+	}
+	minimal, ok := d.renderMinimal()
+	if !ok {
+		return full, nil
+	}
+	// Trust the minimal rendering only if it parses and, once normalized by
+	// the same encoder, matches the mutated tree exactly. This tolerates the
+	// cosmetic differences we want to keep (blank lines, comment alignment,
+	// which the encoder discards on both sides) while catching any case where
+	// the text surgery didn't reproduce the intended edit.
+	var reparsed yaml.Node
+	if err := yaml.Unmarshal(minimal, &reparsed); err != nil {
+		return full, nil
+	}
+	reEnc, err := encodeNode(&reparsed)
+	if err != nil {
+		return full, nil
+	}
+	if !bytes.Equal(reEnc, full) {
+		return full, nil
+	}
+	return minimal, nil
+}
+
+// encodeNode renders a node through yaml.v3 with the project's 2-space indent.
+func encodeNode(n *yaml.Node) ([]byte, error) {
 	var b strings.Builder
 	enc := yaml.NewEncoder(&b)
 	enc.SetIndent(2)
-	if err := enc.Encode(d.root); err != nil {
+	if err := enc.Encode(n); err != nil {
 		return nil, err
 	}
 	if err := enc.Close(); err != nil {
 		return nil, err
 	}
 	return []byte(b.String()), nil
+}
+
+// renderMinimal applies the recorded edits to the original source. Edits are
+// applied bottom-up so line-index shifts from an insertion don't disturb the
+// anchors of edits above it. Returns ok=false if any edit can't be applied,
+// in which case the caller falls back to a full re-encode.
+func (d *Doc) renderMinimal() ([]byte, bool) {
+	lines := strings.Split(string(d.src), "\n")
+	es := make([]edit, len(d.edits))
+	copy(es, d.edits)
+	// Descending by anchor line; a stable order is enough since real fixes
+	// record a single edit.
+	for i := 1; i < len(es); i++ {
+		for j := i; j > 0 && es[j-1].line < es[j].line; j-- {
+			es[j-1], es[j] = es[j], es[j-1]
+		}
+	}
+	for _, e := range es {
+		idx := e.line - 1
+		if idx < 0 || idx >= len(lines) {
+			return nil, false
+		}
+		switch e.kind {
+		case editReplace:
+			l := lines[idx]
+			start := e.col - 1
+			if start < 0 || start > len(l) {
+				return nil, false
+			}
+			end, ok := valueEnd(l, start)
+			if !ok {
+				return nil, false
+			}
+			lines[idx] = l[:start] + e.text + l[end:]
+		case editInsert:
+			ins := strings.Split(e.text, "\n")
+			out := make([]string, 0, len(lines)+len(ins))
+			out = append(out, lines[:idx+1]...)
+			out = append(out, ins...)
+			out = append(out, lines[idx+1:]...)
+			lines = out
+		}
+	}
+	return []byte(strings.Join(lines, "\n")), true
+}
+
+// valueEnd returns the index just past the scalar value that starts at
+// 0-based `start`, i.e. before any trailing spaces or "# comment". Quotes are
+// respected so a value never ends inside them. Returns ok=false on an
+// unterminated quote, so the caller falls back rather than risk a bad edit.
+func valueEnd(line string, start int) (int, bool) {
+	inSingle, inDouble := false, false
+	for i := start; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			}
+		case c == '\'':
+			inSingle = true
+		case c == '"':
+			inDouble = true
+		case c == ' ' || c == '\t':
+			// Unquoted whitespace ends the value token (any comment follows).
+			return i, true
+		}
+	}
+	if inSingle || inDouble {
+		return 0, false
+	}
+	return len(line), true
 }
 
 // service returns the mapping node for a named service, or nil.
@@ -64,13 +201,27 @@ func (d *Doc) AddSecurityOpt(service, opt string) error {
 	}
 	seq := mapGet(svc, "security_opt")
 	if seq == nil {
+		if indent, ok := mappingChildIndent(svc); ok {
+			d.recordInsertAfter(blockEndLine(svc),
+				strings.Repeat(" ", indent)+"security_opt:",
+				strings.Repeat(" ", indent+2)+"- "+opt)
+		} else {
+			d.minimalOff = true
+		}
 		seq = &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
 		mapSet(svc, "security_opt", seq)
+		seq.Content = append(seq.Content, scalar(opt))
+		return nil
 	}
 	for _, item := range seq.Content {
 		if normalizeOpt(item.Value) == normalizeOpt(opt) {
 			return nil // already present
 		}
+	}
+	if prefix, ok := seqItemPrefix(d.src, seq); ok {
+		d.recordInsertAfter(blockEndLine(seq), prefix+opt)
+	} else {
+		d.minimalOff = true
 	}
 	seq.Content = append(seq.Content, scalar(opt))
 	return nil
@@ -82,6 +233,16 @@ func (d *Doc) SetScalar(service, key, value string) error {
 	svc := d.service(service)
 	if svc == nil {
 		return fmt.Errorf("service %q not found", service)
+	}
+	if v := mapGet(svc, key); v != nil {
+		d.recordReplace(v, renderRaw(value, v.Style))
+		mapSet(svc, key, scalar(value))
+		return nil
+	}
+	if indent, ok := mappingChildIndent(svc); ok {
+		d.recordInsertAfter(blockEndLine(svc), strings.Repeat(" ", indent)+key+": "+value)
+	} else {
+		d.minimalOff = true
 	}
 	mapSet(svc, key, scalar(value))
 	return nil
@@ -103,18 +264,100 @@ func (d *Doc) BindPortLoopback(service, hostPort string) error {
 		switch entry.Kind {
 		case yaml.ScalarNode:
 			if rewritten, ok := rewriteShortPort(entry.Value, hostPort); ok {
+				d.recordReplace(entry, `"`+rewritten+`"`)
 				entry.Value = rewritten
 				entry.Style = yaml.DoubleQuotedStyle
 				return nil
 			}
 		case yaml.MappingNode:
 			if hp := mapGet(entry, "published"); hp != nil && strings.Trim(hp.Value, `"`) == hostPort {
+				// Long-form entries add a host_ip key; leave that to the full
+				// re-encode rather than guess the insertion point.
+				d.minimalOff = true
 				mapSet(entry, "host_ip", scalar("127.0.0.1"))
 				return nil
 			}
 		}
 	}
 	return fmt.Errorf("port %s not found on service %q", hostPort, service)
+}
+
+// recordReplace records an in-place replacement of node's scalar value. If the
+// node lacks source position (e.g. it was synthesized), minimal rendering is
+// disabled so the caller falls back to the full re-encode.
+func (d *Doc) recordReplace(node *yaml.Node, newRaw string) {
+	if node == nil || node.Line <= 0 || node.Column <= 0 {
+		d.minimalOff = true
+		return
+	}
+	d.edits = append(d.edits, edit{kind: editReplace, line: node.Line, col: node.Column, text: newRaw})
+}
+
+// recordInsertAfter records line(s) to insert after a 1-based anchor line.
+func (d *Doc) recordInsertAfter(anchor int, lines ...string) {
+	if anchor <= 0 {
+		d.minimalOff = true
+		return
+	}
+	d.edits = append(d.edits, edit{kind: editInsert, line: anchor, text: strings.Join(lines, "\n")})
+}
+
+// renderRaw renders value with the same quoting style as the node it replaces,
+// so the minimal text matches what the encoder would emit.
+func renderRaw(value string, style yaml.Style) string {
+	switch style {
+	case yaml.DoubleQuotedStyle:
+		return `"` + value + `"`
+	case yaml.SingleQuotedStyle:
+		return "'" + value + "'"
+	default:
+		return value
+	}
+}
+
+// mappingChildIndent returns the leading-space count of a mapping's children,
+// derived from its first key's column.
+func mappingChildIndent(m *yaml.Node) (int, bool) {
+	if m == nil || m.Kind != yaml.MappingNode || len(m.Content) == 0 {
+		return 0, false
+	}
+	if m.Content[0].Column < 1 {
+		return 0, false
+	}
+	return m.Content[0].Column - 1, true
+}
+
+// seqItemPrefix returns the leading text (indent + "- ") of a sequence's first
+// item, taken verbatim from the source so an appended item lines up with it.
+func seqItemPrefix(src []byte, seq *yaml.Node) (string, bool) {
+	if seq == nil || len(seq.Content) == 0 {
+		return "", false
+	}
+	first := seq.Content[0]
+	lines := strings.Split(string(src), "\n")
+	if first.Line-1 < 0 || first.Line-1 >= len(lines) {
+		return "", false
+	}
+	i := strings.Index(lines[first.Line-1], "- ")
+	if i < 0 {
+		return "", false // flow sequence or unusual layout — fall back
+	}
+	return lines[first.Line-1][:i+2], true
+}
+
+// blockEndLine returns the largest source line among a node and its
+// descendants — i.e. the last line the node's content occupies.
+func blockEndLine(n *yaml.Node) int {
+	if n == nil {
+		return 0
+	}
+	max := n.Line
+	for _, c := range n.Content {
+		if e := blockEndLine(c); e > max {
+			max = e
+		}
+	}
+	return max
 }
 
 // rewriteShortPort turns "6379:6379" or "0.0.0.0:6379:6379" into

--- a/internal/compose/edit_test.go
+++ b/internal/compose/edit_test.go
@@ -98,3 +98,70 @@ func FuzzEdit(f *testing.F) {
 		}
 	})
 }
+
+// TestMinimalDiffPreservesUnchangedLines guards issue #521: a single-field fix
+// must change only the affected line, leaving aligned inline comments and
+// blank lines between services untouched (no whole-file reflow).
+func TestMinimalDiffPreservesUnchangedLines(t *testing.T) {
+	src := `# A media server stack.
+services:
+  jellyfin:
+    image: jellyfin/jellyfin:10.8.0   # intentionally old
+    ports:
+      - "8096:8096"                    # published on 0.0.0.0
+
+  redis:
+    image: redis:6.0                   # intentionally old
+    ports:
+      - "6379:6379"                    # datastore on 0.0.0.0
+`
+	want := `# A media server stack.
+services:
+  jellyfin:
+    image: jellyfin/jellyfin:10.8.0   # intentionally old
+    ports:
+      - "8096:8096"                    # published on 0.0.0.0
+
+  redis:
+    image: redis:6.0                   # intentionally old
+    ports:
+      - "127.0.0.1:6379:6379"                    # datastore on 0.0.0.0
+`
+	d := loadOrFail(t, src)
+	if err := d.BindPortLoopback("redis", "6379"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := d.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != want {
+		t.Errorf("minimal diff not preserved.\n--- got ---\n%s\n--- want ---\n%s", out, want)
+	}
+}
+
+// TestMinimalDiffFallsBackWhenAmbiguous ensures rendering still produces valid,
+// intended YAML even when the source layout defeats the minimal path (here a
+// flow sequence), by falling back to the full re-encode.
+func TestMinimalDiffFallbackStillCorrect(t *testing.T) {
+	d := loadOrFail(t, "services:\n  cache:\n    image: redis\n    ports: [\"6379:6379\"]\n")
+	if err := d.BindPortLoopback("cache", "6379"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := d.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "127.0.0.1:6379:6379") {
+		t.Errorf("fallback did not apply the bind:\n%s", out)
+	}
+	proj, err := Parse("x.yml", out)
+	if err != nil {
+		t.Fatalf("fallback produced unparseable YAML: %v", err)
+	}
+	for _, p := range proj.Services["cache"].Ports {
+		if p.ExposedOnAllInterfaces() {
+			t.Error("port still exposed after fallback bind")
+		}
+	}
+}


### PR DESCRIPTION
## What

Compose fixes now emit a **minimal** diff that touches only the changed line(s), instead of re-serializing the whole file.

## Why

`Doc.Bytes()` re-encoded the entire document through yaml.v3. yaml.v3 keeps comment *text* but not aligned inline-comment spacing or blank lines between mapping entries, so a single-field fix reflowed formatting everywhere. Example — `hostveil fix compose.ds018 --service redis` previously produced:

```diff
-    image: jellyfin/jellyfin:10.8.0   # intentionally old → image CVEs (cve.*)
+    image: jellyfin/jellyfin:10.8.0 # intentionally old → image CVEs (cve.*)
-      - "8096:8096"                    # published on 0.0.0.0 → compose.dr002
+      - "8096:8096" # published on 0.0.0.0 → compose.dr002
-
   redis:
...
-      - "6379:6379"                    # datastore ...
+      - "127.0.0.1:6379:6379" # datastore ...
```

Only the last line was the intended change; everything else is collateral reflow. All three UIs (CLI/TUI/web) render this diff.

## How

- Each mutation (`BindPortLoopback`, `SetScalar`, `AddSecurityOpt`) records the concrete text edit it makes — an in-place scalar replacement located by the node's source line/column, or a line insertion anchored to a computed block-end line.
- `Bytes()` applies those edits to the original source, then **verifies**: the minimal text must parse and, after normalization by the same encoder, be byte-for-byte identical to the mutated node tree. If it isn't (unusual layouts, flow sequences, long-form ports, quoting surprises), it falls back to the original full re-encode.
- Net effect: correctness is always guaranteed by the proven encoder path; clean files additionally get a minimal diff.

## Result

`compose.ds018` on redis now diffs as just:

```diff
-      - "6379:6379"                    # datastore on 0.0.0.0 → compose.ds018 (Critical)
+      - "127.0.0.1:6379:6379"                    # datastore on 0.0.0.0 → compose.ds018 (Critical)
```

## Tests

- `TestMinimalDiffPreservesUnchangedLines` — aligned comments and blank lines stay byte-identical; only the port line changes.
- `TestMinimalDiffFallbackStillCorrect` — a flow-sequence layout that defeats the minimal path still applies the intended, valid change via fallback.
- Existing `TestAddSecurityOpt` / `TestSetScalarRestart` / `TestBindPortLoopback` and `FuzzEdit` (25s, ~780k execs) pass; the reload invariant holds because the fallback always yields valid YAML.

Fixes #521