### PR TITLE
feat(check): report pending security updates and a required reboot

### DIFF
--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -114,6 +114,8 @@
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
                   <tr><td><code>updates.disabled</code></td><td>Automatic security updates are not enabled (apt unattended-upgrades or dnf-automatic)</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>updates.pending-security</code></td><td>Security updates are available but not installed</td><td><span class="sev high">High</span> / <span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>updates.reboot-required</code></td><td>Installed updates need a reboot to take effect</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                 </tbody>
               </table>
             </div>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -114,6 +114,8 @@
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
                   <tr><td><code>updates.disabled</code></td><td>자동 보안 업데이트가 활성화되지 않음 (apt unattended-upgrades 또는 dnf-automatic)</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>updates.pending-security</code></td><td>보안 업데이트가 나와 있지만 설치되지 않음</td><td><span class="sev high">높음</span> / <span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>updates.reboot-required</code></td><td>설치된 업데이트가 적용되려면 재부팅이 필요함</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                 </tbody>
               </table>
             </div>

--- a/internal/check/updates/updates.go
+++ b/internal/check/updates/updates.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
+	"github.com/seolcu/hostveil/internal/check"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
 )
@@ -18,11 +20,17 @@ import (
 type Checker struct {
 	// AptConfigPath is the apt periodic-upgrade config; overridable for tests.
 	AptConfigPath string
+	// RebootRequiredPath is the flag file apt's packages touch when a
+	// installed update needs a reboot to take effect; overridable for tests.
+	RebootRequiredPath string
 }
 
 // New returns an updates checker.
 func New() *Checker {
-	return &Checker{AptConfigPath: "/etc/apt/apt.conf.d/20auto-upgrades"}
+	return &Checker{
+		AptConfigPath:      "/etc/apt/apt.conf.d/20auto-upgrades",
+		RebootRequiredPath: "/var/run/reboot-required",
+	}
 }
 
 // Source identifies the updates domain.
@@ -45,34 +53,83 @@ func (*Checker) Available(_ context.Context, env platform.Env) (bool, string) {
 	}
 }
 
-// Check dispatches to the package-manager-specific verification. Available
-// has already ruled out every other package manager.
+// Check reports on both halves of staying patched: that the mechanism is
+// enabled, and that it has actually caught up.
+//
+// Having unattended-upgrades enabled was previously the whole test, which
+// meant a host with sixty pending security patches and a kernel update
+// installed but never rebooted scored the axis full marks. The mechanism
+// being switched on says nothing about whether the machine is currently
+// running patched code, and that is the thing an operator cares about.
 func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
 	switch env.PackageManager {
 	case platform.PMApt:
-		return c.auditApt(), nil
+		return c.auditApt(ctx, env)
 	case platform.PMDnf:
-		return c.auditDnf(ctx, env), nil
+		return c.auditDnf(ctx, env)
 	default:
 		return nil, fmt.Errorf("unsupported package manager %q: Available should have skipped this checker", env.PackageManager)
 	}
 }
 
