### PR TITLE
fix(cmd): stop dropping flags on a terminal and exiting 2 on --help

### DIFF
--- a/cmd/hostveil/cli_test.go
+++ b/cmd/hostveil/cli_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+func finding(sev model.Severity, fixed bool) model.Finding {
+	f := model.NewFinding("ssh.rootlogin", "t", sev, model.SourceSSH, model.RemediationManual)
+	f.Fixed = fixed
+	return f
+}
+
+// exitCode is hostveil's CI contract and had no test at all. A regression
+// here silently turns every pipeline gate into a no-op (always 0) or a
+// permanent red (always 1), and nothing else in the suite would notice.
+func TestExitCode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fs   []model.Finding
+		want int
+	}{
+		{"no findings", nil, 0},
+		{"critical", []model.Finding{finding(model.SeverityCritical, false)}, 1},
+		{"high", []model.Finding{finding(model.SeverityHigh, false)}, 1},
+		{"medium only", []model.Finding{finding(model.SeverityMedium, false)}, 0},
+		{"low only", []model.Finding{finding(model.SeverityLow, false)}, 0},
+		{
+			"a fixed critical does not gate",
+			[]model.Finding{finding(model.SeverityCritical, true)},
+			0,
+		},
+		{
+			"one unfixed high among fixed criticals still gates",
+			[]model.Finding{finding(model.SeverityCritical, true), finding(model.SeverityHigh, false)},
+			1,
+		},
+		{
+			"medium and low together never gate",
+			[]model.Finding{finding(model.SeverityMedium, false), finding(model.SeverityLow, false)},
+			0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := exitCode(model.Report{Findings: tc.fs}); got != tc.want {
+				t.Errorf("exitCode = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// -h is a request, not a mistake. Go's flag package reports it as
+// flag.ErrHelp after printing usage, and treating that as a parse failure
+// made `hostveil scan --help` exit 2. The top-level form was fixed in #520
+// and the same bug survived one level down in every subcommand.
+func TestParseFlagsTreatsHelpAsSuccess(t *testing.T) {
+	for _, arg := range []string{"-h", "--help"} {
+		fs := flag.NewFlagSet("scan", flag.ContinueOnError)
+		fs.SetOutput(discard{})
+		fs.Bool("json", false, "")
+		if code := parseFlags(fs, []string{arg}); code != 0 {
+			t.Errorf("parseFlags(%q) = %d, want 0", arg, code)
+		}
+	}
+}
+
+func TestParseFlagsRejectsUnknownFlag(t *testing.T) {
+	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
+	fs.SetOutput(discard{})
+	fs.Bool("json", false, "")
+	if code := parseFlags(fs, []string{"--nope"}); code != 2 {
+		t.Errorf("parseFlags(--nope) = %d, want 2", code)
+	}
+}
+
+func TestParseFlagsCarriesOnWhenValid(t *testing.T) {
+	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
+	jsonOut := fs.Bool("json", false, "")
+	if code := parseFlags(fs, []string{"--json"}); code != -1 {
+		t.Fatalf("parseFlags = %d, want -1 (carry on)", code)
+	}
+	if !*jsonOut {
+		t.Error("--json was not applied")
+	}
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+// needsRoot must not elevate for commands that only print, or a user
+// checking the version gets a password prompt.
+func TestNeedsRootExcludesPrintOnlyCommands(t *testing.T) {
+	for _, cmd := range []string{"version", "help", "bogus", ""} {
+		if needsRoot(cmd) {
+			t.Errorf("%q should not trigger elevation", cmd)
+		}
+	}
+	for _, cmd := range []string{"scan", "tui", "fix", "serve", "web", "explain", "rollback", "history"} {
+		if !needsRoot(cmd) {
+			t.Errorf("%q reads root-only state and should elevate", cmd)
+		}
+	}
+}
+
+// The dispatch bug: a leading flag set explicit=false, which on a terminal
+// picked the TUI — and cmdTUI ignores its arguments entirely. So `hostveil
+// --json` opened the TUI and printed no JSON, and `hostveil --bogus` opened
+// the TUI and reported no error, while both behaved correctly when piped.
+func TestResolveCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		args        []string
+		interactive bool
+		wantCmd     string
+		wantArgs    []string
+	}{
+		{"bare word is the subcommand", []string{"scan", "--json"}, true, "scan", []string{"--json"}},
+		{"nothing on a terminal opens the TUI", nil, true, "tui", nil},
+		{"nothing when piped prints a scan", nil, false, "scan", nil},
+
+		// The regressions. Both must reach scan with the flag intact, on a
+		// terminal as well as piped, so the flag is either honored or refused
+		// rather than silently dropped.
+		{"--json on a terminal reaches scan", []string{"--json"}, true, "scan", []string{"--json"}},
+		{"--json piped reaches scan", []string{"--json"}, false, "scan", []string{"--json"}},
+		{"unknown flag reaches scan to be rejected", []string{"--bogus"}, true, "scan", []string{"--bogus"}},
+		{"-v shorthand reaches scan", []string{"-v"}, true, "scan", []string{"-v"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, args := resolveCommand(tc.args, tc.interactive)
+			if cmd != tc.wantCmd {
+				t.Errorf("cmd = %q, want %q", cmd, tc.wantCmd)
+			}
+			if len(args) != len(tc.wantArgs) {
+				t.Fatalf("args = %v, want %v", args, tc.wantArgs)
+			}
+			for i := range args {
+				if args[i] != tc.wantArgs[i] {
+					t.Errorf("args = %v, want %v", args, tc.wantArgs)
+				}
+			}
+		})
+	}
+}
+
+// TTY-ness must never change whether a flag is honored — only what happens
+// when there are no arguments at all.
+func TestFlagHandlingDoesNotDependOnTTY(t *testing.T) {
+	for _, args := range [][]string{{"--json"}, {"--bogus"}, {"-v", "--no-color"}, {"scan"}} {
+		tty, _ := resolveCommand(args, true)
+		piped, _ := resolveCommand(args, false)
+		if tty != piped {
+			t.Errorf("%v dispatches to %q on a terminal but %q when piped", args, tty, piped)
+		}
+	}
+}

--- a/cmd/hostveil/elevate.go
+++ b/cmd/hostveil/elevate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -43,6 +44,14 @@ func maybeElevate(cmd string) {
 	if err != nil {
 		return
 	}
+	// Say why before sudo asks. A first-time user's opening interaction with
+	// hostveil was otherwise a bare "[sudo] password for ..." with nothing
+	// above it explaining who wanted their password or what for — the highest
+	// friction possible for a tool asking to be trusted with root. This goes
+	// to stderr so it never contaminates `--json` on stdout.
+	fmt.Fprintln(os.Stderr, "hostveil needs root to read /etc/shadow, sshd_config, and the firewall state; re-running with sudo.")
+	fmt.Fprintln(os.Stderr, "It only reads until you ask it to fix something. Set HOSTVEIL_NO_SUDO=1 to skip this (some checks will be skipped too).")
+
 	argv := append([]string{"sudo", exe}, os.Args[1:]...)
 	env := append(os.Environ(), "HOSTVEIL_ELEVATED=1")
 	_ = syscall.Exec(sudo, argv, env)

--- a/cmd/hostveil/explain.go
+++ b/cmd/hostveil/explain.go
@@ -21,8 +21,8 @@ func cmdExplain(args []string) int {
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		findingID, args = args[0], args[1:]
 	}
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code := parseFlags(fs, args); code >= 0 {
+		return code
 	}
 	if findingID == "" {
 		fmt.Fprintln(os.Stderr, "usage: hostveil explain <finding-id> [--service NAME] [--ai]")

--- a/cmd/hostveil/fix.go
+++ b/cmd/hostveil/fix.go
@@ -18,13 +18,11 @@ func cmdFix(args []string) int {
 		action  int
 		yes     bool
 		all     bool
-		noColor bool
 	)
 	fs.StringVar(&service, "service", "", "disambiguate a finding by service name")
 	fs.IntVar(&action, "action", -1, "for Review fixes, the alternative to apply (0-based)")
 	fs.BoolVar(&yes, "yes", false, "apply without an interactive confirmation")
 	fs.BoolVar(&all, "all", false, "apply every safe (Auto) fix at once")
-	fs.BoolVar(&noColor, "no-color", false, "disable colored output")
 
 	// Allow the finding ID to come before flags ("fix <id> --yes"), which
 	// Go's flag package would otherwise stop parsing at.
@@ -32,8 +30,8 @@ func cmdFix(args []string) int {
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		findingID, args = args[0], args[1:]
 	}
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code := parseFlags(fs, args); code >= 0 {
+		return code
 	}
 
 	if all {

--- a/cmd/hostveil/main.go
+++ b/cmd/hostveil/main.go
@@ -34,16 +34,7 @@ func run(args []string) int {
 		}
 	}
 
-	// With an explicit subcommand, dispatch to it. With none, open the TUI
-	// on an interactive terminal, otherwise print a scan (script-friendly).
-	explicit := len(args) > 0 && !strings.HasPrefix(args[0], "-")
-	cmd := "scan"
-	switch {
-	case explicit:
-		cmd, args = args[0], args[1:]
-	case isInteractive():
-		cmd = "tui"
-	}
+	cmd, args := resolveCommand(args, isInteractive())
 
 	maybeElevate(cmd) // on success the process is replaced by sudo and does not return
 
@@ -75,6 +66,35 @@ func run(args []string) int {
 	}
 }
 
+// resolveCommand decides which subcommand to run and what arguments it
+// receives. It is separate from run so the dispatch rules can be tested
+// without a scan, a terminal, or a sudo prompt.
+//
+// The three cases, in order:
+//
+//   - A bare word is the subcommand.
+//   - A leading flag with no subcommand means scan. Flags only ever apply to
+//     scan (cmdTUI accepts none), so scan's parser gets to accept or reject
+//     them. This case used to fall through to the interactive one, which
+//     opened the TUI and discarded the flags: on a terminal `hostveil --json`
+//     printed no JSON and `hostveil --bogus` reported no error, while both
+//     behaved correctly when piped. Same input, divergent behavior by
+//     TTY-ness, and the silent branch was the interactive one.
+//   - Nothing at all opens the TUI on a terminal, or prints a scan when
+//     piped, which is what makes `hostveil > report.txt` do something useful.
+func resolveCommand(args []string, interactive bool) (string, []string) {
+	switch {
+	case len(args) > 0 && !strings.HasPrefix(args[0], "-"):
+		return args[0], args[1:]
+	case len(args) > 0:
+		return "scan", args
+	case interactive:
+		return "tui", args
+	default:
+		return "scan", args
+	}
+}
+
 func printUsage(w *os.File) {
 	fmt.Fprint(w, `hostveil — guided hardening for self-hosted Linux servers
 
@@ -83,8 +103,9 @@ Usage:
   hostveil scan [flags]          Scan the host and report security findings
   hostveil tui                   Open the interactive TUI explicitly
   hostveil fix <id> [flags]      Preview and apply the fix for a finding
-  hostveil explain <id> [--ai]   Explain a finding (optionally via local AI)
-  hostveil serve [--addr]        Serve the localhost web dashboard
+  hostveil fix --all             Apply every safe (Auto) fix at once
+  hostveil explain <id> [flags]  Explain a finding (optionally via local AI)
+  hostveil serve [--addr]        Serve the localhost web dashboard (alias: web)
   hostveil rollback <id>         Undo a previously applied fix
   hostveil history               List applied fixes and their rollback IDs
   hostveil version               Print the version (also: --version, -V)
@@ -96,8 +117,22 @@ Scan flags:
   --no-color      Disable colored output
 
 Fix flags:
+  --all           Apply every safe (Auto) fix; Review and Manual are left alone
   --service NAME  Disambiguate a finding that affects multiple services
   --action N      For Review fixes, pick alternative N (0-based)
   --yes           Apply without an interactive confirmation
+
+Explain flags:
+  --service NAME  Disambiguate a finding that affects multiple services
+  --ai            Add a plain-language explanation from a local Ollama model
+
+Exit status:
+  hostveil scan exits 1 when any unfixed finding is Critical or High, and 0
+  otherwise — useful as a CI or cron gate. Other commands exit 0 on success,
+  1 on failure, and 2 on a usage error.
+
+Environment:
+  HOSTVEIL_NO_SUDO=1   Never re-exec under sudo (for scripts and CI)
+  NO_COLOR=1           Disable colored output
 `)
 }

--- a/cmd/hostveil/parseflags.go
+++ b/cmd/hostveil/parseflags.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"errors"
+	"flag"
+)
+
+// parseFlags parses a subcommand's flags and reports the exit code to return,
+// or -1 to carry on.
+//
+// -h/--help is not an error. Go's flag package reports it as flag.ErrHelp
+// after printing usage, and treating that like a parse failure made every
+// `hostveil <cmd> --help` exit 2. The top-level case was fixed in #520; the
+// same bug survived one level down in all four subcommands.
+func parseFlags(fs *flag.FlagSet, args []string) int {
+	err := fs.Parse(args)
+	switch {
+	case err == nil:
+		return -1
+	case errors.Is(err, flag.ErrHelp):
+		return 0
+	default:
+		return 2 // flag already printed the error and the usage
+	}
+}

--- a/cmd/hostveil/scan.go
+++ b/cmd/hostveil/scan.go
@@ -21,8 +21,8 @@ func cmdScan(args []string) int {
 	fs.BoolVar(&verbose, "verbose", false, "show descriptions and fix guidance")
 	fs.BoolVar(&verbose, "v", false, "show descriptions and fix guidance (shorthand)")
 	fs.BoolVar(&noColor, "no-color", false, "disable colored output")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code := parseFlags(fs, args); code >= 0 {
+		return code
 	}
 
 	engine := buildEngine()

--- a/cmd/hostveil/serve.go
+++ b/cmd/hostveil/serve.go
@@ -13,8 +13,8 @@ func cmdServe(args []string) int {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	var addr string
 	fs.StringVar(&addr, "addr", "127.0.0.1:8787", "address to bind the dashboard to")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code := parseFlags(fs, args); code >= 0 {
+		return code
 	}
 
 	if !strings.HasPrefix(addr, "127.0.0.1") && !strings.HasPrefix(addr, "localhost") {


### PR DESCRIPTION
Four defects in the command surface. Three failed **silently**.

## 1. A leading flag opened the TUI and discarded it

`explicit := len(args) > 0 && !strings.HasPrefix(args[0], "-")` — a leading flag set this false, which on a terminal selected `tui`, and `cmdTUI(_ []string)` ignores its arguments entirely.

| command | on a terminal (before) | piped (before) |
|---|---|---|
| `hostveil --json` | TUI opens, no JSON, no error | correct scan --json |
| `hostveil --bogus` | TUI opens, no error | correct error |

Same input, divergent behavior by TTY-ness — and the silent branch was the interactive one, where a human is watching and least likely to suspect the flag was eaten.

Flags only ever apply to scan (`cmdTUI` accepts none), so a leading flag now dispatches there and scan's parser accepts or rejects it. The rules moved into `resolveCommand` so they're testable without a scan, a terminal, or a sudo prompt; `TestFlagHandlingDoesNotDependOnTTY` pins the property directly.

## 2. `--help` exited 2 in every subcommand

Go's flag package reports `-h` as `flag.ErrHelp` *after* printing usage, and all four subcommands treated it like any parse failure. The top-level form was fixed in #520 — the same bug survived one level down.

Verified against the built binary:

```
scan --help    exit=0    (was 2)
fix --help     exit=0
explain --help exit=0
serve --help   exit=0
--bogus        exit=2  "flag provided but not defined: -bogus"
```

## 3. `fix --all` was undiscoverable

Implemented at `fix.go:26`, absent from `printUsage`. Also missing: `explain --service`, the `web` alias for `serve`, `HOSTVEIL_NO_SUDO`, and **the exit-status contract** — the thing that makes `hostveil scan` usable as a CI gate was documented nowhere.

## 4. `fix --no-color` did nothing

Parsed at `fix.go:27`, never read again; fix output contains no ANSI at all. A flag that advertises something it doesn't do is worse than an absent one, so it's removed.

## Also: the sudo prompt now explains itself

A first-time user's opening interaction was a bare `[sudo] password for ...` with **nothing above it** — no explanation of who wanted their password or why. For a tool asking to be trusted with root on a server, that's the highest-friction possible opening. Now stderr (never stdout, so `--json` stays clean) carries:

```
hostveil needs root to read /etc/shadow, sshd_config, and the firewall state; re-running with sudo.
It only reads until you ask it to fix something. Set HOSTVEIL_NO_SUDO=1 to skip this (some checks will be skipped too).
```

## `exitCode` finally has a test

It's the CI contract and had none. A regression would silently turn every pipeline gate into a no-op (always 0) or a permanent red (always 1), and nothing else in the suite would notice. Now pinned across severity, the `Fixed` flag, and the mixed case.

## Gate

`go build`/`vet`/`gofmt`/`go mod tidy`/`go test -race ./...` green, golangci-lint v2.12.2 **0 issues**. Behavior verified against the built binary, not only unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)