### PR TITLE
feat(check): audit containers started outside Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ undo any fix with one command.
 
 | Domain | What it looks at | Needs |
 | --- | --- | --- |
-| **Docker / Compose** | Privileged mode, Docker socket mounts, exposed datastores and admin panels, host networking, unsafe bind mounts, missing no-new-privileges, hardcoded secrets, and more — a native audit of your Compose files | Docker |
+| **Docker / Compose** | Privileged mode, Docker socket mounts, exposed datastores and admin panels, host networking, unsafe bind mounts, missing no-new-privileges, hardcoded secrets, and more — a native audit of your Compose files, plus containers started with plain `docker run` | Docker |
 | **SSH** | Root login, password authentication, empty passwords, weak brute-force limits, X11 forwarding — parsed natively from `sshd_config`, following `Include` into `sshd_config.d/` | — |
 | **Firewall** | Whether ufw, firewalld, or nftables is actually active | — |
 | **Auto-updates** | Whether unattended-upgrades (apt) or dnf-automatic (dnf) is enabled | — |

--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -7,7 +7,7 @@
               <table>
                 <thead><tr><th>Domain</th><th>Prefix</th><th>Needs</th></tr></thead>
                 <tbody>
-                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker + Compose files</td></tr>
+                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker</td></tr>
                   <tr><td>SSH</td><td><code>ssh.</code></td><td>—</td></tr>
                   <tr><td>Firewall</td><td><code>firewall.</code></td><td>—</td></tr>
                   <tr><td>Auto-updates</td><td><code>updates.</code></td><td>—</td></tr>
@@ -73,7 +73,7 @@
             </div>
 
             <h2 id="compose">Docker / Compose <code>compose.</code></h2>
-            <p>A native audit of your Compose files — no external scanner required.</p>
+            <p>A native audit of your Compose files — no external scanner required. Containers started with plain <code>docker run</code> are audited too, read from the daemon rather than a file. Those findings are always Manual: there is no file for a fix to edit, so hostveil tells you what to change when you recreate the container instead of offering a button that could not work.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -7,7 +7,7 @@
               <table>
                 <thead><tr><th>영역</th><th>접두사</th><th>필요 조건</th></tr></thead>
                 <tbody>
-                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker + Compose 파일</td></tr>
+                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker</td></tr>
                   <tr><td>SSH</td><td><code>ssh.</code></td><td>—</td></tr>
                   <tr><td>방화벽</td><td><code>firewall.</code></td><td>—</td></tr>
                   <tr><td>자동 업데이트</td><td><code>updates.</code></td><td>—</td></tr>
@@ -73,7 +73,7 @@
             </div>
 
             <h2 id="compose">Docker / Compose <code>compose.</code></h2>
-            <p>Compose 파일에 대한 네이티브 감사입니다 — 외부 스캐너가 필요 없습니다.</p>
+            <p>Compose 파일에 대한 네이티브 감사입니다 — 외부 스캐너가 필요 없습니다. <code>docker run</code>으로 직접 띄운 컨테이너도 파일이 아니라 데몬에서 읽어 함께 점검합니다. 이 발견 항목들은 항상 수동입니다 — 수정할 파일이 없으므로, 동작하지 않을 버튼을 보여주는 대신 컨테이너를 다시 만들 때 무엇을 바꿔야 하는지 알려줍니다.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>

--- a/internal/check/compose/compose.go
+++ b/internal/check/compose/compose.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/seolcu/hostveil/internal/check"
 	"github.com/seolcu/hostveil/internal/compose"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
@@ -35,7 +36,14 @@ func (*Checker) Available(ctx context.Context, env platform.Env) (bool, string) 
 	return true, ""
 }
 
-// Check discovers compose projects and audits each service.
+// Check audits every container on the host: those described by a compose
+// file, and those started directly with `docker run`.
+//
+// Compose projects were the only thing this checker looked at, so a
+// hand-started container was invisible to all fifteen rules. Since compose
+// carries the largest single axis weight, that meant the most dangerous
+// object on the box could be published to 0.0.0.0, privileged, and mounting
+// the Docker socket while the axis scored it as if it were not there.
 func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
 	projects, err := compose.Discover(ctx, env.Runner)
 	if err != nil {
@@ -54,7 +62,82 @@ func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, e
 			}
 		}
 	}
+
+	standalone, err := compose.DiscoverContainers(ctx, env.Runner)
+	if err != nil {
+		// The compose half of the domain was covered, so this is a partial
+		// result, not a failure. Returning an ordinary error would discard
+		// findings already gathered and exclude the axis entirely.
+		return findings, &check.PartialError{
+			Reason:  "cannot inspect containers started outside Compose — audited compose projects only",
+			Covered: len(projects),
+		}
+	}
+	for _, c := range standalone {
+		findings = append(findings, auditContainer(c)...)
+	}
 	return findings, nil
