### PR TITLE
docs: add CLAUDE.md and fix stale AGENTS.md reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+hostveil is a single-binary guided hardening tool for self-hosted Linux servers: it scans a host, merges findings into one 0–100 score, explains them in plain language, and applies fixes with preview, backup, and rollback. Go 1.26, GPL-3.0, no config file, no cloud.
+
+## Commands
+
+```bash
+go build ./cmd/hostveil     # produces ./hostveil
+go test ./...
+go test -race ./...         # what CI runs
+go test ./internal/check/ssh -run TestName        # single test
+go test ./internal/compose -run FuzzEdit -fuzz FuzzEdit   # fuzz targets: FuzzEdit, FuzzParse, FuzzParseTrivy
+scripts/bench.sh            # benchmarks (there is intentionally no Makefile)
+go run ./cmd/sitegen        # regenerate site/ — required whenever cmd/sitegen/ changes
+```
+
+Full CI gate, run all of these before sending a change:
+
+```bash
+go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
+go run ./cmd/sitegen && git diff --exit-code site/
+(cd scripts && sha256sum -c install.sh.sha256)   # regenerate the .sha256 if install.sh changed
+```
+
+Lint config (`.golangci.yaml`) enables only staticcheck, ineffassign, misspell.
+
+### Running it for real
+
+The binary builds and tests everywhere, but only *runs* meaningfully on Linux with docker/ssh/ufw present. Don't run it against your own machine — use the Vagrant demo VM, which rsyncs your working tree in and rebuilds:
+
+```bash
+cd demo && ./run.sh up      # then: ./run.sh scan | web | shell | reset | halt
+```
+
+The repo syncs on `up`/`reload` but **not** on `provision` — re-sync after editing code. See `demo/README.md` and `docs/DEVELOPMENT.md`.
+
+## Architecture
+
+The central rule: **one engine, three thin UIs.** `internal/core.Engine` owns all scanning, scoring, classification, preview, apply, and rollback. CLI, TUI, and web are rendering layers over it, so a fix applied anywhere behaves identically and is reversible anywhere.
+
+This is enforced structurally: `internal/ui/tui/layering_test.go` and `internal/ui/web/layering_test.go` parse imports and fail if production UI code imports `internal/fix`, `internal/history`, `internal/check`, or `internal/compose`. UIs may import only `core` and `model`. (v2's duplicated-fix-logic failure is what these tests exist to prevent.)
+
+Flow: `cmd/hostveil/app.go` builds the one engine (all eight checkers + `fix.Default()`) → `Engine.Scan` detects `platform.Env`, runs the checker registry concurrently, validates and classifies findings, scores, diffs against the last saved scan, persists.
+
+### Key seams
+
+- **`internal/platform`** — the only door to the OS. `CommandRunner` (Run/LookPath) is injected everywhere, so checkers and fixes are unit-tested against a fake runner with no real host. Never call `os/exec` directly in a checker or fix.
+- **`internal/check`** — `Checker` is `Source()` / `Available()` / `Check()`. Checkers are strictly read-only. A missing dependency returns `Available() = (false, reason)` → domain recorded **Skipped**, never an error; a panic in one checker degrades only that domain. Adding a detection domain = one package under `internal/check/` implementing `Checker`, registered in `app.go`, plus a scoring axis.
+- **`internal/fix`** — a `Fix` is a set of `Action`s. Edit actions carry a **pure `Transform(in []byte) ([]byte, error)`** — bytes in, bytes out, no disk writes — used by *both* preview (diff only) and apply (write). Preserve that purity; it's what makes previewing safe. Exec actions carry argv lists (no shell). `Validate` enforces shape: Auto = exactly 1 action, Review = ≥2 *independent alternatives* (not sequential steps).
+- **`internal/model`** — pure value types, no I/O. Build findings via `NewFinding(id, title, severity, source, remediation, opts...)`; required args make zero-value footguns unrepresentable, and `Validate()` runs over every finding post-scan so malformed ones never reach a UI.
+
+### Invariants worth knowing
+
+- **The fix registry is authoritative for remediation.** `Engine.classify` overrides a finding's declared `Remediation` with the registered fix's `Kind`, and demotes any fixable-but-unregistered finding to Manual — so a UI can never show a fix button that leads nowhere.
+- **Finding IDs are namespaced by `Source.String()`**: `ssh.rootlogin`, `compose.ds016`, `cve.*`. The fix registry matches exact IDs or globs against these. `Finding.Key()` = `source|id|service`.
+- **Scoring renormalizes over domains that ran.** `model.ScoreReport`'s axis caps sum to 100; a skipped domain (e.g. no Trivy) is marked N/A and excluded rather than scored 100, so a partial scan is never a falsely perfect result. Adding a domain means adding an axis to `axisDefs` and rebalancing the caps.
+- **Apply order is always backup → write → checkpoint.** `applyEdit` refuses to write if the backup fails. Exec fixes have no rollback checkpoint (nothing file-backed), only a history record.
+- **`internal/compose/edit.go` does minimal text-edit YAML surgery** so a one-line change stays a one-line diff, then verifies the result round-trips byte-identically through yaml.v3 and falls back to a full re-encode otherwise. Correctness never depends on the text surgery — keep that fallback.
+- **Auto-elevation**: `cmd/hostveil/elevate.go` re-execs under sudo for root-benefiting commands. `HOSTVEIL_NO_SUDO=1` opts out (scripts/CI); `HOSTVEIL_ELEVATED=1` is the re-exec loop guard. `version`/`help` never prompt.
+- State lives in `/var/lib/hostveil` as root, `~/.local/share/hostveil` otherwise.
+
+## Website
+
+`site/**/*.html` is **generated — never hand-edit it.** Source of truth is `cmd/sitegen/`: `pages.json` (metadata, **plain text** — the generator HTML-escapes it, so write `Fixing & rollback`), `templates/*.tmpl`, `content/{en,ko}/` (raw HTML fragments). Regenerate with `go run ./cmd/sitegen` and commit the output; CI fails if `site/` drifts. CSS/JS and `site/assets/` are *not* generated — edit directly.
+
+## AI
+
+`internal/ai` is optional and strictly advisory (local Ollama, `explain --ai`). It never applies changes; every score, explanation, and fix must work with `ai.Noop`.

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -11,8 +11,9 @@
 # to keep a record for `benchstat` comparison.
 #
 # Why a script and not a Makefile: the project intentionally has no
-# Makefile (see AGENTS.md and DEVELOPMENT.md). This script is the
-# one entry point for "run the benchmarks".
+# Makefile — plain `go` commands (see docs/DEVELOPMENT.md) cover build,
+# test, and lint. This script is the one entry point for "run the
+# benchmarks".
 
 set -euo pipefail
 


### PR DESCRIPTION
Adds `CLAUDE.md` — build/test/CI commands (including the easy-to-miss `go run ./cmd/sitegen` and `install.sh.sha256` steps) plus the architecture that only emerges from reading several files together: the one-engine/thin-UI rule and the layering tests enforcing it, the `platform.CommandRunner` and pure `fix.Transform` seams, and the classification/scoring invariants.

Also fixes `scripts/bench.sh`, which cited an `AGENTS.md` removed in the v2 blank slate. The no-Makefile rationale is now self-contained.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)