-func (c *Checker) auditApt() []model.Finding {
-	if aptUnattendedEnabled(c.AptConfigPath) {
-		return nil
+func (c *Checker) auditApt(ctx context.Context, env platform.Env) ([]model.Finding, error) {
+	var findings []model.Finding
+	if !aptUnattendedEnabled(c.AptConfigPath) {
+		findings = append(findings, disabledFinding("unattended-upgrades",
+			"Install and enable unattended-upgrades: `apt install unattended-upgrades` then `dpkg-reconfigure -plow unattended-upgrades`."))
 	}
-	return []model.Finding{disabledFinding("unattended-upgrades",
-		"Install and enable unattended-upgrades: `apt install unattended-upgrades` then `dpkg-reconfigure -plow unattended-upgrades`.")}
+	// apt's packages create this file from their postinst when an installed
+	// update cannot take effect until the machine restarts — a new kernel,
+	// glibc, or libssl. Absence is a definite answer, not a guess.
+	if _, err := os.Stat(c.RebootRequiredPath); err == nil {
+		findings = append(findings, rebootFinding("sudo reboot"))
+	}
+
+	out, err := env.Runner.Run(ctx, "apt", "list", "--upgradable")
+	if err != nil {
+		return findings, &check.PartialError{
+			Reason: "cannot list pending updates — checked that automatic updates are configured, but not whether they have caught up",
+		}
+	}
+	if n := countAptSecurityUpdates(string(out)); n > 0 {
+		findings = append(findings, pendingFinding(n, "sudo apt update && sudo apt upgrade"))
+	}
+	return findings, nil
 }
 
-func (c *Checker) auditDnf(ctx context.Context, env platform.Env) []model.Finding {
+func (c *Checker) auditDnf(ctx context.Context, env platform.Env) ([]model.Finding, error) {
+	var findings []model.Finding
 	out, err := env.Runner.Run(ctx, "systemctl", "is-enabled", "dnf-automatic.timer")
-	if err == nil && strings.TrimSpace(string(out)) == "enabled" {
-		return nil
+	if err != nil || strings.TrimSpace(string(out)) != "enabled" {
+		findings = append(findings, disabledFinding("dnf-automatic",
+			"Install and enable dnf-automatic: `dnf install dnf-automatic` then `systemctl enable --now dnf-automatic.timer` (configure it to apply security updates)."))
 	}
-	return []model.Finding{disabledFinding("dnf-automatic",
-		"Install and enable dnf-automatic: `dnf install dnf-automatic` then `systemctl enable --now dnf-automatic.timer` (configure it to apply security updates).")}
+
+	// `needs-restarting -r` exits non-zero precisely when a reboot IS
+	// required, so the exit status cannot be read as success or failure here.
+	// Its stdout is unambiguous and is still captured on a non-zero exit, so
+	// the text is the signal — and a reply matching neither phrase means the
+	// command did not answer, which must not be read as "no reboot needed".
+	rebootOut, _ := env.Runner.Run(ctx, "needs-restarting", "-r")
+	switch reboot := classifyNeedsRestarting(string(rebootOut)); reboot {
+	case rebootRequired:
+		findings = append(findings, rebootFinding("sudo reboot"))
+	case rebootUnknown:
+		return findings, &check.PartialError{
+			Reason: "cannot tell whether a reboot is pending — checked that automatic updates are configured, but not whether they have taken effect",
+		}
+	}
+
+	secOut, err := env.Runner.Run(ctx, "dnf", "-q", "updateinfo", "list", "security")
+	if err != nil {
+		return findings, &check.PartialError{
+			Reason: "cannot list pending security updates — checked that automatic updates are configured, but not whether they have caught up",
+		}
+	}
+	if n := countDnfSecurityAdvisories(string(secOut)); n > 0 {
+		findings = append(findings, pendingFinding(n, "sudo dnf upgrade --security"))
+	}
+	return findings, nil
 }
 
 // aptUnattendedEnabled reports whether the apt periodic config enables
@@ -92,6 +149,102 @@ func aptUnattendedEnabled(path string) bool {
 		}
 	}
 	return false
+}
+
+// rebootState is what `needs-restarting -r` told us, including the case
+// where it told us nothing usable.
+type rebootState int
+
+const (
+	rebootNotNeeded rebootState = iota
+	rebootRequired
+	rebootUnknown
+)
+
+// classifyNeedsRestarting reads dnf's answer from its text rather than its
+// exit status, which is inverted: it exits non-zero when a reboot IS needed.
+func classifyNeedsRestarting(out string) rebootState {
+	lower := strings.ToLower(out)
+	switch {
+	case strings.Contains(lower, "reboot is required"),
+		strings.Contains(lower, "reboot is probably required"):
+		return rebootRequired
+	case strings.Contains(lower, "reboot should not be necessary"):
+		return rebootNotNeeded
+	default:
+		return rebootUnknown
+	}
+}
+
+// countAptSecurityUpdates counts upgradable packages coming from a security
+// suite. apt names it in the origin field, e.g.
+//
+//	libssl3/jammy-security 3.0.2-0ubuntu1.18 amd64 [upgradable from: ...]
+//
+// Only security updates are counted. A host deliberately pinned behind on
+// feature updates is a maintenance choice; one behind on security patches is
+// running known-exploitable code.
+func countAptSecurityUpdates(out string) int {
+	n := 0
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		// The first line is "Listing..." and unrelated lines lack a slash.
+		name, rest, ok := strings.Cut(line, "/")
+		if !ok || name == "" || !strings.Contains(rest, "upgradable from:") {
+			continue
+		}
+		suite, _, _ := strings.Cut(rest, " ")
+		if strings.Contains(suite, "-security") {
+			n++
+		}
+	}
+	return n
+}
+
+// countDnfSecurityAdvisories counts advisory rows in `dnf updateinfo list
+// security`. Each row is "ADVISORY SEVERITY package", and dnf prints
+// "Last metadata expiration check" and blank lines around them.
+func countDnfSecurityAdvisories(out string) int {
+	n := 0
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "Last metadata") {
+			continue
+		}
+		if len(strings.Fields(line)) >= 3 {
+			n++
+		}
+	}
+	return n
+}
+
+// rebootFinding reports that patches are installed but not in force. The
+// machine is still executing the vulnerable code it already downloaded the
+// fix for, which is a strictly worse position than not having patched: the
+// operator believes the work is done.
+func rebootFinding(howToFix string) model.Finding {
+	return model.NewFinding("updates.reboot-required", "A reboot is needed for installed security updates to take effect",
+		model.SeverityHigh, model.SourceUpdates, model.RemediationManual,
+		model.WithDescription("Updates to the kernel or a core library have been installed, but the running system is still using the old code held in memory. Until this host restarts, it stays vulnerable to exactly the issues those patches fixed — and because the packages already show as up to date, it is easy to believe the work is finished."),
+		model.WithHowToFix("Restart the host when you can take the downtime: `"+howToFix+"`. Check what will restart with it first if you run services without a restart policy."),
+		model.WithEvidence("mechanism", "reboot flag"),
+	)
+}
+
+// pendingFinding reports security updates that are available and not applied.
+// Severity scales with the count: a couple of pending patches is routine drift,
+// dozens means automatic updates are not actually working.
+func pendingFinding(n int, howToFix string) model.Finding {
+	sev := model.SeverityMedium
+	if n >= 10 {
+		sev = model.SeverityHigh
+	}
+	return model.NewFinding("updates.pending-security", fmt.Sprintf("%d security update(s) are available but not installed", n),
+		sev, model.SourceUpdates, model.RemediationManual,
+		model.WithDescription("These packages have published security fixes that this host has not applied. Every one is a publicly documented vulnerability with a patch already written, which is the category attackers scan for first. A large backlog usually means automatic updates are configured but failing rather than simply switched off."),
+		model.WithHowToFix("Apply them: `"+howToFix+"`. If automatic updates are enabled and this backlog keeps growing, check `systemctl status unattended-upgrades` or the dnf-automatic timer for errors."),
+		model.WithEvidence("pending", strconv.Itoa(n)),
+	)
 }
 
 func disabledFinding(mechanism, howToFix string) model.Finding {

--- a/internal/check/updates/updates_test.go
+++ b/internal/check/updates/updates_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
 )
 
