### PR TITLE
Gate releases on the full CI suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Callable so the release workflow can run this exact gate against the
+  # commit being tagged, rather than trusting that some earlier run of it
+  # passed. Adding this does not change when CI runs on its own.
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,19 @@ jobs:
         with:
           version: v2.12.2
 
+      # The release workflow calls this one, and a broken `uses:` path or a
+      # dangling `needs:` in that wiring is invisible until a tag is pushed —
+      # by which time the thing that was supposed to gate the release is the
+      # thing that is broken. actionlint catches both statically. Pinned for
+      # the same reason golangci-lint is: a floating version can start
+      # failing CI on a commit that changed nothing.
+      #
+      # Runs from the repo root with no arguments, which lints every file
+      # under .github/workflows. The runner has shellcheck installed, so this
+      # also checks the shell in every `run:` block.
+      - name: Lint workflows
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
       - name: Verify site/ is up to date with sitegen
         run: |
           go run ./cmd/sitegen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,29 @@ on:
   push:
     tags: ["v*"]
 
-permissions:
-  contents: write
-  # Required to mint a build-provenance attestation for the release
-  # artifacts: id-token to request the OIDC token that identifies this
-  # workflow, attestations to record the signed statement.
-  id-token: write
-  attestations: write
-
 jobs:
+  # Run the full CI gate against the tagged commit before anything is
+  # published. A tag can be pushed to any commit, including one that never
+  # went through a pull request, so "it was green on main" is not a
+  # guarantee about what is being released.
+  #
+  # This calls the same ci.yml the branch protection uses, resolved from the
+  # tagged ref itself, so the gate that runs is the one belonging to the code
+  # being released — not a newer or older copy of it.
+  ci:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci.yml
+
   goreleaser:
+    needs: ci
+    permissions:
+      contents: write
+      # Required to mint a build-provenance attestation for the release
+      # artifacts: id-token to request the OIDC token that identifies this
+      # workflow, attestations to record the signed statement.
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -21,8 +34,6 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
-      - name: Verify
-        run: go build ./... && go vet ./...
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0
       - uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
`release.yml` verified only `go build && go vet` before publishing. A tag can be pushed to **any** commit — including one that never went through a pull request — so nothing guaranteed that the code being released had passed lint, the race detector, sitegen drift, `go mod tidy`, or the install.sh checksum.

## Approach

Rather than copy those steps into `release.yml`, `ci.yml` gains a `workflow_call` trigger and `release.yml` calls it as a job `goreleaser` depends on.

Two reasons this beats the alternatives:

- **vs. checking a past CI run for the tagged SHA** — that trusts history, and has to handle "no run found" and "still in progress". Calling the workflow *runs* the gate against the commit being released.
- **vs. duplicating the steps** — a local `uses:` resolves from the tagged ref, so the gate that runs is the one belonging to the commit being released, and the two can never drift apart the way copied steps would.

Adding `workflow_call` does not change when CI runs on its own.

## Permissions tightened as a side effect

They move from the workflow down to the jobs that need them. The gate runs with `contents: read`; only `goreleaser` holds `contents: write` plus the `id-token`/`attestations` scopes needed to publish and sign. Previously every job in the workflow got the write scopes.

The inline `Verify` step is removed — it is a strict subset of what the gate now runs.

## Verification

`actionlint` passes clean on all three workflows. I confirmed that check is not vacuous by deliberately breaking it first — it catches both a bad reusable-workflow path and a dangling `needs`:

```
release.yml:18:11: could not read reusable workflow file for "./.github/workflows/nonexistent.yml" [workflow-call]
release.yml:20:3: job "goreleaser" needs job "nosuchjob" which does not exist in this workflow [job-needs]
```

**What is not verified:** the release path itself does not execute until a `v*` tag is pushed, and I did not cut one — that would publish a real release. So this is validated statically and by CI on this PR (which proves `ci.yml` is still sound with the new trigger), but the `release → ci` call first executes on the next real tag. Worth watching that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)