### PR TITLE
Add an agent domain for self-hosted AI agent runtimes

### DIFF
--- a/cmd/hostveil/app.go
+++ b/cmd/hostveil/app.go
@@ -4,6 +4,7 @@ import (
 	"github.com/seolcu/hostveil/internal/ai"
 	"github.com/seolcu/hostveil/internal/check"
 	accountscheck "github.com/seolcu/hostveil/internal/check/accounts"
+	agentcheck "github.com/seolcu/hostveil/internal/check/agent"
 	composecheck "github.com/seolcu/hostveil/internal/check/compose"
 	cvecheck "github.com/seolcu/hostveil/internal/check/cve"
 	filepermscheck "github.com/seolcu/hostveil/internal/check/fileperms"
@@ -33,6 +34,7 @@ func buildEngineWithAI(useAI bool) *core.Engine {
 			portscheck.New(),
 			accountscheck.New(),
 			filepermscheck.New(),
+			agentcheck.New(),
 		),
 		Fixes: fix.Default(),
 	}

--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -14,6 +14,7 @@
                   <tr><td>Exposed services</td><td><code>ports.</code></td><td><code>ss</code></td></tr>
                   <tr><td>Accounts</td><td><code>accounts.</code></td><td>root (for <code>/etc/shadow</code>)</td></tr>
                   <tr><td>File permissions</td><td><code>fileperms.</code></td><td>—</td></tr>
+                  <tr><td>AI agent runtimes</td><td><code>agent.</code></td><td>OpenClaw or Hermes installed</td></tr>
                   <tr><td>Image CVEs <em>(optional)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -42,14 +43,15 @@
               <table>
                 <thead><tr><th>Axis</th><th>Weight</th></tr></thead>
                 <tbody>
-                  <tr><td>Container exposure</td><td>20</td></tr>
-                  <tr><td>SSH hardening</td><td>18</td></tr>
-                  <tr><td>Vulnerabilities</td><td>15</td></tr>
-                  <tr><td>Host firewall</td><td>13</td></tr>
-                  <tr><td>Exposed services</td><td>11</td></tr>
-                  <tr><td>Account hygiene</td><td>9</td></tr>
-                  <tr><td>Auto-updates</td><td>8</td></tr>
-                  <tr><td>File permissions</td><td>6</td></tr>
+                  <tr><td>Container exposure</td><td>18</td></tr>
+                  <tr><td>SSH hardening</td><td>17</td></tr>
+                  <tr><td>Vulnerabilities</td><td>13</td></tr>
+                  <tr><td>Host firewall</td><td>12</td></tr>
+                  <tr><td>Exposed services</td><td>10</td></tr>
+                  <tr><td>AI agent runtimes</td><td>10</td></tr>
+                  <tr><td>Account hygiene</td><td>8</td></tr>
+                  <tr><td>Auto-updates</td><td>7</td></tr>
+                  <tr><td>File permissions</td><td>5</td></tr>
                 </tbody>
               </table>
             </div>
@@ -154,6 +156,29 @@
                 </tbody>
               </table>
             </div>
+
+            <h2 id="agent">AI agent runtimes <code>agent.</code></h2>
+            <p>Self-hosted AI agents — <a href="https://docs.openclaw.ai/">OpenClaw</a> and <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a> — run a network gateway and keep API keys on disk in your home directory. Misconfigured, the worst case is someone reaching that gateway and driving an agent that can read your files and run commands as you.</p>
+            <p>This domain is <strong>skipped entirely</strong> unless one of those runtimes is actually installed, so a host that has never run an agent is not scored on it. hostveil looks up home directories in <code>/etc/passwd</code> and stats only the paths listed below — it never walks your home.</p>
+            <p>These projects ship their own config auditors (<code>openclaw security audit</code>), which cover their settings far more thoroughly than hostveil tries to. What hostveil adds is the part those tools cannot see: whether the gateway is <em>actually</em> listening on a reachable address, whether a firewall stands behind it, and whether your credential files are readable by other accounts on the box.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>agent.auth-disabled</code></td><td>An exposed gateway that accepts requests with no authentication</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.gateway-exposed</code></td><td>The gateway is bound to a network-reachable address (<span class="sev critical">Critical</span> when it is confirmed listening with no firewall)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.secret-exposed</code></td><td>A credentials file or directory is readable beyond its owner</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>agent.exec-unrestricted</code></td><td>The agent may run shell commands with no approval step</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.elevated-enabled</code></td><td>Elevated (host-level) command execution is enabled</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.sandbox-off</code></td><td>Agent tools run unsandboxed, directly on the host</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.control-ui-insecure</code></td><td>The control UI has its auth or device-identity checks disabled</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.config-perms</code></td><td>A config or state path is more permissive than upstream ships it</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>agent.ssrf-private-network</code></td><td>The agent browser may reach private-network addresses</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>The config findings are <strong>Manual</strong> on purpose. OpenClaw's config is JSON5 and carries your own comments; hostveil has no way to edit one key without rewriting the file and deleting them. Hermes settings may come from the config, from <code>.env</code>, from a systemd unit, or from a <code>docker&nbsp;-e</code> flag, and a finding cannot tell which is in force. Rebinding a gateway can also cut you off from the agent you administer remotely — so hostveil explains these and leaves the edit to you.</p>
+            <p>Only the two permission findings are auto-fixable, and both are a <code>chmod</code> that only ever <em>removes</em> access, checkpointed so <code>hostveil rollback</code> restores the previous mode exactly.</p>
 
             <h2 id="cve">Image CVEs <code>cve.</code> <em>(optional)</em></h2>
             <p>When Trivy is installed, hostveil scans the images your Compose services run for known Critical, High, and Medium vulnerabilities. Findings are reported <strong>per image</strong>, not per vulnerability — a single image routinely ships hundreds of CVEs, and they all share one remediation.</p>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -14,6 +14,7 @@
                   <tr><td>노출된 서비스</td><td><code>ports.</code></td><td><code>ss</code></td></tr>
                   <tr><td>계정</td><td><code>accounts.</code></td><td>root (<code>/etc/shadow</code>용)</td></tr>
                   <tr><td>파일 권한</td><td><code>fileperms.</code></td><td>—</td></tr>
+                  <tr><td>AI 에이전트 런타임</td><td><code>agent.</code></td><td>OpenClaw 또는 Hermes 설치</td></tr>
                   <tr><td>이미지 CVE <em>(선택)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -42,14 +43,15 @@
               <table>
                 <thead><tr><th>축</th><th>가중치</th></tr></thead>
                 <tbody>
-                  <tr><td>컨테이너 노출</td><td>20</td></tr>
-                  <tr><td>SSH 하드닝</td><td>18</td></tr>
-                  <tr><td>취약점</td><td>15</td></tr>
-                  <tr><td>호스트 방화벽</td><td>13</td></tr>
-                  <tr><td>노출된 서비스</td><td>11</td></tr>
-                  <tr><td>계정 위생</td><td>9</td></tr>
-                  <tr><td>자동 업데이트</td><td>8</td></tr>
-                  <tr><td>파일 권한</td><td>6</td></tr>
+                  <tr><td>컨테이너 노출</td><td>18</td></tr>
+                  <tr><td>SSH 하드닝</td><td>17</td></tr>
+                  <tr><td>취약점</td><td>13</td></tr>
+                  <tr><td>호스트 방화벽</td><td>12</td></tr>
+                  <tr><td>노출된 서비스</td><td>10</td></tr>
+                  <tr><td>AI 에이전트 런타임</td><td>10</td></tr>
+                  <tr><td>계정 위생</td><td>8</td></tr>
+                  <tr><td>자동 업데이트</td><td>7</td></tr>
+                  <tr><td>파일 권한</td><td>5</td></tr>
                 </tbody>
               </table>
             </div>
@@ -154,6 +156,29 @@
                 </tbody>
               </table>
             </div>
+
+            <h2 id="agent">AI 에이전트 런타임 <code>agent.</code></h2>
+            <p>셀프호스트 AI 에이전트인 <a href="https://docs.openclaw.ai/">OpenClaw</a>와 <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a>는 네트워크 게이트웨이를 띄우고 API 키를 홈 디렉터리에 저장합니다. 설정이 잘못되면 최악의 경우 외부에서 그 게이트웨이에 접근해, 내 파일을 읽고 내 권한으로 명령을 실행하는 에이전트를 그대로 조종할 수 있습니다.</p>
+            <p>이 도메인은 해당 런타임이 실제로 설치되어 있지 않으면 <strong>아예 건너뜁니다</strong>. 에이전트를 쓴 적 없는 호스트는 이 항목으로 점수를 매기지 않습니다. hostveil은 <code>/etc/passwd</code>에서 홈 디렉터리를 찾은 뒤 아래 표에 적힌 경로만 stat합니다. 홈 디렉터리 전체를 훑지 않습니다.</p>
+            <p>두 프로젝트 모두 자체 설정 점검 도구(<code>openclaw security audit</code>)를 제공하며, 설정 항목 자체는 그쪽이 훨씬 촘촘합니다. hostveil이 더하는 것은 그 도구들이 볼 수 없는 부분입니다. 게이트웨이가 <em>실제로</em> 외부에서 닿는 주소에서 대기 중인지, 그 앞에 방화벽이 있는지, 자격 증명 파일을 같은 호스트의 다른 계정이 읽을 수 있는지입니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>무엇을 잡아내는지</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>agent.auth-disabled</code></td><td>외부에 노출된 게이트웨이가 인증 없이 요청을 받음</td><td><span class="sev critical">치명적</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.gateway-exposed</code></td><td>게이트웨이가 네트워크에서 닿는 주소에 바인딩됨 (대기 중인 것이 확인되고 방화벽도 없으면 <span class="sev critical">치명적</span>)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.secret-exposed</code></td><td>자격 증명 파일 또는 디렉터리를 소유자 외에도 읽을 수 있음</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>agent.exec-unrestricted</code></td><td>에이전트가 승인 절차 없이 셸 명령을 실행할 수 있음</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.elevated-enabled</code></td><td>호스트 수준의 권한 상승 실행이 활성화됨</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.sandbox-off</code></td><td>에이전트 도구가 샌드박스 없이 호스트에서 직접 실행됨</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.control-ui-insecure</code></td><td>제어 UI의 인증 또는 기기 확인이 꺼져 있음</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.config-perms</code></td><td>설정·상태 경로가 업스트림 기본값보다 느슨함</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>agent.ssrf-private-network</code></td><td>에이전트 브라우저가 사설망 주소에 접근할 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>설정 관련 항목이 <strong>수동</strong>인 것은 의도된 선택입니다. OpenClaw 설정은 JSON5라 사용자가 직접 쓴 주석이 들어 있는데, hostveil이 키 하나만 고치려 해도 파일을 다시 쓰면서 그 주석을 지우게 됩니다. Hermes 설정값은 설정 파일, <code>.env</code>, systemd 유닛, <code>docker&nbsp;-e</code> 플래그 중 어디서 온 것인지 판별할 수 없습니다. 게이트웨이를 다시 바인딩하면 원격으로 관리하던 에이전트와의 연결이 끊길 수도 있습니다. 그래서 hostveil은 설명만 하고 수정은 사용자에게 맡깁니다.</p>
+            <p>자동 수정되는 것은 권한 관련 두 항목뿐이며, 둘 다 접근 권한을 <em>줄이기만</em> 하는 <code>chmod</code>입니다. 체크포인트가 남으므로 <code>hostveil rollback</code>으로 이전 권한을 그대로 되돌릴 수 있습니다.</p>
 
             <h2 id="cve">이미지 CVE <code>cve.</code> <em>(선택)</em></h2>
             <p>Trivy가 설치되어 있으면, hostveil은 Compose 서비스가 실행하는 이미지를 스캔하여 알려진 심각·높음·보통 등급의 취약점을 찾습니다. 발견 항목은 취약점 단위가 아니라 <strong>이미지 단위</strong>로 보고됩니다 — 이미지 하나가 CVE 수백 개를 싣고 있는 건 흔한 일이고, 그 전부가 같은 조치 하나를 공유하기 때문입니다.</p>

--- a/demo/README.md
+++ b/demo/README.md
@@ -166,6 +166,22 @@ NAT is independent of the host firewall.
 | Accounts | a second UID-0 account (`backdoor`) and a passwordless login account (`demo_nopass`) | `accounts.uid0`, `accounts.emptypassword` |
 | File permissions | `/etc/shadow` made world-readable | `fileperms.shadow` |
 | CVEs | old image tags (redis 6.0, postgres 13, jellyfin 10.8, nextcloud 24, portainer 2.9) | `cve.*` (needs Trivy, installed in the VM) |
+| AI agents | an OpenClaw gateway on the LAN with auth off, unapproved shell exec, sandbox off; world-readable Hermes API keys | `agent.auth-disabled`, `agent.gateway-exposed`, `agent.secret-exposed`, … |
 
-The stacks live in `stacks/`, the weak SSH snippet in `seed/`, and the whole
-build lives in `Vagrantfile` + `provision.sh`.
+The stacks live in `stacks/`, the weak SSH snippet and the agent configs in
+`seed/`, and the whole build lives in `Vagrantfile` + `provision.sh`.
+
+> **On the agent fixtures**: unlike everything else here, OpenClaw and Hermes
+> are not actually *installed* — neither is packaged for apt, and neither
+> ships a daemon the demo could honestly run. `provision.sh` seeds their
+> configuration and file layout instead, which is what the agent domain
+> inspects anyway. The one part this cannot show is the listener
+> cross-check: with nothing bound to the gateway port,
+> `agent.gateway-exposed` reports **High** from the config alone. Start
+> something on the port to watch it escalate to **Critical** (an exposed
+> gateway, confirmed listening, with `ufw` inactive):
+>
+> ```bash
+> python3 -m http.server 18789 --bind 0.0.0.0 &
+> hostveil scan          # severity high → critical, basis config → config+listener
+> ```

--- a/demo/provision.sh
+++ b/demo/provision.sh
@@ -10,23 +10,23 @@ DEMO="$REPO/demo"
 GO_VERSION=1.26.3
 export DEBIAN_FRONTEND=noninteractive
 
-echo "==> [0/9] prefer IPv4 (libvirt NAT usually has no IPv6 egress → apt/curl/docker fail on IPv6)"
+echo "==> [0/10] prefer IPv4 (libvirt NAT usually has no IPv6 egress → apt/curl/docker fail on IPv6)"
 sysctl -w net.ipv6.conf.all.disable_ipv6=1 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.default.disable_ipv6=1 >/dev/null 2>&1 || true
 echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4
 
-echo "==> [1/9] base packages"
+echo "==> [1/10] base packages"
 apt-get update -y || true
 apt-get install -y ca-certificates curl git ufw openssh-server
 
-echo "==> [2/9] Docker (official convenience script — gives 'docker compose')"
+echo "==> [2/10] Docker (official convenience script — gives 'docker compose')"
 if ! command -v docker >/dev/null 2>&1; then
   curl -fsSL https://get.docker.com | sh
 fi
 systemctl enable --now docker
 usermod -aG docker vagrant || true   # so `docker ps` works without sudo in the demo
 
-echo "==> [3/9] Go ${GO_VERSION} (apt's Go is too old to build hostveil)"
+echo "==> [3/10] Go ${GO_VERSION} (apt's Go is too old to build hostveil)"
 ARCH=$(dpkg --print-architecture)     # amd64 | arm64
 if ! /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GO_VERSION}"; then
   curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tgz
@@ -35,7 +35,7 @@ if ! /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GO_VERSION}"; then
 fi
 export PATH="$PATH:/usr/local/go/bin"
 
-echo "==> [4/9] Trivy (optional CVE scanner) + vuln DB"
+echo "==> [4/10] Trivy (optional CVE scanner) + vuln DB"
 # NOTE: this provisioner runs as root, so --download-db-only warms only
 # /root/.cache/trivy. A non-root `hostveil` scan uses ~vagrant/.cache/trivy and
 # will download the DB itself on first use.
@@ -45,7 +45,7 @@ if ! command -v trivy >/dev/null 2>&1; then
 fi
 trivy image --download-db-only 2>/dev/null || echo "   (trivy DB download skipped — CVE scan will fetch on first run)"
 