@@ -25,54 +27,234 @@ func (f fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte,
 	return nil, errors.New("no output for: " + key)
 }
 
+// aptChecker builds a checker whose two file paths point into a temp dir.
+// enabled controls whether unattended-upgrades looks configured; reboot
+// controls whether the reboot-required flag file exists.
+func aptChecker(t *testing.T, enabled, reboot bool) *Checker {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "20auto-upgrades")
+	if enabled {
+		content := "APT::Periodic::Update-Package-Lists \"1\";\nAPT::Periodic::Unattended-Upgrade \"1\";\n"
+		if err := os.WriteFile(cfg, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	flag := filepath.Join(dir, "reboot-required")
+	if reboot {
+		if err := os.WriteFile(flag, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &Checker{AptConfigPath: cfg, RebootRequiredPath: flag}
+}
+
+// aptEnv scripts `apt list --upgradable`.
+func aptEnv(upgradable string) platform.Env {
+	return platform.Env{
+		PackageManager: platform.PMApt,
+		Runner:         fakeRunner{outputs: map[string]string{"apt list --upgradable": upgradable}},
+	}
+}
+
+const noUpgrades = "Listing...\n"
+
+func ids(fs []model.Finding) []string {
+	out := make([]string, len(fs))
+	for i, f := range fs {
+		out[i] = f.ID
+	}
+	return out
+}
+
+func find(t *testing.T, fs []model.Finding, id string) model.Finding {
+	t.Helper()
+	for _, f := range fs {
+		if f.ID == id {
+			return f
+		}
+	}
+	t.Fatalf("no %s in %v", id, ids(fs))
+	return model.Finding{}
+}
+
 func TestAptDisabled(t *testing.T) {
-	c := &Checker{AptConfigPath: filepath.Join(t.TempDir(), "missing")}
-	fs, err := c.Check(context.Background(), platform.Env{PackageManager: platform.PMApt})
+	fs, err := aptChecker(t, false, false).Check(context.Background(), aptEnv(noUpgrades))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(fs) != 1 || fs[0].ID != "updates.disabled" {
-		t.Errorf("expected one updates.disabled finding, got %v", fs)
+		t.Errorf("expected one updates.disabled finding, got %v", ids(fs))
 	}
 }
 
 func TestAptEnabled(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "20auto-upgrades")
-	content := `APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Unattended-Upgrade "1";
-`
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	c := &Checker{AptConfigPath: path}
-	fs, err := c.Check(context.Background(), platform.Env{PackageManager: platform.PMApt})
+	fs, err := aptChecker(t, true, false).Check(context.Background(), aptEnv(noUpgrades))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(fs) != 0 {
-		t.Errorf("enabled unattended-upgrades should yield no finding, got %v", fs)
+		t.Errorf("a fully patched host with unattended-upgrades on is clean, got %v", ids(fs))
+	}
+}
+
+// The case the axis used to score 100 for: the mechanism is on, so the old
+// check was satisfied, while the machine still runs the vulnerable code it
+// already downloaded the fix for.
+func TestEnabledButRebootPendingIsNotClean(t *testing.T) {
+	fs, err := aptChecker(t, true, true).Check(context.Background(), aptEnv(noUpgrades))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := find(t, fs, "updates.reboot-required")
+	if f.Severity != model.SeverityHigh {
+		t.Errorf("severity = %v, want high", f.Severity)
+	}
+	if len(fs) != 1 {
+		t.Errorf("want only the reboot finding, got %v", ids(fs))
+	}
+}
+
+// Likewise: unattended-upgrades enabled and a backlog it never applied.
+func TestEnabledButSecurityUpdatesPendingIsNotClean(t *testing.T) {
+	upgradable := `Listing...
+libssl3/jammy-security 3.0.2-0ubuntu1.18 amd64 [upgradable from: 3.0.2-0ubuntu1.15]
+linux-libc-dev/jammy-security 5.15.0-91.101 amd64 [upgradable from: 5.15.0-88.98]
+vim/jammy-updates 2:8.2.3995-1ubuntu2.15 amd64 [upgradable from: 2:8.2.3995-1ubuntu2.13]
+`
+	fs, err := aptChecker(t, true, false).Check(context.Background(), aptEnv(upgradable))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := find(t, fs, "updates.pending-security")
+	// vim comes from -updates, not -security: a host pinned behind on
+	// feature updates is a maintenance choice, not a vulnerability.
+	if f.Evidence["pending"] != "2" {
+		t.Errorf("pending = %q, want 2 (only the -security rows)", f.Evidence["pending"])
+	}
+	if f.Severity != model.SeverityMedium {
+		t.Errorf("severity = %v, want medium for a small backlog", f.Severity)
+	}
+}
+
+// A large backlog means automatic updates are configured but failing, which
+// is worse than merely switched off — the operator believes it is handled.
+func TestLargeSecurityBacklogIsHigh(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("Listing...\n")
+	for i := 0; i < 12; i++ {
+		b.WriteString("pkg" + strings.Repeat("x", i) + "/jammy-security 1.2 amd64 [upgradable from: 1.1]\n")
+	}
+	fs, err := aptChecker(t, true, false).Check(context.Background(), aptEnv(b.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f := find(t, fs, "updates.pending-security"); f.Severity != model.SeverityHigh {
+		t.Errorf("severity = %v, want high for a 12-package backlog", f.Severity)
+	}
+}
+
+// Not being able to list updates is a blind spot, not a clean result. The
+// mechanism half of the domain was still covered, so this is Degraded.
+func TestAptUnreadableUpgradeListIsPartial(t *testing.T) {
+	env := platform.Env{PackageManager: platform.PMApt, Runner: fakeRunner{}}
+	fs, err := aptChecker(t, false, false).Check(context.Background(), env)
+
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want a PartialError so the axis reports Degraded, got %v", err)
+	}
+	// What we did learn is still reported.
+	find(t, fs, "updates.disabled")
+}
+
+func dnfEnv(outputs map[string]string) platform.Env {
+	return platform.Env{PackageManager: platform.PMDnf, Runner: fakeRunner{outputs: outputs}}
+}
+
+func dnfClean() map[string]string {
+	return map[string]string{
+		"systemctl is-enabled dnf-automatic.timer": "enabled\n",
+		"needs-restarting -r":                      "No core libraries or services have been updated since boot-up.\nReboot should not be necessary.\n",
+		"dnf -q updateinfo list security":          "",
 	}
 }
 
 func TestDnfEnabled(t *testing.T) {
-	r := fakeRunner{outputs: map[string]string{"systemctl is-enabled dnf-automatic.timer": "enabled\n"}}
-	fs, err := New().Check(context.Background(), platform.Env{PackageManager: platform.PMDnf, Runner: r})
+	fs, err := New().Check(context.Background(), dnfEnv(dnfClean()))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(fs) != 0 {
-		t.Errorf("enabled dnf-automatic should yield no finding, got %v", fs)
+		t.Errorf("enabled dnf-automatic on a patched host is clean, got %v", ids(fs))
 	}
 }
 
 func TestDnfDisabled(t *testing.T) {
-	r := fakeRunner{outputs: map[string]string{"systemctl is-enabled dnf-automatic.timer": "disabled\n"}}
-	fs, err := New().Check(context.Background(), platform.Env{PackageManager: platform.PMDnf, Runner: r})
+	out := dnfClean()
+	out["systemctl is-enabled dnf-automatic.timer"] = "disabled\n"
+	fs, err := New().Check(context.Background(), dnfEnv(out))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(fs) != 1 {
-		t.Errorf("disabled dnf-automatic should yield one finding, got %v", fs)
+	if len(fs) != 1 || fs[0].ID != "updates.disabled" {
+		t.Errorf("expected one updates.disabled finding, got %v", ids(fs))
+	}
+}
+
+// `needs-restarting -r` exits NON-zero when a reboot is required, so reading
+// its exit status would inverte the answer. The text is the signal.
+func TestDnfRebootRequiredReadFromText(t *testing.T) {
+	out := dnfClean()
+	out["needs-restarting -r"] = "Core libraries or services have been updated since boot-up:\n  * kernel\n\nReboot is required to fully utilize these updates.\n"
+	fs, err := New().Check(context.Background(), dnfEnv(out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	find(t, fs, "updates.reboot-required")
+}
+
+func TestDnfSecurityAdvisoriesCounted(t *testing.T) {
+	out := dnfClean()
+	out["dnf -q updateinfo list security"] = `FEDORA-2026-aaaa Important/Sec. openssl-3.2.1-1.fc41.x86_64
+FEDORA-2026-bbbb Moderate/Sec.  curl-8.6.0-1.fc41.x86_64
+`
+	fs, err := New().Check(context.Background(), dnfEnv(out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f := find(t, fs, "updates.pending-security"); f.Evidence["pending"] != "2" {
+		t.Errorf("pending = %q, want 2", f.Evidence["pending"])
+	}
+}
+
+// An answer matching neither phrase means the command did not tell us, which
+// must not be read as "no reboot needed".
+func TestDnfUnrecognizedRebootAnswerIsPartial(t *testing.T) {
+	out := dnfClean()
+	out["needs-restarting -r"] = "some future wording nobody anticipated\n"
+	_, err := New().Check(context.Background(), dnfEnv(out))
+
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want a PartialError rather than a silent clean, got %v", err)
+	}
+}
+
+func TestClassifyNeedsRestarting(t *testing.T) {
+	for _, tc := range []struct {
+		out  string
+		want rebootState
+	}{
+		{"Reboot should not be necessary.", rebootNotNeeded},
+		{"Reboot is required to fully utilize these updates.", rebootRequired},
+		{"Reboot is probably required to fully utilize these updates.", rebootRequired},
+		{"", rebootUnknown},
+		{"command not found", rebootUnknown},
+	} {
+		if got := classifyNeedsRestarting(tc.out); got != tc.want {
+			t.Errorf("classifyNeedsRestarting(%q) = %v, want %v", tc.out, got, tc.want)
+		}
 	}
 }
 

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -93,11 +93,13 @@ func TestUnregisteredFindingHasNoFix(t *testing.T) {
 // not quietly reversed.
 func TestKnownUnregisteredFindings(t *testing.T) {
 	declined := map[string]string{
-		"firewall.inactive":       "enabling a default-deny firewall over SSH can lock the user out, and exec fixes have no rollback",
-		"firewall.docker-bypass":  "republishing to loopback means editing an unknown compose file and recreating the container; the ufw-docker alternative is firewall policy with no rollback",
-		"ports.exposed-datastore": "the remediation is a bind-address edit in a daemon config whose path and syntax the finding does not carry",
-		"ports.exposed-admin":     "same as ports.exposed-datastore",
-		"compose.ds016":           "the only honest remediation deletes a mount that Portainer/Traefik/Watchtower legitimately need; :ro is a placebo",
+		"firewall.inactive":        "enabling a default-deny firewall over SSH can lock the user out, and exec fixes have no rollback",
+		"firewall.docker-bypass":   "republishing to loopback means editing an unknown compose file and recreating the container; the ufw-docker alternative is firewall policy with no rollback",
+		"updates.reboot-required":  "rebooting is exec with no checkpoint and takes every service down; only the operator knows when that is acceptable",
+		"updates.pending-security": "apt/dnf upgrade is exec, unbounded, and can restart services or prompt about config files — nothing a checkpoint can undo",
+		"ports.exposed-datastore":  "the remediation is a bind-address edit in a daemon config whose path and syntax the finding does not carry",
+		"ports.exposed-admin":      "same as ports.exposed-datastore",
+		"compose.ds016":            "the only honest remediation deletes a mount that Portainer/Traefik/Watchtower legitimately need; :ro is a placebo",
 		// The checker no longer emits per-CVE findings at all — they were
 		// aggregated into cve.outdated-image / cve.unpatched-image. The pin
 		// stays as a guard: a cve.* glob would make this shape fixable again

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -51,6 +51,16 @@ package fix
 //     ufw-docker rules means appending to /etc/ufw/after.rules and reloading
 //     ufw — firewall policy, so it fails the same recoverability criterion as
 //     firewall.inactive.
+//   - updates.reboot-required — the remediation is rebooting the host, which
+//     is an exec action with no checkpoint and takes every service on the box
+//     down with it. Only the operator knows when that downtime is acceptable,
+//     and a tool that reboots a server as part of "fix all safe" would be
+//     indefensible whatever the finding said.
+//   - updates.pending-security — `apt upgrade` is exec, so never Auto, and it
+//     is also unbounded: it can pull in a new kernel, restart services, and
+//     prompt about modified config files. Nothing about that is reversible
+//     from a checkpoint, and a package upgrade that breaks a service leaves
+//     the operator worse off than the pending patch did.
 //   - firewall.inactive — the only remediation is enabling a firewall, and
 //     the checker records no SSH port, interface, or session data. Enabling
 //     a default-deny policy on a box reached over SSH can lock the user out

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -199,6 +199,8 @@
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
                   <tr><td><code>updates.disabled</code></td><td>Automatic security updates are not enabled (apt unattended-upgrades or dnf-automatic)</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>updates.pending-security</code></td><td>Security updates are available but not installed</td><td><span class="sev high">High</span> / <span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>updates.reboot-required</code></td><td>Installed updates need a reboot to take effect</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                 </tbody>
               </table>
             </div>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -199,6 +199,8 @@
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
                   <tr><td><code>updates.disabled</code></td><td>자동 보안 업데이트가 활성화되지 않음 (apt unattended-upgrades 또는 dnf-automatic)</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>updates.pending-security</code></td><td>보안 업데이트가 나와 있지만 설치되지 않음</td><td><span class="sev high">높음</span> / <span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>updates.reboot-required</code></td><td>설치된 업데이트가 적용되려면 재부팅이 필요함</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
Having unattended-upgrades enabled was the *entire* updates check. So a host with sixty pending security patches — or one that installed a kernel update months ago and never rebooted — scored the axis **full marks**. The mechanism being switched on says nothing about whether the machine is currently running patched code.

## Measured on the demo VM

An Ubuntu apt host with 32 pending security updates:

| | updates axis | findings |
|---|---|---|
| `origin/main` | **88** | `updates.disabled` |
| this branch | **60** | `updates.disabled`, `updates.pending-security` (32) |

## `updates.reboot-required` — High

apt's packages create `/var/run/reboot-required` from their postinst when an installed update can't take effect until restart. Absence is a definite answer, so this is a plain `os.Stat`.

On dnf the signal is the **text** of `needs-restarting -r`, not its exit status — that command exits non-zero *precisely when a reboot IS needed*, so reading the status inverts the answer. Output matching neither known phrase reports **Degraded** rather than being read as "no reboot needed".

The finding matters because it's a strictly worse position than not having patched at all: the packages already show as up to date, so the operator believes the work is finished while the old code is still resident.

## `updates.pending-security` — High at 10+, else Medium

Counts upgradable packages from a security suite (apt) and advisory rows (`dnf updateinfo list security`). Only security updates count — a host pinned behind on feature updates made a maintenance choice; one behind on security patches is running known-exploitable code.

Real apt output includes packages in both pools, which the parser handles:

```
gzip/noble-updates,noble-security 1.12-1ubuntu3.2 amd64 [upgradable from: 1.12-1ubuntu3.1]
```

Severity scales with count because a large backlog means automatic updates are configured **but failing** — a different and worse problem than them being switched off.

## Honesty

Not being able to list updates is **Degraded**, not clean. The mechanism half of the domain was still covered, so `PartialError` is the accurate report — an ordinary error would exclude the axis entirely and throw away what was learned.

## Both Manual, both pinned

`TestKnownUnregisteredFindings` pins them with reasons in `fix.Default()`'s doc comment. Rebooting is exec with no checkpoint and takes every service down — only the operator knows when that downtime is acceptable. `apt upgrade` is unbounded: new kernel, service restarts, config-file prompts, none of it undoable from a checkpoint.

## Gate

`go build`/`vet`/`gofmt`/`go mod tidy`/`go test -race ./...` green, golangci-lint v2.12.2 **0 issues**, sitegen regenerated. `TestEveryEmittedFindingIsDocumented` caught both missing docs rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)