### PR TITLE
demo/docs: clarify the repo syncs on up/reload, not on provision

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -73,9 +73,24 @@ have no restart policy, so they don't come back on their own).
 **Web dashboard**: port 8787 is forwarded to the host, so while
 `./run.sh web` is running, open **<http://localhost:8787>** in your browser.
 
-hostveil is built from the mounted repo (`/hostveil`), so it always reflects
-your **current local source**. Changed the code? `vagrant provision` (or just
-rebuild inside: `cd /hostveil && sudo /usr/local/go/bin/go build -o /usr/local/bin/hostveil ./cmd/hostveil`).
+hostveil is built from the synced repo at `/hostveil`, so it reflects your
+local source **as of the last sync**. The repo is an **rsync** synced folder:
+Vagrant copies it in on `up` and `reload`, but **not** on `provision`. So after
+editing code on the host, re-sync first — otherwise a rebuild just recompiles
+the previously-synced source:
+
+```bash
+vagrant rsync && vagrant provision     # sync, then re-provision + rebuild
+```
+
+To skip the full re-provision, sync and rebuild in one shot:
+
+```bash
+vagrant rsync
+vagrant ssh -c 'cd /hostveil && sudo /usr/local/go/bin/go build -o /usr/local/bin/hostveil ./cmd/hostveil'
+```
+
+(Or run `vagrant rsync-auto` in a separate terminal to sync on every save.)
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -94,8 +94,10 @@ implements the `Checker` interface and registering it.
 ## Running it for real: the demo VM
 
 `demo/` is a code-defined, deliberately vulnerable Ubuntu server you can
-bring up on any machine. hostveil is built from your working tree *inside*
-the VM, so it always reflects your current code.
+bring up on any machine. hostveil is built from your working tree, which is
+rsync-synced *into* the VM, so a freshly booted VM reflects your current code.
+(After editing code, re-sync before rebuilding — the repo syncs on `up`/`reload`
+but not on `provision`; see [demo/README.md](../demo/README.md).)
 
 ```bash
 cd demo


### PR DESCRIPTION
## What

Fixes a misleading instruction in `demo/README.md` (and a matching overclaim in `docs/DEVELOPMENT.md`) about how local code changes reach the demo VM.

## Why

Both docs implied `vagrant provision` picks up local edits:

- `demo/README.md`: *"Changed the code? `vagrant provision` (or just rebuild inside: …)"*
- `docs/DEVELOPMENT.md`: *"hostveil is built from your working tree inside the VM, so it always reflects your current code."*

But the repo is mounted as an **rsync** synced folder (`config.vm.synced_folder "..", "/hostveil", type: "rsync"`). Vagrant syncs rsync folders on `up` and `reload`, **not** on `provision`. So after editing code on the host:

- `vagrant provision` rebuilds `/hostveil` — but `/hostveil` still holds the *previously-synced* source, so the change silently doesn't take effect.
- The "or just rebuild inside" shortcut recompiles that same stale copy.

I hit this while verifying an earlier fix: a `vagrant provision` reported success and rebuilt hostveil, yet the VM still ran the old code until an explicit `vagrant rsync`.

## Fix

- `demo/README.md`: explain the sync boundary and show `vagrant rsync && vagrant provision` (plus a sync-then-build one-liner and a `vagrant rsync-auto` tip).
- `docs/DEVELOPMENT.md`: soften "always reflects your current code" to note a *freshly booted* VM does, and point at the README for the re-sync step after edits.

Docs-only; no code changes.