### PR TITLE
fix(check): follow sshd_config Include directives when parsing SSH config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ undo any fix with one command.
 | Domain | What it looks at | Needs |
 | --- | --- | --- |
 | **Docker / Compose** | Privileged mode, Docker socket mounts, exposed datastores and admin panels, host networking, unsafe bind mounts, missing no-new-privileges, hardcoded secrets, and more — a native audit of your Compose files | Docker |
-| **SSH** | Root login, password authentication, empty passwords, weak brute-force limits, X11 forwarding — parsed natively from `sshd_config` | — |
+| **SSH** | Root login, password authentication, empty passwords, weak brute-force limits, X11 forwarding — parsed natively from `sshd_config`, following `Include` into `sshd_config.d/` | — |
 | **Firewall** | Whether ufw, firewalld, or nftables is actually active | — |
 | **Auto-updates** | Whether unattended-upgrades (apt) or dnf-automatic (dnf) is enabled | — |
 | **Exposed services** | Host processes listening on a non-loopback address — the natively-installed database, admin panel, or app your Compose audit can't see, read from `ss` | `ss` |

--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -58,7 +58,7 @@
             <p><code>hostveil scan</code> exits non-zero when any unfixed finding is <span class="sev critical">Critical</span> or <span class="sev high">High</span> — useful as a CI or cron gate.</p>
 
             <h2 id="ssh">SSH <code>ssh.</code></h2>
-            <p>Parsed natively from <code>sshd_config</code>. Reading it needs root, which <code>hostveil</code> obtains by auto-elevating with <code>sudo</code>.</p>
+            <p>Parsed natively from <code>sshd_config</code>, following <code>Include</code> directives into <code>sshd_config.d/</code>. That matters on Debian and Ubuntu, which put the <code>Include</code> at the top of the file: <code>sshd</code> keeps the first value it obtains for each keyword, so a drop-in wins over the lines below it. Reading these needs root, which <code>hostveil</code> obtains by auto-elevating with <code>sudo</code>. A fix edits the file the winning directive actually lives in.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -58,7 +58,7 @@
             <p><code>hostveil scan</code>은 수정되지 않은 발견 항목 중 <span class="sev critical">심각</span> 또는 <span class="sev high">높음</span>이 하나라도 있으면 0이 아닌 값으로 종료합니다 — CI나 cron 게이트로 유용합니다.</p>
 
             <h2 id="ssh">SSH <code>ssh.</code></h2>
-            <p><code>sshd_config</code>에서 직접 파싱합니다. 읽으려면 root 권한이 필요하며, <code>hostveil</code>은 <code>sudo</code>로 자동 상승하여 이를 얻습니다.</p>
+            <p><code>sshd_config</code>에서 직접 파싱하며, <code>Include</code> 지시어를 따라 <code>sshd_config.d/</code>까지 읽습니다. Debian과 Ubuntu는 <code>Include</code>를 파일 맨 위에 두고, <code>sshd</code>는 각 키워드에 대해 처음 얻은 값을 사용하므로 drop-in 파일이 아래 줄들을 이깁니다. 읽으려면 root 권한이 필요하며, <code>hostveil</code>은 <code>sudo</code>로 자동 상승하여 이를 얻습니다. 수정은 실제로 적용되고 있는 지시어가 있는 파일에 가해집니다.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>

--- a/demo/provision.sh
+++ b/demo/provision.sh
@@ -45,15 +45,27 @@ if ! command -v trivy >/dev/null 2>&1; then
 fi
 trivy image --download-db-only 2>/dev/null || echo "   (trivy DB download skipped — CVE scan will fetch on first run)"
 