-echo "==> [5/9] weak SSH config (appended to the main sshd_config)"
+echo "==> [5/10] weak SSH config (appended to the main sshd_config)"
 if ! grep -q "hostveil demo weak SSH" /etc/ssh/sshd_config; then
   {
     echo ""
@@ -55,7 +55,7 @@ if ! grep -q "hostveil demo weak SSH" /etc/ssh/sshd_config; then
 fi
 systemctl restart ssh || systemctl restart sshd || true
 
-echo "==> [6/9] disable automatic security updates (so updates.disabled fires)"
+echo "==> [6/10] disable automatic security updates (so updates.disabled fires)"
 cat > /etc/apt/apt.conf.d/20auto-upgrades <<'EOF'
 APT::Periodic::Update-Package-Lists "0";
 APT::Periodic::Unattended-Upgrade "0";
@@ -63,7 +63,7 @@ EOF
 # ufw is installed but left INACTIVE → firewall.inactive fires.
 ufw --force disable || true
 
-echo "==> [7/9] host-level weaknesses (native exposed service, weak accounts, loose file perms)"
+echo "==> [7/10] host-level weaknesses (native exposed service, weak accounts, loose file perms)"
 # A NON-Docker datastore bound to every interface → ports.exposed-datastore.
 # This is exactly the kind of exposure a Compose-file audit can never see,
 # because it is a native service, not a container.
@@ -83,7 +83,27 @@ passwd -d demo_nopass || true
 # World-readable /etc/shadow → fileperms.shadow (every password hash exposed).
 chmod 0644 /etc/shadow || true
 
-echo "==> [8/9] deploy vulnerable compose stacks"
+echo "==> [8/10] self-hosted AI agent runtime configs (OpenClaw + Hermes)"
+# NOTE: neither project is packaged for apt, and neither ships a daemon we
+# could honestly run here, so this seeds their *configuration* rather than
+# installing them. That is enough for the agent domain: hostveil detects a
+# runtime by its home-directory layout and judges the config and file modes,
+# which is exactly the ground these fixtures cover.
+#
+# The one thing it cannot show is the listener cross-check. With no gateway
+# actually bound to :18789, agent.gateway-exposed reports High from the
+# config alone; on a host where the gateway is really running with no
+# firewall it escalates to Critical. To see that in the demo, run something
+# on the port first:  python3 -m http.server 18789 --bind 0.0.0.0 &
+install -d -m 0700 -o vagrant -g vagrant /home/vagrant/.openclaw
+install -d -m 0755 -o vagrant -g vagrant /home/vagrant/.openclaw/credentials  # too open → agent.secret-exposed
+install -d -m 0700 -o vagrant -g vagrant /home/vagrant/.openclaw/state
+install -m 0644 -o vagrant -g vagrant "$DEMO/seed/openclaw.json" /home/vagrant/.openclaw/openclaw.json  # → agent.config-perms
+
+install -d -m 0700 -o vagrant -g vagrant /home/vagrant/.hermes
+install -m 0644 -o vagrant -g vagrant "$DEMO/seed/hermes.env" /home/vagrant/.hermes/.env  # → agent.secret-exposed
+
+echo "==> [9/10] deploy vulnerable compose stacks"
 mkdir -p /opt/stacks
 cp -r "$DEMO/stacks/." /opt/stacks/
 # Bring the stacks up once now. They have no restart policy on purpose, so
@@ -96,7 +116,7 @@ for dir in /opt/stacks/*/; do
     || echo "     (stack '$name' had a service that failed to start — hostveil still audits its compose file)"
 done
 
-echo "==> [9/9] build hostveil from the mounted source"
+echo "==> [10/10] build hostveil from the mounted source"
 cd "$REPO"
 GOFLAGS=-buildvcs=false /usr/local/go/bin/go build -o /usr/local/bin/hostveil ./cmd/hostveil
 hostveil version || true

--- a/demo/seed/hermes.env
+++ b/demo/seed/hermes.env
@@ -1,0 +1,15 @@
+# Deliberately exposed Hermes Agent credentials file for the hostveil demo.
+#
+# Storing API keys here is Hermes' normal design, NOT the problem — hostveil
+# does not flag a secrets file for holding secrets. The seeded problem is the
+# mode: provision.sh chmods this to 0644, so every account on the box can read
+# it. Tighten it to 0600 and the finding goes away.
+#
+# These keys are obviously fake. They are long enough and named plausibly
+# enough to trip the credential heuristic, which is the whole job here.
+OPENAI_API_KEY=sk-demo-000000000000-NOT-A-REAL-KEY
+ANTHROPIC_API_KEY=sk-ant-demo-0000000000-NOT-A-REAL-KEY
+
+# Not credential-named, so it must NOT appear in the finding's evidence.
+LOG_LEVEL=debug
+HERMES_DASHBOARD_PORT=9119

--- a/demo/seed/openclaw.json
+++ b/demo/seed/openclaw.json
@@ -1,0 +1,49 @@
+// Deliberately insecure OpenClaw gateway config for the hostveil demo.
+//
+// This file is JSON5 on purpose — comments and trailing commas and all.
+// OpenClaw documents its config as JSON5 and users comment it heavily, so a
+// config that parses ONLY as strict JSON would not exercise the checker's
+// real input. If hostveil ever regresses to a strict-JSON parse, the agent
+// domain reports Degraded here and the demo shows it.
+//
+// Every setting below is one a real self-hoster plausibly sets while trying
+// to make the thing work, with a comment explaining the reasoning that leads
+// there. That is the point: none of it looks reckless in isolation.
+{
+  "gateway": {
+    // "so I can reach it from the tablet in the kitchen"
+    "bind": "lan",
+    "port": 18789,
+    // "it's just my home network, nobody else is on it"
+    "auth": { "mode": "none" },
+    "controlUi": {
+      // "the login kept logging me out while I was setting it up"
+      "allowInsecureAuth": true,
+    },
+  },
+
+  "tools": {
+    // "approving every command got annoying fast"
+    "exec": { "security": "full", "ask": "off" },
+    // "it couldn't restart my containers without this"
+    "elevated": { "enabled": true },
+  },
+
+  "agents": {
+    "defaults": {
+      // "the sandbox broke my file tools"
+      "sandbox": { "mode": "off", "workspaceAccess": "rw" },
+    },
+  },
+
+  "browser": {
+    "ssrfPolicy": {
+      // "it couldn't reach my Home Assistant at 192.168.1.x"
+      "dangerouslyAllowPrivateNetwork": true,
+    },
+  },
+
+  // A URL, to prove the JSON5 comment stripper does not mistake the "//"
+  // inside a string literal for the start of a comment.
+  "notes": "hardening guide: https://docs.openclaw.ai/gateway/security",
+}

--- a/internal/check/agent/agent.go
+++ b/internal/check/agent/agent.go
@@ -339,25 +339,34 @@ func gatewayFindings(s scan, listeners []platform.Listener, fw firewall.Status) 
 	return out
 }
 
-// matchListener finds a non-loopback listener for the gateway: one on the
-// configured port, or one owned by a process the runtime is known to run.
-// The second case matters when the config was unreadable and the port could
-// therefore not be resolved.
+// matchListener finds a non-loopback listener for the gateway.
+//
+// The port is the only trigger. A process name never matches on its own,
+// however tempting it is as a way to catch a gateway moved to a port we could
+// not read: these runtimes are reported by ss under whatever interpreter runs
+// them — python3, node, uvicorn — and matching those would attribute any
+// unrelated Python or Node service on the host to an agent gateway. The
+// default port is always known, so the fallback bought very little and cost a
+// false positive on some of the most common process names there are.
+//
+// ProcNames is still used, for what it is actually good for: when several
+// listeners share the port, prefer the one the runtime plausibly owns, so the
+// evidence names a useful process.
 func matchListener(listeners []platform.Listener, port int, procs []string) (platform.Listener, bool) {
+	var first platform.Listener
+	found := false
 	for _, l := range listeners {
-		if l.Loopback() {
+		if l.Loopback() || l.Port != port {
 			continue
 		}
-		if l.Port == port {
+		if l.Proc != "" && slices.Contains(procs, l.Proc) {
 			return l, true
 		}
-	}
-	for _, l := range listeners {
-		if !l.Loopback() && l.Proc != "" && slices.Contains(procs, l.Proc) {
-			return l, true
+		if !found {
+			first, found = l, true
 		}
 	}
-	return platform.Listener{}, false
+	return first, found
 }
 
 // dangerFindings applies the runtime's danger-key table. Rules sharing an ID

--- a/internal/check/agent/agent.go
+++ b/internal/check/agent/agent.go
@@ -1,0 +1,400 @@
+// Package agent implements a checker for self-hosted AI agent runtimes such
+// as OpenClaw and Hermes Agent. Each runs a network gateway and keeps API
+// keys on disk in a user's home; misconfigured, the failure mode is
+// unauthenticated remote code execution as a real account.
+//
+// The scope is deliberately narrow. These projects ship their own config
+// auditors, which cover their settings far more thoroughly than hostveil
+// could sustain across two fast-moving upstream schemas. What they cannot see
+// is the host: whether the gateway is *actually* listening on a reachable
+// address, whether a firewall is standing behind it, whether the credential
+// file is readable by everyone with an account. That is what this checker
+// judges, plus a small set of stable, unambiguous config keys where the
+// insecure value has no legitimate reading.
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/check/firewall"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// Checker reports insecure self-hosted agent runtime deployments.
+type Checker struct {
+	// PasswdPath and Runtimes are overridable for tests.
+	PasswdPath string
+	Runtimes   []Runtime
+}
+
+// New returns an agent checker with the shipped runtime registry.
+func New() *Checker {
+	return &Checker{PasswdPath: "/etc/passwd", Runtimes: defaultRuntimes()}
+}
+
+// Source identifies the agent domain.
+func (*Checker) Source() model.Source { return model.SourceAgent }
+
+// Available probes for an actual agent installation, not merely for the
+// ability to look.
+//
+// The two failure modes are kept distinct on purpose. An unreadable
+// /etc/passwd means we could not look, and a host with no runtime installed
+// means there was nothing to find; both skip the domain, but conflating them
+// would let "I couldn't look" pass for "nothing there". The domain is skipped
+// rather than reported clean because a host that has never installed an agent
+// should not collect a free perfect score for a domain that never applied.
+func (c *Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
+	hs, err := homes(c.PasswdPath)
+	if err != nil {
+		return false, "cannot read " + c.PasswdPath + " to locate home directories"
+	}
+	found, _ := installs(hs, c.Runtimes)
+	if len(found) == 0 {
+		names := make([]string, 0, len(c.Runtimes))
+		for _, rt := range c.Runtimes {
+			names = append(names, rt.Display)
+		}
+		return false, "no self-hosted agent runtime found (" + strings.Join(names, ", ") + ")"
+	}
+	return true, ""
+}
+
+// scan is one runtime installation plus whatever we managed to read of it.
+type scan struct {
+	in       install
+	cfg      map[string]any
+	cfgKnown bool
+	env      envFile
+	envKnown bool
+}
+
+// Check audits every discovered runtime installation.
+func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
+	hs, err := homes(c.PasswdPath)
+	if err != nil {
+		return nil, err
+	}
+	found, unreadableHomes := installs(hs, c.Runtimes)
+
+	// A missing or failing `ss` is not partial coverage: the config is the
+	// authoritative statement of what the operator asked for, and the listener
+	// only corroborates it and sharpens the severity. Losing a confidence
+	// booster is not losing ground.
+	listeners, _ := platform.Listeners(ctx, env.Runner)
+	// Likewise the firewall: it decides only whether an exposed gateway is
+	// High or Critical, never whether the finding exists.
+	fwStatus, _ := firewall.Probe(ctx, env.Runner)
+
+	var findings []model.Finding
+	var reasons []string
+	// Coverage counts configs we needed to read, not installs. An install
+	// that has no config file yet is not ground we failed to cover, and
+	// counting it would understate the fraction for no reason.
+	covered, total := 0, 0
+
+	for _, in := range found {
+		s := scan{in: in}
+
+		if rel := in.rt.EnvFile; rel != "" {
+			safe := make([]string, 0, len(in.rt.EnvOverrides))
+			for _, v := range in.rt.EnvOverrides {
+				safe = append(safe, v)
+			}
+			if ef, err := loadEnvFile(in.path(rel), safe); err == nil {
+				s.env, s.envKnown = ef, true
+			}
+		}
+
+		b, err := os.ReadFile(in.path(in.rt.Config)) //nolint:gosec // path from the runtime registry
+		switch {
+		case err != nil && os.IsNotExist(err):
+			// Installed but never configured. Nothing to read, nothing lost.
+		case err != nil:
+			total++
+			reasons = append(reasons, fmt.Sprintf("cannot read %s config for %s", in.rt.Display, in.user.Name))
+		default:
+			total++
+			cfg, derr := decodeConfig(b, in.rt.Format)
+			if derr != nil {
+				// An unparseable config is our blind spot, not the operator's
+				// defect, so it degrades coverage without inventing a finding.
+				reasons = append(reasons, fmt.Sprintf("cannot parse %s config for %s", in.rt.Display, in.user.Name))
+			} else {
+				s.cfg, s.cfgKnown = cfg, true
+				covered++
+			}
+		}
+
+		findings = append(findings, modeFindings(s)...)
+		findings = append(findings, gatewayFindings(s, listeners, fwStatus)...)
+		if s.cfgKnown {
+			findings = append(findings, dangerFindings(s)...)
+		}
+	}
+
+	for _, h := range unreadableHomes {
+		reasons = append(reasons, "cannot read home directory "+h)
+	}
+	if len(reasons) > 0 {
+		sort.Strings(reasons)
+		return findings, &check.PartialError{
+			Reason:  strings.Join(reasons, "; ") + " — re-run with sudo for full coverage",
+			Covered: covered,
+			Total:   total,
+		}
+	}
+	return findings, nil
+}
+
+// modeFindings flags registry paths whose permissions are looser than the
+// runtime's own hardened baseline.
+func modeFindings(s scan) []model.Finding {
+	var out []model.Finding
+	for _, rule := range s.in.rt.Modes {
+		path := s.in.path(rule.Rel)
+		fi, err := os.Stat(path)
+		if err != nil {
+			continue // a path the user never created is not a finding
+		}
+		if fi.IsDir() != rule.Dir {
+			continue // the layout is not what the registry describes; do not guess
+		}
+		perm := fi.Mode().Perm()
+		if perm&^rule.Max == 0 {
+			continue
+		}
+
+		var keys []string
+		if rule.Secret && !rule.Dir {
+			// "Secrets live in a secrets file" is the design, not a defect.
+			// The finding is only meaningful once we know real credentials are
+			// in there *and* the file is readable beyond its owner.
+			keys = secretKeysIn(s, path)
+			if len(keys) == 0 {
+				continue
+			}
+		}
+
+		id, title, desc := "agent.config-perms",
+			s.in.rt.Display+" configuration is readable beyond its owner",
+			"This file configures an agent that can run commands and hold credentials. Any account able to read it learns how the agent is set up; any account able to write it can retarget the agent."
+		sev := model.SeverityMedium
+		if rule.Secret {
+			id, sev = "agent.secret-exposed", model.SeverityHigh
+			title = s.in.rt.Display + " credentials are readable beyond their owner"
+			desc = "This path holds the API keys the agent authenticates with. Every account on this host can read it, so any of them — or anything running as them — can take those keys and spend, read, or act with them elsewhere."
+		}
+
+		opts := []model.FindingOption{
+			// The path is part of the subject: two rules under one install
+			// are two distinct problems and must not collapse into one Key.
+			model.WithService(s.in.subject() + ":" + rule.Rel),
+			model.WithDescription(desc),
+			model.WithHowToFix(fmt.Sprintf("Tighten it to %#o, e.g. `chmod %#o %s`. Upstream ships this path at %#o; if a service account reads it via group permissions, give that account its own copy instead of widening this one.", rule.Max, rule.Max, path, rule.Max)),
+			model.WithEvidence("files", fmt.Sprintf("%s (%#o)", path, perm)),
+			// The machine-readable twin of "files", in the shape the mode fix
+			// expects. Parsing paths back out of the human string breaks on
+			// any path containing ", " or " (".
+			model.WithEvidence("paths", path),
+			model.WithEvidence("expected", fmt.Sprintf("%#o", rule.Max)),
+		}
+		if len(keys) > 0 {
+			// Names only. The values are the thing being protected, and
+			// evidence is rendered by every UI and persisted to disk.
+			opts = append(opts, model.WithEvidence("keys", strings.Join(keys, model.EvidenceSeparator)))
+		}
+		out = append(out, model.NewFinding(id, title, sev, model.SourceAgent, model.RemediationAuto, opts...))
+	}
+	return out
+}
+
+// secretKeysIn returns the credential-named keys carrying a literal value in
+// a KEY=value file, reusing the already-parsed env file when it is the same
+// path.
+func secretKeysIn(s scan, path string) []string {
+	if s.envKnown && s.in.rt.EnvFile != "" && path == s.in.path(s.in.rt.EnvFile) {
+		return s.env.SecretKeys
+	}
+	ef, err := loadEnvFile(path, nil)
+	if err != nil {
+		return nil
+	}
+	return ef.SecretKeys
+}
+
+// gatewayFindings judges the runtime's network exposure from its configured
+// bind, corroborated by what the host is actually listening on.
+func gatewayFindings(s scan, listeners []platform.Listener, fw firewall.Status) []model.Finding {
+	gw := s.in.rt.Gateway
+	if gw.BindKey == "" {
+		return nil
+	}
+
+	port := gw.DefaultPort
+	if s.cfgKnown && gw.PortKey != "" {
+		if v := lookupString(s.cfg, gw.PortKey); v != "" {
+			if p, err := strconv.Atoi(v); err == nil {
+				port = p
+			}
+		}
+	}
+
+	// Resolve the bind: config first, then the documented default, then any
+	// environment override. An empty result means "we cannot tell", which is
+	// different from "loopback" — we fall back to the listener rather than
+	// assuming either way.
+	bind := ""
+	if s.cfgKnown {
+		if bind = lookupString(s.cfg, gw.BindKey); bind == "" {
+			bind = gw.BindDefault
+		}
+	}
+	if s.envKnown {
+		if ev, ok := s.in.rt.EnvOverrides[gw.BindKey]; ok {
+			if v := s.env.Values[ev]; v != "" {
+				bind = v
+			}
+		}
+	}
+	bindExposed := bind != "" && !slices.Contains(gw.LoopbackOnly, bind)
+
+	listener, listenerFound := matchListener(listeners, port, gw.ProcNames)
+	if !bindExposed && !listenerFound {
+		return nil
+	}
+
+	basis := "config"
+	switch {
+	case bindExposed && listenerFound:
+		basis = "config+listener"
+	case listenerFound:
+		basis = "listener"
+	}
+
+	// The firewall decides how bad it is, never whether it is true. An
+	// observed listener with no firewall behind it is reachable now, today.
+	sev := model.SeverityHigh
+	if listenerFound && fw == firewall.StatusInactive {
+		sev = model.SeverityCritical
+	}
+
+	opts := []model.FindingOption{
+		model.WithService(s.in.subject()),
+		model.WithDescription("The " + s.in.rt.Display + " gateway is bound to an address reachable from the network. The gateway drives an agent that can read files and run commands, so anyone who can reach this port — and get past whatever authentication is configured — is operating the agent on this host."),
+		model.WithHowToFix("Bind the gateway to loopback and reach it over an SSH tunnel or a tailnet instead of exposing the port. If it must be remote, put it behind an authenticated reverse proxy and a firewall rule that allows only the addresses you use."),
+		model.WithEvidence("port", strconv.Itoa(port)),
+		model.WithEvidence("basis", basis),
+	}
+	if bind != "" {
+		opts = append(opts, model.WithEvidence("bind", bind))
+	}
+	if listenerFound {
+		opts = append(opts, model.WithEvidence("address", listener.Addr))
+		if listener.Proc != "" {
+			opts = append(opts, model.WithEvidence("process", listener.Proc))
+		}
+	}
+	out := []model.Finding{model.NewFinding("agent.gateway-exposed",
+		s.in.rt.Display+" gateway is reachable from the network",
+		sev, model.SourceAgent, model.RemediationManual, opts...)}
+
+	// Authentication is only judged once the gateway is actually exposed.
+	// Every one of these runtimes treats "no auth on loopback" as a
+	// legitimate single-user default, so flagging it would put a Critical on
+	// a correct install — a score you could not improve by doing everything
+	// right.
+	if s.cfgKnown && gw.AuthKey != "" {
+		auth := lookupString(s.cfg, gw.AuthKey)
+		if ev, ok := s.in.rt.EnvOverrides[gw.AuthKey]; ok && s.envKnown {
+			if v := s.env.Values[ev]; v != "" {
+				auth = v
+			}
+		}
+		if slices.Contains(gw.AuthDisabled, auth) {
+			shown := auth
+			if shown == "" {
+				shown = "(unset)"
+			}
+			out = append(out, model.NewFinding("agent.auth-disabled",
+				s.in.rt.Display+" gateway accepts requests with no authentication",
+				model.SeverityCritical, model.SourceAgent, model.RemediationManual,
+				model.WithService(s.in.subject()),
+				model.WithDescription("The gateway is reachable from the network and requires no credential to talk to. Anyone who can reach the port can drive the agent: read the files it can read, run the commands it can run, and use the API keys it holds."),
+				model.WithHowToFix("Set the gateway's authentication mode to a token or password with a long random value, and bind the gateway to loopback as well — authentication is the second line, not the first."),
+				model.WithEvidence("setting", gw.AuthKey),
+				model.WithEvidence("value", shown),
+				model.WithEvidence("port", strconv.Itoa(port)),
+			))
+		}
+	}
+	return out
+}
+
+// matchListener finds a non-loopback listener for the gateway: one on the
+// configured port, or one owned by a process the runtime is known to run.
+// The second case matters when the config was unreadable and the port could
+// therefore not be resolved.
+func matchListener(listeners []platform.Listener, port int, procs []string) (platform.Listener, bool) {
+	for _, l := range listeners {
+		if l.Loopback() {
+			continue
+		}
+		if l.Port == port {
+			return l, true
+		}
+	}
+	for _, l := range listeners {
+		if !l.Loopback() && l.Proc != "" && slices.Contains(procs, l.Proc) {
+			return l, true
+		}
+	}
+	return platform.Listener{}, false
+}
+
+// dangerFindings applies the runtime's danger-key table. Rules sharing an ID
+// are collapsed into one finding listing every key that tripped it, so an
+// operator sees one problem rather than the same problem twice.
+func dangerFindings(s scan) []model.Finding {
+	type hit struct {
+		rule DangerRule
+		keys []string
+	}
+	byID := map[string]*hit{}
+	var order []string
+
+	for _, dr := range s.in.rt.Danger {
+		v, ok := lookup(s.cfg, dr.Key)
+		if !ok || !slices.Contains(dr.Bad, scalar(v)) {
+			continue
+		}
+		if h, seen := byID[dr.ID]; seen {
+			h.keys = append(h.keys, dr.Key)
+			continue
+		}
+		byID[dr.ID] = &hit{rule: dr, keys: []string{dr.Key}}
+		order = append(order, dr.ID)
+	}
+
+	out := make([]model.Finding, 0, len(order))
+	for _, id := range order {
+		h := byID[id]
+		out = append(out, model.NewFinding(id, h.rule.Title, h.rule.Sev,
+			model.SourceAgent, model.RemediationManual,
+			model.WithService(s.in.subject()),
+			model.WithDescription(h.rule.Desc),
+			model.WithHowToFix(h.rule.HowToFix),
+			model.WithEvidence("settings", strings.Join(h.keys, model.EvidenceSeparator)),
+			model.WithEvidence("config", s.in.path(s.in.rt.Config)),
+		))
+	}
+	return out
+}

--- a/internal/check/agent/agent_test.go
+++ b/internal/check/agent/agent_test.go
@@ -316,6 +316,46 @@ func TestListenerAloneExposesGateway(t *testing.T) {
 	}
 }
 
+// These runtimes appear in ss under whatever interpreter runs them, so a
+// process name must never be enough on its own to call a socket an agent
+// gateway. An unrelated python3 or node service on some other port is not
+// evidence of anything, and attributing it would put a Critical on a host
+// that is not running the runtime at all.
+func TestUnrelatedInterpreterProcessIsNotAGateway(t *testing.T) {
+	h := newHost(t, "alice")
+	// Hermes is installed but its dashboard is not running; the python3 here
+	// is an ordinary service on an unrelated port.
+	h.write("alice", ".hermes/.env", "LOG_LEVEL=debug\n", 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(ssLine("0.0.0.0", 8000, "python3")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f, ok := findByID(fs, "agent.gateway-exposed"); ok {
+		t.Errorf("a python3 listener on port 8000 was mistaken for a gateway: %+v", f.Evidence)
+	}
+}
+
+// Among several listeners on the gateway port, the one the runtime plausibly
+// owns is the one worth naming in evidence.
+func TestListenerEvidencePrefersTheRuntimesOwnProcess(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)
+
+	ss := ssLine("0.0.0.0", 18789, "haproxy") + "\n" + ssLine("192.168.1.5", 18789, "openclaw")
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(ss))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := findByID(fs, "agent.gateway-exposed")
+	if !ok {
+		t.Fatal("expected the gateway to be reported")
+	}
+	if got := f.Evidence["process"]; got != "openclaw" {
+		t.Errorf("evidence names %q, want the runtime's own process", got)
+	}
+}
+
 // A loopback listener on the gateway port is the correct deployment.
 func TestLoopbackListenerIsNotExposure(t *testing.T) {
 	h := newHost(t, "alice")

--- a/internal/check/agent/agent_test.go
+++ b/internal/check/agent/agent_test.go
@@ -1,0 +1,712 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// fakeRunner scripts `ss` output and controls which binaries appear present,
+// which is what firewall.Probe keys off.
+type fakeRunner struct {
+	ss      string
+	ssErr   error
+	missing map[string]bool
+	outputs map[string]string
+}
+
+func (f fakeRunner) LookPath(name string) (string, error) {
+	if f.missing[name] {
+		return "", errors.New("not found: " + name)
+	}
+	return "/usr/bin/" + name, nil
+}
+
+func (f fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	if name == "ss" {
+		return []byte(f.ss), f.ssErr
+	}
+	key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	if out, ok := f.outputs[key]; ok {
+		return []byte(out), nil
+	}
+	return nil, errors.New("no output for: " + key)
+}
+
+// noFirewall reports every firewall front-end as absent, which Probe reads as
+// a definite StatusInactive rather than "could not look".
+func noFirewall() map[string]bool {
+	return map[string]bool{"ufw": true, "firewall-cmd": true, "nft": true}
+}
+
+func envNoFirewall(ss string) platform.Env {
+	return platform.Env{Runner: fakeRunner{ss: ss, missing: noFirewall()}}
+}
+
+func envActiveFirewall(ss string) platform.Env {
+	return platform.Env{Runner: fakeRunner{
+		ss:      ss,
+		missing: map[string]bool{"firewall-cmd": true, "nft": true},
+		outputs: map[string]string{"ufw status": "Status: active"},
+	}}
+}
+
+// ssLine renders one `ss -tlnp` row.
+func ssLine(addr string, port int, proc string) string {
+	p := "users:((\"" + proc + "\",pid=1,fd=3))"
+	if proc == "" {
+		p = ""
+	}
+	return fmt.Sprintf("LISTEN 0 128 %s:%d 0.0.0.0:* %s", addr, port, p)
+}
+
+// host is a synthetic /etc/passwd plus real temp home directories, so the
+// checker exercises genuine absolute paths and real permission bits.
+type host struct {
+	t      *testing.T
+	passwd string
+	homes  map[string]string
+}
+
+func newHost(t *testing.T, users ...string) *host {
+	t.Helper()
+	root := t.TempDir()
+	h := &host{t: t, passwd: filepath.Join(root, "passwd"), homes: map[string]string{}}
+
+	// A service account and a nobody entry that must both be ignored.
+	lines := []string{
+		"daemon:x:1:1::/usr/sbin:/usr/sbin/nologin",
+		"nobody:x:65534:65534::/nonexistent:/usr/sbin/nologin",
+	}
+	for i, u := range users {
+		home := filepath.Join(root, u)
+		if err := os.MkdirAll(home, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		h.homes[u] = home
+		lines = append(lines, fmt.Sprintf("%s:x:%d:%d::%s:/bin/bash", u, 1000+i, 1000+i, home))
+	}
+	if err := os.WriteFile(h.passwd, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func (h *host) write(user, rel, content string, mode os.FileMode) string {
+	h.t.Helper()
+	p := filepath.Join(h.homes[user], rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		h.t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		h.t.Fatal(err)
+	}
+	if err := os.Chmod(p, mode); err != nil {
+		h.t.Fatal(err)
+	}
+	return p
+}
+
+func (h *host) mkdir(user, rel string, mode os.FileMode) string {
+	h.t.Helper()
+	p := filepath.Join(h.homes[user], rel)
+	if err := os.MkdirAll(p, 0o700); err != nil {
+		h.t.Fatal(err)
+	}
+	if err := os.Chmod(p, mode); err != nil {
+		h.t.Fatal(err)
+	}
+	return p
+}
+
+func (h *host) checker() *Checker {
+	return &Checker{PasswdPath: h.passwd, Runtimes: defaultRuntimes()}
+}
+
+func findByID(fs []model.Finding, id string) (model.Finding, bool) {
+	for _, f := range fs {
+		if f.ID == id {
+			return f, true
+		}
+	}
+	return model.Finding{}, false
+}
+
+func countByID(fs []model.Finding, id string) int {
+	n := 0
+	for _, f := range fs {
+		if f.ID == id {
+			n++
+		}
+	}
+	return n
+}
+
+// A loopback-bound, authenticated, correctly-permissioned install. Anything
+// this produces a finding for is noise.
+const cleanOpenClaw = `{"gateway":{"bind":"loopback","auth":{"mode":"token","token":"a-long-random-token"}}}`
+
+// --- Available -------------------------------------------------------------
+
+// "I could not look" and "there was nothing there" are different facts. They
+// both skip the domain, but collapsing them is how a scan starts reporting a
+// clean result for ground it never covered.
+func TestAvailableDistinguishesUnreadableFromAbsent(t *testing.T) {
+	h := newHost(t, "alice")
+
+	c := &Checker{PasswdPath: filepath.Join(t.TempDir(), "nope"), Runtimes: defaultRuntimes()}
+	ok, reason := c.Available(context.Background(), platform.Env{})
+	if ok {
+		t.Error("expected unavailable when passwd is unreadable")
+	}
+	if !strings.Contains(reason, "cannot read") {
+		t.Errorf("reason %q should say we could not look", reason)
+	}
+
+	ok, reason = h.checker().Available(context.Background(), platform.Env{})
+	if ok {
+		t.Error("expected unavailable when no runtime is installed")
+	}
+	if !strings.Contains(reason, "no self-hosted agent runtime") {
+		t.Errorf("reason %q should say nothing was installed", reason)
+	}
+	if strings.Contains(reason, "cannot read") {
+		t.Errorf("reason %q conflates absence with unreadability", reason)
+	}
+}
+
+func TestAvailableTrueWhenMarkerExists(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)
+
+	if ok, reason := h.checker().Available(context.Background(), platform.Env{}); !ok {
+		t.Errorf("expected available once .openclaw exists, got %q", reason)
+	}
+}
+
+// --- Config parsing --------------------------------------------------------
+
+// OpenClaw documents its config as JSON5 and users comment it heavily. If a
+// commented config were unparseable, every OpenClaw host would report
+// Degraded, and a flag that fires everywhere tells an operator nothing.
+func TestJSON5ConfigWithCommentsAndTrailingCommasParses(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", `{
+  // the gateway is on the LAN so the family tablet can reach it
+  "gateway": {
+    "bind": "lan",           // not loopback!
+    "auth": { "mode": "none" },   /* nobody else is on this network */
+  },
+  "notes": "a url with // inside must survive: https://example.com/x",
+}`, 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatalf("a commented JSON5 config must not degrade: %v", err)
+	}
+	if _, ok := findByID(fs, "agent.gateway-exposed"); !ok {
+		t.Error("bind: lan should have been read out of the JSON5 config")
+	}
+	if _, ok := findByID(fs, "agent.auth-disabled"); !ok {
+		t.Error("auth.mode: none should have been read out of the JSON5 config")
+	}
+}
+
+// An unparseable config is our blind spot, not the operator's defect, so it
+// costs coverage without inventing a finding to explain itself.
+func TestUnparseableConfigDegradesWithoutInventingAFinding(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", "{{{ this is not a config", 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("expected a PartialError, got %v", err)
+	}
+	if partial.Covered != 0 || partial.Total != 1 {
+		t.Errorf("coverage = %d/%d, want 0/1", partial.Covered, partial.Total)
+	}
+	for _, f := range fs {
+		if strings.Contains(strings.ToLower(f.Title), "pars") {
+			t.Errorf("a parse failure must not become a finding: %q", f.Title)
+		}
+	}
+}
+
+// An install with no config file at all is a normal state, not partial
+// coverage — there is nothing we failed to read.
+func TestInstalledButUnconfiguredDoesNotDegrade(t *testing.T) {
+	h := newHost(t, "alice")
+	h.mkdir("alice", ".openclaw", 0o700)
+
+	if _, err := h.checker().Check(context.Background(), envNoFirewall("")); err != nil {
+		t.Errorf("an unconfigured install must not degrade the domain: %v", err)
+	}
+}
+
+// --- Gateway exposure ------------------------------------------------------
+
+// The firewall decides how loud the finding is, never whether it is true.
+func TestGatewayExposureSeverityMatrix(t *testing.T) {
+	exposedCfg := `{"gateway":{"bind":"lan","auth":{"mode":"token","token":"a-long-random-token"}}}`
+	listening := ssLine("0.0.0.0", 18789, "openclaw")
+
+	cases := []struct {
+		name string
+		cfg  string
+		env  platform.Env
+		want model.Severity
+		ok   bool
+		why  string
+	}{
+		{"config only, nothing listening", exposedCfg, envNoFirewall(""), model.SeverityHigh, true,
+			"configured intent is enough to report, but nothing is confirmed reachable yet"},
+		{"listening, firewall active", exposedCfg, envActiveFirewall(listening), model.SeverityHigh, true,
+			"a firewall is a real backstop, so this is not the worst case"},
+		{"listening, no firewall", exposedCfg, envNoFirewall(listening), model.SeverityCritical, true,
+			"reachable right now with nothing in front of it"},
+		{"loopback and quiet", cleanOpenClaw, envNoFirewall(""), 0, false,
+			"the correct configuration must produce no finding at all"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := newHost(t, "alice")
+			h.write("alice", ".openclaw/openclaw.json", c.cfg, 0o600)
+
+			fs, err := h.checker().Check(context.Background(), c.env)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f, ok := findByID(fs, "agent.gateway-exposed")
+			if ok != c.ok {
+				t.Fatalf("finding present = %v, want %v — %s", ok, c.ok, c.why)
+			}
+			if ok && f.Severity != c.want {
+				t.Errorf("severity = %v, want %v — %s", f.Severity, c.want, c.why)
+			}
+		})
+	}
+}
+
+// A listener the config never predicted still counts: the operator may have
+// configured one thing and be running another.
+func TestListenerAloneExposesGateway(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(ssLine("0.0.0.0", 18789, "openclaw")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := findByID(fs, "agent.gateway-exposed")
+	if !ok {
+		t.Fatal("an observed non-loopback listener on the gateway port must be reported")
+	}
+	if got := f.Evidence["basis"]; got != "listener" {
+		t.Errorf("basis = %q, want \"listener\" — the config said loopback", got)
+	}
+}
+
+// A loopback listener on the gateway port is the correct deployment.
+func TestLoopbackListenerIsNotExposure(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(ssLine("127.0.0.1", 18789, "openclaw")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := findByID(fs, "agent.gateway-exposed"); ok {
+		t.Error("a loopback-bound gateway is not exposed")
+	}
+}
+
+// `ss` is a corroborator, not a source of coverage. Losing it costs sharper
+// severity, not ground, so it must not degrade the domain.
+func TestMissingSsDoesNotDegrade(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", `{"gateway":{"bind":"lan","auth":{"mode":"token","token":"a-long-random-token"}}}`, 0o600)
+
+	env := platform.Env{Runner: fakeRunner{ssErr: errors.New("ss: not found"), missing: noFirewall()}}
+	fs, err := h.checker().Check(context.Background(), env)
+	if err != nil {
+		t.Fatalf("a missing ss must not degrade the domain: %v", err)
+	}
+	f, ok := findByID(fs, "agent.gateway-exposed")
+	if !ok {
+		t.Fatal("the configured bind alone should still report exposure")
+	}
+	if got := f.Evidence["basis"]; got != "config" {
+		t.Errorf("basis = %q, want \"config\"", got)
+	}
+}
+
+// --- Authentication --------------------------------------------------------
+
+// auth.mode: none on a loopback gateway is upstream's documented single-user
+// default. Flagging it would put a Critical on a correct install — a score
+// nobody could improve by doing everything right.
+func TestAuthDisabledIsSilentOnALoopbackGateway(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", `{"gateway":{"bind":"loopback","auth":{"mode":"none"}}}`, 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := findByID(fs, "agent.auth-disabled"); ok {
+		t.Error("no-auth on loopback is the legitimate default and must not be flagged")
+	}
+}
+
+func TestAuthDisabledFiresOnAnExposedGateway(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", `{"gateway":{"bind":"lan","auth":{"mode":"none"}}}`, 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := findByID(fs, "agent.auth-disabled")
+	if !ok {
+		t.Fatal("an exposed gateway with no authentication must be reported")
+	}
+	if f.Severity != model.SeverityCritical {
+		t.Errorf("severity = %v, want Critical", f.Severity)
+	}
+}
+
+// OpenClaw fails closed when the auth mode is unset, so an absent key is not
+// the open case and must not be reported as one.
+func TestUnsetAuthModeIsNotTreatedAsDisabled(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", `{"gateway":{"bind":"lan"}}`, 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := findByID(fs, "agent.auth-disabled"); ok {
+		t.Error("an unset auth mode fails closed upstream; reporting it is a false positive")
+	}
+}
+
+// --- Danger keys -----------------------------------------------------------
+
+func TestEachDangerKeyTriggersItsFinding(t *testing.T) {
+	cases := []struct {
+		cfg string
+		id  string
+	}{
+		{`{"tools":{"exec":{"security":"full"}}}`, "agent.exec-unrestricted"},
+		{`{"tools":{"exec":{"ask":"off"}}}`, "agent.exec-unrestricted"},
+		{`{"tools":{"elevated":{"enabled":true}}}`, "agent.elevated-enabled"},
+		{`{"agents":{"defaults":{"sandbox":{"mode":"off"}}}}`, "agent.sandbox-off"},
+		{`{"gateway":{"controlUi":{"allowInsecureAuth":true}}}`, "agent.control-ui-insecure"},
+		{`{"gateway":{"controlUi":{"dangerouslyDisableDeviceAuth":true}}}`, "agent.control-ui-insecure"},
+		{`{"browser":{"ssrfPolicy":{"dangerouslyAllowPrivateNetwork":true}}}`, "agent.ssrf-private-network"},
+	}
+	for _, c := range cases {
+		t.Run(c.id+" via "+c.cfg[:20], func(t *testing.T) {
+			h := newHost(t, "alice")
+			h.write("alice", ".openclaw/openclaw.json", c.cfg, 0o600)
+
+			fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := findByID(fs, c.id); !ok {
+				t.Errorf("config %s did not produce %s", c.cfg, c.id)
+			}
+		})
+	}
+}
+
+// Two keys describing the same weakening are one problem, and the operator
+// should see it once — with both keys named.
+func TestSharedIDDangerRulesCollapseToOneFinding(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", `{"tools":{"exec":{"security":"full","ask":"off"}}}`, 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := countByID(fs, "agent.exec-unrestricted"); n != 1 {
+		t.Fatalf("got %d exec findings, want exactly 1", n)
+	}
+	f, _ := findByID(fs, "agent.exec-unrestricted")
+	for _, want := range []string{"tools.exec.security", "tools.exec.ask"} {
+		if !strings.Contains(f.Evidence["settings"], want) {
+			t.Errorf("evidence %q should name %s", f.Evidence["settings"], want)
+		}
+	}
+}
+
+func TestSafeConfigProducesNoDangerFindings(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json",
+		`{"gateway":{"bind":"loopback","auth":{"mode":"token","token":"a-long-random-token"}},
+		  "tools":{"exec":{"security":"deny","ask":"always"},"elevated":{"enabled":false}}}`, 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("a hardened install must be clean, got %d findings: %+v", len(fs), fs)
+	}
+}
+
+// --- Permissions and secrets ----------------------------------------------
+
+func TestLooseConfigModeIsReportedInTheShapeTheFixNeeds(t *testing.T) {
+	h := newHost(t, "alice")
+	path := h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o644)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := findByID(fs, "agent.config-perms")
+	if !ok {
+		t.Fatal("a 0644 config must be reported")
+	}
+	if f.Remediation != model.RemediationAuto {
+		t.Errorf("remediation = %v, want Auto", f.Remediation)
+	}
+	// buildTightenMode reads exactly these two keys.
+	if f.Evidence["paths"] != path {
+		t.Errorf("paths = %q, want %q", f.Evidence["paths"], path)
+	}
+	if f.Evidence["expected"] != "0600" {
+		t.Errorf("expected = %q, want \"0600\"", f.Evidence["expected"])
+	}
+}
+
+func TestCompliantModesAreClean(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)
+	h.mkdir("alice", ".openclaw/credentials", 0o700)
+	h.mkdir("alice", ".openclaw/state", 0o700)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("upstream's own baseline must score clean, got: %+v", fs)
+	}
+}
+
+func TestLooseCredentialsDirectoryIsReported(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)
+	dir := h.mkdir("alice", ".openclaw/credentials", 0o755)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := findByID(fs, "agent.secret-exposed")
+	if !ok {
+		t.Fatal("a world-readable credentials directory must be reported")
+	}
+	if f.Evidence["paths"] != dir || f.Evidence["expected"] != "0700" {
+		t.Errorf("evidence not shaped for the mode fix: %+v", f.Evidence)
+	}
+}
+
+// Hermes keeping API keys in ~/.hermes/.env is the design, not a defect. The
+// actionable claim is that the file is readable by other accounts.
+func TestSecretEnvIsOnlyAFindingWhenReadable(t *testing.T) {
+	const env = "OPENAI_API_KEY=sk-notarealkeybutlongenough\nLOG_LEVEL=debug\n"
+
+	h := newHost(t, "alice")
+	h.write("alice", ".hermes/.env", env, 0o600)
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := findByID(fs, "agent.secret-exposed"); ok {
+		t.Error("a 0600 secrets file is correct and must not be flagged")
+	}
+
+	h2 := newHost(t, "bob")
+	h2.write("bob", ".hermes/.env", env, 0o644)
+	fs, err = h2.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := findByID(fs, "agent.secret-exposed")
+	if !ok {
+		t.Fatal("a 0644 secrets file holding a real key must be reported")
+	}
+	if !strings.Contains(f.Evidence["keys"], "OPENAI_API_KEY") {
+		t.Errorf("evidence should name the credential key, got %q", f.Evidence["keys"])
+	}
+	if strings.Contains(f.Evidence["keys"], "LOG_LEVEL") {
+		t.Errorf("non-credential keys should not be listed, got %q", f.Evidence["keys"])
+	}
+}
+
+// A readable env file with nothing credential-shaped in it is not a secrets
+// leak; reporting it would be unactionable noise.
+func TestReadableEnvWithoutCredentialsIsNotASecretFinding(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".hermes/.env", "LOG_LEVEL=debug\nTZ=UTC\n", 0o644)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := findByID(fs, "agent.secret-exposed"); ok {
+		t.Error("no credentials in the file means no credential exposure")
+	}
+}
+
+// The load-bearing guarantee of the whole domain: hostveil reads secrets to
+// judge them and must never carry one back out. Evidence is rendered by every
+// UI and persisted to disk, so a value that reaches a Finding has leaked.
+func TestSecretValuesNeverReachAFinding(t *testing.T) {
+	const sentinel = "sk-thisisthesentinelvalue1234567890"
+
+	h := newHost(t, "alice")
+	h.write("alice", ".hermes/.env",
+		"OPENAI_API_KEY="+sentinel+"\nHERMES_DASHBOARD_BASIC_AUTH_PASSWORD="+sentinel+"\n", 0o644)
+	h.write("alice", ".openclaw/openclaw.json",
+		`{"gateway":{"bind":"lan","auth":{"mode":"token","token":"`+sentinel+`"}}}`, 0o644)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(ssLine("0.0.0.0", 18789, "openclaw")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) == 0 {
+		t.Fatal("expected findings; a test that finds nothing proves nothing here")
+	}
+	for _, f := range fs {
+		for k, v := range f.Evidence {
+			if strings.Contains(v, sentinel) {
+				t.Errorf("finding %s leaked the secret via evidence[%q]", f.ID, k)
+			}
+		}
+		for name, text := range map[string]string{
+			"Title": f.Title, "Description": f.Description, "HowToFix": f.HowToFix, "Service": f.Service,
+		} {
+			if strings.Contains(text, sentinel) {
+				t.Errorf("finding %s leaked the secret via %s", f.ID, name)
+			}
+		}
+	}
+}
+
+// --- Attribution -----------------------------------------------------------
+
+// Two users each running an exposed gateway are two problems. If they shared
+// a Key the scorer would count one and the operator would fix one.
+func TestFindingsFromDifferentUsersHaveDistinctKeys(t *testing.T) {
+	h := newHost(t, "alice", "bob")
+	exposed := `{"gateway":{"bind":"lan","auth":{"mode":"none"}}}`
+	h.write("alice", ".openclaw/openclaw.json", exposed, 0o600)
+	h.write("bob", ".openclaw/openclaw.json", exposed, 0o600)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := countByID(fs, "agent.auth-disabled"); n != 2 {
+		t.Fatalf("got %d auth findings, want one per user", n)
+	}
+
+	keys := map[string]bool{}
+	for _, f := range fs {
+		if keys[f.Key()] {
+			t.Errorf("duplicate Key %q — one user's finding will mask the other's", f.Key())
+		}
+		keys[f.Key()] = true
+	}
+}
+
+// Two mode rules under one install are two separate problems and must not
+// collapse into a single Key either.
+func TestModeFindingsForDifferentPathsHaveDistinctKeys(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o644)
+	h.mkdir("alice", ".openclaw/state", 0o755)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var perms []model.Finding
+	for _, f := range fs {
+		if f.ID == "agent.config-perms" {
+			perms = append(perms, f)
+		}
+	}
+	if len(perms) != 2 {
+		t.Fatalf("got %d config-perms findings, want 2 (the file and the state dir)", len(perms))
+	}
+	if perms[0].Key() == perms[1].Key() {
+		t.Errorf("both paths share Key %q, so one would be dropped", perms[0].Key())
+	}
+}
+
+// Every finding the domain can emit must survive model validation, or it is
+// silently dropped after the scan — the failure the Source.Valid() bound
+// exists to cause and this test exists to catch.
+func TestAllEmittedFindingsValidate(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", `{
+		"gateway":{"bind":"lan","auth":{"mode":"none"},
+			"controlUi":{"allowInsecureAuth":true}},
+		"tools":{"exec":{"security":"full"},"elevated":{"enabled":true}},
+		"agents":{"defaults":{"sandbox":{"mode":"off"}}},
+		"browser":{"ssrfPolicy":{"dangerouslyAllowPrivateNetwork":true}}}`, 0o644)
+	h.mkdir("alice", ".openclaw/credentials", 0o755)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(ssLine("0.0.0.0", 18789, "openclaw")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) < 7 {
+		t.Fatalf("expected the full spread of findings, got %d", len(fs))
+	}
+	for _, f := range fs {
+		if err := f.Validate(); err != nil {
+			t.Errorf("finding %s is invalid and would be dropped: %v", f.ID, err)
+		}
+		if f.Source != model.SourceAgent {
+			t.Errorf("finding %s has source %v, want SourceAgent", f.ID, f.Source)
+		}
+		if !strings.HasPrefix(f.ID, "agent.") {
+			t.Errorf("finding ID %q is outside the domain's namespace", f.ID)
+		}
+	}
+}
+
+// Service accounts and nobody are not people running agents; probing their
+// homes would be noise at best and misattribution at worst.
+func TestSystemAccountsAreNotProbed(t *testing.T) {
+	hs, err := homes(newHost(t, "alice").passwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hs {
+		if h.Name == "daemon" || h.Name == "nobody" {
+			t.Errorf("system account %q should not be probed", h.Name)
+		}
+	}
+	if len(hs) != 1 || hs[0].Name != "alice" {
+		t.Errorf("got %+v, want just alice", hs)
+	}
+}

--- a/internal/check/agent/config.go
+++ b/internal/check/agent/config.go
@@ -1,0 +1,238 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/seolcu/hostveil/internal/secretkey"
+)
+
+// decodeConfig parses a runtime config into a generic tree.
+//
+// JSON5 is tried as strict JSON first and only re-parsed after stripping
+// comments and trailing commas if that fails. The strip pass is not a nicety:
+// OpenClaw documents its config as JSON5 and users comment it heavily, so
+// without it a commented config would be unparseable, every OpenClaw host
+// would report Degraded, and a flag that means "partial coverage" everywhere
+// means nothing anywhere.
+func decodeConfig(b []byte, format ConfigFormat) (map[string]any, error) {
+	if format == FormatYAML {
+		var m map[string]any
+		if err := yaml.Unmarshal(b, &m); err != nil {
+			return nil, fmt.Errorf("parsing YAML config: %w", err)
+		}
+		return m, nil
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err == nil {
+		return m, nil
+	}
+	if err := json.Unmarshal(stripJSON5(b), &m); err != nil {
+		return nil, fmt.Errorf("parsing JSON5 config: %w", err)
+	}
+	return m, nil
+}
+
+// stripJSON5 removes line comments, block comments, and trailing commas,
+// leaving something encoding/json will accept.
+//
+// It tracks string literals so a "//" inside a value — a URL, most often — is
+// never mistaken for a comment. Comments are replaced by nothing rather than
+// by spaces except for the newline that ends a line comment, which is kept so
+// that a trailing comma before it is still recognised.
+func stripJSON5(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	inStr, esc := false, false
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		if inStr {
+			out = append(out, c)
+			switch {
+			case esc:
+				esc = false
+			case c == '\\':
+				esc = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		if c == '"' {
+			inStr = true
+			out = append(out, c)
+			continue
+		}
+		if c == '/' && i+1 < len(b) {
+			if b[i+1] == '/' {
+				for i < len(b) && b[i] != '\n' {
+					i++
+				}
+				if i < len(b) {
+					out = append(out, '\n')
+				}
+				continue
+			}
+			if b[i+1] == '*' {
+				i += 2
+				for i+1 < len(b) && (b[i] != '*' || b[i+1] != '/') {
+					i++
+				}
+				i++ // sit on the closing '/', the loop's i++ steps past it
+				continue
+			}
+		}
+		out = append(out, c)
+	}
+	return stripTrailingCommas(out)
+}
+
+// stripTrailingCommas removes any comma whose next non-space character closes
+// an object or array. It is string-aware for the same reason stripJSON5 is.
+func stripTrailingCommas(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	inStr, esc := false, false
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		if inStr {
+			out = append(out, c)
+			switch {
+			case esc:
+				esc = false
+			case c == '\\':
+				esc = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		if c == '"' {
+			inStr = true
+			out = append(out, c)
+			continue
+		}
+		if c == ',' {
+			j := i + 1
+			for j < len(b) && (b[j] == ' ' || b[j] == '\t' || b[j] == '\n' || b[j] == '\r') {
+				j++
+			}
+			if j < len(b) && (b[j] == '}' || b[j] == ']') {
+				continue // drop the comma, keep the whitespace
+			}
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// lookup walks a dotted key path ("gateway.auth.mode") through a decoded
+// config tree.
+func lookup(m map[string]any, dotted string) (any, bool) {
+	if m == nil || dotted == "" {
+		return nil, false
+	}
+	var cur any = m
+	for _, part := range strings.Split(dotted, ".") {
+		node, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		v, ok := node[part]
+		if !ok {
+			return nil, false
+		}
+		cur = v
+	}
+	return cur, true
+}
+
+// scalar renders a config value as the string the DangerRule table compares
+// against, so one table covers string enums and booleans alike.
+func scalar(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case int:
+		return strconv.Itoa(t)
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+// lookupString resolves a dotted config key to a string, "" when absent.
+func lookupString(m map[string]any, dotted string) string {
+	v, ok := lookup(m, dotted)
+	if !ok {
+		return ""
+	}
+	return scalar(v)
+}
+
+// envFile is what a runtime's KEY=value file tells us. Values holds only the
+// keys the caller declared safe to read; Present records every key by name.
+//
+// The split is the whole point. A credential must be able to influence a
+// finding — "your API key file is world-readable" needs to know a key is in
+// there — without the value ever reaching a Finding, because evidence is
+// rendered by every UI and persisted to disk. Presence is enough to make the
+// claim; the value would only ever be a liability.
+type envFile struct {
+	Values  map[string]string
+	Present map[string]bool
+	// SecretKeys are the credential-named keys carrying a literal value,
+	// sorted. Names only, never values.
+	SecretKeys []string
+}
+
+// loadEnvFile parses a KEY=value file. safeKeys names the variables whose
+// values the caller needs; every other variable is reported by presence only.
+func loadEnvFile(path string, safeKeys []string) (envFile, error) {
+	b, err := os.ReadFile(path) //nolint:gosec // path comes from the runtime registry
+	if err != nil {
+		return envFile{}, err
+	}
+	safe := make(map[string]bool, len(safeKeys))
+	for _, k := range safeKeys {
+		safe[k] = true
+	}
+
+	ef := envFile{Values: map[string]string{}, Present: map[string]bool{}}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		v = strings.Trim(strings.TrimSpace(v), `"'`)
+
+		ef.Present[k] = true
+		if safe[k] {
+			ef.Values[k] = v
+		}
+		if secretkey.Matches(k) && secretkey.LooksLiteral(v) {
+			ef.SecretKeys = append(ef.SecretKeys, k)
+		}
+	}
+	sort.Strings(ef.SecretKeys) // stable evidence across runs
+	return ef, nil
+}

