### PR TITLE
fix(check): skip hosts whose automatic updates cannot be verified

### DIFF
--- a/internal/check/updates/updates.go
+++ b/internal/check/updates/updates.go
@@ -6,6 +6,7 @@ package updates
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -27,13 +28,25 @@ func New() *Checker {
 // Source identifies the updates domain.
 func (*Checker) Source() model.Source { return model.SourceUpdates }
 
-// Available is always true; on an unrecognized package manager Check
-// simply reports nothing.
-func (*Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
-	return true, ""
+// Available requires a package manager whose auto-update mechanism this
+// checker knows how to verify. Anywhere else it reports a skip rather than
+// running: apk and pacman have no standard unattended-upgrade daemon to
+// look for, so "found nothing" would be indistinguishable from "did not
+// look" — and the two score identically while meaning opposite things.
+// A skip excludes the axis as N/A instead of awarding it full marks.
+func (*Checker) Available(_ context.Context, env platform.Env) (bool, string) {
+	switch env.PackageManager {
+	case platform.PMApt, platform.PMDnf:
+		return true, ""
+	case platform.PMUnknown:
+		return false, "no recognized package manager — cannot verify automatic updates"
+	default:
+		return false, "automatic-update checks cover apt and dnf hosts only — detected " + string(env.PackageManager)
+	}
 }
 
-// Check dispatches to the package-manager-specific verification.
+// Check dispatches to the package-manager-specific verification. Available
+// has already ruled out every other package manager.
 func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
 	switch env.PackageManager {
 	case platform.PMApt:
@@ -41,7 +54,7 @@ func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding,
 	case platform.PMDnf:
 		return c.auditDnf(ctx, env), nil
 	default:
-		return nil, nil // no supported auto-update mechanism to assess
+		return nil, fmt.Errorf("unsupported package manager %q: Available should have skipped this checker", env.PackageManager)
 	}
 }
 

--- a/internal/check/updates/updates_test.go
+++ b/internal/check/updates/updates_test.go
@@ -76,12 +76,46 @@ func TestDnfDisabled(t *testing.T) {
 	}
 }
 
-func TestUnknownPackageManagerNoFinding(t *testing.T) {
-	fs, err := New().Check(context.Background(), platform.Env{PackageManager: platform.PMUnknown})
-	if err != nil {
-		t.Fatal(err)
+// TestAvailableByPackageManager pins the distinction between "looked and
+// found nothing" and "could not look". Only apt and dnf have an
+// auto-update mechanism this checker knows how to verify; on anything else
+// it must skip so the axis is excluded as N/A, never scored as clean.
+func TestAvailableByPackageManager(t *testing.T) {
+	for _, tc := range []struct {
+		pm      platform.PackageManager
+		wantOK  bool
+		wantSub string
+	}{
+		{platform.PMApt, true, ""},
+		{platform.PMDnf, true, ""},
+		{platform.PMApk, false, "apk"},
+		{platform.PMPacman, false, "pacman"},
+		{platform.PMUnknown, false, "no recognized package manager"},
+	} {
+		ok, reason := New().Available(context.Background(), platform.Env{PackageManager: tc.pm})
+		if ok != tc.wantOK {
+			t.Errorf("%q: Available = %v, want %v", tc.pm, ok, tc.wantOK)
+		}
+		if ok && reason != "" {
+			t.Errorf("%q: available checker gave a skip reason %q", tc.pm, reason)
+		}
+		if !ok && !strings.Contains(reason, tc.wantSub) {
+			t.Errorf("%q: reason %q does not mention %q", tc.pm, reason, tc.wantSub)
+		}
 	}
-	if len(fs) != 0 {
-		t.Errorf("unknown package manager should yield no finding, got %v", fs)
+}
+
+// TestCheckRejectsUnsupportedPackageManager guards the invariant from the
+// other side: if Available ever stops filtering, Check must error (→ the
+// axis is excluded) rather than return nil findings (→ scored 100).
+func TestCheckRejectsUnsupportedPackageManager(t *testing.T) {
+	for _, pm := range []platform.PackageManager{platform.PMApk, platform.PMPacman, platform.PMUnknown} {
+		fs, err := New().Check(context.Background(), platform.Env{PackageManager: pm})
+		if err == nil {
+			t.Errorf("%q: Check returned nil error — a silent clean result", pm)
+		}
+		if len(fs) != 0 {
+			t.Errorf("%q: Check returned findings %v alongside the error", pm, fs)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

`Available()` returned `true` unconditionally and `Check()` returned no findings for any package manager that was not apt or dnf. The old doc comment said so outright:

> Available is always true; on an unrecognized package manager Check simply reports nothing.

On an Alpine, Arch, or openSUSE host that scored the updates axis a perfect **100**. "I could not look" rendered as "there is nothing there" — the scoring model treats those identically and they mean opposite things.

This is the invariant AGENTS.md states explicitly:

> A checker must never let "I couldn't look" pass for "nothing there." The two score identically and mean opposite things.

## Change

`Available()` now reports a skip with a reason for package managers whose auto-update mechanism this checker does not know how to verify, so the domain is recorded **Skipped** and the axis is excluded as **N/A** rather than scored. That is the existing skip path, so all three UIs already render it.

`Check()` errors on those instead of returning `nil, nil`, so the invariant holds from both sides if `Available` ever stops filtering.

No new detection: apk and pacman have no standard unattended-upgrade daemon to look for, so honestly reporting "not checked" is the whole fix.

`TestUnknownPackageManagerNoFinding` pinned the old behavior and is replaced by tests for both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)