-echo "==> [5/10] weak SSH config (appended to the main sshd_config)"
-if ! grep -q "hostveil demo weak SSH" /etc/ssh/sshd_config; then
-  {
-    echo ""
-    echo "# --- hostveil demo weak SSH (intentionally insecure) ---"
-    cat "$DEMO/seed/sshd_hostveil.conf"
-  } >> /etc/ssh/sshd_config
+echo "==> [5/10] weak SSH config (a drop-in that outranks the image's own)"
+# The seed goes in sshd_config.d, not at the end of the main file, because
+# the main file loses. Ubuntu's sshd_config puts `Include
+# sshd_config.d/*.conf` at the top and sshd keeps the first value it
+# obtains for each keyword, so the cloud image's 50-cloud-init.conf and
+# 60-cloudimg-settings.conf — both of which set PasswordAuthentication no —
+# beat anything appended below. Appending is what this script used to do,
+# and it left ssh.passwordauth silently unreproducible.
+#
+# The 00- prefix sorts ahead of the image's drop-ins, so these win. That
+# also makes the demo exercise the checker's Include handling rather than
+# only its main-file parsing.
+install -m 0644 "$DEMO/seed/sshd_hostveil.conf" /etc/ssh/sshd_config.d/00-hostveil-demo.conf
+
+# Converge VMs provisioned by the older version of this script, which
+# appended the same settings to the main file and left them there.
+if grep -q "hostveil demo weak SSH" /etc/ssh/sshd_config; then
+  sed -i '/# --- hostveil demo weak SSH/,$d' /etc/ssh/sshd_config
 fi
-systemctl restart ssh || systemctl restart sshd || true
+
+sshd -t && (systemctl restart ssh || systemctl restart sshd || true)
 
 echo "==> [6/10] disable automatic security updates (so updates.disabled fires)"
 cat > /etc/apt/apt.conf.d/20auto-upgrades <<'EOF'

--- a/demo/seed/sshd_hostveil.conf
+++ b/demo/seed/sshd_hostveil.conf
@@ -1,8 +1,14 @@
 # Weak SSH settings a non-expert self-hoster might leave in place.
-# provision.sh appends this to /etc/ssh/sshd_config so hostveil's SSH
-# checker (which reads the main config) flags them:
-#   ssh.rootlogin, ssh.passwordauth, ssh.emptypasswords,
-#   ssh.x11forwarding, ssh.maxauthtries
+#
+# provision.sh installs this as /etc/ssh/sshd_config.d/00-hostveil-demo.conf.
+# The 00- prefix matters: sshd expands Include in sorted order and keeps the
+# first value it obtains for each keyword, so this has to sort ahead of the
+# cloud image's own drop-ins (50-cloud-init.conf, 60-cloudimg-settings.conf)
+# to take effect. Appending to the main sshd_config does not work — the
+# Include sits at the top of that file, so the drop-ins outrank it.
+#
+# Flags: ssh.rootlogin, ssh.passwordauth, ssh.emptypasswords,
+#        ssh.x11forwarding, ssh.maxauthtries
 PermitRootLogin yes
 PasswordAuthentication yes
 PermitEmptyPasswords yes

--- a/internal/check/ssh/ssh.go
+++ b/internal/check/ssh/ssh.go
@@ -9,9 +9,12 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/seolcu/hostveil/internal/check"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
 )
@@ -48,23 +51,86 @@ func (c *Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
 	return true, ""
 }
 
-// Check parses sshd_config and applies the hardening rules.
+// Check parses sshd_config and applies the hardening rules. Include files
+// that exist but cannot be read make the audit partial, not wrong: the
+// findings we did derive are real, but a directive in the unread file could
+// override any of them, so the domain is reported Degraded rather than
+// clean.
 func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, error) {
-	data, err := os.ReadFile(c.ConfigPath) //nolint:gosec // fixed system path
+	cfg, unread, err := parseConfigFile(c.ConfigPath)
 	if err != nil {
 		return nil, err
 	}
-	return auditConfig(parseConfig(data), c.ConfigPath), nil
+	findings := auditConfig(cfg, c.ConfigPath)
+	if len(unread) > 0 {
+		return findings, &check.PartialError{
+			Reason: "could not read included sshd config: " + strings.Join(unread, ", ") +
+				" — settings there may override what was scanned",
+			Covered: cfg.filesRead,
+			Total:   cfg.filesRead + len(unread),
+		}
+	}
+	return findings, nil
 }
 
