### PR TITLE
feat(check): flag container ports that bypass an active ufw firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ undo any fix with one command.
 | --- | --- | --- |
 | **Docker / Compose** | Privileged mode, Docker socket mounts, exposed datastores and admin panels, host networking, unsafe bind mounts, missing no-new-privileges, hardcoded secrets, and more — a native audit of your Compose files | Docker |
 | **SSH** | Root login, password authentication, empty passwords, weak brute-force limits, X11 forwarding — parsed natively from `sshd_config`, following `Include` into `sshd_config.d/` | — |
-| **Firewall** | Whether ufw, firewalld, nftables, or iptables is actually active | — |
+| **Firewall** | Whether ufw, firewalld, nftables, or iptables is actually active — and whether published container ports are quietly bypassing it | — |
 | **Auto-updates** | Whether unattended-upgrades (apt) or dnf-automatic (dnf) is enabled | — |
 | **Exposed services** | Host processes listening on a non-loopback address — the natively-installed database, admin panel, or app your Compose audit can't see, read from `ss` | `ss` |
 | **Accounts** | Non-root accounts with root's UID (0) and login accounts with an empty password, parsed from `/etc/passwd` and `/etc/shadow` | root (for `/etc/shadow`) |

--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -103,6 +103,7 @@
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
                   <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>firewall.docker-bypass</code></td><td>Published container ports are reachable despite an active ufw</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
                 </tbody>
               </table>
             </div>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -103,6 +103,7 @@
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
                   <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>firewall.docker-bypass</code></td><td>ufw가 켜져 있는데도 publish된 컨테이너 포트가 외부에서 접근 가능</td><td><span class="sev critical">심각</span></td><td>수동</td></tr>
                 </tbody>
               </table>
             </div>