--- a/internal/check/agent/discover.go
+++ b/internal/check/agent/discover.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// userHome is one account that could plausibly own an agent runtime.
+type userHome struct {
+	Name string
+	Home string
+}
+
+// skeletonHomes are the placeholder home directories system accounts are
+// given. They are shared by many accounts and never hold a user's config, so
+// probing them would produce duplicate work and misattributed findings.
+var skeletonHomes = map[string]bool{
+	"/":            true,
+	"/nonexistent": true,
+	"/dev/null":    true,
+	"/bin/false":   true,
+	"":             true,
+}
+
+// homes parses /etc/passwd for the accounts a person might actually log in as
+// and run an agent under: root, plus the regular-user UID range. The nobody
+// UID (65534) and the service accounts below 1000 are excluded — an agent
+// runtime under those is not a configuration hostveil should be guessing at.
+//
+// Results are deduplicated by home directory, because two accounts sharing a
+// home would otherwise produce two identical findings for one config file.
+func homes(passwdPath string) ([]userHome, error) {
+	b, err := os.ReadFile(passwdPath) //nolint:gosec // caller-supplied system path
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]bool{}
+	var out []userHome
+	for _, line := range strings.Split(string(b), "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) < 6 {
+			continue
+		}
+		uid, err := strconv.Atoi(strings.TrimSpace(fields[2]))
+		if err != nil {
+			continue
+		}
+		if uid != 0 && (uid < 1000 || uid >= 65534) {
+			continue
+		}
+		home := filepath.Clean(strings.TrimSpace(fields[5]))
+		if skeletonHomes[home] || seen[home] {
+			continue
+		}
+		seen[home] = true
+		out = append(out, userHome{Name: fields[0], Home: home})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// install is one runtime found under one user's home.
+type install struct {
+	user userHome
+	rt   Runtime
+}
+
+// subject identifies the install for a finding's Service field, so two users
+// each running the same runtime produce two distinct Finding.Key()s rather
+// than deduplicating to one.
+func (i install) subject() string { return i.rt.Name + "@" + i.user.Name }
+
+// path resolves a home-relative path from the runtime registry.
+func (i install) path(rel string) string { return filepath.Join(i.user.Home, rel) }
+
+// installs stats each runtime's markers under each home. It only ever stats
+// paths named in the registry — no home directory is ever walked, so the
+// checker learns that a runtime exists without reading anything it was not
+// explicitly pointed at.
+//
+// unreadable collects homes that could not be stat'ed at all, which the
+// caller reports as partial coverage: an unreadable home may hide a runtime,
+// and silently returning fewer installs would let that pass for "none".
+func installs(hs []userHome, rts []Runtime) (found []install, unreadable []string) {
+	for _, h := range hs {
+		if _, err := os.Stat(h.Home); err != nil {
+			if !os.IsNotExist(err) {
+				unreadable = append(unreadable, h.Home)
+			}
+			continue
+		}
+		for _, rt := range rts {
+			for _, m := range rt.Markers {
+				if _, err := os.Stat(filepath.Join(h.Home, m)); err == nil {
+					found = append(found, install{user: h, rt: rt})
+					break
+				}
+			}
+		}
+	}
+	return found, unreadable
+}

