### PR TITLE
feat(ui): tell the user what to do after a scan

### DIFF
--- a/internal/clirender/nextsteps_test.go
+++ b/internal/clirender/nextsteps_test.go
@@ -1,0 +1,143 @@
+package clirender
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+func fnd(id string, sev model.Severity, rem model.RemediationKind) model.Finding {
+	return model.NewFinding(id, "Title for "+id, sev, model.SourceSSH, rem,
+		model.WithDescription("why it matters"),
+		model.WithHowToFix("do the thing"),
+	)
+}
+
+func report(fs ...model.Finding) model.Report {
+	return model.Report{Findings: fs, Score: model.ScoreBreakdown{Overall: 42}}
+}
+
+// The report named a remediation kind per finding but never the command that
+// acts on one, so a first-time user got a score, a list of problems, and no
+// way in.
+func TestReportEndsWithActionableCommands(t *testing.T) {
+	out := Text(report(fnd("ssh.rootlogin", model.SeverityHigh, model.RemediationReview)), Options{})
+
+	for _, want := range []string{"Next:", "hostveil explain <id>", "hostveil fix <id>"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report does not offer %q:\n%s", want, out)
+		}
+	}
+}
+
+// fix --all is only worth naming when something can actually use it, and the
+// count has to be the number of Auto findings, not the total.
+func TestFixAllOfferedOnlyWithAutoFindings(t *testing.T) {
+	withAuto := Text(report(
+		fnd("ssh.maxauthtries", model.SeverityLow, model.RemediationAuto),
+		fnd("ssh.x11forwarding", model.SeverityLow, model.RemediationAuto),
+		fnd("firewall.inactive", model.SeverityHigh, model.RemediationManual),
+	), Options{})
+	if !strings.Contains(withAuto, "hostveil fix --all") {
+		t.Error("fix --all not offered when Auto findings exist")
+	}
+	if !strings.Contains(withAuto, "2 safe fix(es)") {
+		t.Errorf("count should be the Auto findings only, got:\n%s", withAuto)
+	}
+
+	noAuto := Text(report(
+		fnd("firewall.inactive", model.SeverityHigh, model.RemediationManual),
+		fnd("ssh.rootlogin", model.SeverityHigh, model.RemediationReview),
+	), Options{})
+	if strings.Contains(noAuto, "fix --all") {
+		t.Errorf("fix --all offered with nothing to apply:\n%s", noAuto)
+	}
+}
+
+// A clean host has nothing to act on, so the guidance would be noise.
+func TestNoNextStepsOnACleanReport(t *testing.T) {
+	if out := Text(report(), Options{}); strings.Contains(out, "Next:") {
+		t.Errorf("clean report should not suggest next steps:\n%s", out)
+	}
+}
+
+// Suggesting -v to someone who already passed it is the kind of small thing
+// that makes a tool feel like it is not listening.
+func TestVerboseHintOnlyWhenNotAlreadyVerbose(t *testing.T) {
+	f := fnd("ssh.rootlogin", model.SeverityHigh, model.RemediationReview)
+	if !strings.Contains(Text(report(f), Options{}), "hostveil scan -v") {
+		t.Error("plain output should mention -v")
+	}
+	if strings.Contains(Text(report(f), Options{Verbose: true}), "hostveil scan -v") {
+		t.Error("-v should not be suggested to someone already using it")
+	}
+}
+
+// --- gaps the audit found in this package's existing coverage ---
+
+// Every existing test rendered with Color:false, so nothing checked that the
+// color path terminates its escapes. An unclosed sequence leaves the user's
+// terminal stuck in whatever color the last finding used.
+func TestColoredOutputResetsEveryEscape(t *testing.T) {
+	out := Text(report(
+		fnd("ssh.rootlogin", model.SeverityCritical, model.RemediationReview),
+		fnd("ssh.maxauthtries", model.SeverityLow, model.RemediationAuto),
+	), Options{Color: true, Verbose: true})
+
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatal("Color:true produced no escape sequences at all")
+	}
+	// Not one reset per set: \x1b[0m clears every attribute at once, so
+	// several sets followed by a single reset is correct and normal. What
+	// must hold is that the report does not *end* with an attribute still
+	// in force, which is what leaves the user's shell prompt colored.
+	const reset = "\x1b[0m"
+	last := strings.LastIndex(out, "\x1b[")
+	if last < 0 || !strings.HasPrefix(out[last:], reset) {
+		t.Errorf("output ends with an unreset color escape (%q) — the terminal would stay colored", out[last:min(last+20, len(out))])
+	}
+}
+
+// Color:false must emit no escapes at all, which is what keeps piped output
+// and CI logs clean.
+func TestUncoloredOutputHasNoEscapes(t *testing.T) {
+	out := Text(report(fnd("ssh.rootlogin", model.SeverityHigh, model.RemediationReview)), Options{Verbose: true})
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("uncolored output leaked an ANSI escape:\n%q", out)
+	}
+}
+
+// JSON is the machine-readable contract and nothing asserted it was even
+// valid JSON, let alone that it carried the fields a script would read.
+func TestJSONIsValidAndCarriesTheReport(t *testing.T) {
+	out, err := JSON(report(fnd("ssh.rootlogin", model.SeverityHigh, model.RemediationReview)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if _, ok := parsed["findings"]; !ok {
+		t.Errorf("no findings key in JSON output: %v", keys(parsed))
+	}
+	if _, ok := parsed["score"]; !ok {
+		t.Errorf("no score key in JSON output: %v", keys(parsed))
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Error("JSON output must never contain ANSI escapes")
+	}
+	if strings.Contains(out, "Next:") {
+		t.Error("JSON output must not carry the human-facing next-steps block")
+	}
+}
+
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/clirender/text.go
+++ b/internal/clirender/text.go
@@ -83,6 +83,45 @@ func Text(r model.Report, opts Options) string {
 			}
 		}
 	}