+}
+
+// runtimeOnlyRules are the rules that mean the same thing for a container
+// the daemon describes as they do for a service a compose file describes.
+//
+// Two of the fifteen are deliberately absent, both because the daemon's
+// record cannot support the claim the rule would make:
+//
+//   - dr005 (hardcoded secret in the environment) — `docker inspect` reports
+//     the resolved environment, which merges the image's own ENV defaults and
+//     anything loaded from an env_file. Flagging that would accuse an
+//     operator who did exactly the right thing, and tell them to do the thing
+//     they already did.
+//   - dr004 (loads secrets from an env_file) — a running container has no
+//     env_file; the values were resolved when it was created and the daemon
+//     keeps no record of where they came from.
+//
+// ds009 (runs as root) is kept, and is more accurate here than for compose:
+// Config.User reflects the effective user including an image's baked-in
+// USER, so a container reported as root really is running as root. The
+// compose rule has to guess from the file alone, which is part of why its
+// fix is declined.
+var runtimeOnlyRules = []rule{
+	rulePrivileged,
+	ruleDockerSocket,
+	ruleExposedDatastore,
+	ruleExposedAdminPanel,
+	ruleHostNetwork,
+	ruleSensitiveHostMount,
+	ruleDangerousCaps,
+	ruleNoNewPrivileges,
+	ruleRunsAsRoot,
+	rulePortAllInterfaces,
+	ruleNoRestart,
+	ruleNoHealthcheck,
+	ruleNoResourceLimits,
+}
+
+// auditContainer audits a container with no compose file behind it.
+//
+// Every finding is forced to Manual. The remediations these rules describe
+// are all file edits — "bind the port to 127.0.0.1", "add security_opt" —
+// and there is no file. Engine.classify takes whichever of the checker and
+// the registry demands more human involvement, so declaring Manual here
+// keeps the registry from offering a fix that would have nothing to edit.
+// Without it a UI would show a fix button leading nowhere, which is exactly
+// what the classify rule exists to prevent.
+func auditContainer(c compose.Container) []model.Finding {
+	var out []model.Finding
+	for _, rule := range runtimeOnlyRules {
+		f, ok := rule(c.Service)
+		if !ok {
+			continue
+		}
+		f.Remediation = model.RemediationManual
+		f.HowToFix = "This container was started with `docker run`, not Compose, so there is no file to edit. " +
+			"Recreate it with the corrected flag, or move it into a compose file where hostveil can fix it for you. " + f.HowToFix
+		f.Evidence = mergeMeta(f.Evidence, map[string]string{"managed_by": "docker run"})
+		out = append(out, f)
+	}
+	return out
 }
 
 func mergeMeta(base, add map[string]string) map[string]string {

--- a/internal/check/compose/container_test.go
+++ b/internal/check/compose/container_test.go
@@ -1,0 +1,188 @@
+package compose
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// runRunner scripts a host with no compose projects and one hand-started
+// container described by inspectJSON.
+type runRunner struct {
+	inspect string
+	psErr   bool
+}
+
+func (runRunner) LookPath(name string) (string, error) { return "/usr/bin/" + name, nil }
+
+func (r runRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	joined := strings.Join(args, " ")
+	switch {
+	case name == "docker" && joined == "version --format {{.Server.Version}}":
+		return []byte("27.0.3\n"), nil
+	case name == "docker" && joined == "compose ls --all --format json":
+		return []byte(`[]`), nil
+	case name == "docker" && joined == "ps --quiet --no-trunc":
+		if r.psErr {
+			return nil, errors.New("cannot connect to the Docker daemon")
+		}
+		return []byte("abc123\n"), nil
+	case name == "docker" && len(args) > 0 && args[0] == "inspect":
+		return []byte(r.inspect), nil
+	}
+	return nil, errors.New("unexpected command: " + name + " " + joined)
+}
+
+// The container the plan was written for: `docker run -d --privileged
+// -p 6379:6379 -v /var/run/docker.sock:/var/run/docker.sock redis`.
+const dangerousContainer = `[{
+ "Name": "/cache",
+ "Config": {"Image": "redis:alpine", "User": "", "Labels": {}},
+ "HostConfig": {
+  "Privileged": true,
+  "NetworkMode": "bridge",
+  "Binds": ["/var/run/docker.sock:/var/run/docker.sock:rw"],
+  "PortBindings": {"6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]},
+  "RestartPolicy": {"Name": "no"}
+ }
+}]`
+
+func check2(t *testing.T, r platform.CommandRunner) []model.Finding {
+	t.Helper()
+	fs, err := New().Check(context.Background(), platform.Env{Runner: r})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs
+}
+
+func has(fs []model.Finding, id string) (model.Finding, bool) {
+	for _, f := range fs {
+		if f.ID == id {
+			return f, true
+		}
+	}
+	return model.Finding{}, false
+}
+
+// Before this, every one of these produced nothing: the container is not in
+// any compose file, so the checker never looked at it.
+func TestStandaloneContainerIsAudited(t *testing.T) {
+	fs := check2(t, runRunner{inspect: dangerousContainer})
+
+	for _, id := range []string{
+		"compose.ds001", // privileged
+		"compose.ds016", // docker socket
+		"compose.ds018", // datastore on 0.0.0.0
+		"compose.ds006", // no no-new-privileges
+		"compose.ds009", // runs as root
+		"compose.ds008", // no restart policy
+		"compose.ds012", // no healthcheck
+		"compose.ds010", // no memory limit
+	} {
+		if _, ok := has(fs, id); !ok {
+			t.Errorf("%s not reported for a hand-started container", id)
+		}
+	}
+	if f, _ := has(fs, "compose.ds018"); f.Service != "cache" {
+		t.Errorf("finding should be attributed to the container name, got %q", f.Service)
+	}
+}
+
+// The rule that matters most: there is no file to edit, so no UI may offer a
+// fix. Engine.classify takes the stricter of checker and registry, so the
+// checker declaring Manual is what keeps a fix button from leading nowhere.
+func TestStandaloneFindingsAreAlwaysManual(t *testing.T) {
+	fs := check2(t, runRunner{inspect: dangerousContainer})
+	if len(fs) == 0 {
+		t.Fatal("expected findings")
+	}
+	for _, f := range fs {
+		if f.Remediation != model.RemediationManual {
+			t.Errorf("%s is %v; a container with no compose file has nothing to edit", f.ID, f.Remediation)
+		}
+		if f.Evidence["managed_by"] != "docker run" {
+			t.Errorf("%s does not record how the container is managed", f.ID)
+		}
+		if !strings.Contains(f.HowToFix, "docker run") {
+			t.Errorf("%s how-to-fix does not explain why it cannot be automated: %q", f.ID, f.HowToFix)
+		}
+	}
+}
+
+// ds018 is registered as an Auto fix that edits a compose file. If the
+// checker did not demote it, the registry would win and the fix would try to
+// edit the empty path.
+func TestExposedDatastoreIsNotAutoForAStandaloneContainer(t *testing.T) {
+	fs := check2(t, runRunner{inspect: dangerousContainer})
+	f, ok := has(fs, "compose.ds018")
+	if !ok {
+		t.Fatal("expected ds018")
+	}
+	if f.Remediation == model.RemediationAuto {
+		t.Error("ds018 must not stay Auto: there is no compose file for the fix to write")
+	}
+	if f.Metadata["file"] != "" {
+		t.Errorf("no compose file should be claimed, got %q", f.Metadata["file"])
+	}
+}
+
+// A resolved environment merges the image's own ENV and anything an env_file
+// supplied, so flagging it would accuse an operator who used a secrets file
+// correctly — and tell them to do what they already did.
+func TestResolvedEnvironmentIsNotScannedForSecrets(t *testing.T) {
+	withSecret := `[{
+	 "Name": "/app",
+	 "Config": {"Image": "myapp", "Env": ["DB_PASSWORD=hunter2"], "Labels": {}},
+	 "HostConfig": {"RestartPolicy": {"Name": "always"}}
+	}]`
+	fs := check2(t, runRunner{inspect: withSecret})
+	if _, ok := has(fs, "compose.dr005"); ok {
+		t.Error("dr005 must not fire on a resolved container environment")
+	}
+	if _, ok := has(fs, "compose.dr004"); ok {
+		t.Error("dr004 has no meaning for a running container")
+	}
+}
+
+// Losing the ability to enumerate containers is a smaller blind spot than a
+// failed scan, but it is still one: the domain covered compose only and has
+// to say so rather than report a clean result.
+func TestUninspectableContainersAreDegraded(t *testing.T) {
+	_, err := New().Check(context.Background(), platform.Env{Runner: runRunner{psErr: true}})
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want a PartialError so the axis reports Degraded, got %v", err)
+	}
+}
+
+// A container that is fine produces nothing, so the new code path cannot
+// become a source of noise on a well-run host.
+func TestWellConfiguredStandaloneContainerIsClean(t *testing.T) {
+	good := `[{
+	 "Name": "/app",
+	 "Config": {
+	   "Image": "myapp:1.2",
+	   "User": "1000:1000",
+	   "Labels": {},
+	   "Healthcheck": {"Test": ["CMD", "true"]}
+	 },
+	 "HostConfig": {
+	   "Privileged": false,
+	   "NetworkMode": "bridge",
+	   "SecurityOpt": ["no-new-privileges:true"],
+	   "Binds": ["/srv/app/data:/data:rw"],
+	   "Memory": 536870912,
+	   "PortBindings": {"8080/tcp": [{"HostIp": "127.0.0.1", "HostPort": "8080"}]},
+	   "RestartPolicy": {"Name": "unless-stopped"}
+	 }
+	}]`
+	if fs := check2(t, runRunner{inspect: good}); len(fs) != 0 {
+		t.Errorf("a correctly configured container should be clean, got %v", fs)
+	}
+}