--- a/internal/check/agent/runtime.go
+++ b/internal/check/agent/runtime.go
@@ -1,0 +1,223 @@
+package agent
+
+import (
+	"os"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// ConfigFormat is how a runtime encodes its config file.
+type ConfigFormat int
+
+const (
+	// FormatJSON5 is JSON plus comments and trailing commas. OpenClaw's
+	// config is documented as JSON5 and users comment it freely, so a strict
+	// JSON decode is only the first attempt, never the last word.
+	FormatJSON5 ConfigFormat = iota
+	// FormatYAML is plain YAML.
+	FormatYAML
+)
+
+// ModeRule declares the strictest acceptable permission for one path inside a
+// runtime's state directory, relative to the owning user's home. A path is
+// flagged when perm &^ Max != 0 — the same test fileperms.Rule uses.
+//
+// Secret marks a path that holds raw credentials. It changes which finding is
+// emitted (agent.secret-exposed rather than agent.config-perms) and, for
+// files, requires that the contents actually look like credentials before the
+// finding fires.
+type ModeRule struct {
+	Rel    string
+	Max    os.FileMode
+	Dir    bool
+	Secret bool
+}
+
+// DangerRule is one config key whose value names a known-dangerous posture.
+// Bad is compared against the value rendered as a string, so one table covers
+// both string enums ("full") and booleans ("true").
+//
+// Several rules may share an ID: two different keys can describe the same
+// weakening, and the operator should see one finding, not two.
+type DangerRule struct {
+	ID       string
+	Key      string
+	Bad      []string
+	Sev      model.Severity
+	Title    string
+	Desc     string
+	HowToFix string
+}
+
+// GatewayDesc describes a runtime's network surface, so the checker can judge
+// the configured intent and cross-check it against what the host is actually
+// listening on.
+type GatewayDesc struct {
+	DefaultPort int    // used when PortKey is absent or unset
+	PortKey     string // "" when the port is not configurable
+	BindKey     string
+
+	// BindDefault is the documented bind when BindKey is absent. Leave it
+	// empty when the default is genuinely unknown: an empty resolved bind
+	// means "we cannot tell from config", and the checker falls back to the
+	// observed listener rather than guessing a finding into existence.
+	BindDefault string
+
+	// LoopbackOnly are bind values that mean "not reachable from the network".
+	LoopbackOnly []string
+
+	AuthKey string
+	// AuthDisabled are auth values that mean "no authentication". Include ""
+	// only when an unset key really does mean open; a runtime that fails
+	// closed when unset must not list it.
+	AuthDisabled []string
+
+	// ProcNames are the program names ss may report for this gateway, used to
+	// attribute an observed listener with more confidence than the port alone.
+	ProcNames []string
+}
+
+// Runtime describes one self-hosted AI agent runtime entirely as data.
+// Adding a third runtime should be an entry in defaultRuntimes, not new code.
+type Runtime struct {
+	Name    string // short lowercase name, used in Service; never in a finding ID
+	Display string
+
+	// Markers are home-relative paths whose existence means the runtime is
+	// installed for that user.
+	Markers []string
+
+	Config string // home-relative
+	Format ConfigFormat
+
+	// EnvFile is a home-relative KEY=value file, "" when the runtime has none.
+	EnvFile string
+
+	// EnvOverrides maps a dotted config key to the environment variable that
+	// overrides it. Some settings (Hermes' dashboard bind) live only in the
+	// env file, never in the config.
+	EnvOverrides map[string]string
+
+	Modes   []ModeRule
+	Gateway GatewayDesc
+	Danger  []DangerRule
+}
+
+// defaultRuntimes is the shipped registry. Every path, key, and default here
+// mirrors upstream documentation; keep it that way, and prefer a small set of
+// stable high-signal keys over a full port of each project's own hardening
+// matrix. OpenClaw ships `openclaw security audit`, which covers its config
+// exhaustively; hostveil's job is the host-observable half — what is actually
+// listening, what is actually readable — scored beside the other domains.
+func defaultRuntimes() []Runtime {
+	return []Runtime{
+		{
+			Name:    "openclaw",
+			Display: "OpenClaw",
+			Markers: []string{".openclaw"},
+			Config:  ".openclaw/openclaw.json",
+			Format:  FormatJSON5,
+			Modes: []ModeRule{
+				{Rel: ".openclaw/openclaw.json", Max: 0o600},
+				{Rel: ".openclaw/credentials", Max: 0o700, Dir: true, Secret: true},
+				{Rel: ".openclaw/state", Max: 0o700, Dir: true},
+			},
+			Gateway: GatewayDesc{
+				DefaultPort: 18789,
+				PortKey:     "gateway.port",
+				BindKey:     "gateway.bind",
+				BindDefault: "loopback",
+				// "auto" and "tailnet" are not loopback, but neither is
+				// plainly reachable from an untrusted network; they are
+				// treated as exposed so the auth check still applies.
+				LoopbackOnly: []string{"loopback"},
+				AuthKey:      "gateway.auth.mode",
+				// Unset is deliberately absent: OpenClaw fails closed when
+				// gateway.auth.mode is unset, so an absent key is not "open".
+				AuthDisabled: []string{"none"},
+				ProcNames:    []string{"openclaw", "node"},
+			},
+			Danger: []DangerRule{
+				{
+					ID: "agent.exec-unrestricted", Key: "tools.exec.security", Bad: []string{"full"},
+					Sev:      model.SeverityHigh,
+					Title:    "Agent can run shell commands without approval",
+					Desc:     "The agent is allowed to execute shell commands on this host with no approval step. Anything that can steer the agent — a malicious web page it reads, a poisoned document, a message from an untrusted contact — can run commands as the user it runs as.",
+					HowToFix: "Set `tools.exec.security` to `deny` (or `ask`) and `tools.exec.ask` to `always`, so command execution requires an explicit approval.",
+				},
+				{
+					ID: "agent.exec-unrestricted", Key: "tools.exec.ask", Bad: []string{"off"},
+					Sev:      model.SeverityHigh,
+					Title:    "Agent can run shell commands without approval",
+					Desc:     "The agent is allowed to execute shell commands on this host with no approval step. Anything that can steer the agent — a malicious web page it reads, a poisoned document, a message from an untrusted contact — can run commands as the user it runs as.",
+					HowToFix: "Set `tools.exec.ask` to `always` so command execution requires an explicit approval.",
+				},
+				{
+					ID: "agent.elevated-enabled", Key: "tools.elevated.enabled", Bad: []string{"true"},
+					Sev:      model.SeverityHigh,
+					Title:    "Agent is permitted to run elevated commands",
+					Desc:     "Elevated mode is the documented escape hatch out of the agent's sandbox and onto the host. Combined with any path by which an attacker can influence the agent's input, it turns prompt injection into host compromise.",
+					HowToFix: "Set `tools.elevated.enabled` to `false`. If some workflow genuinely needs it, restrict `tools.elevated.allowFrom` to a single trusted channel.",
+				},
+				{
+					ID: "agent.sandbox-off", Key: "agents.defaults.sandbox.mode", Bad: []string{"off"},
+					Sev:      model.SeverityHigh,
+					Title:    "Agent tools run unsandboxed on the host",
+					Desc:     "With the sandbox off, the agent's tools run directly on the gateway host rather than in an isolated container, so a tool call that goes wrong reaches your real filesystem and network.",
+					HowToFix: "Enable the sandbox (`agents.defaults.sandbox.mode`) and keep `workspaceAccess` at `none` or `ro` unless the agent genuinely needs to write.",
+				},
+				{
+					ID: "agent.control-ui-insecure", Key: "gateway.controlUi.allowInsecureAuth", Bad: []string{"true"},
+					Sev:      model.SeverityHigh,
+					Title:    "Agent control UI has its auth safeguards disabled",
+					Desc:     "The control UI drives the agent. With its authentication safeguards switched off, anyone who can reach the UI — including anything running locally on this host — can operate the agent.",
+					HowToFix: "Remove `gateway.controlUi.allowInsecureAuth` (and `dangerouslyDisableDeviceAuth`) from the config and reach the UI over an SSH tunnel or a tailnet instead.",
+				},
+				{
+					ID: "agent.control-ui-insecure", Key: "gateway.controlUi.dangerouslyDisableDeviceAuth", Bad: []string{"true"},
+					Sev:      model.SeverityHigh,
+					Title:    "Agent control UI has its auth safeguards disabled",
+					Desc:     "Device-identity checks are what stop an unknown client from pairing with the gateway. Disabled, any client that reaches the UI can act as an approved device.",
+					HowToFix: "Remove `gateway.controlUi.dangerouslyDisableDeviceAuth` from the config and reach the UI over an SSH tunnel or a tailnet instead.",
+				},
+				{
+					ID: "agent.ssrf-private-network", Key: "browser.ssrfPolicy.dangerouslyAllowPrivateNetwork", Bad: []string{"true"},
+					Sev:      model.SeverityMedium,
+					Title:    "Agent browser may reach private network addresses",
+					Desc:     "The agent's browser is permitted to fetch private and link-local addresses, so a page it visits can steer it into your LAN or a cloud metadata endpoint and read back the response — a server-side request forgery with an LLM driving it.",
+					HowToFix: "Remove `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork` so the default private-network block applies.",
+				},
+			},
+		},
+		{
+			Name:    "hermes",
+			Display: "Hermes Agent",
+			Markers: []string{".hermes"},
+			Config:  ".hermes/config.yaml",
+			Format:  FormatYAML,
+			EnvFile: ".hermes/.env",
+			EnvOverrides: map[string]string{
+				"dashboard.host":          "HERMES_DASHBOARD_HOST",
+				"dashboard.auth.username": "HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
+			},
+			Modes: []ModeRule{
+				{Rel: ".hermes/config.yaml", Max: 0o600},
+				{Rel: ".hermes/.env", Max: 0o600, Secret: true},
+			},
+			Gateway: GatewayDesc{
+				DefaultPort: 9119,
+				BindKey:     "dashboard.host",
+				// Left empty on purpose: the dashboard binds 0.0.0.0 in the
+				// container image but the native default is not documented,
+				// so an unset key means "ask ss", not "assume exposed".
+				BindDefault:  "",
+				LoopbackOnly: []string{"127.0.0.1", "localhost", "::1"},
+				AuthKey:      "dashboard.auth.username",
+				// Hermes' auth gate is mandatory on a non-loopback bind, so an
+				// unset username on an exposed dashboard is the open case.
+				AuthDisabled: []string{""},
+				ProcNames:    []string{"hermes", "uvicorn", "python", "python3"},
+			},
+		},
+	}
+}

--- a/internal/check/compose/compose.go
+++ b/internal/check/compose/compose.go
@@ -12,6 +12,7 @@ import (
 	"github.com/seolcu/hostveil/internal/compose"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
+	"github.com/seolcu/hostveil/internal/secretkey"
 )
 
 // Checker audits discovered Docker Compose projects.
@@ -315,18 +316,11 @@ func ruleNoResourceLimits(s compose.Service) (model.Finding, bool) {
 	), true
 }
 