-// parseConfig parses sshd_config into effective directive values. sshd
-// uses the first value obtained for each keyword, so we keep the first
-// occurrence. Match blocks introduce conditional overrides we cannot
-// evaluate statically, so parsing stops at the first Match.
-func parseConfig(data []byte) map[string]string {
-	cfg := map[string]string{}
+// sshdConfig is the effective configuration: the first value seen for each
+// keyword, plus the file that value came from. The origin matters as much
+// as the value — a fix has to edit the file that actually wins, not the
+// top-level sshd_config, or it writes a directive that stays overridden.
+type sshdConfig struct {
+	values    map[string]string
+	origin    map[string]string
+	filesRead int
+}
+
+// maxIncludeDepth mirrors OpenSSH's own nesting limit.
+const maxIncludeDepth = 16
+
+// parseConfigFile parses sshd_config, following Include directives, into
+// effective directive values. sshd uses the first value obtained for each
+// keyword and expands an Include in place, so a file included at the top —
+// which is how Debian and Ubuntu ship it, and how cloud images inject
+// their own defaults — wins over the lines below it. Reading only the
+// top-level file therefore both misses directives and reports ones that
+// are overridden.
+//
+// Match blocks introduce conditional overrides we cannot evaluate
+// statically, so parsing stops at the first Match, in whichever file it
+// appears. The returned slice names include files that matched a glob but
+// could not be read.
+func parseConfigFile(path string) (sshdConfig, []string, error) {
+	p := &includeParser{
+		baseDir: filepath.Dir(path),
+		cfg: sshdConfig{
+			values: map[string]string{},
+			origin: map[string]string{},
+		},
+		visited: map[string]bool{},
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // caller-supplied fixed system path
+	if err != nil {
+		return p.cfg, nil, err
+	}
+	p.visited[path] = true
+	p.cfg.filesRead++
+	p.parse(data, path, 0)
+	return p.cfg, p.unread, nil
+}
+
+type includeParser struct {
+	baseDir string
+	cfg     sshdConfig
+	visited map[string]bool
+	unread  []string
+	stopped bool // hit a Match block; everything after it is conditional
+}
+
+func (p *includeParser) parse(data []byte, path string, depth int) {
 	sc := bufio.NewScanner(bytes.NewReader(data))
 	for sc.Scan() {
+		if p.stopped {
+			return
+		}
 		line := strings.TrimSpace(sc.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -73,15 +139,68 @@ func parseConfig(data []byte) map[string]string {
 		if !ok {
 			continue
 		}
-		lkey := strings.ToLower(key)
-		if lkey == "match" {
-			break // stop at conditional blocks
-		}
-		if _, seen := cfg[lkey]; !seen {
-			cfg[lkey] = val
+		switch strings.ToLower(key) {
+		case "match":
+			p.stopped = true
+			return
+		case "include":
+			p.include(val, depth)
+		default:
+			p.set(strings.ToLower(key), val, path)
 		}
 	}
-	return cfg
+}
+
+func (p *includeParser) set(key, val, path string) {
+	if _, seen := p.cfg.values[key]; seen {
+		return // sshd keeps the first value obtained
+	}
+	p.cfg.values[key] = val
+	p.cfg.origin[key] = path
+}
+
+// include expands one Include directive in place. A directive may carry
+// several patterns; each is expanded in turn, and glob matches are read in
+// sorted order, which is the order sshd uses.
+func (p *includeParser) include(val string, depth int) {
+	if depth >= maxIncludeDepth {
+		return
+	}
+	for _, pattern := range strings.Fields(val) {
+		if !filepath.IsAbs(pattern) {
+			pattern = filepath.Join(p.baseDir, pattern)
+		}
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue // malformed pattern; sshd would reject the config outright
+		}
+		sort.Strings(matches)
+		for _, m := range matches {
+			if p.stopped {
+				return
+			}
+			p.readInto(m, depth)
+		}
+	}
+}
+
+func (p *includeParser) readInto(path string, depth int) {
+	if p.visited[path] {
+		return // cycle, or the same file reached by two patterns
+	}
+	p.visited[path] = true
+
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return // sshd ignores directories matched by a glob
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path came from the config's own Include glob
+	if err != nil {
+		p.unread = append(p.unread, path)
+		return
+	}
+	p.cfg.filesRead++
+	p.parse(data, path, depth+1)
 }
 
 func splitDirective(line string) (key, val string, ok bool) {
@@ -94,23 +213,34 @@ func splitDirective(line string) (key, val string, ok bool) {
 	return fields[0], strings.Join(fields[1:], " "), true
 }
 
-func effective(cfg map[string]string, key, def string) string {
-	if v, ok := cfg[strings.ToLower(key)]; ok {
+func effective(cfg sshdConfig, key, def string) string {
+	if v, ok := cfg.values[strings.ToLower(key)]; ok {
 		return strings.ToLower(v)
 	}
 	return def
 }
 
-func auditConfig(cfg map[string]string, path string) []model.Finding {
+// configFor names the file a fix must edit to change key. When the
+// directive is set, that is the file it is set in — editing anywhere else
+// leaves the winning value in place. When it is absent and the finding
+// rests on sshd's compiled-in default, the top-level file is the right
+// place to add it.
+func configFor(cfg sshdConfig, mainPath, key string) model.FindingOption {
+	if origin, ok := cfg.origin[strings.ToLower(key)]; ok {
+		return model.WithEvidence("config", origin)
+	}
+	return model.WithEvidence("config", mainPath)
+}
+
+func auditConfig(cfg sshdConfig, path string) []model.Finding {
 	var out []model.Finding
-	ev := model.WithEvidence("config", path)
 
 	if effective(cfg, "PermitRootLogin", "prohibit-password") == "yes" {
 		out = append(out, model.NewFinding("ssh.rootlogin", "SSH permits root login with a password",
 			model.SeverityHigh, model.SourceSSH, model.RemediationReview,
 			model.WithDescription("Allowing root to log in over SSH with a password makes the most powerful account a direct brute-force target. A single guessed password is a full host compromise."),
 			model.WithHowToFix("Set `PermitRootLogin prohibit-password` (key-only) or `no`, and log in as a normal user with sudo instead."),
-			ev))
+			configFor(cfg, path, "PermitRootLogin")))
 	}
 
 	if effective(cfg, "PermitEmptyPasswords", "no") == "yes" {
@@ -118,7 +248,7 @@ func auditConfig(cfg map[string]string, path string) []model.Finding {
 			model.SeverityCritical, model.SourceSSH, model.RemediationAuto,
 			model.WithDescription("Accounts with no password could be logged into by anyone. This is almost never intended and is trivially exploitable."),
 			model.WithHowToFix("Set `PermitEmptyPasswords no` in sshd_config."),
-			ev))
+			configFor(cfg, path, "PermitEmptyPasswords")))
 	}
 
 	if effective(cfg, "PasswordAuthentication", "yes") == "yes" {
@@ -126,7 +256,7 @@ func auditConfig(cfg map[string]string, path string) []model.Finding {
 			model.SeverityMedium, model.SourceSSH, model.RemediationReview,
 			model.WithDescription("Password logins are vulnerable to brute-force and credential-stuffing attacks that key-based authentication is immune to. Bots constantly scan the internet for SSH servers accepting passwords."),
 			model.WithHowToFix("Set up an SSH key, then set `PasswordAuthentication no`. Make sure your key works before disabling passwords so you do not lock yourself out."),
-			ev))
+			configFor(cfg, path, "PasswordAuthentication")))
 	}
 
 	if tries := atoiDefault(effective(cfg, "MaxAuthTries", "6"), 6); tries > 6 {
@@ -134,7 +264,7 @@ func auditConfig(cfg map[string]string, path string) []model.Finding {
 			model.SeverityLow, model.SourceSSH, model.RemediationAuto,
 			model.WithDescription("A high MaxAuthTries lets an attacker try many passwords per connection, speeding up brute-force attacks."),
 			model.WithHowToFix("Lower `MaxAuthTries` to 3 or 4."),
-			model.WithEvidence("value", strconv.Itoa(tries)), ev))
+			model.WithEvidence("value", strconv.Itoa(tries)), configFor(cfg, path, "MaxAuthTries")))
 	}
 
 	if effective(cfg, "X11Forwarding", "no") == "yes" {
@@ -142,7 +272,7 @@ func auditConfig(cfg map[string]string, path string) []model.Finding {
 			model.SeverityLow, model.SourceSSH, model.RemediationAuto,
 			model.WithDescription("X11 forwarding widens the attack surface and is rarely needed on a headless server."),
 			model.WithHowToFix("Set `X11Forwarding no` unless you specifically forward graphical applications."),
-			ev))
+			configFor(cfg, path, "X11Forwarding")))
 	}
 
 	return out