--- a/internal/check/cve/cve.go
+++ b/internal/check/cve/cve.go
@@ -81,10 +81,43 @@ func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, e
 		}
 	}
 
+	// Images belonging to containers no compose file describes. Without
+	// these, a hand-started container's vulnerabilities were not merely
+	// unreported — the axis scored as though the image were not on the host.
+	// A failure to enumerate these is tracked apart from a failure to scan an
+	// image. Folding it into the image counters would make "3 of 4 images
+	// scanned" mean two different things, and could make a host whose only
+	// images all scanned cleanly look like a total failure.
+	standalone, enumErr := compose.DiscoverContainers(ctx, env.Runner)
+	for _, c := range standalone {
+		if c.Service.Image == "" || scanned[c.Service.Image] {
+			continue
+		}
+		scanned[c.Service.Image] = true
+		attempted++
+		fs, err := scanImage(ctx, env.Runner, c.Service.Image, c.Name, "", "")
+		if err != nil {
+			failed++
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		findings = append(findings, demoteToManual(fs)...)
+	}
+
 	// Case order matters: with no images at all, failed and attempted are both
 	// zero and the clean case must win.
 	switch failed {
 	case 0:
+		if enumErr != nil {
+			// Every image we knew about scanned, but we could not find out
+			// which containers exist outside Compose — so the axis covered
+			// less ground than a clean result would claim.
+			return findings, &check.PartialError{
+				Reason: "scanned compose images only — cannot enumerate containers started outside Compose",
+			}
+		}
 		// Includes the no-images case: a host with no containers genuinely
 		// has no image vulnerabilities.
 		return findings, nil
@@ -121,6 +154,25 @@ type trivyVuln struct {
 // the network allows — the flag makes Trivy exit with a legible message, and
 // the context guarantees termination if it hangs before parsing its own flags.
 const imageTimeout = 5 * time.Minute
+
+// demoteToManual marks findings for an image whose container has no compose
+// file. The registered fix for cve.outdated-image runs
+// `docker compose -f <file> pull <service>`, and there is no file — so the
+// checker declares Manual and Engine.classify, which takes whichever side
+// demands more human involvement, keeps the registry from offering a fix
+// that could not run.
+func demoteToManual(fs []model.Finding) []model.Finding {
+	for i := range fs {
+		fs[i].Remediation = model.RemediationManual
+		fs[i].HowToFix = "This container was started with `docker run`, not Compose, so hostveil cannot update it for you. " +
+			"Pull the image and recreate the container yourself. " + fs[i].HowToFix
+		if fs[i].Evidence == nil {
+			fs[i].Evidence = map[string]string{}
+		}
+		fs[i].Evidence["managed_by"] = "docker run"
+	}
+	return fs
+}
 
 func scanImage(ctx context.Context, r platform.CommandRunner, image, service, file, project string) ([]model.Finding, error) {
 	ctx, cancel := context.WithTimeout(ctx, imageTimeout+time.Minute)

--- a/internal/check/cve/cve_test.go
+++ b/internal/check/cve/cve_test.go
@@ -71,7 +71,15 @@ func TestCVESkipsWhenDaemonUnreachable(t *testing.T) {
 // scriptRunner scripts a full Check(): a compose project on disk plus a
 // per-image Trivy result (or failure).
 type scriptRunner struct {
-	lsJSON   string
+	lsJSON string
+	// psIDs is the output of `docker ps --quiet --no-trunc`; empty means no
+	// containers exist outside the compose projects lsJSON describes.
+	psIDs string
+	// inspectJSON is the output of `docker inspect <ids...>`.
+	inspectJSON string
+	// psErr makes container enumeration fail, which is a partial result
+	// rather than an image scan failure.
+	psErr    bool
 	trivy    map[string]string // image → JSON output
 	trivyErr map[string]bool   // image → fail
 	argv     []string          // the last trivy argv, for flag assertions
@@ -86,6 +94,13 @@ func (s *scriptRunner) Run(_ context.Context, name string, args ...string) ([]by
 		return []byte("27.0.3\n"), nil
 	case name == "docker" && joined == "compose ls --all --format json":
 		return []byte(s.lsJSON), nil
+	case name == "docker" && joined == "ps --quiet --no-trunc":
+		if s.psErr {
+			return nil, errors.New("cannot connect to the Docker daemon")
+		}
+		return []byte(s.psIDs), nil
+	case name == "docker" && args[0] == "inspect":
+		return []byte(s.inspectJSON), nil
 	case name == "trivy":
 		s.argv = args
 		image := args[len(args)-1]

--- a/internal/compose/inspect.go
+++ b/internal/compose/inspect.go
@@ -1,0 +1,202 @@
+package compose
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/platform"
+	"gopkg.in/yaml.v3"
+)
+
+// composeProjectLabel is set by Docker Compose on every container it creates.
+// Its presence is how a container started by `docker run` is told apart from
+// one this package already audits through its compose file.
+const composeProjectLabel = "com.docker.compose.project"
+
+// Container is a running container that no compose file describes, normalized
+// into the same Service shape the compose rules already audit.
+//
+// The two are deliberately not interchangeable. A compose service can be
+// fixed by editing its file; a container started with `docker run` has no
+// file to edit, and its settings live only in the daemon's record of how it
+// was created. Callers must not offer a file-editing fix for one of these.
+type Container struct {
+	// Name is the container name with Docker's leading slash removed.
+	Name string
+	// Service is the normalized view the audit rules consume.
+	Service Service
+}
+
+// DiscoverContainers returns running containers that Docker Compose did not
+// create.
+//
+// Without this the compose and CVE checkers see only what `docker compose ls`
+// reports, so a hand-started `docker run -d --privileged -p 6379:6379 redis`
+// — the most dangerous object likely to be on the box — produced no findings
+// on either of the two highest-weighted axes. Those axes were not reporting
+// "nothing wrong"; they were reporting on a subset of the containers and
+// scoring as if it were all of them.
+func DiscoverContainers(ctx context.Context, r platform.CommandRunner) ([]Container, error) {
+	out, err := r.Run(ctx, "docker", "ps", "--quiet", "--no-trunc")
+	if err != nil {
+		return nil, fmt.Errorf("list containers: %w", err)
+	}
+	ids := strings.Fields(string(out))
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	raw, err := r.Run(ctx, "docker", append([]string{"inspect"}, ids...)...)
+	if err != nil {
+		return nil, fmt.Errorf("inspect containers: %w", err)
+	}
+	return parseInspect(raw)
+}
+
+// dockerContainer is the subset of `docker inspect` output the rules need.
+type dockerContainer struct {
+	Name   string `json:"Name"`
+	Config struct {
+		Image       string            `json:"Image"`
+		User        string            `json:"User"`
+		Env         []string          `json:"Env"`
+		Labels      map[string]string `json:"Labels"`
+		Healthcheck *struct {
+			Test []string `json:"Test"`
+		} `json:"Healthcheck"`
+	} `json:"Config"`
+	HostConfig struct {
+		Privileged    bool                `json:"Privileged"`
+		NetworkMode   string              `json:"NetworkMode"`
+		PidMode       string              `json:"PidMode"`
+		IpcMode       string              `json:"IpcMode"`
+		CapAdd        []string            `json:"CapAdd"`
+		SecurityOpt   []string            `json:"SecurityOpt"`
+		Binds         []string            `json:"Binds"`
+		Memory        int64               `json:"Memory"`
+		PortBindings  map[string][]hostIP `json:"PortBindings"`
+		RestartPolicy struct {
+			Name string `json:"Name"`
+		} `json:"RestartPolicy"`
+	} `json:"HostConfig"`
+}
+
+type hostIP struct {
+	HostIP   string `json:"HostIp"`
+	HostPort string `json:"HostPort"`
+}
+
+func parseInspect(raw []byte) ([]Container, error) {
+	var entries []dockerContainer
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("parse docker inspect: %w", err)
+	}
+	var out []Container
+	for _, e := range entries {
+		if e.Config.Labels[composeProjectLabel] != "" {
+			continue // already audited through its compose file
+		}
+		name := strings.TrimPrefix(e.Name, "/")
+		if name == "" {
+			continue
+		}
+		out = append(out, Container{Name: name, Service: e.toService(name)})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// toService maps the daemon's record of a container onto the Service fields
+// the rules read. Fields with no meaningful runtime equivalent are left zero
+// and the caller skips the rules that depend on them — see the checker.
+func (e dockerContainer) toService(name string) Service {
+	s := Service{
+		Name:        name,
+		Image:       e.Config.Image,
+		Privileged:  e.HostConfig.Privileged,
+		NetworkMode: e.HostConfig.NetworkMode,
+		Pid:         e.HostConfig.PidMode,
+		Ipc:         e.HostConfig.IpcMode,
+		User:        e.Config.User,
+		Restart:     e.HostConfig.RestartPolicy.Name,
+		CapAdd:      e.HostConfig.CapAdd,
+		SecurityOpt: e.HostConfig.SecurityOpt,
+		Ports:       inspectPorts(e.HostConfig.PortBindings),
+		Volumes:     inspectVolumes(e.HostConfig.Binds),
+	}
+	// Docker reports "no restart policy" as the empty string on older
+	// daemons and as "no" on newer ones; the rule already treats both as
+	// unset, so no normalization is needed here.
+	if e.Config.Healthcheck != nil && len(e.Config.Healthcheck.Test) > 0 {
+		// The rule only tests this for nil. A container's healthcheck has no
+		// YAML form to reproduce, and inventing one would be a lie about
+		// where the setting came from, so a bare node stands for "present".
+		s.Healthcheck = &yaml.Node{Kind: yaml.MappingNode}
+	}
+	if e.HostConfig.Memory > 0 {
+		s.MemLimit = fmt.Sprintf("%d", e.HostConfig.Memory)
+	}
+	return s
+}
+
+// inspectPorts converts PortBindings ("6379/tcp" -> [{HostIp, HostPort}])
+// into the normalized Port list. Only bindings with a host port are
+// published; a container port with no binding is not reachable from the host.
+func inspectPorts(bindings map[string][]hostIP) []Port {
+	var ports []Port
+	for spec, binds := range bindings {
+		containerPort, proto, _ := strings.Cut(spec, "/")
+		for _, b := range binds {
+			if b.HostPort == "" {
+				continue
+			}
+			ports = append(ports, Port{
+				HostIP:        b.HostIP,
+				HostPort:      b.HostPort,
+				ContainerPort: containerPort,
+				Protocol:      proto,
+				Published:     true,
+			})
+		}
+	}
+	// Map iteration order is random and these ports reach a finding's
+	// evidence, so a stable order keeps repeat scans from producing a delta
+	// that reports a change nobody made.
+	sort.Slice(ports, func(i, j int) bool {
+		if ports[i].HostPort != ports[j].HostPort {
+			return ports[i].HostPort < ports[j].HostPort
+		}
+		return ports[i].HostIP < ports[j].HostIP
+	})
+	return ports
+}
+
+// inspectVolumes converts HostConfig.Binds ("/src:/dst:ro") into the
+// normalized Volume list. Only bind mounts appear there; named volumes are
+// listed under Mounts and are not host paths, so the sensitive-path rule
+// has nothing to say about them.
+func inspectVolumes(binds []string) []Volume {
+	var vols []Volume
+	for _, b := range binds {
+		parts := strings.Split(b, ":")
+		if len(parts) < 2 {
+			continue
+		}
+		v := Volume{Source: parts[0], Target: parts[1]}
+		// A source that starts with / is a host path; anything else is a
+		// named volume, which cannot be a sensitive host directory.
+		v.Bind = strings.HasPrefix(v.Source, "/")
+		for _, opt := range parts[2:] {
+			for _, o := range strings.Split(opt, ",") {
+				if o == "ro" {
+					v.ReadOnly = true
+				}
+			}
+		}
+		vols = append(vols, v)
+	}
+	return vols
+}

--- a/internal/compose/inspect_test.go
+++ b/internal/compose/inspect_test.go
@@ -1,0 +1,226 @@
+package compose
+
+import "testing"
+
+// A realistic `docker inspect` array: one hand-started container and one
+// created by Compose.
+const twoContainers = `[
+ {
+  "Name": "/cache",
+  "Config": {
+   "Image": "redis:alpine",
+   "User": "",
+   "Env": ["PATH=/usr/local/bin", "REDIS_PASSWORD=hunter2"],
+   "Labels": {"maintainer": "me"},
+   "Healthcheck": null
+  },
+  "HostConfig": {
+   "Privileged": true,
+   "NetworkMode": "bridge",
+   "CapAdd": ["SYS_ADMIN"],
+   "SecurityOpt": null,
+   "Binds": ["/etc:/host-etc:rw", "mydata:/data"],
+   "Memory": 0,
+   "PortBindings": {"6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]},
+   "RestartPolicy": {"Name": "no"}
+  }
+ },
+ {
+  "Name": "/media-jellyfin-1",
+  "Config": {
+   "Image": "jellyfin/jellyfin:latest",
+   "Labels": {"com.docker.compose.project": "media"}
+  },
+  "HostConfig": {"NetworkMode": "bridge", "RestartPolicy": {"Name": "unless-stopped"}}
+ }
+]`
+
+// Compose-managed containers are already audited through their compose file.
+// Including them here would report every finding twice — once fixable, once
+// not — which is worse than not seeing them at all.
+func TestComposeManagedContainersAreExcluded(t *testing.T) {
+	cs, err := parseInspect([]byte(twoContainers))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cs) != 1 {
+		t.Fatalf("want 1 standalone container, got %d: %+v", len(cs), cs)
+	}
+	if cs[0].Name != "cache" {
+		t.Errorf("name = %q, want cache (leading slash stripped)", cs[0].Name)
+	}
+}
+
+func TestInspectMapsSecurityRelevantFields(t *testing.T) {
+	cs, err := parseInspect([]byte(twoContainers))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := cs[0].Service
+
+	if !s.Privileged {
+		t.Error("Privileged not mapped")
+	}
+	if s.Image != "redis:alpine" {
+		t.Errorf("Image = %q", s.Image)
+	}
+	if len(s.CapAdd) != 1 || s.CapAdd[0] != "SYS_ADMIN" {
+		t.Errorf("CapAdd = %v", s.CapAdd)
+	}
+	if s.Restart != "no" {
+		t.Errorf("Restart = %q", s.Restart)
+	}
+	if s.Healthcheck != nil {
+		t.Error("a null healthcheck must stay nil so the rule fires")
+	}
+
+	// The port is published on all interfaces — the thing that makes a
+	// datastore reachable from the internet.
+	if len(s.Ports) != 1 {
+		t.Fatalf("Ports = %+v", s.Ports)
+	}
+	if !s.Ports[0].ExposedOnAllInterfaces() {
+		t.Errorf("0.0.0.0:6379 should read as exposed, got %+v", s.Ports[0])
+	}
+
+	// /etc mounted read-write is a bind; a named volume is not, so the
+	// sensitive-path rule never considers it.
+	if len(s.Volumes) != 2 {
+		t.Fatalf("Volumes = %+v", s.Volumes)
+	}
+	etc, data := s.Volumes[0], s.Volumes[1]
+	if !etc.Bind || etc.ReadOnly || etc.Source != "/etc" {
+		t.Errorf("/etc bind mapped wrong: %+v", etc)
+	}
+	if data.Bind {
+		t.Errorf("named volume %q must not be treated as a host bind", data.Source)
+	}
+}
+
+func TestReadOnlyBindDetected(t *testing.T) {
+	in := `[{"Name":"/x","Config":{"Image":"a"},"HostConfig":{"Binds":["/var/run/docker.sock:/var/run/docker.sock:ro"]}}]`
+	cs, err := parseInspect([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := cs[0].Service.Volumes[0]
+	if !v.ReadOnly {
+		t.Errorf(":ro not detected: %+v", v)
+	}
+}
+
+// Docker writes bind options as a comma-joined list ("rw,z" under SELinux),
+// so :ro has to be found inside it rather than compared to the whole field.
+func TestReadOnlyInsideCommaJoinedOptions(t *testing.T) {
+	in := `[{"Name":"/x","Config":{"Image":"a"},"HostConfig":{"Binds":["/etc:/etc:ro,z"]}}]`
+	cs, err := parseInspect([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cs[0].Service.Volumes[0].ReadOnly {
+		t.Error("ro not detected inside a comma-joined option list")
+	}
+}
+
+// A container port with no host binding is not reachable from the host, so
+// it must not read as published.
+func TestUnpublishedPortNotMarkedPublished(t *testing.T) {
+	in := `[{"Name":"/x","Config":{"Image":"a"},"HostConfig":{"PortBindings":{"80/tcp":null,"443/tcp":[{"HostIp":"","HostPort":""}]}}}]`
+	cs, err := parseInspect([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(cs[0].Service.Ports); n != 0 {
+		t.Errorf("want no published ports, got %d: %+v", n, cs[0].Service.Ports)
+	}
+}
+
+// PortBindings is a map, so iteration order is random. Findings carry these
+// values as evidence, and unstable evidence makes every rescan report a
+// change nobody made.
+func TestPortOrderIsStable(t *testing.T) {
+	in := `[{"Name":"/x","Config":{"Image":"a"},"HostConfig":{"PortBindings":{
+	 "80/tcp":[{"HostIp":"0.0.0.0","HostPort":"8080"}],
+	 "443/tcp":[{"HostIp":"0.0.0.0","HostPort":"8443"}],
+	 "22/tcp":[{"HostIp":"0.0.0.0","HostPort":"2222"}]}}}]`
+	var first []string
+	for i := 0; i < 20; i++ {
+		cs, err := parseInspect([]byte(in))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got []string
+		for _, p := range cs[0].Service.Ports {
+			got = append(got, p.HostPort)
+		}
+		if first == nil {
+			first = got
+			continue
+		}
+		for j := range got {
+			if got[j] != first[j] {
+				t.Fatalf("port order varies between runs: %v vs %v", first, got)
+			}
+		}
+	}
+}
+
+func TestMemoryLimitMapped(t *testing.T) {
+	in := `[{"Name":"/x","Config":{"Image":"a"},"HostConfig":{"Memory":536870912}}]`
+	cs, err := parseInspect([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cs[0].Service.MemLimit != "536870912" {
+		t.Errorf("MemLimit = %q", cs[0].Service.MemLimit)
+	}
+
+	unlimited := `[{"Name":"/x","Config":{"Image":"a"},"HostConfig":{"Memory":0}}]`
+	cs, err = parseInspect([]byte(unlimited))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cs[0].Service.MemLimit != "" {
+		t.Errorf("Memory 0 means unlimited and must stay empty, got %q", cs[0].Service.MemLimit)
+	}
+}
+
+func TestHealthcheckPresenceMapped(t *testing.T) {
+	in := `[{"Name":"/x","Config":{"Image":"a","Healthcheck":{"Test":["CMD-SHELL","curl -f localhost"]}},"HostConfig":{}}]`
+	cs, err := parseInspect([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cs[0].Service.Healthcheck == nil {
+		t.Error("a defined healthcheck should be mapped as present")
+	}
+
+	// An entry of {"Test": ["NONE"]}... is still a Test list, but an empty
+	// one means no healthcheck at all.
+	empty := `[{"Name":"/x","Config":{"Image":"a","Healthcheck":{"Test":[]}},"HostConfig":{}}]`
+	cs, err = parseInspect([]byte(empty))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cs[0].Service.Healthcheck != nil {
+		t.Error("an empty Test list is not a healthcheck")
+	}
+}
+
+func TestContainerOrderIsStable(t *testing.T) {
+	in := `[{"Name":"/zeta","Config":{"Image":"a"},"HostConfig":{}},
+	        {"Name":"/alpha","Config":{"Image":"b"},"HostConfig":{}}]`
+	cs, err := parseInspect([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cs[0].Name != "alpha" || cs[1].Name != "zeta" {
+		t.Errorf("containers not sorted by name: %v, %v", cs[0].Name, cs[1].Name)
+	}
+}
+
+func TestMalformedInspectOutputIsAnError(t *testing.T) {
+	if _, err := parseInspect([]byte("not json")); err == nil {
+		t.Error("malformed docker inspect output must be an error, not an empty clean result")
+	}
+}

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -92,7 +92,7 @@
               <table>
                 <thead><tr><th>Domain</th><th>Prefix</th><th>Needs</th></tr></thead>
                 <tbody>
-                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker + Compose files</td></tr>
+                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker</td></tr>
                   <tr><td>SSH</td><td><code>ssh.</code></td><td>—</td></tr>
                   <tr><td>Firewall</td><td><code>firewall.</code></td><td>—</td></tr>
                   <tr><td>Auto-updates</td><td><code>updates.</code></td><td>—</td></tr>
@@ -158,7 +158,7 @@
             </div>
 
             <h2 id="compose">Docker / Compose <code>compose.</code></h2>
-            <p>A native audit of your Compose files — no external scanner required.</p>
+            <p>A native audit of your Compose files — no external scanner required. Containers started with plain <code>docker run</code> are audited too, read from the daemon rather than a file. Those findings are always Manual: there is no file for a fix to edit, so hostveil tells you what to change when you recreate the container instead of offering a button that could not work.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -92,7 +92,7 @@
               <table>
                 <thead><tr><th>영역</th><th>접두사</th><th>필요 조건</th></tr></thead>
                 <tbody>
-                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker + Compose 파일</td></tr>
+                  <tr><td>Docker / Compose</td><td><code>compose.</code></td><td>Docker</td></tr>
                   <tr><td>SSH</td><td><code>ssh.</code></td><td>—</td></tr>
                   <tr><td>방화벽</td><td><code>firewall.</code></td><td>—</td></tr>
                   <tr><td>자동 업데이트</td><td><code>updates.</code></td><td>—</td></tr>
@@ -158,7 +158,7 @@
             </div>
 
             <h2 id="compose">Docker / Compose <code>compose.</code></h2>
-            <p>Compose 파일에 대한 네이티브 감사입니다 — 외부 스캐너가 필요 없습니다.</p>
+            <p>Compose 파일에 대한 네이티브 감사입니다 — 외부 스캐너가 필요 없습니다. <code>docker run</code>으로 직접 띄운 컨테이너도 파일이 아니라 데몬에서 읽어 함께 점검합니다. 이 발견 항목들은 항상 수동입니다 — 수정할 파일이 없으므로, 동작하지 않을 버튼을 보여주는 대신 컨테이너를 다시 만들 때 무엇을 바꿔야 하는지 알려줍니다.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>


### PR DESCRIPTION
The compose and CVE checkers enumerated targets **exclusively** through `docker compose ls`. A container started with `docker run` was invisible to all fifteen compose rules and to every image scan.

Those two axes carry **31 of the 100 points**. They weren't reporting "nothing wrong" — they were reporting on a subset of the containers and scoring as if it were all of them.

## Measured on the demo VM

A host whose only container is:

```
docker run -d --privileged -p 6390:6379 -v /etc:/host-etc redis:alpine
```

| | container axis | findings |
|---|---|---|
| `origin/main` | **100** — a perfect score | 0 |
| this branch | **15** | 8 |

The eight: `ds001` privileged · `ds016`/`ds017` host mounts · `ds018` datastore on 0.0.0.0 · `ds006` no-new-privileges · `ds009` root · `ds008` restart · `ds010` memory · `ds012` healthcheck.

## How

`compose.DiscoverContainers` reads `docker ps` + `docker inspect` through the existing `CommandRunner` seam and normalizes each container into the **same `Service` value the rules already consume** — so no rule changed.

Containers carrying `com.docker.compose.project` are skipped: they're already audited through their file, and including them would report every finding twice, once fixable and once not.

## Every standalone finding is Manual

This is the part that matters architecturally. These rules' remediations are file edits, and there is no file. The checker declares Manual, and `Engine.classify` — which takes whichever side demands more human involvement — keeps the registry from offering a fix that has nothing to edit.

Without it, `ds018` stays Auto and its fix writes to the empty path. That's precisely the "fix button that leads nowhere" the classify rule exists to prevent, and there's a test pinning it.

The how-to-fix explains *why* it can't be automated rather than repeating advice about a compose file that doesn't exist.

## Two rules deliberately excluded

The daemon's record can't support the claim they'd make:

- **`dr005`** (hardcoded secret) — `docker inspect` reports the **resolved** environment, merging the image's own ENV defaults with anything loaded from an env_file. Flagging that accuses an operator who did exactly the right thing, and tells them to do it again.
- **`dr004`** (loads from env_file) — no runtime meaning; the values were resolved at creation and the daemon keeps no record of their origin.

`ds009` is **kept**, and is more accurate here than for compose: `Config.User` reflects the effective user *including* an image's baked-in `USER`, which the file-based rule has to guess at.

## Details worth a look

- Port and container ordering are sorted. `PortBindings` is a map, and those values reach a finding's evidence — unstable evidence makes every rescan report a change nobody made. There's a 20-iteration test for it.
- In the CVE checker, failing to *enumerate* containers is tracked separately from failing to *scan* an image. Folding them together would make "3 of 4 images scanned" mean two different things, and could make a host whose images all scanned cleanly look like a total failure.
- Losing enumeration is `PartialError` → Degraded, not a clean result.

## Gate

`go build`/`vet`/`gofmt`/`go mod tidy`/`go test -race ./...` green, golangci-lint v2.12.2 **0 issues**, sitegen regenerated. Docs updated: the domain no longer requires Compose files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)