### PR TITLE
Fail the build when AGENTS.md stops matching the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Guidance for AI coding agents working in this repository. OpenCode and Codex read this file directly; Claude Code does not, so it reads it through the `@AGENTS.md` import in `CLAUDE.md` — keep that file, it is the only thing wiring the two together.
 
+`internal/docs/agents_test.go` checks the mechanical claims below against the code — that referenced paths and symbols exist, that the checker count and lint list match. Reword the prose freely; renaming something this file names will fail the build until the sentence is updated too.
+
 ## What this is
 
 hostveil is a single-binary guided hardening tool for self-hosted Linux servers: it scans a host, merges findings into one 0–100 score, explains them in plain language, and applies fixes with preview, backup, and rollback. Go 1.26, GPL-3.0, no config file, no cloud.

--- a/internal/docs/agents_test.go
+++ b/internal/docs/agents_test.go
@@ -232,31 +232,41 @@ func TestReferencedPathsExist(t *testing.T) {
 // (`compose.ds016`, `cve.*`) and are emphatically not Go symbols.
 var pkgRef = regexp.MustCompile(`^([a-z][a-z0-9]*)\.([A-Z][A-Za-z0-9_]*)(\(\))?$`)
 
-// declaredNames returns every top-level name a package declares, plus its
-// method names.
+// declaredNames returns every top-level name the .go files in dir declare —
+// funcs and methods, types, vars, and consts.
+//
+// The files are parsed one at a time rather than with parser.ParseDir, which
+// is deprecated: it ignores build tags when grouping files into packages.
+// Nothing here needs that grouping, since a name declared anywhere in the
+// directory is a name the doc may legitimately reference.
 func declaredNames(t *testing.T, dir string) map[string]bool {
 	t.Helper()
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, dir, nil, 0)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("parse %s: %v", dir, err)
+		t.Fatalf("read %s: %v", dir, err)
 	}