--- a/internal/check/ssh/ssh_test.go
+++ b/internal/check/ssh/ssh_test.go
@@ -2,13 +2,41 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/seolcu/hostveil/internal/check"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
 )
+
+// parseConfig parses a config from bytes with no Include resolution. The
+// rule tests below care about which directives win, not about file layout;
+// the Include tests use parseConfigFile against a real directory tree.
+func parseConfig(data []byte) sshdConfig {
+	p := &includeParser{
+		cfg:     sshdConfig{values: map[string]string{}, origin: map[string]string{}},
+		visited: map[string]bool{},
+	}
+	p.parse(data, "x", 0)
+	return p.cfg
+}
+
+// writeTree writes files (relative path → content) under dir.
+func writeTree(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, body := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
 
 func idsOf(fs []model.Finding) map[string]model.Finding {
 	m := map[string]model.Finding{}
@@ -74,6 +102,146 @@ Match User backup
 	got := idsOf(auditConfig(parseConfig([]byte(cfg)), "x"))
 	if _, ok := got["ssh.passwordauth"]; ok {
 		t.Error("top-level PasswordAuthentication no should win; Match block ignored")
+	}
+}
+
+// TestIncludedFileWinsOverMainFile is the false-negative half of the
+// Include bug: Debian and Ubuntu put the Include at the top of
+// sshd_config, so a drop-in that loosens a setting beats the hardened line
+// below it. Reading only the top-level file reports the host as clean.
+func TestIncludedFileWinsOverMainFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"sshd_config":               "Include sshd_config.d/*.conf\nPermitRootLogin no\n",
+		"sshd_config.d/90-lax.conf": "PermitRootLogin yes\n",
+	})
+	main := filepath.Join(dir, "sshd_config")
+	cfg, unread, err := parseConfigFile(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unread) != 0 {
+		t.Errorf("unexpected unread files: %v", unread)
+	}
+	got := idsOf(auditConfig(cfg, main))
+	f, ok := got["ssh.rootlogin"]
+	if !ok {
+		t.Fatal("PermitRootLogin yes in a drop-in should be flagged")
+	}
+	// The fix edits Evidence["config"]; pointing it at the main file would
+	// write a directive the drop-in keeps overriding.
+	want := filepath.Join(dir, "sshd_config.d/90-lax.conf")
+	if f.Evidence["config"] != want {
+		t.Errorf("finding points at %q, want the drop-in %q", f.Evidence["config"], want)
+	}
+}
+
+// TestMainFileWinsWhenItComesFirst is the same mechanism in reverse: an
+// Include below a directive cannot override it, because sshd keeps the
+// first value it obtains.
+func TestMainFileWinsWhenItComesFirst(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"sshd_config":               "PermitRootLogin no\nInclude sshd_config.d/*.conf\n",
+		"sshd_config.d/90-lax.conf": "PermitRootLogin yes\n",
+	})
+	main := filepath.Join(dir, "sshd_config")
+	cfg, _, err := parseConfigFile(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := idsOf(auditConfig(cfg, main))["ssh.rootlogin"]; ok {
+		t.Error("an Include below the directive must not override it")
+	}
+}
+
+// TestCloudImageDropInIsNotAFalsePositive is the false-positive half, and
+// the one that hits nearly every cloud VPS: the image ships
+// PasswordAuthentication no in a drop-in while the stock sshd_config below
+// still says yes.
+func TestCloudImageDropInIsNotAFalsePositive(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"sshd_config": "Include sshd_config.d/*.conf\nPasswordAuthentication yes\n",
+		"sshd_config.d/60-cloudimg-settings.conf": "PasswordAuthentication no\n",
+	})
+	main := filepath.Join(dir, "sshd_config")
+	cfg, _, err := parseConfigFile(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := idsOf(auditConfig(cfg, main))["ssh.passwordauth"]; ok {
+		t.Error("password auth disabled by a drop-in must not be reported as enabled")
+	}
+}
+
+// TestIncludeGlobOrderIsLexical pins the tie-break: sshd reads glob
+// matches in sorted order, so the lower-numbered file wins.
+func TestIncludeGlobOrderIsLexical(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"sshd_config":           "Include conf.d/*.conf\n",
+		"conf.d/10-first.conf":  "MaxAuthTries 3\n",
+		"conf.d/20-second.conf": "MaxAuthTries 99\n",
+	})
+	main := filepath.Join(dir, "sshd_config")
+	cfg, _, err := parseConfigFile(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := effective(cfg, "MaxAuthTries", "6"); got != "3" {
+		t.Errorf("MaxAuthTries = %q, want 3 from the lexically first file", got)
+	}
+}
+
+func TestIncludeHandlesCyclesAndMissingGlobs(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"sshd_config": "Include a.conf\nInclude empty.d/*.conf\n",
+		"a.conf":      "Include sshd_config\nPermitEmptyPasswords yes\n",
+	})
+	main := filepath.Join(dir, "sshd_config")
+	cfg, unread, err := parseConfigFile(main) // must terminate
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unread) != 0 {
+		t.Errorf("a glob matching nothing is normal, not unread: %v", unread)
+	}
+	if effective(cfg, "PermitEmptyPasswords", "no") != "yes" {
+		t.Error("directives after a cyclic Include should still be parsed")
+	}
+}
+
+// TestUnreadableIncludeIsPartial: a file we cannot read may contain a
+// directive that overrides anything we did read, so the domain is Degraded
+// rather than reported as a complete audit.
+func TestUnreadableIncludeIsPartial(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read mode-000 files")
+	}
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"sshd_config":           "Include conf.d/*.conf\nPermitRootLogin yes\n",
+		"conf.d/50-secret.conf": "PermitRootLogin no\n",
+	})
+	secret := filepath.Join(dir, "conf.d/50-secret.conf")
+	if err := os.Chmod(secret, 0o000); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Checker{ConfigPath: filepath.Join(dir, "sshd_config")}
+	fs, err := c.Check(context.Background(), platform.Env{})
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("expected a PartialError, got %v", err)
+	}
+	if partial.Covered >= partial.Total {
+		t.Errorf("coverage %d/%d does not report a gap", partial.Covered, partial.Total)
+	}
+	// Findings are kept: PartialError means incomplete, not failed.
+	if _, ok := idsOf(fs)["ssh.rootlogin"]; !ok {
+		t.Error("a partial audit should still return the findings it did derive")
 	}
 }
 

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -143,7 +143,7 @@
             <p><code>hostveil scan</code> exits non-zero when any unfixed finding is <span class="sev critical">Critical</span> or <span class="sev high">High</span> — useful as a CI or cron gate.</p>
 
             <h2 id="ssh">SSH <code>ssh.</code></h2>