-var secretKeyPattern = []string{"password", "passwd", "secret", "api_key", "apikey", "token", "private_key", "access_key"}
-
 func ruleInlineSecret(s compose.Service) (model.Finding, bool) {
 	for k, v := range s.Environment {
-		lk := strings.ToLower(k)
-		if !matchesSecretKey(lk) {
-			continue
-		}
-		if v == "" || strings.HasPrefix(v, "${") || strings.HasPrefix(v, "$$") {
-			continue // references an external value, not a hardcoded secret
-		}
-		if len(v) < 6 {
+		// The heuristic is shared with the agent checker; keeping one copy
+		// stops the two domains from drifting on what counts as a secret.
+		if !secretkey.Matches(k) || !secretkey.LooksLiteral(v) {
 			continue
 		}
 		return f("dr005", "Hardcoded secret in compose environment", model.SeverityHigh, model.RemediationReview, s.Name,
@@ -336,15 +330,6 @@ func ruleInlineSecret(s compose.Service) (model.Finding, bool) {
 		), true
 	}
 	return model.Finding{}, false
-}
-
-func matchesSecretKey(lowerKey string) bool {
-	for _, p := range secretKeyPattern {
-		if strings.Contains(lowerKey, p) {
-			return true
-		}
-	}
-	return false
 }
 
 func ruleEnvFile(s compose.Service) (model.Finding, bool) {

--- a/internal/check/ports/ports.go
+++ b/internal/check/ports/ports.go
@@ -8,7 +8,6 @@ package ports
 import (
 	"context"
 	"fmt"
-	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -62,57 +61,46 @@ var adminPorts = map[int]string{
 	9443: "Portainer (HTTPS)",
 }
 
-// listener is one parsed TCP listening socket.
-type listener struct {
-	addr string
-	port int
-	proc string
-}
-
 // Check reads listening TCP sockets and flags non-loopback exposure.
 func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
-	// No `-H`: it is a relatively recent flag, so we skip the header row
-	// ourselves (parseListener rejects it) and stay compatible with older
-	// iproute2 rather than hard-erroring on an unknown flag.
-	out, err := env.Runner.Run(ctx, "ss", "-tlnp")
+	listeners, err := platform.Listeners(ctx, env.Runner)
 	if err != nil {
-		return nil, fmt.Errorf("listing listening sockets with ss: %w", err)
+		return nil, err
 	}
 
 	var findings []model.Finding
-	generic := map[int]listener{} // exposed, non-sensitive; deduped by port
-	seenDS := map[int]bool{}      // avoid duplicate findings for v4+v6 of same port
+	generic := map[int]platform.Listener{} // exposed, non-sensitive; deduped by port
+	seenDS := map[int]bool{}               // avoid duplicate findings for v4+v6 of same port
 
-	for _, line := range strings.Split(string(out), "\n") {
-		l, ok := parseListener(line)
-		if !ok || isLoopback(l.addr) {
+	for _, l := range listeners {
+		if l.Loopback() {
 			continue
 		}
 		switch {
-		case datastorePorts[l.port] != "":
-			if seenDS[l.port] {
+		case datastorePorts[l.Port] != "":
+			if seenDS[l.Port] {
 				continue
 			}
-			seenDS[l.port] = true
+			seenDS[l.Port] = true
 			findings = append(findings, exposedFinding(l, "ports.exposed-datastore",
-				"Datastore reachable from the network: "+datastorePorts[l.port],
+				"Datastore reachable from the network: "+datastorePorts[l.Port],
 				"A database listening on a non-loopback address is reachable from every network this host is on. Datastores rarely need to accept remote connections directly; exposing one invites credential-stuffing and data theft.",
 				model.SeverityHigh))
-		case adminPorts[l.port] != "":
-			if seenDS[l.port] {
+		case adminPorts[l.Port] != "":
+			if seenDS[l.Port] {
 				continue
 			}
-			seenDS[l.port] = true
+			seenDS[l.Port] = true
 			findings = append(findings, exposedFinding(l, "ports.exposed-admin",
-				"Admin panel reachable from the network: "+adminPorts[l.port],
+				"Admin panel reachable from the network: "+adminPorts[l.Port],
 				"A management UI listening on a non-loopback address lets anyone who can reach this host attempt to log in and control your services. Bind it to localhost and reach it over an SSH tunnel or VPN.",
 				model.SeverityHigh))
 		default:
-			if l.port == 22 { // SSH is expected to be reachable; not a finding here
+			if l.Port == 22 { // SSH is expected to be reachable; not a finding here
 				continue
 			}
-			if _, dup := generic[l.port]; !dup {
-				generic[l.port] = l
+			if _, dup := generic[l.Port]; !dup {
+				generic[l.Port] = l
 			}
 		}
 	}
@@ -140,19 +128,19 @@ func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, e
 	return findings, nil
 }
 
-func exposedFinding(l listener, id, title, desc string, sev model.Severity) model.Finding {
+func exposedFinding(l platform.Listener, id, title, desc string, sev model.Severity) model.Finding {
 	opts := []model.FindingOption{
 		// Attribute the finding to this specific listener so two different
 		// exposed datastores (e.g. Redis and Postgres) get distinct Keys and
 		// are each counted, rather than deduplicated to one by (source, id).
 		model.WithService(listenerSubject(l)),
 		model.WithDescription(desc),
-		model.WithHowToFix(fmt.Sprintf("Bind %s to 127.0.0.1 instead of %s, or restrict access with a host firewall / VPN. If it must be remote, put it behind an authenticated reverse proxy.", portLabel(l), l.addr)),
-		model.WithEvidence("port", strconv.Itoa(l.port)),
-		model.WithEvidence("address", l.addr),
+		model.WithHowToFix(fmt.Sprintf("Bind %s to 127.0.0.1 instead of %s, or restrict access with a host firewall / VPN. If it must be remote, put it behind an authenticated reverse proxy.", portLabel(l), l.Addr)),
+		model.WithEvidence("port", strconv.Itoa(l.Port)),
+		model.WithEvidence("address", l.Addr),
 	}
-	if l.proc != "" {
-		opts = append(opts, model.WithEvidence("process", l.proc))
+	if l.Proc != "" {
+		opts = append(opts, model.WithEvidence("process", l.Proc))
 	}
 	return model.NewFinding(id, title, sev, model.SourcePorts, model.RemediationReview, opts...)
 }
@@ -160,14 +148,14 @@ func exposedFinding(l listener, id, title, desc string, sev model.Severity) mode
 // listenerSubject identifies a listener for the finding's Service field:
 // the process name qualified by port when known (unique across same-named
 // processes on different ports), else just the port.
-func listenerSubject(l listener) string {
-	if l.proc != "" {
-		return fmt.Sprintf("%s:%d", l.proc, l.port)
+func listenerSubject(l platform.Listener) string {
+	if l.Proc != "" {
+		return fmt.Sprintf("%s:%d", l.Proc, l.Port)
 	}
-	return "port " + strconv.Itoa(l.port)
+	return "port " + strconv.Itoa(l.Port)
 }
 
-func genericFinding(generic map[int]listener) model.Finding {
+func genericFinding(generic map[int]platform.Listener) model.Finding {
 	ports := make([]int, 0, len(generic))
 	for p := range generic {
 		ports = append(ports, p)
@@ -175,7 +163,7 @@ func genericFinding(generic map[int]listener) model.Finding {
 	sort.Ints(ports)
 	parts := make([]string, len(ports))
 	for i, p := range ports {
-		if proc := generic[p].proc; proc != "" {
+		if proc := generic[p].Proc; proc != "" {
 			parts[i] = fmt.Sprintf("%d (%s)", p, proc)
 		} else {
 			parts[i] = strconv.Itoa(p)
@@ -190,73 +178,9 @@ func genericFinding(generic map[int]listener) model.Finding {
 	)
 }
 
-func portLabel(l listener) string {
-	if l.proc != "" {
-		return fmt.Sprintf("%s (port %d)", l.proc, l.port)
+func portLabel(l platform.Listener) string {
+	if l.Proc != "" {
+		return fmt.Sprintf("%s (port %d)", l.Proc, l.Port)
 	}
-	return "port " + strconv.Itoa(l.port)
-}
-
-// parseListener parses one `ss -tlnp` row into a listener. The local
-// address:port is the 4th whitespace-separated field; the process column
-// (from -p) is the last. The header row and any malformed row are skipped,
-// never an error.
-func parseListener(line string) (listener, bool) {
-	fields := strings.Fields(line)
-	if len(fields) < 4 || fields[0] == "State" { // "State" == header row
-		return listener{}, false
-	}
-	addr, portStr, ok := splitHostPort(fields[3])
-	if !ok {
-		return listener{}, false
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return listener{}, false
-	}
-	l := listener{addr: addr, port: port}
-	if len(fields) >= 6 {
-		l.proc = procName(fields[len(fields)-1])
-	}
-	return l, true
-}
-
-// splitHostPort splits ss's "host:port" local-address field. It defers to
-// net.SplitHostPort, which correctly handles bracketed IPv6 literals
-// ("[::]:22", "[fe80::1%lo]:6379") and wildcards ("*:22"). A field it cannot
-// parse is rejected rather than turned into a malformed address.
-func splitHostPort(s string) (host, port string, ok bool) {
-	h, p, err := net.SplitHostPort(s)
-	if err != nil || p == "" {
-		return "", "", false
-	}
-	return h, p, true
-}
-
-// isLoopback reports whether an address is a loopback / host-only bind that
-// is not reachable from the network. Everything else — the 0.0.0.0/:: /*
-// wildcards and specific LAN/public IPs — counts as exposed. An IPv6 zone
-// suffix (e.g. "::1%lo") is stripped before parsing.
-func isLoopback(addr string) bool {
-	if i := strings.IndexByte(addr, '%'); i >= 0 {
-		addr = addr[:i]
-	}
-	if ip := net.ParseIP(addr); ip != nil {
-		return ip.IsLoopback()
-	}
-	return false
-}
-
-// procName extracts the program name from ss's process column, e.g.
-// `users:(("redis-server",pid=999,fd=6))` -> "redis-server".
-func procName(field string) string {
-	i := strings.Index(field, `("`)
-	if i < 0 {
-		return ""
-	}
-	rest := field[i+2:]
-	if j := strings.Index(rest, `"`); j >= 0 {
-		return rest[:j]
-	}
-	return ""
+	return "port " + strconv.Itoa(l.Port)
 }

--- a/internal/core/fixflow_test.go
+++ b/internal/core/fixflow_test.go
@@ -465,6 +465,67 @@ func TestModeFixAbortsWhenAPathIsMissing(t *testing.T) {
 	}
 }
 
+// A directory already at its target mode must produce no change at all.
+// tighten() carries the type bits through precisely so that planModes sees a
+// fixed point here; when it dropped fs.ModeDir the comparison against the
+// full mode never matched, and applyMode would checkpoint and chmod a
+// compliant directory while reporting success for work it had not done.
+func TestModeFixOnCompliantDirectoryIsANoOp(t *testing.T) {
+	engine := fixEngine(t)
+	dir := filepath.Join(t.TempDir(), "credentials")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f := model.NewFinding("fileperms.shadow", "over-permissive", model.SeverityHigh,
+		model.SourceFilePerms, model.RemediationAuto,
+		model.WithEvidence("paths", dir),
+		model.WithEvidence("expected", "0700"),
+	)
+
+	if _, err := engine.ApplyFix(context.Background(), f, 0); err == nil {
+		t.Fatal("expected an 'already as strict as required' error for a compliant directory")
+	}
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.IsDir() {
+		t.Error("path is no longer a directory")
+	}
+	if fi.Mode().Perm() != 0o700 {
+		t.Errorf("mode = %#o, want 0700", fi.Mode().Perm())
+	}
+}
+
+// A directory that genuinely is too permissive must still be tightened, and
+// must still be a directory afterwards.
+func TestModeFixTightensLooseDirectory(t *testing.T) {
+	engine := fixEngine(t)
+	dir := filepath.Join(t.TempDir(), "credentials")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f := model.NewFinding("fileperms.shadow", "over-permissive", model.SeverityHigh,
+		model.SourceFilePerms, model.RemediationAuto,
+		model.WithEvidence("paths", dir),
+		model.WithEvidence("expected", "0700"),
+	)
+
+	if _, err := engine.ApplyFix(context.Background(), f, 0); err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.IsDir() {
+		t.Error("path is no longer a directory")
+	}
+	if fi.Mode().Perm() != 0o700 {
+		t.Errorf("mode = %#o, want 0700", fi.Mode().Perm())
+	}
+}
+
 // Auto means "safe to apply unattended", so `fix --all` must actually pick
 // a mode fix up. ApplyBatch takes only single-action Auto fixes, which is
 // exactly the shape ActionMode produces.

--- a/internal/fix/agent.go
+++ b/internal/fix/agent.go
@@ -1,0 +1,19 @@
+package fix
+
+// registerAgent wires the agent-runtime permission fixes into the registry.
+//
+// Only the two mode findings are registered. Everything else the agent domain
+// reports is a config-key edit, and those are declined for reasons recorded
+// in Default's doc comment.
+//
+// Exact IDs, not an "agent.*" glob, for the same reason registerFilePerms
+// spells its five out: TestEveryRegisteredFixIsValid rejects globs so that
+// widening what the registry claims to fix is a deliberate act.
+func registerAgent(r *Registry) {
+	for _, id := range []string{
+		"agent.config-perms",
+		"agent.secret-exposed",
+	} {
+		r.Register(id, buildTightenMode)
+	}
+}

--- a/internal/fix/fileperms.go
+++ b/internal/fix/fileperms.go
@@ -26,23 +26,26 @@ func registerFilePerms(r *Registry) {
 	}
 }
 
-// specialBits are the mode bits outside the permission triplet that a chmod
-// must carry through. fs.FileMode.Perm() covers only the low nine, so
-// rebuilding a mode from Perm() alone would silently clear setuid, setgid,
-// or the sticky bit. The checker judged the file on its permission bits, so
-// those are the only bits this fix is entitled to touch.
-const specialBits = fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky
-
-// tighten returns the mode with every bit outside mask cleared, and nothing
-// else changed.
+// tighten returns the mode with every permission bit outside mask cleared,
+// and nothing else changed.
 //
 // It is subtractive on purpose. Assigning the rule's MaxMode outright would
 // *grant* access the file did not have: /etc/shadow at 0604 violates a 0640
 // rule, and setting it to 0640 would hand the shadow group a read bit it
 // never had. Masking gives 0600 instead. Only ever removing bits is what
 // makes this fix unambiguous enough to apply unattended.
+//
+// Everything outside the permission triplet is carried through untouched:
+// setuid/setgid/sticky, which rebuilding from Perm() alone would silently
+// clear, and the type bits — ModeDir above all. Clearing ModeDir would not
+// corrupt anything (os.Chmod ignores it), but planModes compares the result
+// against the full fs.FileMode, so a directory would compare unequal to
+// itself forever: preview would print a phantom 0700 → 0700 row and apply
+// would checkpoint and chmod a directory that was already compliant. The
+// checker judged the path on its permission bits, so those are the only bits
+// this fix is entitled to touch.
 func tighten(current fs.FileMode, mask fs.FileMode) fs.FileMode {
-	return current&specialBits | (current.Perm() & mask)
+	return current&^fs.ModePerm | (current.Perm() & mask)
 }
 
 func buildTightenMode(f model.Finding) (Fix, error) {

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -111,6 +111,18 @@ func TestKnownUnregisteredFindings(t *testing.T) {
 		"compose.ds005":       "removal-shaped: same, for cap_add",
 		"compose.dr001":       "removing host networking without knowing which ports to publish leaves the service unreachable",
 		"compose.dr005":       "a two-file change where Action carries one Path, and the real remediation is rotating the leaked secret",
+
+		// Every agent.* config-key finding. OpenClaw's config is JSON5 and
+		// re-encoding it would delete the operator's comments; Hermes' bind
+		// and auth may come from config, .env, a unit file, or a docker flag,
+		// and the finding cannot tell which is in force.
+		"agent.gateway-exposed":      "rebinding a gateway to loopback can cut the operator off from the agent they administer remotely",
+		"agent.auth-disabled":        "editing JSON5 without a round-tripper deletes the operator's comments, and there is no second alternative to make it a Review fix",
+		"agent.exec-unrestricted":    "same JSON5 edit problem; two keys can express it and the finding cannot pick one",
+		"agent.elevated-enabled":     "same JSON5 edit problem",
+		"agent.sandbox-off":          "same JSON5 edit problem, and enabling a sandbox can break tools the operator relies on",
+		"agent.control-ui-insecure":  "same JSON5 edit problem",
+		"agent.ssrf-private-network": "same JSON5 edit problem",
 	}
 	r := Default()
 	for id, why := range declined {

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -356,6 +356,22 @@ func TestTightenPreservesSpecialBits(t *testing.T) {
 	}
 }
 
+// ModeDir must survive too. planModes compares tighten's result against the
+// full fs.FileMode, so dropping the type bit makes an already-compliant
+// directory compare unequal to itself: preview prints a phantom 0700 → 0700
+// row and apply checkpoints and chmods a directory that needed nothing.
+func TestTightenPreservesModeDir(t *testing.T) {
+	if got := tighten(fs.ModeDir|0o777, 0o700); got != fs.ModeDir|0o700 {
+		t.Errorf("tighten(d0777, 0700) = %v, want d0700", got)
+	}
+	// The identity that planModes depends on: a compliant directory is a
+	// fixed point, so it produces no change at all.
+	compliant := fs.ModeDir | 0o700
+	if got := tighten(compliant, 0o700); got != compliant {
+		t.Errorf("tighten(%v, 0700) = %v, want it unchanged", compliant, got)
+	}
+}
+
 func TestFilePermsFixIsAutoAndModeShaped(t *testing.T) {
 	f := model.NewFinding("fileperms.hostkey", "t", model.SeverityHigh,
 		model.SourceFilePerms, model.RemediationAuto,

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -103,6 +103,40 @@ package fix
 //     original improves nothing. More to the point, by the time the secret
 //     is found it has already leaked into backups and git history, so the
 //     real remediation is rotating it, which hostveil cannot do.
+//   - agent.gateway-exposed, agent.auth-disabled, agent.exec-unrestricted,
+//     agent.elevated-enabled, agent.sandbox-off, agent.control-ui-insecure,
+//     agent.ssrf-private-network — all seven reduce to editing one key in a
+//     runtime's config, and neither runtime can be edited safely. OpenClaw's
+//     config is JSON5 carrying the operator's own comments and trailing
+//     commas; hostveil has no JSON5 round-tripper, and re-encoding through
+//     encoding/json deletes every comment in the file. (internal/compose's
+//     minimal text surgery exists precisely to avoid that class of damage,
+//     and it is YAML-specific.) Hermes is worse: its bind and auth may come
+//     from config, from ~/.hermes/.env, from a systemd unit, or from a
+//     docker -e flag, and the finding cannot tell which is in force, so an
+//     edit could silently change nothing. There is also no second
+//     independent alternative to pair any of these with, which Review
+//     requires. agent.gateway-exposed fails the recoverability test on top
+//     of all that: rebinding a gateway to loopback can cut an operator off
+//     from the agent they administer remotely.
+//
+// # Auto fixes that touch a user's home
+//
+// agent.config-perms and agent.secret-exposed are the first Auto fixes
+// aimed outside /etc: they chmod paths under ~/.openclaw and ~/.hermes,
+// which means root running `fix --all` tightens another user's files.
+//
+// That is deliberate and meets the standard. tighten is subtractive, so it
+// only ever removes access; SaveModes checkpoints the prior mode, so it
+// rolls back exactly; and no permission on an agent's own state directory
+// can sever the operator's access to the host the way an SSH or firewall
+// edit can. The values are also not guesses — each target's mode is the
+// baseline the runtime's own hardening guide specifies.
+//
+// The one deployment it could disrupt is an agent daemon running as a
+// different user and reading the config through group permissions. Upstream
+// ships these paths at 0600/0700, so that arrangement is a deviation rather
+// than a design, and the finding's how-to-fix names it explicitly.
 //
 // # The one CVE finding that does have a fix
 //
@@ -136,5 +170,6 @@ func Default() *Registry {
 	registerFilePerms(r)
 	registerSSH(r)
 	registerUpdates(r)
+	registerAgent(r)
 	return r
 }

--- a/internal/model/score.go
+++ b/internal/model/score.go
@@ -45,15 +45,23 @@ type axisDef struct {
 // axis's share of the overall score and nothing else — it is purely how
 // much this domain matters, never a threshold. The caps sum to 100 so the
 // overall is a weighted average of the axes that ran.
+//
+// "agent" ties with "ports" deliberately: both describe a network service
+// that should not be reachable. The agent domain's worst case is strictly
+// worse — an unauthenticated gateway is remote code execution as a real
+// user — but it applies to far fewer hosts, and it is N/A-excluded entirely
+// on any host with no agent runtime installed. So the generous cap costs a
+// typical host nothing and carries real weight where it applies.
 var axisDefs = []axisDef{
-	{"container", "Container exposure", SourceCompose, 20},
-	{"ssh", "SSH hardening", SourceSSH, 18},
-	{"firewall", "Host firewall", SourceFirewall, 13},
-	{"updates", "Auto-updates", SourceUpdates, 8},
-	{"cve", "Vulnerabilities", SourceCVE, 15},
-	{"ports", "Exposed services", SourcePorts, 11},
-	{"accounts", "Account hygiene", SourceAccounts, 9},
-	{"fileperms", "File permissions", SourceFilePerms, 6},
+	{"container", "Container exposure", SourceCompose, 18},
+	{"ssh", "SSH hardening", SourceSSH, 17},
+	{"firewall", "Host firewall", SourceFirewall, 12},
+	{"updates", "Auto-updates", SourceUpdates, 7},
+	{"cve", "Vulnerabilities", SourceCVE, 13},
+	{"ports", "Exposed services", SourcePorts, 10},
+	{"accounts", "Account hygiene", SourceAccounts, 8},
+	{"fileperms", "File permissions", SourceFilePerms, 5},
+	{"agent", "AI agent runtimes", SourceAgent, 10},
 }
 
 // criticalHalves is the anchor of the whole penalty model: one Critical

--- a/internal/model/source.go
+++ b/internal/model/source.go
@@ -20,6 +20,7 @@ const (
 	SourcePorts
 	SourceAccounts
 	SourceFilePerms
+	SourceAgent
 )
 
 // String returns the stable lowercase domain name, also used as the
@@ -42,20 +43,27 @@ func (s Source) String() string {
 		return "accounts"
 	case SourceFilePerms:
 		return "fileperms"
+	case SourceAgent:
+		return "agent"
 	default:
 		return "unset"
 	}
 }
 
 // Valid reports whether the source was set to a real domain.
+//
+// The upper bound is a range check, so a new domain appended to the const
+// block must be added here too. Forgetting is silent and total: every
+// finding from the new domain fails Validate() and is dropped after the
+// scan, so the domain reports clean rather than reporting nothing.
 func (s Source) Valid() bool {
-	return s >= SourceCompose && s <= SourceFilePerms
+	return s >= SourceCompose && s <= SourceAgent
 }
 
 // AllSources lists every real detection domain in scan/report order.
 func AllSources() []Source {
 	return []Source{
 		SourceCompose, SourceSSH, SourceFirewall, SourceUpdates, SourceCVE,
-		SourcePorts, SourceAccounts, SourceFilePerms,
+		SourcePorts, SourceAccounts, SourceFilePerms, SourceAgent,
 	}
 }

--- a/internal/platform/listeners.go
+++ b/internal/platform/listeners.go
@@ -1,0 +1,103 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// Listener is one TCP socket the host is listening on.
+type Listener struct {
+	Addr string // bind address as ss reported it, e.g. "0.0.0.0", "::1", "*"
+	Port int
+	Proc string // program name from ss's -p column; "" when unknown
+}
+
+// Loopback reports whether the bind address is a loopback / host-only bind
+// that is not reachable from the network. Everything else — the 0.0.0.0, ::
+// and * wildcards, and specific LAN or public IPs — counts as exposed. An
+// IPv6 zone suffix (e.g. "::1%lo") is stripped before parsing.
+func (l Listener) Loopback() bool {
+	addr := l.Addr
+	if i := strings.IndexByte(addr, '%'); i >= 0 {
+		addr = addr[:i]
+	}
+	if ip := net.ParseIP(addr); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// Listeners lists the host's listening TCP sockets via `ss -tlnp`.
+//
+// Callers should gate on Has(r, "ss") first; a missing tool surfaces here as
+// an ordinary error, and it is the caller's domain that decides whether that
+// means skipped, degraded, or fatal.
+func Listeners(ctx context.Context, r CommandRunner) ([]Listener, error) {
+	// No `-H`: it is a relatively recent flag, so we skip the header row
+	// ourselves (parseListener rejects it) and stay compatible with older
+	// iproute2 rather than hard-erroring on an unknown flag.
+	out, err := r.Run(ctx, "ss", "-tlnp")
+	if err != nil {
+		return nil, fmt.Errorf("listing listening sockets with ss: %w", err)
+	}
+	var ls []Listener
+	for _, line := range strings.Split(string(out), "\n") {
+		if l, ok := parseListener(line); ok {
+			ls = append(ls, l)
+		}
+	}
+	return ls, nil
+}
+
+// parseListener parses one `ss -tlnp` row into a Listener. The local
+// address:port is the 4th whitespace-separated field; the process column
+// (from -p) is the last. The header row and any malformed row are skipped,
+// never an error.
+func parseListener(line string) (Listener, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 4 || fields[0] == "State" { // "State" == header row
+		return Listener{}, false
+	}
+	addr, portStr, ok := splitHostPort(fields[3])
+	if !ok {
+		return Listener{}, false
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return Listener{}, false
+	}
+	l := Listener{Addr: addr, Port: port}
+	if len(fields) >= 6 {
+		l.Proc = procName(fields[len(fields)-1])
+	}
+	return l, true
+}
+
+// splitHostPort splits ss's "host:port" local-address field. It defers to
+// net.SplitHostPort, which correctly handles bracketed IPv6 literals
+// ("[::]:22", "[fe80::1%lo]:6379") and wildcards ("*:22"). A field it cannot
+// parse is rejected rather than turned into a malformed address.
+func splitHostPort(s string) (host, port string, ok bool) {
+	h, p, err := net.SplitHostPort(s)
+	if err != nil || p == "" {
+		return "", "", false
+	}
+	return h, p, true
+}
+
+// procName extracts the program name from ss's process column, e.g.
+// `users:(("redis-server",pid=999,fd=6))` -> "redis-server".
+func procName(field string) string {
+	i := strings.Index(field, `("`)
+	if i < 0 {
+		return ""
+	}
+	rest := field[i+2:]
+	if j := strings.Index(rest, `"`); j >= 0 {
+		return rest[:j]
+	}
+	return ""
+}

--- a/internal/platform/listeners_test.go
+++ b/internal/platform/listeners_test.go
@@ -1,0 +1,94 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type ssRunner struct {
+	out string
+	err error
+}
+
+func (ssRunner) LookPath(name string) (string, error) { return "/usr/bin/" + name, nil }
+func (r ssRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return []byte(r.out), r.err
+}
+
+const ssSample = `State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process
+LISTEN 0      511          0.0.0.0:80        0.0.0.0:*     users:(("nginx",pid=101,fd=6))
+LISTEN 0      511        127.0.0.1:6379      0.0.0.0:*     users:(("redis-server",pid=999,fd=6))
+LISTEN 0      128             [::]:22           [::]:*     users:(("sshd",pid=77,fd=4))
+LISTEN 0      128     [fe80::1%lo]:5432         [::]:*     users:(("postgres",pid=88,fd=5))
+LISTEN 0      128            *:18789               *:*
+garbage
+`
+
+func TestListenersParsesSsOutput(t *testing.T) {
+	ls, err := Listeners(context.Background(), ssRunner{out: ssSample})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ls) != 5 {
+		t.Fatalf("parsed %d listeners, want 5: %+v", len(ls), ls)
+	}
+
+	want := []Listener{
+		{Addr: "0.0.0.0", Port: 80, Proc: "nginx"},
+		{Addr: "127.0.0.1", Port: 6379, Proc: "redis-server"},
+		{Addr: "::", Port: 22, Proc: "sshd"},
+		{Addr: "fe80::1%lo", Port: 5432, Proc: "postgres"},
+		// No process column at all: -p output is absent without root.
+		{Addr: "*", Port: 18789, Proc: ""},
+	}
+	for i, w := range want {
+		if ls[i] != w {
+			t.Errorf("listener %d = %+v, want %+v", i, ls[i], w)
+		}
+	}
+}
+
+// The header row and unparseable junk are skipped, never surfaced as an
+// error — one odd line must not cost us the whole socket table.
+func TestListenersSkipsHeaderAndGarbage(t *testing.T) {
+	ls, err := Listeners(context.Background(), ssRunner{out: "State Recv-Q Send-Q Local\nnonsense\n\n"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ls) != 0 {
+		t.Errorf("got %d listeners, want none: %+v", len(ls), ls)
+	}
+}
+
+func TestListenersPropagatesRunError(t *testing.T) {
+	_, err := Listeners(context.Background(), ssRunner{err: errors.New("ss: not found")})
+	if err == nil {
+		t.Fatal("expected the runner error to propagate")
+	}
+}
+
+// Only genuine loopback addresses are host-only. The wildcards are the whole
+// point of the check: 0.0.0.0 and :: mean "every interface".
+func TestLoopbackClassification(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"127.0.0.53", true},
+		{"::1", true},
+		{"::1%lo", true}, // zone suffix must be stripped before parsing
+		{"0.0.0.0", false},
+		{"::", false},
+		{"*", false},
+		{"192.168.1.10", false},
+		{"fe80::1%eth0", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := (Listener{Addr: c.addr}).Loopback(); got != c.want {
+			t.Errorf("Listener{Addr: %q}.Loopback() = %v, want %v", c.addr, got, c.want)
+		}
+	}
+}

--- a/internal/secretkey/secretkey.go
+++ b/internal/secretkey/secretkey.go
@@ -1,0 +1,48 @@
+// Package secretkey holds the shared heuristic for deciding that a
+// configuration key names a credential, and that its value looks like a real
+// one rather than a placeholder.
+//
+// It is deliberately name-based. hostveil has to judge a value sensitive
+// without ever recording the value itself: findings are rendered by every UI
+// and persisted to disk, so a checker that quoted the secret it found would
+// leak it into exactly the places a secret must not reach. Matching on the
+// key name means the value is only ever measured, never kept.
+package secretkey
+
+import "strings"
+
+// Patterns are the substrings that mark a key as naming a credential. They
+// are matched case-insensitively against the whole key, so "DB_PASSWORD" and
+// "apiKeyProd" both hit.
+var Patterns = []string{
+	"password", "passwd", "secret", "api_key", "apikey",
+	"token", "private_key", "access_key",
+}
+
+// Matches reports whether key names a credential. Callers pass the key as
+// written; case folding happens here.
+func Matches(key string) bool {
+	lower := strings.ToLower(key)
+	for _, p := range Patterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// LooksLiteral reports whether a value for a credential-named key looks like
+// a real secret rather than a reference to one.
+//
+// Interpolation references ("${DB_PASSWORD}", "$$escaped") are how a config
+// is *supposed* to name a secret it does not contain, so flagging them would
+// penalize the correct pattern. Very short values are placeholders,
+// disabled-by-empty-string markers, or too weak for the finding to be about
+// leakage. Both exclusions exist to keep a "you have a hardcoded secret"
+// finding from firing on configs that do not.
+func LooksLiteral(value string) bool {
+	if value == "" || strings.HasPrefix(value, "${") || strings.HasPrefix(value, "$$") {
+		return false
+	}
+	return len(value) >= 6
+}

--- a/internal/secretkey/secretkey_test.go
+++ b/internal/secretkey/secretkey_test.go
@@ -1,0 +1,49 @@
+package secretkey
+
+import "testing"
+
+func TestMatchesIsCaseInsensitiveAndSubstring(t *testing.T) {
+	hits := []string{
+		"password", "PASSWORD", "DB_PASSWORD", "mysql_root_passwd",
+		"SECRET", "app_secret_key", "API_KEY", "apiKeyProd", "APIKEY",
+		"GITHUB_TOKEN", "access_token", "SSH_PRIVATE_KEY", "AWS_ACCESS_KEY_ID",
+	}
+	for _, k := range hits {
+		if !Matches(k) {
+			t.Errorf("Matches(%q) = false, want true", k)
+		}
+	}
+
+	misses := []string{
+		"", "PATH", "HOSTNAME", "TZ", "PUID", "LOG_LEVEL",
+		"DATABASE_URL", "PORT", "NODE_ENV",
+	}
+	for _, k := range misses {
+		if Matches(k) {
+			t.Errorf("Matches(%q) = true, want false", k)
+		}
+	}
+}
+
+// A config that references a secret instead of containing one is the correct
+// pattern; treating it as a leak would penalize doing the right thing.
+func TestLooksLiteralRejectsReferencesAndPlaceholders(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+		why   string
+	}{
+		{"hunter2again", true, "a plain literal value"},
+		{"${DB_PASSWORD}", false, "interpolation reference"},
+		{"$$escaped", false, "escaped reference"},
+		{"", false, "empty"},
+		{"abc", false, "too short to be a real secret"},
+		{"abcde", false, "five chars is still under the threshold"},
+		{"abcdef", true, "six chars is the threshold"},
+	}
+	for _, c := range cases {
+		if got := LooksLiteral(c.value); got != c.want {
+			t.Errorf("LooksLiteral(%q) = %v, want %v — %s", c.value, got, c.want, c.why)
+		}
+	}
+}

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -248,6 +248,8 @@ func sourceLabel(s model.Source) string {
 		return "Accounts"
 	case model.SourceFilePerms:
 		return "File perms"
+	case model.SourceAgent:
+		return "AI agents"
 	default:
 		return s.String()
 	}

--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -2,7 +2,7 @@
 
 const SEV = ["critical", "high", "medium", "low"];
 // Finding.source (int) -> short domain label, mirrors the score axes.
-const SRC = { 1: "Container", 2: "SSH", 3: "Firewall", 4: "Updates", 5: "CVEs", 6: "Ports", 7: "Accounts", 8: "File perms" };
+const SRC = { 1: "Container", 2: "SSH", 3: "Firewall", 4: "Updates", 5: "CVEs", 6: "Ports", 7: "Accounts", 8: "File perms", 9: "AI agents" };
 const REM_AUTO = 1;
 // model.ScanState (int), in declaration order.
 const SCAN_DONE = 2, SCAN_SKIPPED = 3, SCAN_DEGRADED = 4, SCAN_ERROR = 5;
@@ -190,7 +190,7 @@ function render() {
   );
 
   // Per-axis bars (short labels so they never crowd the meter).
-  const AX = { container: "Container", ssh: "SSH", firewall: "Firewall", updates: "Updates", cve: "CVEs", ports: "Ports", accounts: "Accounts", fileperms: "File perms" };
+  const AX = { container: "Container", ssh: "SSH", firewall: "Firewall", updates: "Updates", cve: "CVEs", ports: "Ports", accounts: "Accounts", fileperms: "File perms", agent: "AI agents" };
   document.getElementById("axes").replaceChildren(
     ...score.axes.map((ax) =>
       el("div", { class: "axis" + (ax.applicable ? "" : " na") + (ax.degraded ? " partial" : "") },

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -99,6 +99,7 @@
                   <tr><td>Exposed services</td><td><code>ports.</code></td><td><code>ss</code></td></tr>
                   <tr><td>Accounts</td><td><code>accounts.</code></td><td>root (for <code>/etc/shadow</code>)</td></tr>
                   <tr><td>File permissions</td><td><code>fileperms.</code></td><td>—</td></tr>
+                  <tr><td>AI agent runtimes</td><td><code>agent.</code></td><td>OpenClaw or Hermes installed</td></tr>
                   <tr><td>Image CVEs <em>(optional)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -127,14 +128,15 @@
               <table>
                 <thead><tr><th>Axis</th><th>Weight</th></tr></thead>
                 <tbody>
-                  <tr><td>Container exposure</td><td>20</td></tr>
-                  <tr><td>SSH hardening</td><td>18</td></tr>
-                  <tr><td>Vulnerabilities</td><td>15</td></tr>
-                  <tr><td>Host firewall</td><td>13</td></tr>
-                  <tr><td>Exposed services</td><td>11</td></tr>
-                  <tr><td>Account hygiene</td><td>9</td></tr>
-                  <tr><td>Auto-updates</td><td>8</td></tr>
-                  <tr><td>File permissions</td><td>6</td></tr>
+                  <tr><td>Container exposure</td><td>18</td></tr>
+                  <tr><td>SSH hardening</td><td>17</td></tr>
+                  <tr><td>Vulnerabilities</td><td>13</td></tr>
+                  <tr><td>Host firewall</td><td>12</td></tr>
+                  <tr><td>Exposed services</td><td>10</td></tr>
+                  <tr><td>AI agent runtimes</td><td>10</td></tr>
+                  <tr><td>Account hygiene</td><td>8</td></tr>
+                  <tr><td>Auto-updates</td><td>7</td></tr>
+                  <tr><td>File permissions</td><td>5</td></tr>
                 </tbody>
               </table>
             </div>
@@ -239,6 +241,29 @@
                 </tbody>
               </table>
             </div>
+
+            <h2 id="agent">AI agent runtimes <code>agent.</code></h2>
+            <p>Self-hosted AI agents — <a href="https://docs.openclaw.ai/">OpenClaw</a> and <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a> — run a network gateway and keep API keys on disk in your home directory. Misconfigured, the worst case is someone reaching that gateway and driving an agent that can read your files and run commands as you.</p>
+            <p>This domain is <strong>skipped entirely</strong> unless one of those runtimes is actually installed, so a host that has never run an agent is not scored on it. hostveil looks up home directories in <code>/etc/passwd</code> and stats only the paths listed below — it never walks your home.</p>
+            <p>These projects ship their own config auditors (<code>openclaw security audit</code>), which cover their settings far more thoroughly than hostveil tries to. What hostveil adds is the part those tools cannot see: whether the gateway is <em>actually</em> listening on a reachable address, whether a firewall stands behind it, and whether your credential files are readable by other accounts on the box.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>agent.auth-disabled</code></td><td>An exposed gateway that accepts requests with no authentication</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.gateway-exposed</code></td><td>The gateway is bound to a network-reachable address (<span class="sev critical">Critical</span> when it is confirmed listening with no firewall)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.secret-exposed</code></td><td>A credentials file or directory is readable beyond its owner</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>agent.exec-unrestricted</code></td><td>The agent may run shell commands with no approval step</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.elevated-enabled</code></td><td>Elevated (host-level) command execution is enabled</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.sandbox-off</code></td><td>Agent tools run unsandboxed, directly on the host</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.control-ui-insecure</code></td><td>The control UI has its auth or device-identity checks disabled</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>agent.config-perms</code></td><td>A config or state path is more permissive than upstream ships it</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>agent.ssrf-private-network</code></td><td>The agent browser may reach private-network addresses</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>The config findings are <strong>Manual</strong> on purpose. OpenClaw's config is JSON5 and carries your own comments; hostveil has no way to edit one key without rewriting the file and deleting them. Hermes settings may come from the config, from <code>.env</code>, from a systemd unit, or from a <code>docker&nbsp;-e</code> flag, and a finding cannot tell which is in force. Rebinding a gateway can also cut you off from the agent you administer remotely — so hostveil explains these and leaves the edit to you.</p>
+            <p>Only the two permission findings are auto-fixable, and both are a <code>chmod</code> that only ever <em>removes</em> access, checkpointed so <code>hostveil rollback</code> restores the previous mode exactly.</p>
 
             <h2 id="cve">Image CVEs <code>cve.</code> <em>(optional)</em></h2>
             <p>When Trivy is installed, hostveil scans the images your Compose services run for known Critical, High, and Medium vulnerabilities. Findings are reported <strong>per image</strong>, not per vulnerability — a single image routinely ships hundreds of CVEs, and they all share one remediation.</p>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -99,6 +99,7 @@
                   <tr><td>노출된 서비스</td><td><code>ports.</code></td><td><code>ss</code></td></tr>
                   <tr><td>계정</td><td><code>accounts.</code></td><td>root (<code>/etc/shadow</code>용)</td></tr>
                   <tr><td>파일 권한</td><td><code>fileperms.</code></td><td>—</td></tr>
+                  <tr><td>AI 에이전트 런타임</td><td><code>agent.</code></td><td>OpenClaw 또는 Hermes 설치</td></tr>
                   <tr><td>이미지 CVE <em>(선택)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -127,14 +128,15 @@
               <table>
                 <thead><tr><th>축</th><th>가중치</th></tr></thead>
                 <tbody>
-                  <tr><td>컨테이너 노출</td><td>20</td></tr>
-                  <tr><td>SSH 하드닝</td><td>18</td></tr>
-                  <tr><td>취약점</td><td>15</td></tr>
-                  <tr><td>호스트 방화벽</td><td>13</td></tr>
-                  <tr><td>노출된 서비스</td><td>11</td></tr>
-                  <tr><td>계정 위생</td><td>9</td></tr>
-                  <tr><td>자동 업데이트</td><td>8</td></tr>
-                  <tr><td>파일 권한</td><td>6</td></tr>
+                  <tr><td>컨테이너 노출</td><td>18</td></tr>
+                  <tr><td>SSH 하드닝</td><td>17</td></tr>
+                  <tr><td>취약점</td><td>13</td></tr>
+                  <tr><td>호스트 방화벽</td><td>12</td></tr>
+                  <tr><td>노출된 서비스</td><td>10</td></tr>
+                  <tr><td>AI 에이전트 런타임</td><td>10</td></tr>
+                  <tr><td>계정 위생</td><td>8</td></tr>
+                  <tr><td>자동 업데이트</td><td>7</td></tr>
+                  <tr><td>파일 권한</td><td>5</td></tr>
                 </tbody>
               </table>
             </div>
@@ -239,6 +241,29 @@
                 </tbody>
               </table>
             </div>
+
+            <h2 id="agent">AI 에이전트 런타임 <code>agent.</code></h2>
+            <p>셀프호스트 AI 에이전트인 <a href="https://docs.openclaw.ai/">OpenClaw</a>와 <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a>는 네트워크 게이트웨이를 띄우고 API 키를 홈 디렉터리에 저장합니다. 설정이 잘못되면 최악의 경우 외부에서 그 게이트웨이에 접근해, 내 파일을 읽고 내 권한으로 명령을 실행하는 에이전트를 그대로 조종할 수 있습니다.</p>
+            <p>이 도메인은 해당 런타임이 실제로 설치되어 있지 않으면 <strong>아예 건너뜁니다</strong>. 에이전트를 쓴 적 없는 호스트는 이 항목으로 점수를 매기지 않습니다. hostveil은 <code>/etc/passwd</code>에서 홈 디렉터리를 찾은 뒤 아래 표에 적힌 경로만 stat합니다. 홈 디렉터리 전체를 훑지 않습니다.</p>
+            <p>두 프로젝트 모두 자체 설정 점검 도구(<code>openclaw security audit</code>)를 제공하며, 설정 항목 자체는 그쪽이 훨씬 촘촘합니다. hostveil이 더하는 것은 그 도구들이 볼 수 없는 부분입니다. 게이트웨이가 <em>실제로</em> 외부에서 닿는 주소에서 대기 중인지, 그 앞에 방화벽이 있는지, 자격 증명 파일을 같은 호스트의 다른 계정이 읽을 수 있는지입니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>무엇을 잡아내는지</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>agent.auth-disabled</code></td><td>외부에 노출된 게이트웨이가 인증 없이 요청을 받음</td><td><span class="sev critical">치명적</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.gateway-exposed</code></td><td>게이트웨이가 네트워크에서 닿는 주소에 바인딩됨 (대기 중인 것이 확인되고 방화벽도 없으면 <span class="sev critical">치명적</span>)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.secret-exposed</code></td><td>자격 증명 파일 또는 디렉터리를 소유자 외에도 읽을 수 있음</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>agent.exec-unrestricted</code></td><td>에이전트가 승인 절차 없이 셸 명령을 실행할 수 있음</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.elevated-enabled</code></td><td>호스트 수준의 권한 상승 실행이 활성화됨</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.sandbox-off</code></td><td>에이전트 도구가 샌드박스 없이 호스트에서 직접 실행됨</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.control-ui-insecure</code></td><td>제어 UI의 인증 또는 기기 확인이 꺼져 있음</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>agent.config-perms</code></td><td>설정·상태 경로가 업스트림 기본값보다 느슨함</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>agent.ssrf-private-network</code></td><td>에이전트 브라우저가 사설망 주소에 접근할 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>설정 관련 항목이 <strong>수동</strong>인 것은 의도된 선택입니다. OpenClaw 설정은 JSON5라 사용자가 직접 쓴 주석이 들어 있는데, hostveil이 키 하나만 고치려 해도 파일을 다시 쓰면서 그 주석을 지우게 됩니다. Hermes 설정값은 설정 파일, <code>.env</code>, systemd 유닛, <code>docker&nbsp;-e</code> 플래그 중 어디서 온 것인지 판별할 수 없습니다. 게이트웨이를 다시 바인딩하면 원격으로 관리하던 에이전트와의 연결이 끊길 수도 있습니다. 그래서 hostveil은 설명만 하고 수정은 사용자에게 맡깁니다.</p>
+            <p>자동 수정되는 것은 권한 관련 두 항목뿐이며, 둘 다 접근 권한을 <em>줄이기만</em> 하는 <code>chmod</code>입니다. 체크포인트가 남으므로 <code>hostveil rollback</code>으로 이전 권한을 그대로 되돌릴 수 있습니다.</p>
 
             <h2 id="cve">이미지 CVE <code>cve.</code> <em>(선택)</em></h2>
             <p>Trivy가 설치되어 있으면, hostveil은 Compose 서비스가 실행하는 이미지를 스캔하여 알려진 심각·높음·보통 등급의 취약점을 찾습니다. 발견 항목은 취약점 단위가 아니라 <strong>이미지 단위</strong>로 보고됩니다 — 이미지 하나가 CVE 수백 개를 싣고 있는 건 흔한 일이고, 그 전부가 같은 조치 하나를 공유하기 때문입니다.</p>


### PR DESCRIPTION
Self-hosted AI agent runtimes — [OpenClaw](https://docs.openclaw.ai/) and [Hermes Agent](https://hermes-agent.nousresearch.com/docs/) — are now common on exactly the kind of box hostveil targets, and hostveil could not see any of them. Each runs a network gateway (`:18789`, `:9119`) and keeps API keys on disk in a user's home. Misconfigured, the failure mode is unauthenticated remote code execution as a real account — worse than anything the `ports` domain can currently report.

This adds a ninth domain, `agent.*`, with a new scoring axis.

## Scope: deliberately not a full config audit

OpenClaw ships `openclaw security audit --fix`, which covers its config matrix far more thoroughly than we could sustain across two fast-moving upstream schemas. What those tools cannot see is the host: whether the gateway is *actually* listening on a reachable address, whether a firewall stands behind it, whether the credential file is readable by every account on the box. That — plus a small set of stable keys whose insecure value has no legitimate reading — is what this checker judges.

## The two decisions carrying most of the weight

**`Available()` is discovery-gated and distinguishes "could not read `/etc/passwd`" from "no runtime installed."** Both skip the domain, but conflating them would let a failure to look pass for a clean result. An always-available checker would instead hand a free axis to every host that never installed an agent.

**The noise guards are what make the axis worth scoring.** `auth.mode: none` is only reported on a gateway that is actually exposed, because on loopback it is upstream's documented single-user default. Secrets in a secrets file are only reported when the file is readable beyond its owner, because storing them there *is* the design. Flagging either unconditionally would put a Critical on a correct install — a score nobody could improve by doing everything right.

## Secrets are read to judge, never carried out

Evidence reaches every UI and is persisted to `/var/lib/hostveil`, so the dotenv loader returns values only for keys the caller names as non-sensitive and reports everything else by presence alone. Verified on the demo VM: the finding's evidence is `keys: "ANTHROPIC_API_KEY, OPENAI_API_KEY"` — names only, non-credential keys excluded — and the key values appear nowhere in persisted state.

## Findings

| ID | Sev | Fix |
|---|---|---|
| `agent.auth-disabled` | Critical | Manual |
| `agent.gateway-exposed` | High → Critical when confirmed listening with no firewall | Manual |
| `agent.secret-exposed` | High | **Auto** |
| `agent.exec-unrestricted` / `elevated-enabled` / `sandbox-off` / `control-ui-insecure` | High | Manual |
| `agent.config-perms` | Medium | **Auto** |
| `agent.ssrf-private-network` | Medium | Manual |

The seven config-key findings are declined with reasons in `fix.Default()`'s doc comment and pinned by `TestKnownUnregisteredFindings`: OpenClaw's config is JSON5 carrying the operator's own comments, and hostveil has no round-tripper that could edit one key without deleting them; Hermes settings may come from config, `.env`, a systemd unit, or a `docker -e` flag, and the finding cannot tell which is in force. `agent.gateway-exposed` also fails the recoverability clause — rebinding can cut an operator off from the agent they administer remotely.

Runtimes are described entirely as data, so a third one is a table entry rather than new code.

## Scoring

Axis caps rebalanced by a proportional shave that preserves every existing pairwise ordering. `agent` ties with `ports` at 10: larger blast radius, far smaller prevalence, and N/A-excluded on hosts without an agent, so it costs a typical host nothing.

## Commits

1. **`fix: keep type bits when tightening a mode`** — a pre-existing bug this feature exposed. `tighten()` dropped `fs.ModeDir`, and `planModes` compares against the full `fs.FileMode`, so a directory compared unequal to itself forever: preview printed a phantom `0700 → 0700` row and apply checkpointed and chmod'ed an already-compliant directory, reporting success for work it had not done. Latent because `fileperms` skips directories. Both new tests confirmed failing against the old code.
2. **`feat: add an agent domain`** — the checker, plus two seams extracted rather than forked (`internal/secretkey`, `platform.Listeners`; existing `ports` tests pass untouched).
3. **`fix: do not call any interpreter process an agent gateway`** — a false positive **found by running the demo VM**, not by unit tests. `matchListener` treated any non-loopback listener owned by a process in `ProcNames` as the gateway regardless of port; those names are interpreters (`python3`, `uvicorn`, `node`), so a plain `python3 -m http.server` on an unrelated port was reported Critical as a Hermes gateway on a host not running Hermes. The port is now the only trigger.
4. **`demo: seed OpenClaw and Hermes configs`** — fixtures shaped to exercise rather than merely trigger: real JSON5 (comments, trailing commas, a URL in a string) so a regression to strict-JSON parsing shows as a Degraded axis, and non-credential keys alongside the fake API keys so the evidence filtering is visible.

## Verification

Full gate green: `go build`, `vet`, `gofmt`, `mod tidy`, `test -race`, `golangci-lint` (0 issues), sitegen drift, install.sh checksum.

Verified end-to-end on the demo VM: N/A on a host with no agent (with the reason naming absence, not a read failure); JSON5-with-comments parsed without Degraded; the two `tools.exec.*` keys collapsed into one finding; directory chmod `0755 → 0700` staying a directory; rollback restoring `0755` exactly; `fix --all` sweeping up all three Auto fixes; severity escalating High → Critical against a real listener with `ufw` inactive; and a hardened config reaching **100/100**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)