### PR TITLE
fix(core): show newline-only changes and elide distant context in fix previews

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,6 +1,14 @@
 // Package diff produces a compact unified diff between two texts. Fixes
 // make small, localized edits, so a straightforward LCS-based diff is both
 // correct and readable in previews.
+//
+// The output is the last thing an operator reads before authorizing a write
+// to a file like /etc/ssh/sshd_config, which makes two properties matter
+// more than they would in a general-purpose diff. It must show every byte
+// the apply would change — a change the preview cannot render is consent
+// obtained on a false basis. And it must show little else: a one-line edit
+// to a several-hundred-line compose file that echoes the whole file buries
+// the very line being authorized.
 package diff
 
 import (
@@ -8,27 +16,44 @@ import (
 	"strings"
 )
 
+// contextLines is how many unchanged lines surround each change. Three is
+// the conventional unified-diff default and is enough to locate an edit in
+// a config file without reproducing it.
+const contextLines = 3
+
+// noNewline is the standard marker for a final line with no line ending.
+// Without it a missing trailing newline is invisible: both sides split to
+// the same lines, the diff renders as pure context, and the operator is
+// asked to approve a change they cannot see while applyEdit writes
+// different bytes.
+const noNewline = "\\ No newline at end of file"
+
 // Unified returns a unified diff of a→b labeled with path. It returns the
 // empty string when the inputs are identical.
 func Unified(path, a, b string) string {
 	if a == b {
 		return ""
 	}
-	al := splitLines(a)
-	bl := splitLines(b)
+	al, aHasEOL := splitLines(a)
+	bl, bHasEOL := splitLines(b)
 	ops := lcsDiff(al, bl)
+
+	// When the sides differ only in whether the final line is terminated,
+	// every line matches and the LCS emits nothing but context. Split that
+	// final equal line into a delete and an add so each side can carry its
+	// own marker, which is what git does for the same case.
+	if aHasEOL != bHasEOL && len(ops) > 0 {
+		if last := ops[len(ops)-1]; last.kind == opEqual {
+			ops = append(ops[:len(ops)-1],
+				op{kind: opDel, line: last.line, aLine: last.aLine},
+				op{kind: opAdd, line: last.line, bLine: last.bLine})
+		}
+	}
 
 	var out strings.Builder
 	fmt.Fprintf(&out, "--- %s\n+++ %s\n", path, path)
-	for _, op := range ops {
-		switch op.kind {
-		case opEqual:
-			fmt.Fprintf(&out, " %s\n", op.line)
-		case opDel:
-			fmt.Fprintf(&out, "-%s\n", op.line)
-		case opAdd:
-			fmt.Fprintf(&out, "+%s\n", op.line)
-		}
+	for _, h := range hunks(ops) {
+		writeHunk(&out, ops[h.start:h.end], len(al), len(bl), aHasEOL, bHasEOL)
 	}
 	return out.String()
 }
@@ -42,16 +67,117 @@ const (
 )
 
 type op struct {
-	kind opKind
-	line string
+	kind  opKind
+	line  string
+	aLine int // 1-based line number in a; 0 for an addition
+	bLine int // 1-based line number in b; 0 for a deletion
 }
 
-func splitLines(s string) []string {
-	s = strings.TrimSuffix(s, "\n")
+func (o op) changed() bool { return o.kind != opEqual }
+
+// splitLines splits s into lines and reports whether it ended with a
+// newline. The terminator is not part of the last line, but whether it was
+// there is a real difference between two texts, so it is returned rather
+// than discarded. The empty string has no final line to be unterminated,
+// so it reports true.
+func splitLines(s string) (lines []string, hasEOL bool) {
 	if s == "" {
-		return nil
+		return nil, true
 	}
-	return strings.Split(s, "\n")
+	if hasEOL = strings.HasSuffix(s, "\n"); hasEOL {
+		s = s[:len(s)-1]
+	}
+	return strings.Split(s, "\n"), hasEOL
+}
+
+// hunkRange is a half-open range of ops forming one hunk.
+type hunkRange struct{ start, end int }
+
+// hunks groups changed ops into hunks, each padded by contextLines of
+// surrounding equal lines. Ranges that would touch or overlap are merged,
+// so two edits three lines apart render as one hunk rather than two that
+// repeat the same context.
+func hunks(ops []op) []hunkRange {
+	var out []hunkRange
+	for i := 0; i < len(ops); {
+		if !ops[i].changed() {
+			i++
+			continue
+		}
+		// Walk forward absorbing later changes while the equal run between
+		// them is short enough that two hunks would repeat context anyway.
+		last := i
+		for j := i + 1; j < len(ops); j++ {
+			if !ops[j].changed() {
+				continue
+			}
+			if j-last-1 > 2*contextLines {
+				break
+			}
+			last = j
+		}
+		out = append(out, hunkRange{
+			start: max(0, i-contextLines),
+			end:   min(len(ops), last+1+contextLines),
+		})
+		i = last + 1
+	}
+	return out
+}
+
+// writeHunk emits one hunk: the @@ header naming both line ranges, then the
+// lines. A no-newline marker follows the final line of whichever side lacks
+// a terminator.
+func writeHunk(out *strings.Builder, ops []op, aTotal, bTotal int, aHasEOL, bHasEOL bool) {
+	aStart, aCount, bStart, bCount := hunkBounds(ops)
+	fmt.Fprintf(out, "@@ -%s +%s @@\n", rangeSpec(aStart, aCount), rangeSpec(bStart, bCount))
+
+	for _, o := range ops {
+		switch o.kind {
+		case opEqual:
+			fmt.Fprintf(out, " %s\n", o.line)
+		case opDel:
+			fmt.Fprintf(out, "-%s\n", o.line)
+		case opAdd:
+			fmt.Fprintf(out, "+%s\n", o.line)
+		}
+		// The marker belongs to the side whose last line this is. An equal
+		// line is the last of both, and reaches here only when the two
+		// sides agree about the terminator.
+		lastOfA := o.kind != opAdd && o.aLine == aTotal
+		lastOfB := o.kind != opDel && o.bLine == bTotal
+		if (lastOfA && !aHasEOL) || (lastOfB && !bHasEOL) {
+			fmt.Fprintf(out, "%s\n", noNewline)
+		}
+	}
+}
+
+// hunkBounds returns the 1-based start and the line count for each side.
+// A side contributing no lines gets start 0, which is the unified-diff
+// convention for an empty range.
+func hunkBounds(ops []op) (aStart, aCount, bStart, bCount int) {
+	for _, o := range ops {
+		if o.kind != opAdd {
+			if aStart == 0 {
+				aStart = o.aLine
+			}
+			aCount++
+		}
+		if o.kind != opDel {
+			if bStart == 0 {
+				bStart = o.bLine
+			}
+			bCount++
+		}
+	}
+	return aStart, aCount, bStart, bCount
+}
+
+func rangeSpec(start, count int) string {
+	if count == 1 {
+		return fmt.Sprintf("%d", start)
+	}
+	return fmt.Sprintf("%d,%d", start, count)
 }
 
 // lcsDiff computes edit operations via a longest-common-subsequence DP.
@@ -77,22 +203,22 @@ func lcsDiff(a, b []string) []op {
 	for i < n && j < m {
 		switch {
 		case a[i] == b[j]:
-			ops = append(ops, op{opEqual, a[i]})
+			ops = append(ops, op{kind: opEqual, line: a[i], aLine: i + 1, bLine: j + 1})
 			i++
 			j++
 		case dp[i+1][j] >= dp[i][j+1]:
-			ops = append(ops, op{opDel, a[i]})
+			ops = append(ops, op{kind: opDel, line: a[i], aLine: i + 1})
 			i++
 		default:
-			ops = append(ops, op{opAdd, b[j]})
+			ops = append(ops, op{kind: opAdd, line: b[j], bLine: j + 1})
 			j++
 		}
 	}
 	for ; i < n; i++ {
-		ops = append(ops, op{opDel, a[i]})
+		ops = append(ops, op{kind: opDel, line: a[i], aLine: i + 1})
 	}
 	for ; j < m; j++ {
-		ops = append(ops, op{opAdd, b[j]})
+		ops = append(ops, op{kind: opAdd, line: b[j], bLine: j + 1})
 	}
 	return ops
 }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,456 @@
+package diff
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This diff is the last thing an operator reads before authorizing hostveil to
+// write to files like /etc/ssh/sshd_config, so its output is a security
+// surface, not cosmetics: a preview that omits a line the apply would write, or
+// shows one it would not, hands the operator a false basis for consent. These
+// tests pin the exact rendered bytes rather than substring-matching, because
+// "the diff mentions PermitRootLogin somewhere" is not the property that
+// matters — "the diff is precisely the change" is.
+//
+// Note on the format: Unified emits ---/+++ file headers, then one @@ header
+// per hunk with three lines of surrounding context, eliding equal runs
+// between hunks. An unterminated final line is marked. Both were once
+// missing, and both were correctness problems rather than cosmetic ones: the
+// unmarked newline made a real change invisible to the operator approving
+// it, and echoing every line buried a one-line edit in the file it lived in.
+
+func TestUnified(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want string
+	}{
+		{
+			// The empty string is the contract fixflow.go leans on: previewMode
+			// exists precisely because a no-op edit renders as "" and callers
+			// treat that as "nothing would change".
+			name: "identical inputs yield no diff",
+			a:    "PermitRootLogin yes\n",
+			b:    "PermitRootLogin yes\n",
+			want: "",
+		},
+		{
+			name: "identical empty inputs yield no diff",
+			a:    "",
+			b:    "",
+			want: "",
+		},
+		{
+			name: "pure insertion keeps surrounding lines as context",
+			a:    "one\ntwo\n",
+			b:    "one\ninserted\ntwo\n",
+			want: "--- f\n+++ f\n@@ -1,2 +1,3 @@\n one\n+inserted\n two\n",
+		},
+		{
+			name: "pure deletion",
+			a:    "one\ngone\ntwo\n",
+			b:    "one\ntwo\n",
+			want: "--- f\n+++ f\n@@ -1,3 +1,2 @@\n one\n-gone\n two\n",
+		},
+		{
+			// A replaced line is a delete followed by an add, in that order:
+			// lcsDiff breaks the LCS tie toward deletion (dp[i+1][j] >=
+			// dp[i][j+1]). Order matters for readability — the operator reads
+			// "was X, now Y", not the reverse — so it is pinned.
+			name: "replacement renders as delete then add",
+			a:    "PermitRootLogin yes\n",
+			b:    "PermitRootLogin no\n",
+			want: "--- f\n+++ f\n@@ -1 +1 @@\n-PermitRootLogin yes\n+PermitRootLogin no\n",
+		},
+		{
+			// The realistic sshd_config case: one directive changes inside an
+			// otherwise untouched file.
+			name: "single directive changed in a larger file",
+			a:    "Port 22\nPermitRootLogin yes\nPasswordAuthentication yes\n",
+			b:    "Port 22\nPermitRootLogin no\nPasswordAuthentication yes\n",
+			want: "--- f\n+++ f\n@@ -1,3 +1,3 @@\n Port 22\n-PermitRootLogin yes\n+PermitRootLogin no\n PasswordAuthentication yes\n",
+		},
+		{
+			name: "empty original renders as all additions",
+			a:    "",
+			b:    "alpha\nbeta\n",
+			want: "--- f\n+++ f\n@@ -0,0 +1,2 @@\n+alpha\n+beta\n",
+		},
+		{
+			name: "empty replacement renders as all deletions",
+			a:    "alpha\nbeta\n",
+			b:    "",
+			want: "--- f\n+++ f\n@@ -1,2 +0,0 @@\n-alpha\n-beta\n",
+		},
+		{
+			// splitLines strips exactly one trailing newline, so both sides
+			// produce the same line slice and the LCS sees no change. The
+			// final line is therefore forced apart into a delete and an add
+			// so the marker can say which side lost its terminator — what
+			// git does for the same case. See the dedicated test below.
+			name: "trailing newline only difference renders both sides",
+			a:    "alpha\n",
+			b:    "alpha",
+			want: "--- f\n+++ f\n@@ -1 +1 @@\n-alpha\n+alpha\n\\ No newline at end of file\n",
+		},
+		{
+			// Only the *last* newline is stripped, so a blank final line is a
+			// real, visible line in the diff.
+			name: "blank line is a content line",
+			a:    "alpha\n\n",
+			b:    "alpha\n",
+			want: "--- f\n+++ f\n@@ -1,2 +1 @@\n alpha\n-\n",
+		},
+		{
+			// Two changes separated by four unchanged lines. Splitting here
+			// would emit two hunks whose context overlapped, repeating the
+			// middle lines, so they merge into one instead.
+			name: "changes closer than twice the context share one hunk",
+			a:    "a\nk1\nk2\nk3\nk4\nb\n",
+			b:    "A\nk1\nk2\nk3\nk4\nB\n",
+			want: "--- f\n+++ f\n@@ -1,6 +1,6 @@\n-a\n+A\n k1\n k2\n k3\n k4\n-b\n+B\n",
+		},
+		{
+			name: "wholly disjoint texts",
+			a:    "x\ny\n",
+			b:    "p\nq\n",
+			want: "--- f\n+++ f\n@@ -1,2 +1,2 @@\n-x\n-y\n+p\n+q\n",
+		},
+		{
+			// Repeated lines are where a naive diff drifts: the LCS must match
+			// through the common run rather than deleting and re-adding it.
+			// Equality is tested before the LCS tie-break, so the walk consumes
+			// matches greedily and the deletion lands at the end of the run.
+			name: "repeated lines match through the common run",
+			a:    "dup\ndup\ndup\n",
+			b:    "dup\ndup\n",
+			want: "--- f\n+++ f\n@@ -1,3 +1,2 @@\n dup\n dup\n-dup\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Unified("f", tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("Unified(%q, %q, %q) mismatch\n got: %q\nwant: %q", "f", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnifiedLabelsBothSidesWithPath pins the header, because the path is the
+// operator's only confirmation of *which* file is about to be written. A fix
+// preview showing the right change against the wrong file is worse than no
+// preview.
+func TestUnifiedHeaderNamesTheFile(t *testing.T) {
+	got := Unified("/etc/ssh/sshd_config", "a\n", "b\n")
+	const wantPrefix = "--- /etc/ssh/sshd_config\n+++ /etc/ssh/sshd_config\n"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("header missing or malformed:\n%s", got)
+	}
+}
+
+// TestUnifiedNewlineOnlyChangeIsVisible pins the fix for a preview that
+// used to lie. splitLines drops the trailing newline, so a transform whose
+// only effect was adding or removing the file's final newline produced a
+// diff with a header and nothing but context: non-empty, so fixflow treated
+// it as "there is a change to review", yet showing the operator zero +/-
+// lines to review — while applyEdit wrote the differing bytes. The preview
+// and the write disagreed. Both sides of the change must now be visible and
+// the missing terminator stated.
+func TestUnifiedNewlineOnlyChangeIsVisible(t *testing.T) {
+	for _, tc := range []struct{ name, a, b string }{
+		{"newline added", "PermitRootLogin no", "PermitRootLogin no\n"},
+		{"newline removed", "PermitRootLogin no\n", "PermitRootLogin no"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Unified("/etc/ssh/sshd_config", tc.a, tc.b)
+			if got == "" {
+				t.Fatal("expected a non-empty diff for differing inputs")
+			}
+			var changed int
+			for _, line := range strings.Split(got, "\n") {
+				if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+					continue
+				}
+				if strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") {
+					changed++
+				}
+			}
+			if changed != 2 {
+				t.Errorf("expected the line to render on both sides, got %d changed lines:\n%s", changed, got)
+			}
+			if !strings.Contains(got, noNewline) {
+				t.Errorf("the missing final newline is not stated:\n%s", got)
+			}
+		})
+	}
+}
+
+// TestUnifiedElidesDistantContext is the other half of the preview being
+// readable: a one-line edit to a long file must show the edit and its
+// neighbourhood, not the whole file. Before hunking, authorizing a single
+// change to a several-hundred-line compose file meant reading the entire
+// file back with one line marked.
+func TestUnifiedElidesDistantContext(t *testing.T) {
+	var a, b strings.Builder
+	for i := range 200 {
+		a.WriteString(fmt.Sprintf("line%d\n", i))
+		if i == 100 {
+			b.WriteString("changed\n")
+			continue
+		}
+		b.WriteString(fmt.Sprintf("line%d\n", i))
+	}
+	got := Unified("big.conf", a.String(), b.String())
+
+	body := strings.Split(strings.TrimRight(got, "\n"), "\n")[2:]
+	// One @@ header, 2*contextLines of context, one '-' and one '+'.
+	if want := 1 + 2*contextLines + 2; len(body) != want {
+		t.Errorf("hunk should be %d lines, got %d:\n%s", want, len(body), got)
+	}
+	if !strings.Contains(got, "@@ -98,7 +98,7 @@") {
+		t.Errorf("hunk header does not locate the change at line 101:\n%s", got)
+	}
+	if strings.Contains(got, "line5\n") {
+		t.Errorf("distant context was not elided:\n%s", got)
+	}
+}
+
+// TestUnifiedSeparatesDistantChanges: two edits far apart get their own
+// hunks, so neither is buried in the other's context.
+func TestUnifiedSeparatesDistantChanges(t *testing.T) {
+	var a, b strings.Builder
+	for i := range 100 {
+		a.WriteString(fmt.Sprintf("line%d\n", i))
+		switch i {
+		case 10, 80:
+			b.WriteString(fmt.Sprintf("changed%d\n", i))
+		default:
+			b.WriteString(fmt.Sprintf("line%d\n", i))
+		}
+	}
+	got := Unified("big.conf", a.String(), b.String())
+	if n := strings.Count(got, "@@ -"); n != 2 {
+		t.Errorf("expected 2 hunks for 2 distant changes, got %d:\n%s", n, got)
+	}
+}
+
+// TestUnifiedHandlesLargeInputs guards against the quadratic LCS table blowing
+// up on a realistically sized config. sshd_config is ~120 lines; docker-compose
+// files can be several hundred. This is a smoke test for termination and shape,
+// not a benchmark.
+func TestUnifiedLargeInput(t *testing.T) {
+	var a, b strings.Builder
+	for i := range 2000 {
+		a.WriteString("line\n")
+		if i == 1000 {
+			b.WriteString("changed\n")
+			continue
+		}
+		b.WriteString("line\n")
+	}
+	got := Unified("big.conf", a.String(), b.String())
+	if strings.Count(got, "\n+changed") != 1 {
+		t.Errorf("expected exactly one added line, got:\n%s", got[:min(len(got), 400)])
+	}
+}
+
+// FuzzUnified asserts the property that makes a preview trustworthy: the diff
+// must be a faithful, lossless rendering of both texts. Because Unified emits
+// every line (no hunks, no elided context), the reconstruction is exact at line
+// granularity — the ' ' and '-' lines rebuild the original, the ' ' and '+'
+// lines rebuild the modification.
+//
+// The one documented lossiness is the trailing newline: splitLines strips it,
+// so reconstruction is compared against splitLines' output rather than against
+// the raw strings. That weaker form is still the meaningful invariant — it
+// catches any line that is dropped, duplicated, reordered, or attributed to the
+// wrong side, which is the whole class of "the preview lied" failures.
+func FuzzUnified(f *testing.F) {
+	f.Add("PermitRootLogin yes\n", "PermitRootLogin no\n")
+	f.Add("", "")
+	f.Add("a\nb\nc\n", "a\nc\n")
+	f.Add("a\nb\n", "a\nb")
+	f.Add("dup\ndup\ndup\n", "dup\n")
+	f.Add("\n\n\n", "\n")
+	f.Add("x", "")
+
+	f.Fuzz(func(t *testing.T, a, b string) {
+		got := Unified("p", a, b)
+
+		if got == "" {
+			if a != b {
+				t.Fatalf("empty diff for differing inputs: %q vs %q", a, b)
+			}
+			return
+		}
+		if a == b {
+			t.Fatalf("non-empty diff for identical inputs %q:\n%s", a, got)
+		}
+
+		// The rendered body always ends in "\n", so Split leaves one trailing
+		// empty element. An empty *content* line renders as " ", never "", so
+		// only that final element is spurious.
+		lines := strings.Split(got, "\n")
+		if lines[len(lines)-1] != "" {
+			t.Fatalf("diff does not end in a newline: %q", got)
+		}
+		lines = lines[:len(lines)-1]
+
+		if len(lines) < 2 || lines[0] != "--- p" || lines[1] != "+++ p" {
+			t.Fatalf("malformed header: %q", got)
+		}
+
+		// Now that equal runs are elided, the body no longer reconstructs the
+		// whole file — so the property checked is the one that actually makes
+		// a hunk trustworthy: every hunk's own line numbers must locate it
+		// exactly, and its ' '/'-' lines must be the original's lines at that
+		// offset, its ' '/'+' lines the modification's. A hunk that renders
+		// real lines at the wrong place is as misleading as a missing one.
+		aLines, _ := splitLines(a)
+		bLines, _ := splitLines(b)
+
+		var hunkCount int
+		var claims []*hunkClaim
+		var cur *hunkClaim
+		flush := func() {
+			if cur == nil {
+				return
+			}
+			cur.verify(t, aLines, bLines, got)
+			claims = append(claims, cur)
+			cur = nil
+		}
+		for _, line := range lines[2:] {
+			if strings.HasPrefix(line, "@@ ") {
+				flush()
+				hunkCount++
+				cur = parseHunkHeader(t, line, got)
+				continue
+			}
+			if cur == nil {
+				t.Fatalf("body line %q before any @@ header in:\n%s", line, got)
+			}
+			if line == noNewline {
+				cur.sawMarker = true
+				continue
+			}
+			if line == "" {
+				t.Fatalf("body line with no marker prefix: %q", got)
+			}
+			switch line[0] {
+			case ' ':
+				cur.a = append(cur.a, line[1:])
+				cur.b = append(cur.b, line[1:])
+			case '-':
+				cur.a = append(cur.a, line[1:])
+			case '+':
+				cur.b = append(cur.b, line[1:])
+			default:
+				t.Fatalf("body line with unknown marker %q in:\n%s", line[0], got)
+			}
+		}
+		flush()
+
+		if hunkCount == 0 {
+			t.Fatalf("differing inputs produced no hunk:\n%s", got)
+		}
+		// A missing terminator must be stated whenever the line it belongs to
+		// is actually on screen, or the operator approves bytes the diff never
+		// showed. It must NOT be stated otherwise: when the change is far from
+		// the end of the file, the unterminated last line is elided as distant
+		// context and there is nothing for the marker to attach to.
+		_, aEOL := splitLines(a)
+		_, bEOL := splitLines(b)
+		wantMarker := (!aEOL && rendersLastLine(claims, "a", len(aLines))) ||
+			(!bEOL && rendersLastLine(claims, "b", len(bLines)))
+		if hasMarker := strings.Contains(got, noNewline); hasMarker != wantMarker {
+			t.Fatalf("no-newline marker present=%v, want %v:\n%s", hasMarker, wantMarker, got)
+		}
+	})
+}
+
+// hunkClaim is one @@ header plus the lines rendered under it: what the
+// diff claims about a region of each file.
+type hunkClaim struct {
+	aStart, aCount int
+	bStart, bCount int
+	a, b           []string
+	sawMarker      bool
+}
+
+func parseHunkHeader(t *testing.T, line, whole string) *hunkClaim {
+	t.Helper()
+	m := regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@$`).FindStringSubmatch(line)
+	if m == nil {
+		t.Fatalf("malformed hunk header %q in:\n%s", line, whole)
+	}
+	num := func(s string, def int) int {
+		if s == "" {
+			return def
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			t.Fatalf("bad number %q in header %q", s, line)
+		}
+		return n
+	}
+	return &hunkClaim{
+		aStart: num(m[1], 0), aCount: num(m[2], 1),
+		bStart: num(m[3], 0), bCount: num(m[4], 1),
+	}
+}
+
+// rendersLastLine reports whether any hunk's range for the given side
+// reaches the file's final line.
+func rendersLastLine(claims []*hunkClaim, side string, total int) bool {
+	for _, h := range claims {
+		start, count := h.aStart, h.aCount
+		if side == "b" {
+			start, count = h.bStart, h.bCount
+		}
+		if count > 0 && start-1+count == total {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *hunkClaim) verify(t *testing.T, aLines, bLines []string, whole string) {
+	t.Helper()
+	check := func(side string, start, count int, got, file []string) {
+		if len(got) != count {
+			t.Fatalf("%s: header claims %d lines but %d rendered in:\n%s", side, count, len(got), whole)
+		}
+		if count == 0 {
+			return
+		}
+		if start < 1 || start-1+count > len(file) {
+			t.Fatalf("%s: hunk range %d,%d is outside the %d-line file in:\n%s",
+				side, start, count, len(file), whole)
+		}
+		if !equalLines(got, file[start-1:start-1+count]) {
+			t.Fatalf("%s: hunk at %d,%d renders %q but the file has %q in:\n%s",
+				side, start, count, got, file[start-1:start-1+count], whole)
+		}
+	}
+	check("original", h.aStart, h.aCount, h.a, aLines)
+	check("modified", h.bStart, h.bCount, h.b, bLines)
+}
+
+func equalLines(x, y []string) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	for i := range x {
+		if x[i] != y[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -199,12 +199,12 @@ func TestUnifiedNewlineOnlyChangeIsVisible(t *testing.T) {
 func TestUnifiedElidesDistantContext(t *testing.T) {
 	var a, b strings.Builder
 	for i := range 200 {
-		a.WriteString(fmt.Sprintf("line%d\n", i))
+		fmt.Fprintf(&a, "line%d\n", i)
 		if i == 100 {
 			b.WriteString("changed\n")
 			continue
 		}
-		b.WriteString(fmt.Sprintf("line%d\n", i))
+		fmt.Fprintf(&b, "line%d\n", i)
 	}
 	got := Unified("big.conf", a.String(), b.String())
 
@@ -226,12 +226,12 @@ func TestUnifiedElidesDistantContext(t *testing.T) {
 func TestUnifiedSeparatesDistantChanges(t *testing.T) {
 	var a, b strings.Builder
 	for i := range 100 {
-		a.WriteString(fmt.Sprintf("line%d\n", i))
+		fmt.Fprintf(&a, "line%d\n", i)
 		switch i {
 		case 10, 80:
-			b.WriteString(fmt.Sprintf("changed%d\n", i))
+			fmt.Fprintf(&b, "changed%d\n", i)
 		default:
-			b.WriteString(fmt.Sprintf("line%d\n", i))
+			fmt.Fprintf(&b, "line%d\n", i)
 		}
 	}
 	got := Unified("big.conf", a.String(), b.String())

--- a/internal/diff/testdata/fuzz/FuzzUnified/ff20a239587c2f52
+++ b/internal/diff/testdata/fuzz/FuzzUnified/ff20a239587c2f52
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("1\n\n\n\n1")
+string("\n\n\n1")

--- a/internal/docs/findings_test.go
+++ b/internal/docs/findings_test.go
@@ -1,0 +1,148 @@
+package docs
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The docs table in content/{en,ko}/docs/checks.html is the enumeration of
+// every finding hostveil can report, and cmd/sitegen's TestDocumentedFixKinds
+// MatchTheRegistry already pins each documented row against the fix registry.
+// But it iterates the *documented* rows, so it can only check findings the
+// table already lists. A checker that starts emitting a new ID and nobody
+// adds a row stays invisible to every guard in the repo: the docs test never
+// looks at it, the fix registry never has to declare a position on it, and
+// the finding ships undocumented with whatever remediation the checker
+// happened to declare.
+//
+// This test closes that loop from the other end — it harvests the IDs the
+// checkers actually construct and requires each to be documented. Together
+// the two make the chain complete: emitted → documented → registry position.
+
+// findingID matches a namespaced finding ID. The namespace must be one of
+// the real sources, so incidental dotted strings in the check packages
+// (config filenames, config keys like net.bindIp) do not masquerade as IDs.
+var findingID = regexp.MustCompile(`^(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent)\.[a-z0-9][a-z0-9.\-]*$`)
+
+// composeRuleID matches compose's bare rule IDs, which reach NewFinding
+// through a helper that prefixes them: f("ds016", …) → "compose.ds016".
+var composeRuleID = regexp.MustCompile(`^(ds|dr)\d+$`)
+
+// emittedFindingIDs walks internal/check and collects every finding ID the
+// checkers can construct from a string literal.
+func emittedFindingIDs(t *testing.T) []string {
+	t.Helper()
+	root := filepath.Join(repoRoot(t), "internal", "check")
+	seen := map[string]bool{}
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		file, perr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", path, perr)
+		}
+		isCompose := file.Name.Name == "compose"
+
+		// Any namespaced string literal counts, wherever it sits. Keying off
+		// an argument position was tried and was wrong: IDs reach the
+		// constructor as arg 0 (model.NewFinding), as arg 1 (ports'
+		// exposedFinding helper), through a local (agent's id, title, desc
+		// := …), and through a table field (agent's danger rules). The
+		// namespace prefix is what actually identifies a finding ID, and
+		// over-collecting only ever demands a doc row for something that
+		// looks like a finding — the safe direction to err in.
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := stringLit(n)
+			if !ok {
+				return true
+			}
+			switch {
+			case findingID.MatchString(lit):
+				seen[lit] = true
+			case isCompose && composeRuleID.MatchString(lit):
+				seen["compose."+lit] = true // f("ds016", …) → compose.ds016
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk internal/check: %v", err)
+	}
+
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+func stringLit(n ast.Node) (string, bool) {
+	lit, ok := n.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// documentedFindingIDs reads the IDs listed in the English checks page. The
+// two languages are already pinned against each other by
+// TestBothLanguagesDocumentTheSameFindings, so one is enough here.
+func documentedFindingIDs(t *testing.T) []string {
+	t.Helper()
+	page := readRepoFile(t, filepath.Join("cmd", "sitegen", "content", "en", "docs", "checks.html"))
+	rows := regexp.MustCompile(`<tr><td><code>([a-z0-9.\-]+)</code></td>`).FindAllStringSubmatch(page, -1)
+	if len(rows) == 0 {
+		t.Fatal("no finding rows parsed from the checks page; the table markup changed")
+	}
+	var ids []string
+	for _, r := range rows {
+		ids = append(ids, r[1])
+	}
+	slices.Sort(ids)
+	return slices.Compact(ids)
+}
+
+// TestEveryEmittedFindingIsDocumented is the guard the repo was missing: a
+// finding a checker can report but the table does not list.
+func TestEveryEmittedFindingIsDocumented(t *testing.T) {
+	documented := documentedFindingIDs(t)
+	for _, id := range emittedFindingIDs(t) {
+		if !slices.Contains(documented, id) {
+			t.Errorf("checkers can emit %s but cmd/sitegen/content/{en,ko}/docs/checks.html does not "+
+				"list it — an undocumented finding also escapes the docs-vs-fix-registry check", id)
+		}
+	}
+}
+
+// TestDocumentedFindingsAreStillEmitted is the same guard pointing the other
+// way: a row for a finding no checker constructs any more is a promise the
+// tool no longer keeps. It is a softer failure than the reverse, so it names
+// the retired ID rather than guessing whether the row or the checker is
+// wrong. It also keeps the harvest itself honest: the two tests together
+// assert set equality, so a checker that starts building IDs in a shape the
+// walk cannot see fails here rather than silently shrinking coverage.
+func TestDocumentedFindingsAreStillEmitted(t *testing.T) {
+	emitted := emittedFindingIDs(t)
+	for _, id := range documentedFindingIDs(t) {
+		if !slices.Contains(emitted, id) {
+			t.Errorf("the checks table documents %s but no checker constructs it — "+
+				"either the row is stale or the ID was renamed", id)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`internal/diff` had **no tests at all** (0% coverage) despite producing the only preview an operator sees before authorizing a write to files like `/etc/ssh/sshd_config`. Writing them surfaced two real defects.

**1. A newline-only change rendered as an empty diff.** `splitLines` dropped the trailing newline, so a transform whose only effect was adding or removing a file's final newline produced a header and nothing but context lines. `fixflow` treats non-empty as "there is a change to review", so the operator was asked to approve a change showing zero `+`/`-` lines — while `applyEdit` wrote the differing bytes anyway. **The preview and the write disagreed.**

**2. The output was not a unified diff.** No `@@` headers, no context window, every line of the file echoed. A one-line fix to a 121-line `sshd_config` rendered 123 lines of preview, burying the change being authorized. It also could not be consumed by `patch(1)`, which matters because `history.Checkpoint.Diff` stores this string.

## Change

`splitLines` now reports whether the text was terminated, and a side that was not gets the standard `\ No newline at end of file` marker — forcing the final line apart into a delete and an add so each side can carry its own, which is what git does for the same case. It also fixes `"\n"` splitting to `nil` instead of one empty line.

Output is now real unified diff: `@@` headers with three lines of context, eliding equal runs, merging hunks whose context would overlap. The same 121-line `sshd_config` fix previews in **11 lines** instead of 123.

No UI changes needed — the TUI's `renderDiff` and the web's `diffPre` colorize by prefix, so `@@` and `\` lines fall through to the context style.

## Tests

`internal/diff` goes from **0% to 100%** coverage. The table pins exact bytes, since "the diff mentions PermitRootLogin somewhere" is not the property that matters.

The fuzz target's old whole-file reconstruction property no longer holds now that equal runs are elided, so it checks a stronger one: **every hunk's line numbers must locate it exactly**, and its rendered lines must match the file at that offset. A hunk showing real lines in the wrong place misleads as badly as a missing one. 3.6M executions clean.

Fuzzing found one case during development that turned out to be an over-strong assertion rather than a code bug — when the change is far from the end of the file, the unterminated last line is correctly elided and there is nothing for the marker to attach to. The assertion now requires the marker exactly when the line it belongs to is on screen. That input is kept as regression corpus.

## Also included

A second commit adds a guard the repo was missing. `cmd/sitegen`'s `TestDocumentedFixKindsMatchTheRegistry` pins each documented finding against the fix registry, but it iterates the *documented* rows — so a checker that starts emitting a new ID and nobody adds a row stays invisible to every guard here, shipping with no recorded position on whether it should be fixable. The new test harvests the IDs the checkers construct and requires each to be documented, and the reverse; together the two assert set equality, so a checker that starts building IDs in a shape the walk cannot see fails loudly rather than silently shrinking coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)