+	b.WriteString(nextSteps(active, opts))
+	return b.String()
+}
+
+// nextSteps closes the report with the commands that act on what it just
+// listed.
+//
+// The report used to end at the last finding. It named a remediation kind
+// per finding — "Auto", "Review", "Manual" — without ever naming the command
+// that acts on one, so a first-time user was shown a score, a list of
+// problems, and no way in. `fix --all` already closes with a next step; the
+// primary output path, the one everybody sees first, was the one without.
+func nextSteps(active []model.Finding, opts Options) string {
+	if len(active) == 0 {
+		return ""
+	}
+	c := palette(opts.Color)
+
+	auto := 0
+	for _, f := range active {
+		if f.Remediation == model.RemediationAuto {
+			auto++
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n%sNext:%s\n", c.bold, c.reset)
+	if auto > 0 {
+		// Named before the per-finding commands because it is the one action
+		// that needs no decision: every Auto fix is reversible, cannot cut
+		// off access to the host, and has exactly one correct form.
+		fmt.Fprintf(&b, "  %shostveil fix --all%s        apply the %d safe fix(es) — each is previewed and reversible\n",
+			c.green, c.reset, auto)
+	}
+	fmt.Fprintf(&b, "  %shostveil explain <id>%s     what a finding means and why it matters\n", c.green, c.reset)
+	fmt.Fprintf(&b, "  %shostveil fix <id>%s         preview one fix and apply it after confirming\n", c.green, c.reset)
+	if !opts.Verbose {
+		fmt.Fprintf(&b, "  %shostveil scan -v%s          show every finding's description and fix guidance\n", c.green, c.reset)
+	}
 	return b.String()
 }
 


### PR DESCRIPTION
The report ended at the last finding. It labelled each one `Auto` / `Review` / `Manual` without ever naming the command that acts on one — so a first-time user got a score, a list of problems, and **no way in**.

`fix --all` already closes with a next step (`fix.go:127`). The primary output path, the one everybody sees first, was the one without.

## After

```
Findings (1):

  [MEDIUM] updates.disabled  Automatic security updates are not enabled Review

Next:
  hostveil explain <id>     what a finding means and why it matters
  hostveil fix <id>         preview one fix and apply it after confirming
  hostveil scan -v          show every finding's description and fix guidance
```

With Auto findings present, `hostveil fix --all` leads — it's the one action needing no decision, since every Auto fix is reversible, can't cut off host access, and has exactly one correct form. The count is the number of **Auto** findings, not the total.

Suppressed where it would be noise: nothing on a clean report, and no `-v` hint for someone already passing `-v`.

## Test gaps closed

Every existing test in this package rendered with `Color:false, Verbose:false`. So the ANSI path had no coverage, and nothing asserted `JSON()` output was even valid JSON.

**On the color test — I got this wrong first.** I initially asserted one reset per set escape, which failed against perfectly good code: `\x1b[0m` clears *every* attribute at once, so N sets followed by a single reset is correct and normal. The property that actually matters is that the report doesn't **end** with an attribute still in force — that's what leaves a user's shell prompt colored.

Verified by mutation rather than assumed:

| mutation | result |
|---|---|
| drop reset from the `-v` line | still passes — that line isn't rendered when `Verbose:true`, so it was unreachable from this test |
| drop reset from the last rendered line | **fails**: `output ends with an unreset color escape ("\x1b[32mhostveil fix <i")` |

The first attempt is worth recording: a mutation test that "passes" because the mutated line was never executed proves nothing, and I nearly took it as evidence.

## Gate

`go build`/`vet`/`gofmt`/`go mod tidy`/`go test -race ./...` green, golangci-lint v2.12.2 **0 issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)