### PR TITLE
fix(check): detect firewalld by exit status and recognize iptables-only hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ undo any fix with one command.
 | --- | --- | --- |
 | **Docker / Compose** | Privileged mode, Docker socket mounts, exposed datastores and admin panels, host networking, unsafe bind mounts, missing no-new-privileges, hardcoded secrets, and more — a native audit of your Compose files | Docker |
 | **SSH** | Root login, password authentication, empty passwords, weak brute-force limits, X11 forwarding — parsed natively from `sshd_config`, following `Include` into `sshd_config.d/` | — |
-| **Firewall** | Whether ufw, firewalld, or nftables is actually active | — |
+| **Firewall** | Whether ufw, firewalld, nftables, or iptables is actually active | — |
 | **Auto-updates** | Whether unattended-upgrades (apt) or dnf-automatic (dnf) is enabled | — |
 | **Exposed services** | Host processes listening on a non-loopback address — the natively-installed database, admin panel, or app your Compose audit can't see, read from `ss` | `ss` |
 | **Accounts** | Non-root accounts with root's UID (0) and login accounts with an empty password, parsed from `/etc/passwd` and `/etc/shadow` | root (for `/etc/shadow`) |

--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -102,7 +102,7 @@
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
-                  <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, or nftables)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                 </tbody>
               </table>
             </div>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -102,7 +102,7 @@
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
-                  <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, 또는 nftables)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                 </tbody>
               </table>
             </div>

--- a/internal/check/agent/agent_test.go
+++ b/internal/check/agent/agent_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/check/firewall"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
 )
@@ -42,9 +43,15 @@ func (f fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte,
 }
 
 // noFirewall reports every firewall front-end as absent, which Probe reads as
-// a definite StatusInactive rather than "could not look".
+// a definite StatusInactive rather than "could not look". The list comes from
+// the firewall package so adding a probe there cannot silently turn these
+// fixtures into "unreadable" and change what the tests assert.
 func noFirewall() map[string]bool {
-	return map[string]bool{"ufw": true, "firewall-cmd": true, "nft": true}
+	missing := map[string]bool{}
+	for _, t := range firewall.ProbedTools {
+		missing[t] = true
+	}
+	return missing
 }
 
 func envNoFirewall(ss string) platform.Env {

--- a/internal/check/firewall/firewall.go
+++ b/internal/check/firewall/firewall.go
@@ -103,12 +103,28 @@ func probe(ctx context.Context, r platform.CommandRunner) (Status, string) {
 	}); st == StatusActive {
 		return st, which
 	}