-            <p>Parsed natively from <code>sshd_config</code>. Reading it needs root, which <code>hostveil</code> obtains by auto-elevating with <code>sudo</code>.</p>
+            <p>Parsed natively from <code>sshd_config</code>, following <code>Include</code> directives into <code>sshd_config.d/</code>. That matters on Debian and Ubuntu, which put the <code>Include</code> at the top of the file: <code>sshd</code> keeps the first value it obtains for each keyword, so a drop-in wins over the lines below it. Reading these needs root, which <code>hostveil</code> obtains by auto-elevating with <code>sudo</code>. A fix edits the file the winning directive actually lives in.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -143,7 +143,7 @@
             <p><code>hostveil scan</code>은 수정되지 않은 발견 항목 중 <span class="sev critical">심각</span> 또는 <span class="sev high">높음</span>이 하나라도 있으면 0이 아닌 값으로 종료합니다 — CI나 cron 게이트로 유용합니다.</p>
 
             <h2 id="ssh">SSH <code>ssh.</code></h2>
-            <p><code>sshd_config</code>에서 직접 파싱합니다. 읽으려면 root 권한이 필요하며, <code>hostveil</code>은 <code>sudo</code>로 자동 상승하여 이를 얻습니다.</p>
+            <p><code>sshd_config</code>에서 직접 파싱하며, <code>Include</code> 지시어를 따라 <code>sshd_config.d/</code>까지 읽습니다. Debian과 Ubuntu는 <code>Include</code>를 파일 맨 위에 두고, <code>sshd</code>는 각 키워드에 대해 처음 얻은 값을 사용하므로 drop-in 파일이 아래 줄들을 이깁니다. 읽으려면 root 권한이 필요하며, <code>hostveil</code>은 <code>sudo</code>로 자동 상승하여 이를 얻습니다. 수정은 실제로 적용되고 있는 지시어가 있는 파일에 가해집니다.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>