+	fset := token.NewFileSet()
 	names := map[string]bool{}
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				switch d := decl.(type) {
-				case *ast.FuncDecl:
-					names[d.Name.Name] = true
-				case *ast.GenDecl:
-					for _, spec := range d.Specs {
-						switch s := spec.(type) {
-						case *ast.TypeSpec:
-							names[s.Name.Name] = true
-						case *ast.ValueSpec:
-							for _, n := range s.Names {
-								names[n.Name] = true
-							}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", e.Name(), err)
+		}
+		for _, decl := range file.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				names[d.Name.Name] = true
+			case *ast.GenDecl:
+				for _, spec := range d.Specs {
+					switch s := spec.(type) {
+					case *ast.TypeSpec:
+						names[s.Name.Name] = true
+					case *ast.ValueSpec:
+						for _, n := range s.Names {
+							names[n.Name] = true
 						}
 					}
 				}

--- a/internal/docs/agents_test.go
+++ b/internal/docs/agents_test.go
@@ -1,0 +1,378 @@
+// Package docs tests that AGENTS.md still describes the code it claims to
+// describe.
+//
+// AGENTS.md is the first thing a new contributor — human or agent — reads,
+// and it restates things the code decides: which files hold which seam, how
+// many checkers the engine builds, which linters run. Prose cannot fail a
+// build, so those restatements go stale silently. They already did: the
+// engine grew a ninth checker and the CI gate grew an actionlint step, and
+// the file kept saying "eight" and omitting the step for a day, through two
+// merges, with nobody noticing.
+//
+// These tests are deliberately narrow. They check claims that are mechanical
+// and unambiguous — a path exists, a symbol is declared, a count matches, a
+// list matches — and nothing about the prose. Rewording an invariant must
+// never fail a build; renaming the thing it names must.
+package docs
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// repoRoot walks up from the test's directory to the module root, so the
+// tests read the real AGENTS.md rather than an embedded copy that could
+// itself drift.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod above the test directory")
+		}
+		dir = parent
+	}
+}
+
+func readRepoFile(t *testing.T, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(repoRoot(t), rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}
+
+func agentsMD(t *testing.T) string { return readRepoFile(t, "AGENTS.md") }
+
+var (
+	// Fenced blocks must be removed before inline spans are extracted. A
+	// fence is three backticks, so a naive inline pattern pairs the fence's
+	// backticks with each other and swallows the whole block as one span —
+	// which then looks like prose and is skipped, silently taking every real
+	// reference near it along. That bug made an earlier version of this file
+	// see 1 path reference where there are 14.
+	fencedBlock = regexp.MustCompile("(?s)```.*?```")
+	// No newline in the class, so an unbalanced backtick cannot run away
+	// across half the document.
+	inlineCode = regexp.MustCompile("`([^`\n]+)`")
+	// Paths as they appear inside command blocks: `scripts/bench.sh`,
+	// `./cmd/sitegen`, `internal/check/ssh`. Anchored on a real top-level
+	// directory so flags and `./...` cannot match.
+	commandPath = regexp.MustCompile(`(?m)(?:^|\s)\.?/?((?:cmd|internal|demo|docs|scripts|site|test)/[A-Za-z0-9._/-]*)`)
+)
+
+func addUnique(out []string, s string) []string {
+	if s != "" && !slices.Contains(out, s) {
+		return append(out, s)
+	}
+	return out
+}
+
+// tokens returns every distinct inline-code span in AGENTS.md, with fenced
+// code blocks removed first.
+func tokens(t *testing.T) []string {
+	t.Helper()
+	prose := fencedBlock.ReplaceAllString(agentsMD(t), "")
+	var out []string
+	for _, m := range inlineCode.FindAllStringSubmatch(prose, -1) {
+		out = addUnique(out, m[1])
+	}
+	return out
+}
+
+// commandPaths returns repo paths named inside the fenced command blocks.
+// Those blocks are what a contributor copies and runs, so a path that has
+// moved out from under one is worth catching too.
+func commandPaths(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	for _, block := range fencedBlock.FindAllString(agentsMD(t), -1) {
+		for _, m := range commandPath.FindAllStringSubmatch(block, -1) {
+			// Keep any trailing slash: it is what marks `site/` as a
+			// directory rather than a bare filename to go hunting for.
+			out = addUnique(out, m[1])
+		}
+	}
+	return out
+}
+
+// repoDirs are the top-level directories a path reference can start with.
+// Requiring one is what keeps this from trying to resolve prose: `core`,
+// `app.go`, and `pages.json` are all real things written relative to some
+// context the doc establishes in words, and guessing at them would produce
+// failures that say nothing.
+var repoDirs = []string{"cmd/", "internal/", "demo/", "docs/", "scripts/", "site/", "test/"}
+
+var (
+	// bareFile matches a filename written without a directory, like
+	// `pages.json` or `app.go`. The doc names these relative to a directory
+	// it established in the surrounding prose, so they are resolved by
+	// searching the tree rather than by guessing at that context.
+	bareFile = regexp.MustCompile(`^[A-Za-z0-9._-]+\.(md|yaml|yml|json|sh|go|tmpl)$`)
+	// pkgQualified matches a package path with an exported symbol hung off
+	// it — `internal/core.Engine`. It reads as a path but the last segment
+	// is not a file, so only the package directory can be stat'ed.
+	pkgQualified = regexp.MustCompile(`^(.*/[a-z][a-z0-9]*)\.[A-Z]\w*$`)
+)
+
+func isPathRef(tok string) bool {
+	if strings.ContainsAny(tok, " \t(=") {
+		return false // prose or a code fragment, not a path
+	}
+	if bareFile.MatchString(tok) {
+		return true
+	}
+	for _, d := range repoDirs {
+		if strings.HasPrefix(tok, d) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolve turns a reference into the path to stat, and reports whether the
+// name may be found anywhere in the tree rather than at that exact location.
+func resolve(tok string) (path string, anywhere bool) {
+	if m := pkgQualified.FindStringSubmatch(tok); m != nil {
+		return m[1], false // check the package dir, not the symbol
+	}
+	if !strings.Contains(tok, "/") {
+		return tok, true // a bare filename: the doc's context says where
+	}
+	// A glob (`site/**/*.html`) cannot be stat'ed, and expanding `**`
+	// correctly is not worth it — checking the fixed prefix catches the
+	// failure that actually happens, which is the tree being moved out from
+	// under the pattern.
+	if i := strings.IndexAny(tok, "*{"); i >= 0 {
+		tok = tok[:i]
+	}
+	return strings.TrimSuffix(tok, "/"), false
+}
+
+// existsAnywhere reports whether a file with this basename exists in the
+// repo, ignoring directories that are not ours to describe.
+func existsAnywhere(t *testing.T, root, name string) bool {
+	t.Helper()
+	found := false
+	err := filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil || found {
+			return nil //nolint:nilerr // an unreadable subtree is not a doc defect
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "dist", ".vagrant":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == name {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return found
+}
+
+// TestReferencedPathsExist is the check that earns its keep on an ordinary
+// day: files get renamed and moved constantly, and a doc that points at
+// somewhere no longer there sends a contributor hunting.
+func TestReferencedPathsExist(t *testing.T) {
+	root := repoRoot(t)
+
+	refs := commandPaths(t)
+	for _, tok := range tokens(t) {
+		if isPathRef(tok) {
+			refs = addUnique(refs, tok)
+		}
+	}
+	// A guard against this test quietly checking nothing, which is exactly
+	// how it failed before: the extraction broke, every reference vanished,
+	// and it went on passing.
+	if len(refs) < 10 {
+		t.Fatalf("only %d path references extracted from AGENTS.md (%v) — extraction is broken, not the doc", len(refs), refs)
+	}
+
+	for _, tok := range refs {
+		p, anywhere := resolve(tok)
+		if p == "" {
+			continue
+		}
+		if anywhere {
+			if !existsAnywhere(t, root, p) {
+				t.Errorf("AGENTS.md references %q, but no file named %s exists in the repo", tok, p)
+			}
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, p)); err != nil {
+			t.Errorf("AGENTS.md references %q, but %s does not exist", tok, p)
+		}
+	}
+}
+
+// pkgRef matches `pkg.Symbol`, where Symbol is exported. The uppercase
+// requirement is load-bearing: finding IDs are spelled the same way
+// (`compose.ds016`, `cve.*`) and are emphatically not Go symbols.
+var pkgRef = regexp.MustCompile(`^([a-z][a-z0-9]*)\.([A-Z][A-Za-z0-9_]*)(\(\))?$`)
+
+// declaredNames returns every top-level name a package declares, plus its
+// method names.
+func declaredNames(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", dir, err)
+	}
+	names := map[string]bool{}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				switch d := decl.(type) {
+				case *ast.FuncDecl:
+					names[d.Name.Name] = true
+				case *ast.GenDecl:
+					for _, spec := range d.Specs {
+						switch s := spec.(type) {
+						case *ast.TypeSpec:
+							names[s.Name.Name] = true
+						case *ast.ValueSpec:
+							for _, n := range s.Names {
+								names[n.Name] = true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return names
+}
+
+// TestReferencedSymbolsExist catches the rename that a path check cannot: the
+// file stays put, but the thing inside it the doc named is gone.
+func TestReferencedSymbolsExist(t *testing.T) {
+	root := repoRoot(t)
+	checked := 0
+	for _, tok := range tokens(t) {
+		m := pkgRef.FindStringSubmatch(tok)
+		if m == nil {
+			continue
+		}
+		pkg, symbol := m[1], m[2]
+		dir := filepath.Join(root, "internal", pkg)
+		if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+			continue // not a reference to an internal package
+		}
+		checked++
+		if !declaredNames(t, dir)[symbol] {
+			t.Errorf("AGENTS.md references %q, but internal/%s declares no %s", tok, pkg, symbol)
+		}
+	}
+	// Same guard as the path test, for the same reason.
+	if checked < 5 {
+		t.Fatalf("only %d package symbols extracted from AGENTS.md — extraction is broken, not the doc", checked)
+	}
+}
+
+// numberWords covers the range a checker count could plausibly reach. Writing
+// the count as a word is the natural prose, so the test meets the prose where
+// it is rather than forcing a digit into the sentence.
+var numberWords = map[string]int{
+	"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7,
+	"eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13,
+	"fourteen": 14, "fifteen": 15, "sixteen": 16, "seventeen": 17, "eighteen": 18,
+	"nineteen": 19, "twenty": 20,
+}
+
+var (
+	documentedCheckers  = regexp.MustCompile(`all (\w+) checkers`)
+	checkerRegistration = regexp.MustCompile(`\b[a-z]+check\.New\(\)`)
+)
+
+// TestDocumentedCheckerCountMatchesTheEngine pins the exact claim that went
+// stale when the agent domain landed.
+func TestDocumentedCheckerCountMatchesTheEngine(t *testing.T) {
+	m := documentedCheckers.FindStringSubmatch(agentsMD(t))
+	if m == nil {
+		t.Fatal(`AGENTS.md no longer says "all N checkers" — update this test if the wording moved on purpose`)
+	}
+	want, ok := numberWords[strings.ToLower(m[1])]
+	if !ok {
+		t.Fatalf("AGENTS.md says %q checkers, which is not a number word this test knows", m[1])
+	}
+	got := len(checkerRegistration.FindAllString(readRepoFile(t, "cmd/hostveil/app.go"), -1))
+	if got != want {
+		t.Errorf("AGENTS.md says the engine builds %s (%d) checkers, but cmd/hostveil/app.go registers %d",
+			m[1], want, got)
+	}
+}
+
+var (
+	documentedLinters = regexp.MustCompile(`enables only ([^.]+)\.`)
+	enabledLinter     = regexp.MustCompile(`(?m)^\s*-\s*(\w+)\s*$`)
+)
+
+// TestDocumentedLintersMatchTheConfig keeps the doc honest about what the
+// lint gate actually enforces — a contributor who trusts a stale list writes
+// code expecting checks that are not running.
+func TestDocumentedLintersMatchTheConfig(t *testing.T) {
+	m := documentedLinters.FindStringSubmatch(agentsMD(t))
+	if m == nil {
+		t.Fatal(`AGENTS.md no longer says which linters the config "enables only"`)
+	}
+	var documented []string
+	for _, l := range strings.Split(m[1], ",") {
+		if l = strings.Trim(strings.TrimSpace(l), "`"); l != "" {
+			documented = append(documented, l)
+		}
+	}
+
+	cfg := readRepoFile(t, ".golangci.yaml")
+	_, after, found := strings.Cut(cfg, "enable:")
+	if !found {
+		t.Fatal(".golangci.yaml has no enable: list")
+	}
+	var enabled []string
+	for _, m := range enabledLinter.FindAllStringSubmatch(after, -1) {
+		enabled = append(enabled, m[1])
+	}
+
+	slices.Sort(documented)
+	slices.Sort(enabled)
+	if !slices.Equal(documented, enabled) {
+		t.Errorf("AGENTS.md documents linters %v, but .golangci.yaml enables %v", documented, enabled)
+	}
+}
+
+// TestClaudeMdImportsAgentsMd guards the wiring that makes this file reach
+// Claude Code at all. Claude Code does not read AGENTS.md natively, so the
+// import in CLAUDE.md is the only thing connecting them — and CLAUDE.md now
+// looks so much like a redundant stub that deleting it is the obvious
+// tidy-up. It is not: the guidance would silently stop loading.
+func TestClaudeMdImportsAgentsMd(t *testing.T) {
+	claude := readRepoFile(t, "CLAUDE.md")
+	for _, line := range strings.Split(claude, "\n") {
+		if strings.TrimSpace(line) == "@AGENTS.md" {
+			return
+		}
+	}
+	t.Error("CLAUDE.md must contain a bare `@AGENTS.md` import line, or Claude Code loads no project guidance at all")
+}


### PR DESCRIPTION
`AGENTS.md` is the first thing a new contributor — human or agent — reads, and it restates things the code decides: which file holds which seam, how many checkers the engine builds, which linters run. Prose cannot fail a build, so those restatements rot silently.

They already had. The engine grew a ninth checker (#533) and the CI gate grew an actionlint step (#534), and the file kept saying "eight" and omitting the step for a day, across two merges, until it was noticed by hand.

This follows the precedent already set by `cmd/sitegen/docs_test.go`, which does the same job for the website.

## The five checks

| Check | Catches |
|---|---|
| Referenced paths exist | A file named in the doc was renamed, moved, or deleted — inline **and** inside the copy-paste command blocks |
| Referenced symbols exist | `pkg.Symbol` where the file stayed put but the thing inside it was renamed |
| Checker count matches | The exact claim that went stale in #533 |
| Linter list matches `.golangci.yaml` | A contributor trusting a stale list writes code expecting checks that are not running |
| `CLAUDE.md` still imports `@AGENTS.md` | `CLAUDE.md` now looks like a redundant stub, so deleting it is the obvious tidy-up. It is not — the guidance would silently stop loading |

Deliberately narrow: they check claims that are mechanical and unambiguous, and nothing about the prose. **Rewording an invariant must never fail the build; renaming the thing it names must.**

## Every check was verified by breaking it

Including a real `mv internal/compose/edit.go`, not just a fabricated reference:

```
1a inline bad path      → references "internal/nonexistent/foo.go", but ... does not exist
1b bad path in a block  → references "cmd/gonepackage", but ... does not exist
1c REAL file rename     → references "internal/compose/edit.go", but ... does not exist
2  bad symbol           → references "model.NoSuchSymbol", but internal/model declares no NoSuchSymbol
3  count drift          → says the engine builds eight (8) checkers, but app.go registers 9
4  linter drift         → documents [errcheck ...], but .golangci.yaml enables [...]
5  import removed       → CLAUDE.md must contain a bare `@AGENTS.md` import line
```

## That discipline caught a real bug in the tests themselves

**The first version passed everything while checking almost nothing.** `AGENTS.md` contains fenced code blocks, and an inline-code pattern that can span newlines pairs a fence's three backticks with each other and swallows the entire block as one "token" — which then contains spaces, reads as prose, and is skipped. It saw **1 path reference where there are 30**.

Two changes: fenced blocks are stripped before inline spans are extracted, and both the path and symbol tests now `Fatal` on an implausibly small harvest. So the next time extraction breaks, it says *"extraction is broken, not the doc"* instead of going quiet — verified by reproducing the original bug and confirming the guard fires.

## Two false positives worth knowing about

Both were the test's fault, not the doc's, and are handled rather than suppressed:

- `internal/core.Engine` reads like a path but is a package-qualified symbol, so only the package directory is stat'ed.
- `pages.json` is named relative to `cmd/sitegen/`, context the prose establishes in words. Bare filenames are resolved by searching the tree rather than assuming the repo root.

## Verification

Full gate green: `go build`, `vet`, `gofmt`, `go mod tidy`, `go test -race`, actionlint, sitegen drift. The new tests run inside the existing `go test ./...`, so no CI change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)