-	if st, which := query("firewall-cmd", "firewalld", []string{"--state"}, func(s string) bool {
-		return strings.Contains(s, "running")
-	}); st == StatusActive {
-		return st, which
+	// firewalld is detected by exit status, not by the text of `--state`.
+	// The command exits 0 when the daemon is running and non-zero when it is
+	// not, which is the only signal stable across versions: some print
+	// "running" to stdout, others to stderr, and Run captures stdout only.
+	// Matching the text therefore read a running firewalld as absent on every
+	// host of the second kind — a High finding on a firewalled machine.
+	if platform.Has(r, "firewall-cmd") {
+		if _, err := r.Run(ctx, "firewall-cmd", "--state"); err != nil {
+			unreadable = true
+		} else {
+			return StatusActive, "firewalld"
+		}
 	}
 	if st, which := query("nft", "nftables", []string{"list", "ruleset"}, hasHostFirewall); st == StatusActive {
+		return st, which
+	}
+	// iptables last, and only as a fallback: on a modern host the nft backend
+	// already reported the same rules above. It matters for a host still on
+	// iptables-persistent with no nft binary, which every probe above misses —
+	// so a correctly firewalled machine was told it had no firewall at all,
+	// and the ports checker simultaneously stopped treating it as shielded.
+	if st, which := query("iptables", "iptables", []string{"-S", "INPUT"}, hasDropPolicy); st == StatusActive {
 		return st, which
 	}
 
@@ -145,9 +161,31 @@ func hasHostFirewall(out string) bool {
 	return false
 }
 
+// hasDropPolicy reports whether `iptables -S INPUT` shows a default-deny
+// INPUT policy. Only the chain policy counts: individual ACCEPT rules say
+// nothing about what happens to traffic that matches none of them, and a
+// policy of ACCEPT means everything not explicitly dropped gets through.
+func hasDropPolicy(out string) bool {
+	for _, line := range strings.Split(strings.ToLower(out), "\n") {
+		switch strings.TrimSpace(line) {
+		case "-p input drop", "-p input reject":
+			return true
+		}
+	}
+	return false
+}
+
+// ProbedTools names every binary probe consults. It is exported because the
+// ports and agent checkers both call Probe, and their tests need to build a
+// host with no firewall at all. Hardcoding the list in each of those packages
+// meant that adding a probe here silently turned their "no firewall" fixtures
+// into "firewall state unreadable", changing what they asserted without
+// changing what they said.
+var ProbedTools = []string{"ufw", "firewall-cmd", "nft", "iptables"}
+
 func availableTools(r platform.CommandRunner) []string {
 	var tools []string
-	for _, t := range []string{"ufw", "firewall-cmd", "nft"} {
+	for _, t := range ProbedTools {
 		if platform.Has(r, t) {
 			tools = append(tools, t)
 		}

--- a/internal/check/firewall/firewall_test.go
+++ b/internal/check/firewall/firewall_test.go
@@ -139,6 +139,49 @@ func TestFirewallUnreadableIsNotReportedAsAbsent(t *testing.T) {
 	}
 }
 
+// TestFirewalldDetectedWhenStateGoesToStderr guards the false positive where
+// a running firewalld was reported as no firewall at all. Older firewalld
+// prints "running" to stderr, and the runner captures stdout only, so the
+// text match saw an empty string. Exit status is the stable signal.
+func TestFirewalldDetectedWhenStateGoesToStderr(t *testing.T) {
+	r := fakeRunner{
+		present: map[string]bool{"firewall-cmd": true},
+		outputs: map[string]string{"firewall-cmd --state": ""}, // exits 0, says nothing on stdout
+	}
+	if n := countFindings(t, r); n != 0 {
+		t.Errorf("firewalld running with empty stdout must count as active, got %d findings", n)
+	}
+}
+
+// TestIptablesOnlyHostIsNotFlagged guards the false positive on a host still
+// using iptables-persistent: ufw, firewalld and nft are all absent, but INPUT
+// defaults to DROP, so the host is firewalled and must not be accused.
+func TestIptablesOnlyHostIsNotFlagged(t *testing.T) {
+	r := fakeRunner{
+		present: map[string]bool{"iptables": true},
+		outputs: map[string]string{
+			"iptables -S INPUT": "-P INPUT DROP\n-A INPUT -i lo -j ACCEPT\n-A INPUT -p tcp --dport 22 -j ACCEPT\n",
+		},
+	}
+	if n := countFindings(t, r); n != 0 {
+		t.Errorf("an iptables INPUT DROP policy is a host firewall, got %d findings", n)
+	}
+}
+
+// An ACCEPT policy is the opposite: allow rules say nothing about traffic
+// that matches none of them, so the host is still open.
+func TestIptablesAcceptPolicyIsStillFlagged(t *testing.T) {
+	r := fakeRunner{
+		present: map[string]bool{"iptables": true},
+		outputs: map[string]string{
+			"iptables -S INPUT": "-P INPUT ACCEPT\n-A INPUT -p tcp --dport 22 -j ACCEPT\n",
+		},
+	}
+	if n := countFindings(t, r); n != 1 {
+		t.Errorf("an iptables ACCEPT policy is not a firewall; want 1 finding, got %d", n)
+	}
+}
+
 // "Cannot tell" and "definitely absent" must stay distinct: a host with no
 // firewall tooling at all is still a confident Inactive.
 func TestFirewallProbeStatuses(t *testing.T) {
@@ -163,6 +206,17 @@ func TestFirewallProbeStatuses(t *testing.T) {
 			present: map[string]bool{"ufw": true, "nft": true},
 			outputs: map[string]string{"ufw status": "Status: active\n"},
 		}, StatusActive},
+		{"firewalld installed but unreadable", fakeRunner{
+			present: map[string]bool{"firewall-cmd": true},
+		}, StatusUnknown},
+		{"iptables answers drop", fakeRunner{
+			present: map[string]bool{"iptables": true},
+			outputs: map[string]string{"iptables -S INPUT": "-P INPUT DROP\n"},
+		}, StatusActive},
+		{"iptables answers accept", fakeRunner{
+			present: map[string]bool{"iptables": true},
+			outputs: map[string]string{"iptables -S INPUT": "-P INPUT ACCEPT\n"},
+		}, StatusInactive},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/check/ports/ports_test.go
+++ b/internal/check/ports/ports_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/check/firewall"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
 )
@@ -34,6 +35,18 @@ func (f fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte,
 		return []byte(out), nil
 	}
 	return nil, errors.New("no output for: " + key)
+}
+
+// noFirewall builds a runner for a host with no firewall tooling at all, so
+// firewall.Probe returns a confident Inactive rather than StatusUnknown. It
+// reads the tool list from the firewall package so adding a probe there can
+// never silently change what these tests assert.
+func noFirewall(ss string) fakeRunner {
+	missing := map[string]bool{}
+	for _, t := range firewall.ProbedTools {
+		missing[t] = true
+	}
+	return fakeRunner{ss: ss, missing: missing}
 }
 
 func findByID(fs []model.Finding, id string) (model.Finding, bool) {
@@ -136,7 +149,7 @@ func TestGenericExposedOnlyWithoutFirewall(t *testing.T) {
 LISTEN 0 128 0.0.0.0:8080 0.0.0.0:* users:(("myapp",pid=7,fd=3))`
 
 	// No firewall active -> the generic exposure finding appears (SSH excluded).
-	noFW := fakeRunner{ss: ss, missing: map[string]bool{"ufw": true, "firewall-cmd": true, "nft": true}}
+	noFW := noFirewall(ss)
 	fs, err := New().Check(context.Background(), platform.Env{Runner: noFW})
 	if err != nil {
 		t.Fatal(err)
@@ -170,7 +183,7 @@ func TestZoneScopedLoopbackIgnored(t *testing.T) {
 	// A zone-scoped IPv6 loopback ([::1%lo]) is host-only and must not be
 	// reported as network-exposed.
 	ss := `LISTEN 0 128 [::1%lo]:6379 [::]:* users:(("redis-server",pid=9,fd=6))`
-	fs, err := New().Check(context.Background(), platform.Env{Runner: fakeRunner{ss: ss, missing: map[string]bool{"ufw": true, "firewall-cmd": true, "nft": true}}})
+	fs, err := New().Check(context.Background(), platform.Env{Runner: noFirewall(ss)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +212,7 @@ func findByIDok(fs []model.Finding, id string) bool {
 
 func TestMalformedLinesSkipped(t *testing.T) {
 	ss := "garbage line without enough fields\nLISTEN\n\n"
-	fs, err := New().Check(context.Background(), platform.Env{Runner: fakeRunner{ss: ss, missing: map[string]bool{"ufw": true, "firewall-cmd": true, "nft": true}}})
+	fs, err := New().Check(context.Background(), platform.Env{Runner: noFirewall(ss)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -187,7 +187,7 @@
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
-                  <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, or nftables)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                 </tbody>
               </table>
             </div>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -187,7 +187,7 @@
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
-                  <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, 또는 nftables)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
Two probe defects on the firewall axis (cap 12, the second-largest in the model), one in each direction.

## False positive: firewalld reported as absent

`probe` decided firewalld was running by matching `running` in the **stdout** of `firewall-cmd --state`. Some versions write that to stderr, and `CommandRunner.Run` captures stdout only — so on those hosts the probe matched against an empty string and returned `StatusInactive`. A correctly firewalled machine got a High `firewall.inactive` finding.

Exit status is the signal that's stable across versions and streams: the command exits 0 when the daemon is running.

## False positive: iptables-only hosts

The probe knew ufw, firewalld and nft. A host still on `iptables-persistent` with `-P INPUT DROP` and no `nft` binary was reported as having no firewall — and because `internal/check/ports` treats an active firewall as a backstop, it *also* stopped suppressing `ports.exposed` on that host. One missing probe, two wrong findings.

`iptables` is probed last: on a modern host the nft backend has already reported the same ruleset. Only the chain policy counts — allow rules say nothing about traffic matching none of them, so `-P INPUT ACCEPT` is still flagged.

## Test fixtures that lied

`ports` and `agent` both call `firewall.Probe`, and each hardcoded the front-end list in its own "no firewall" fixture. Adding the iptables probe turned those fixtures into *"firewall state unreadable"* — so they silently began asserting something other than what their names said. `TestGatewayExposureSeverityMatrix` failed with `severity = high, want critical` for exactly this reason.

The list is now exported as `firewall.ProbedTools` and both fixtures read it, so the next probe can't repeat this.

## Verification

Both fixes mutation-tested — reverting either makes the new tests fail:

| mutation | fails |
|---|---|
| drop the iptables probe | `TestIptablesOnlyHostIsNotFlagged`, `TestFirewallProbeStatuses/iptables_answers_drop` |
| firewalld back to stdout text match | `TestFirewalldDetectedWhenStateGoesToStderr` |

Full gate green: `go build`/`vet`/`gofmt`/`go mod tidy`/`go test -race ./...`, golangci-lint v2.12.2 **0 issues**, sitegen regenerated (README + `checks.html` en/ko now say iptables).

Not yet verified on the demo VM — the VM is apt/ufw, so neither path is reachable there. Both are covered by unit tests against the fake runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)