--- a/internal/check/firewall/docker.go
+++ b/internal/check/firewall/docker.go
@@ -1,0 +1,188 @@
+package firewall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// defaultDaemonConfig is where the Docker daemon reads its options.
+const defaultDaemonConfig = "/etc/docker/daemon.json"
+
+// publishedPortRE matches the host side of a public port mapping in
+// `docker ps` output: "0.0.0.0:6379->6379/tcp" and its IPv6 twin
+// ":::6379->6379/tcp". A mapping published to 127.0.0.1 is deliberately not
+// matched — it is reachable only from the host, so no firewall is being
+// bypassed.
+var publishedPortRE = regexp.MustCompile(`(?:0\.0\.0\.0|\[::\]|::):(\d+)->`)
+
+// checkDockerBypass reports container ports that are reachable from the
+// network even though ufw is active.
+//
+// Docker publishes a port by writing DNAT into nat/PREROUTING and an accept
+// rule into the filter table's DOCKER chain. Both are traversed before ufw's
+// rules in the INPUT chain, so `ufw deny 6379` has no effect on a container
+// started with `-p 6379:6379`. The port is open to the internet while every
+// tool the operator would think to check reports the firewall as active.
+//
+// This is the single most common real exposure on a self-hosted Docker host,
+// and until this check existed hostveil actively rewarded it: an active ufw
+// scored the firewall axis full marks, and the ports checker suppresses its
+// generic exposure finding precisely because a firewall is up. A host with
+// Postgres open to the world scored better than one with no firewall and
+// nothing running.
+//
+// It reports nothing unless every condition holds, because a Critical finding
+// that fires on a correctly configured host is worse than none:
+//
+//   - ufw is the active firewall. firewalld and plain nftables interact with
+//     Docker differently and the ufw-docker remediation does not apply.
+//   - at least one container publishes a port to a non-loopback address.
+//   - the DOCKER-USER chain is empty, i.e. the operator has not already
+//     installed the ufw-docker rules that close this.
+//   - Docker is managing iptables at all. With "iptables": false in
+//     daemon.json it adds no rules and ufw governs normally.
+func checkDockerBypass(ctx context.Context, r platform.CommandRunner, daemonConfig string) ([]model.Finding, error) {
+	if ok, _ := platform.DockerReachable(ctx, r); !ok {
+		return nil, nil
+	}
+	if dockerIptablesDisabled(daemonConfig) {
+		return nil, nil
+	}
+
+	published, err := publishedPorts(ctx, r)
+	if err != nil || len(published) == 0 {
+		return nil, err
+	}
+
+	// Whether the operator already closed this is the one thing we cannot
+	// guess. Claiming the bypass without reading DOCKER-USER would accuse
+	// every host that has already applied ufw-docker.
+	mitigated, err := dockerUserChainFiltered(ctx, r)
+	if err != nil {
+		return nil, &check.PartialError{
+			Reason: "cannot read the DOCKER-USER firewall chain — re-run with sudo to check whether published container ports bypass ufw",
+		}
+	}
+	if mitigated {
+		return nil, nil
+	}
+
+	list := describePorts(published)
+	return []model.Finding{
+		model.NewFinding("firewall.docker-bypass", "Container ports bypass the ufw firewall",
+			model.SeverityCritical, model.SourceFirewall, model.RemediationManual,
+			model.WithDescription("ufw is active, but Docker publishes container ports by writing its own rules ahead of ufw's. Traffic to a published port is accepted before ufw ever sees it, so `ufw deny` on these ports does nothing and they are reachable from any network this host is on — including the internet, on a VPS. The firewall looks correct in `ufw status` while these ports are open."),
+			model.WithHowToFix("Either publish only to loopback (`-p 127.0.0.1:6379:6379`, or `ports: [\"127.0.0.1:6379:6379\"]` in Compose) and reach the service over an SSH tunnel or VPN, or install the ufw-docker rules in /etc/ufw/after.rules so the DOCKER-USER chain enforces your ufw policy. Published ports: "+list+"."),
+			model.WithEvidence("published", list),
+			model.WithEvidence("firewall", "ufw"),
+		),
+	}, nil
+}
+
+// dockerIptablesDisabled reports whether daemon.json turns off Docker's
+// iptables management. An unreadable or absent file means the default, which
+// is that Docker does manage iptables.
+func dockerIptablesDisabled(path string) bool {
+	data, err := os.ReadFile(path) //nolint:gosec // operator-controlled daemon config, read-only
+	if err != nil {
+		return false
+	}
+	var cfg struct {
+		Iptables *bool `json:"iptables"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false
+	}
+	return cfg.Iptables != nil && !*cfg.Iptables
+}
+
+// publishedPort is one container port reachable from off-host.
+type publishedPort struct {
+	container string
+	port      int
+}
+
+// publishedPorts lists container ports mapped to a non-loopback host address.
+// A docker that cannot be listed is treated as nothing published rather than
+// as an error: DockerReachable already gated this, so a failure here is a
+// daemon that went away mid-scan, not a blind spot worth a finding.
+func publishedPorts(ctx context.Context, r platform.CommandRunner) ([]publishedPort, error) {
+	out, err := r.Run(ctx, "docker", "ps", "--format", "{{.Names}}\t{{.Ports}}")
+	if err != nil {
+		return nil, nil
+	}
+
+	seen := map[publishedPort]bool{}
+	var ports []publishedPort
+	for _, line := range strings.Split(string(out), "\n") {
+		name, portSpec, ok := strings.Cut(strings.TrimSpace(line), "\t")
+		if !ok {
+			continue
+		}
+		for _, m := range publishedPortRE.FindAllStringSubmatch(portSpec, -1) {
+			n, err := strconv.Atoi(m[1])
+			if err != nil {
+				continue
+			}
+			// A container publishing on both IPv4 and IPv6 lists the same
+			// host port twice; it is one exposure.
+			p := publishedPort{container: name, port: n}
+			if !seen[p] {
+				seen[p] = true
+				ports = append(ports, p)
+			}
+		}
+	}
+	return ports, nil
+}
+
+// dockerUserChainFiltered reports whether DOCKER-USER carries any rule beyond
+// the default, which is the chain declaration plus an unconditional RETURN.
+// That chain is the documented place to enforce host policy on container
+// traffic, so anything in it means the operator has addressed this.
+func dockerUserChainFiltered(ctx context.Context, r platform.CommandRunner) (bool, error) {
+	if !platform.Has(r, "iptables") {
+		return false, fmt.Errorf("iptables not installed")
+	}
+	out, err := r.Run(ctx, "iptables", "-S", "DOCKER-USER")
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		switch line = strings.TrimSpace(line); {
+		case line == "", strings.HasPrefix(line, "-N "):
+			continue // chain declaration
+		case line == "-A DOCKER-USER -j RETURN":
+			continue // Docker's own default; filters nothing
+		default:
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// describePorts renders the exposure list deterministically, so the finding
+// and its evidence do not churn between scans and produce a spurious delta.
+func describePorts(ports []publishedPort) string {
+	sort.Slice(ports, func(i, j int) bool {
+		if ports[i].port != ports[j].port {
+			return ports[i].port < ports[j].port
+		}
+		return ports[i].container < ports[j].container
+	})
+	parts := make([]string, len(ports))
+	for i, p := range ports {
+		parts[i] = fmt.Sprintf("%d (%s)", p.port, p.container)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/check/firewall/docker_test.go
+++ b/internal/check/firewall/docker_test.go
@@ -1,0 +1,197 @@
+package firewall
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// dockerHost builds a runner for a host with ufw active and Docker reachable.
+// Callers override or add entries to shape the specific scenario.
+func dockerHost(ps, dockerUser string) fakeRunner {
+	return fakeRunner{
+		present: map[string]bool{"ufw": true, "iptables": true, "docker": true},
+		outputs: map[string]string{
+			"ufw status": "Status: active\n",
+			"docker version --format {{.Server.Version}}": "27.3.1\n",
+			"docker ps --format {{.Names}}\t{{.Ports}}":   ps,
+			"iptables -S DOCKER-USER":                     dockerUser,
+		},
+	}
+}
+
+// emptyDockerUser is what Docker installs by default: the chain exists and
+// unconditionally returns, so it filters nothing.
+const emptyDockerUser = "-N DOCKER-USER\n-A DOCKER-USER -j RETURN\n"
+
+func checkWith(t *testing.T, r fakeRunner) ([]model.Finding, error) {
+	t.Helper()
+	c := &Checker{DaemonConfigPath: filepath.Join(t.TempDir(), "absent.json")}
+	return c.Check(context.Background(), platform.Env{Runner: r})
+}
+
+// The headline case: ufw reports active, so every axis scored this host
+// clean, while Redis and Postgres were reachable from the internet.
+func TestPublishedPortsBypassingUFWAreCritical(t *testing.T) {
+	r := dockerHost("cache\t0.0.0.0:6379->6379/tcp, :::6379->6379/tcp\ndb\t0.0.0.0:5432->5432/tcp\n", emptyDockerUser)
+
+	fs, err := checkWith(t, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 1 {
+		t.Fatalf("want 1 finding, got %d (%v)", len(fs), fs)
+	}
+	f := fs[0]
+	if f.ID != "firewall.docker-bypass" {
+		t.Errorf("id = %q", f.ID)
+	}
+	if f.Severity != model.SeverityCritical {
+		t.Errorf("severity = %v, want critical", f.Severity)
+	}
+	// Both containers listed, IPv4+IPv6 of the same port collapsed to one,
+	// and ordered by port so repeat scans produce no spurious delta.
+	if got, want := f.Evidence["published"], "5432 (db), 6379 (cache)"; got != want {
+		t.Errorf("published = %q, want %q", got, want)
+	}
+}
+
+// Loopback publishing is the recommended remediation, so it must never be
+// reported as the problem it solves.
+func TestLoopbackPublishedPortIsNotABypass(t *testing.T) {
+	r := dockerHost("cache\t127.0.0.1:6379->6379/tcp\n", emptyDockerUser)
+
+	fs, err := checkWith(t, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("loopback-published port is not exposed, got %v", fs)
+	}
+}
+
+// A container with no published ports at all.
+func TestUnpublishedPortIsNotABypass(t *testing.T) {
+	r := dockerHost("cache\t6379/tcp\n", emptyDockerUser)
+
+	fs, err := checkWith(t, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("an unpublished container port is not exposed, got %v", fs)
+	}
+}
+
+// An operator who already installed the ufw-docker rules has fixed this.
+// Flagging them would be the false positive that discredits the finding.
+func TestFilteredDockerUserChainSuppressesTheFinding(t *testing.T) {
+	filtered := "-N DOCKER-USER\n-A DOCKER-USER -s 10.0.0.0/8 -j RETURN\n-A DOCKER-USER -j DROP\n"
+	r := dockerHost("cache\t0.0.0.0:6379->6379/tcp\n", filtered)
+
+	fs, err := checkWith(t, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("a filtered DOCKER-USER chain means the bypass is closed, got %v", fs)
+	}
+}
+
+// With "iptables": false Docker writes no rules, so ufw governs normally.
+func TestDockerNotManagingIptablesSuppressesTheFinding(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "daemon.json")
+	if err := os.WriteFile(cfg, []byte(`{"iptables": false}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := dockerHost("cache\t0.0.0.0:6379->6379/tcp\n", emptyDockerUser)
+
+	c := &Checker{DaemonConfigPath: cfg}
+	fs, err := c.Check(context.Background(), platform.Env{Runner: r})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("Docker is not managing iptables, so ufw applies; got %v", fs)
+	}
+}
+
+// The inverse: an explicit "iptables": true, and any other daemon.json
+// content, leaves the check armed.
+func TestDaemonConfigWithoutIptablesKeyStillFlags(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "daemon.json")
+	if err := os.WriteFile(cfg, []byte(`{"log-driver": "json-file"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := dockerHost("cache\t0.0.0.0:6379->6379/tcp\n", emptyDockerUser)
+
+	c := &Checker{DaemonConfigPath: cfg}
+	fs, err := c.Check(context.Background(), platform.Env{Runner: r})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 1 {
+		t.Errorf("an unrelated daemon.json must not disarm the check, got %v", fs)
+	}
+}
+
+// No Docker means no Docker rules to jump the queue.
+func TestNoDockerNoBypass(t *testing.T) {
+	r := fakeRunner{
+		present: map[string]bool{"ufw": true},
+		outputs: map[string]string{"ufw status": "Status: active\n"},
+	}
+	fs, err := checkWith(t, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("no Docker, no bypass; got %v", fs)
+	}
+}
+
+// The finding names ufw and its remediation edits /etc/ufw/after.rules, so
+// it must not fire on a firewalld host where neither applies.
+func TestBypassScopedToUFW(t *testing.T) {
+	r := fakeRunner{
+		present: map[string]bool{"firewall-cmd": true, "iptables": true, "docker": true},
+		outputs: map[string]string{
+			"firewall-cmd --state":                        "running\n",
+			"docker version --format {{.Server.Version}}": "27.3.1\n",
+			"docker ps --format {{.Names}}\t{{.Ports}}":   "cache\t0.0.0.0:6379->6379/tcp\n",
+			"iptables -S DOCKER-USER":                     emptyDockerUser,
+		},
+	}
+	fs, err := checkWith(t, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("the ufw-docker finding must not fire on firewalld, got %v", fs)
+	}
+}
+
+// Whether the operator already closed the bypass is the one thing that
+// cannot be guessed. Unreadable means say so, not assume either answer:
+// assuming closed hides a Critical exposure, assuming open accuses a host
+// that may be correctly configured.
+func TestUnreadableDockerUserChainIsPartial(t *testing.T) {
+	r := dockerHost("cache\t0.0.0.0:6379->6379/tcp\n", "")
+	delete(r.outputs, "iptables -S DOCKER-USER") // no scripted output -> Run errors
+
+	fs, err := checkWith(t, r)
+	if len(fs) != 0 {
+		t.Errorf("must not invent a finding from unread evidence, got %v", fs)
+	}
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want a PartialError so the axis reports Degraded, got %v", err)
+	}
+}

--- a/internal/check/firewall/firewall.go
+++ b/internal/check/firewall/firewall.go
@@ -13,10 +13,21 @@ import (
 )
 
 // Checker reports whether the host has an active firewall.
-type Checker struct{}
+type Checker struct {
+	// DaemonConfigPath is Docker's daemon.json. Overridable for tests;
+	// empty means the real /etc/docker/daemon.json.
+	DaemonConfigPath string
+}
 
 // New returns a firewall checker.
 func New() *Checker { return &Checker{} }
+
+func (c *Checker) daemonConfig() string {
+	if c.DaemonConfigPath != "" {
+		return c.DaemonConfigPath
+	}
+	return defaultDaemonConfig
+}
 
 // Source identifies the firewall domain.
 func (*Checker) Source() model.Source { return model.SourceFirewall }
@@ -35,9 +46,16 @@ func (*Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
 // not "no firewall". Reporting the finding there would accuse a properly
 // firewalled host of being wide open purely because the scan lacked
 // privileges.
-func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
-	switch status, _ := probe(ctx, env.Runner); status {
+func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
+	switch status, which := probe(ctx, env.Runner); status {
 	case StatusActive:
+		// An active firewall is not the end of the question on a Docker
+		// host: published container ports are accepted before ufw's rules
+		// are consulted. Scoring this case clean is what let a host with an
+		// open datastore outscore one running nothing at all.
+		if which == "ufw" {
+			return checkDockerBypass(ctx, env.Runner, c.daemonConfig())
+		}
 		return nil, nil // the good case: no finding
 	case StatusUnknown:
 		return nil, &check.PartialError{

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -94,6 +94,7 @@ func TestUnregisteredFindingHasNoFix(t *testing.T) {
 func TestKnownUnregisteredFindings(t *testing.T) {
 	declined := map[string]string{
 		"firewall.inactive":       "enabling a default-deny firewall over SSH can lock the user out, and exec fixes have no rollback",
+		"firewall.docker-bypass":  "republishing to loopback means editing an unknown compose file and recreating the container; the ufw-docker alternative is firewall policy with no rollback",
 		"ports.exposed-datastore": "the remediation is a bind-address edit in a daemon config whose path and syntax the finding does not carry",
 		"ports.exposed-admin":     "same as ports.exposed-datastore",
 		"compose.ds016":           "the only honest remediation deletes a mount that Portainer/Traefik/Watchtower legitimately need; :ro is a placebo",

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -43,6 +43,14 @@ package fix
 // TestKnownUnregisteredFindings pins each one, so registering a fix means
 // deleting an assertion and arguing with the reason.
 //
+//   - firewall.docker-bypass — the two remediations are unrelated and only
+//     the operator can choose. Republishing the port to loopback means
+//     editing whichever Compose file or `docker run` invocation started the
+//     container, then recreating it, which takes the service down and is not
+//     a file edit hostveil can locate from the finding. Installing the
+//     ufw-docker rules means appending to /etc/ufw/after.rules and reloading
+//     ufw — firewall policy, so it fails the same recoverability criterion as
+//     firewall.inactive.
 //   - firewall.inactive — the only remediation is enabling a firewall, and
 //     the checker records no SSH port, interface, or session data. Enabling
 //     a default-deny policy on a box reached over SSH can lock the user out

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -188,6 +188,7 @@
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
                   <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>firewall.docker-bypass</code></td><td>Published container ports are reachable despite an active ufw</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
                 </tbody>
               </table>
             </div>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -188,6 +188,7 @@
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
                   <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>firewall.docker-bypass</code></td><td>ufw가 켜져 있는데도 publish된 컨테이너 포트가 외부에서 접근 가능</td><td><span class="sev critical">심각</span></td><td>수동</td></tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
## The hole

Docker publishes a port by writing DNAT into `nat/PREROUTING` and an accept rule into the filter table's `DOCKER` chain. Both are traversed **before** ufw's rules in `INPUT`, so `ufw deny 6379` does nothing to a container started with `-p 6379:6379`. The port is open to the internet while `ufw status` reports the firewall as active.

## hostveil was rewarding it

- an active ufw scored the firewall axis **full marks**
- `internal/check/ports` suppresses `ports.exposed` *precisely because* a firewall is up

So a host with Postgres published to `0.0.0.0` scored **better** than one with no firewall running nothing. This is the most common real exposure on a self-hosted Docker VPS, and it was the one configuration the tool couldn't see.

## Measured on the demo VM

ufw active (only 22 allowed), five containers published to `0.0.0.0`, empty `DOCKER-USER`. Both binaries run back to back against the same host state:

| | firewall axis | firewall findings | ports axis |
|---|---|---|---|
| `origin/main` | **100** | none | 47 |
| this branch | **50** | `firewall.docker-bypass` Critical | 47 |

The ports axis is identical in both, confirming no side effect on the neighbouring domain. Evidence from the real scan:

```
published = 5432 (cloud-db-1), 6380 (media-redis-1), 8080 (cloud-nextcloud-1),
            8096 (media-jellyfin-1), 9000 (mgmt-portainer-1)
```

## Kept quiet unless it's certain

A Critical that fires on a correctly configured host is worse than none, so **all** of these must hold:

- ufw is the active front-end — firewalld and plain nftables interact with Docker differently and the ufw-docker remediation doesn't apply
- a container publishes to a non-loopback address (`127.0.0.1:6379->` is the *recommended fix*, never flagged)
- `DOCKER-USER` is empty — an operator who already installed the ufw-docker rules has fixed this
- `daemon.json` doesn't set `"iptables": false` — then Docker adds no rules and ufw governs normally

When `DOCKER-USER` can't be read, the domain reports **Degraded** rather than guessing. Assuming closed hides a Critical; assuming open accuses a host that may be fine.

## Manual, and pinned

Registered in `fix.Default()`'s declined list with a reason, pinned by `TestKnownUnregisteredFindings`. The two remediations are unrelated and only the operator can pick: republishing to loopback means editing an unknown Compose file and recreating the container; the ufw-docker alternative is firewall policy, failing the same recoverability criterion as `firewall.inactive`.

## Gate

`go build`/`vet`/`gofmt`/`go mod tidy`/`go test -race ./...` green, golangci-lint v2.12.2 **0 issues**, sitegen regenerated (`checks.html` en/ko + README). The `TestEveryEmittedFindingIsDocumented` guard caught the missing docs row before I did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)