### PR DESCRIPTION
## Problem

`parseConfig` read only the top-level `sshd_config`. Debian and Ubuntu ship it with `Include /etc/ssh/sshd_config.d/*.conf` **at the top**, and sshd keeps the first value it obtains for each keyword — so a drop-in wins over everything below it.

That made the checker wrong in both directions:

- **False negative** — a drop-in loosening a setting was never seen.
- **False positive** — settings the image had already hardened were reported as weak. Cloud images ship exactly this: the demo VM carries `50-cloud-init.conf` and `60-cloudimg-settings.conf`, both setting `PasswordAuthentication no`, while the stock `sshd_config` below still says `yes`. hostveil reported password auth as enabled on what is probably the most common self-hosting setup there is.

A false positive costs more trust than a false negative here, because the operator checks and finds us wrong.

## Change

Parsing expands `Include` in place, glob matches sorted, with a visited set and OpenSSH's depth limit of 16. It still stops at the first `Match` block, in whichever file that appears. An include file that matches a glob but cannot be read returns a `check.PartialError` → the domain is **Degraded**, since a directive in the unread file could override anything that was scanned.

Findings now carry **the file the winning directive actually lives in**. This is not cosmetic: fixes edit `Evidence["config"]`, so pointing at the top-level file would write a directive the drop-in keeps overriding — apply would report success and change nothing.

The demo's own seed had the same bug and is fixed in the second commit: it appended the weak settings to the main file, where the cloud drop-ins outranked them, so `ssh.passwordauth` was never actually in force. It went unnoticed because the checker had the matching blind spot — the two bugs were covering for each other.

## Verification

On the demo VM, against `sshd -T` (sshd's own effective config) as ground truth:

| directive | `sshd -T` | hostveil |
| --- | --- | --- |
| permitemptypasswords | yes | flagged |
| permitrootlogin | yes | flagged |
| maxauthtries | 10 | flagged |
| x11forwarding | yes | flagged |
| passwordauthentication | **no** | **not flagged** (was a false positive) |

Origin targeting was checked end to end: with a drop-in setting `MaxAuthTries 12` outranking the main file's `10`, the fix preview targeted the drop-in, applying it moved `sshd -T` to `4`, and rollback restored `12`.

New tests cover a drop-in winning, the main file winning when it comes first, the cloud-image false positive, glob ordering, include cycles, empty globs, and an unreadable include producing a `PartialError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)