### PR TITLE
feat(ui): show what changed since the last scan in the TUI and dashboard

### DIFF
--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -41,6 +41,7 @@ type appModel struct {
 	width, height int
 	mode          mode
 
+	delta         model.Delta // how this scan differs from the previous one
 	preview       model.FixPreview
 	previewAction int
 	status        string
@@ -71,7 +72,10 @@ func Run(engine *core.Engine) error {
 
 // --- messages ---
 
-type scannedMsg struct{ report model.Report }
+type scannedMsg struct {
+	report model.Report
+	delta  model.Delta
+}
 type previewMsg struct {
 	preview model.FixPreview
 	err     error
@@ -82,7 +86,10 @@ type appliedMsg struct {
 }
 
 func scanCmd(e *core.Engine) tea.Cmd {
-	return func() tea.Msg { return scannedMsg{report: e.Scan(context.Background(), nil)} }
+	return func() tea.Msg {
+		report := e.Scan(context.Background(), nil)
+		return scannedMsg{report: report, delta: e.LastDelta()}
+	}
 }
 
 func previewCmd(e *core.Engine, f model.Finding) tea.Cmd {
@@ -142,6 +149,7 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case scannedMsg:
 		m.report = msg.report
+		m.delta = msg.delta
 		m.selected = map[string]bool{} // a fresh scan invalidates old picks
 		m.rebuildActive()
 		m.offset = 0

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -480,3 +480,26 @@ func TestNonReversibleCheckpointOffersNoRollback(t *testing.T) {
 		t.Errorf("unexpected status: %q", am.status)
 	}
 }
+
+// TestDeltaLineRendersOnlyWhenSomethingMoved: the engine computes a delta
+// on every scan, but a first scan has nothing to compare against, and a
+// scan that changed nothing should not add a line saying so.
+func TestDeltaLineRendersOnlyWhenSomethingMoved(t *testing.T) {
+	m := &appModel{engine: nil, mode: modeList}
+	m = send(m, tea.WindowSizeMsg{Width: 100, Height: 40}).(*appModel)
+
+	m = send(m, scannedMsg{report: sampleReport()}).(*appModel)
+	if strings.Contains(m.View().Content, "since last scan") {
+		t.Error("a scan with no delta should not render a since-last-scan line")
+	}
+
+	prev := sampleReport().Findings[0]
+	m = send(m, scannedMsg{
+		report: sampleReport(),
+		delta:  model.Delta{Resolved: []model.Finding{prev}, StillPresent: 2},
+	}).(*appModel)
+	view := m.View().Content
+	if !strings.Contains(view, "since last scan") || !strings.Contains(view, "1 resolved") {
+		t.Errorf("expected a since-last-scan summary naming 1 resolved:\n%s", view)
+	}
+}

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -111,7 +111,32 @@ func (m *appModel) header() string {
 	b.WriteString("\n")
 	b.WriteString(m.axesLine())
 	b.WriteString("\n")
+	if line := m.deltaLine(); line != "" {
+		b.WriteString(line + "\n")
+	}
 	return b.String()
+}
+
+// deltaLine summarises what moved since the previous scan. The CLI prints
+// the same counts and then names the findings; here it stays one line —
+// the list below already shows what is outstanding, and the question this
+// answers is only "did the last round of fixes help?". Nothing is rendered
+// when there is no previous scan to compare against.
+func (m *appModel) deltaLine() string {
+	if !m.delta.HasChanges() {
+		return ""
+	}
+	var parts []string
+	if n := len(m.delta.Resolved); n > 0 {
+		parts = append(parts, styleSafe.Render(fmt.Sprintf("✓ %d resolved", n)))
+	}
+	if n := len(m.delta.New); n > 0 {
+		parts = append(parts, lipgloss.NewStyle().Foreground(cHigh).Render(fmt.Sprintf("+ %d new", n)))
+	}
+	if n := len(m.delta.Changed); n > 0 {
+		parts = append(parts, styleBone.Render(fmt.Sprintf("~ %d changed", n)))
+	}
+	return styleDim.Render("since last scan  ") + strings.Join(parts, styleDim.Render("   "))
 }
 
 func (m *appModel) axesLine() string {

--- a/internal/ui/web/assets/app.css
+++ b/internal/ui/web/assets/app.css
@@ -80,6 +80,15 @@ button:disabled { opacity: .45; cursor: default; }
 .domains .dom-err { color: var(--crit); }
 .domains .dom-skip { color: var(--slate); }
 
+/* ── since-last-scan summary ── */
+.delta { flex: 0 0 auto; padding: 8px 18px; border-bottom: 1px solid var(--line);
+  font-size: 12px; display: flex; flex-wrap: wrap; gap: 4px 16px; }
+.delta .delta-label { color: var(--slate); text-transform: uppercase; font-size: 10px;
+  letter-spacing: 1px; align-self: center; }
+.delta .delta-good { color: var(--safe); }
+.delta .delta-new { color: var(--high); }
+.delta .delta-chg { color: var(--bone); }
+
 /* ── transient status line ── */
 .status { flex: 0 0 auto; margin: 0; padding: 9px 18px; border-bottom: 1px solid var(--line);
   color: var(--safe); font-size: 12px; }

--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -160,6 +160,30 @@ async function applyBatch() {
 // dashboard renders a score built from a partial scan exactly like one built
 // from a complete scan — the CVE axis reading a confident 100 because Trivy
 // could not reach a single image is the case that motivated it.
+// renderDelta summarises what moved since the previous scan. The CLI prints
+// the same counts and then names the findings; here it stays one line — the
+// list below already shows what is outstanding, and the question this
+// answers is only "did the last round of fixes help?". Hidden when there is
+// no previous scan to compare against.
+function renderDelta() {
+  const box = document.getElementById("delta");
+  const d = report.delta || {};
+  const resolved = (d.resolved || []).length;
+  const added = (d.new || []).length;
+  const changed = (d.changed || []).length;
+  if (!resolved && !added && !changed) {
+    box.hidden = true;
+    box.replaceChildren();
+    return;
+  }
+  const parts = [el("span", { class: "delta-label" }, "Since last scan")];
+  if (resolved) parts.push(el("span", { class: "delta-good" }, `✓ ${resolved} resolved`));
+  if (added) parts.push(el("span", { class: "delta-new" }, `+ ${added} new`));
+  if (changed) parts.push(el("span", { class: "delta-chg" }, `~ ${changed} changed`));
+  box.hidden = false;
+  box.replaceChildren(...parts);
+}
+
 function renderDomainNotice() {
   const box = document.getElementById("domains");
   const bad = (report.domains || []).filter((d) => d.state !== SCAN_DONE);
@@ -204,6 +228,7 @@ function render() {
     )
   );
 
+  renderDelta();
   renderDomainNotice();
 
   // Findings list.

--- a/internal/ui/web/assets/index.html
+++ b/internal/ui/web/assets/index.html
@@ -18,6 +18,7 @@
   </div>
 
   <div class="axes" id="axes"></div>
+  <div class="delta" id="delta" hidden></div>
   <div class="domains" id="domains" hidden></div>
   <div class="status" id="status" hidden></div>
 

--- a/internal/ui/web/server.go
+++ b/internal/ui/web/server.go
@@ -126,14 +126,24 @@ func hostFromURL(u string) string {
 
 // --- handlers ---
 
+// resultPayload is the dashboard's view of a scan: the report, plus how it
+// differs from the one before it. The engine already computes the delta on
+// every scan; without this the dashboard would throw away the one thing
+// that tells an operator whether their last round of fixes helped. Report
+// is embedded so its JSON stays flat and the shape only gains a field.
+type resultPayload struct {
+	model.Report
+	Delta model.Delta `json:"delta"`
+}
+
 func (s *Server) handleResult(w http.ResponseWriter, _ *http.Request) {
 	report, _ := s.engine.Current()
-	writeJSON(w, report)
+	writeJSON(w, resultPayload{Report: report, Delta: s.engine.LastDelta()})
 }
 
 func (s *Server) handleRescan(w http.ResponseWriter, r *http.Request) {
 	report := s.engine.Scan(r.Context(), nil)
-	writeJSON(w, report)
+	writeJSON(w, resultPayload{Report: report, Delta: s.engine.LastDelta()})
 }
 
 func (s *Server) handlePreview(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/web/server_test.go
+++ b/internal/ui/web/server_test.go
@@ -285,3 +285,41 @@ func TestDashboardServed(t *testing.T) {
 		t.Error("missing CSP header")
 	}
 }
+
+// TestResultCarriesDelta: the dashboard has to be able to answer "did my
+// last round of fixes help?", which means the engine's delta must survive
+// the trip through the API rather than being dropped as it used to be.
+func TestResultCarriesDelta(t *testing.T) {
+	s, _ := testServer(t)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	for _, path := range []string{"/api/result", "/api/rescan"} {
+		var payload struct {
+			Findings []model.Finding `json:"findings"`
+			Delta    *model.Delta    `json:"delta"`
+		}
+		var resp *http.Response
+		var err error
+		if path == "/api/rescan" {
+			resp, err = http.Post(srv.URL+path, "application/json", nil)
+		} else {
+			resp, err = http.Get(srv.URL + path)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = json.NewDecoder(resp.Body).Decode(&payload)
+		resp.Body.Close()
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		if payload.Delta == nil {
+			t.Errorf("%s: response carries no delta field", path)
+		}
+		// Embedding must not have disturbed the existing flat shape.
+		if len(payload.Findings) == 0 {
+			t.Errorf("%s: findings disappeared from the payload", path)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The engine computes a delta on every scan and `Engine.LastDelta()` has always been public, but only the CLI rendered it. The TUI's `r` rescan and the dashboard's `POST /api/rescan` both discarded it — so the one question an operator asks after fixing things ("did that help?") was answerable in one interface out of three.

## Change

Both now show a one-line summary near the score header: resolved / new / changed. The CLI keeps naming the individual findings; in the TUI and web the list below already shows what is outstanding, so the counts are the useful part. Nothing renders when there is no previous scan to compare against.

No layering change was needed — `LastDelta()` is on `core`, so `internal/ui/{tui,web}/layering_test.go` is untouched.

The web payload embeds `model.Report` so its JSON stays flat and the shape only gains a `delta` field; a test asserts both that the field arrives and that `findings` did not move.

Verified on the demo VM: the CLI, the TUI, and `/api/result` report the same counts for the same pair of scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)