### PR TITLE
docs: add a security policy and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+Thanks for looking. hostveil is a single Go binary that scans a Linux server,
+scores it, and fixes what it safely can.
+
+## Getting set up
+
+```bash
+git clone https://github.com/seolcu/hostveil
+cd hostveil
+go build ./cmd/hostveil
+go test ./...
+```
+
+Go 1.26. No other tooling is required to build or test.
+
+## Running it for real
+
+The binary compiles and tests everywhere, but only *does* anything on Linux
+with docker, ssh, and a firewall present. **Do not run it against your own
+machine** — it applies changes to system files. Use the Vagrant demo VM, which
+rsyncs your working tree in and rebuilds:
+
+```bash
+cd demo && ./run.sh up      # then: ./run.sh scan | web | shell | reset | halt
+```
+
+The VM is deliberately misconfigured, so it has something to find.
+`./run.sh reset` puts it back.
+
+## Before you open a pull request
+
+Run the same gate CI does:
+
+```bash
+go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
+go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
+go run ./cmd/sitegen && git diff --exit-code site/
+```
+
+`go run` works for the linters without installing anything.
+
+**Pull request titles matter.** Merges are squashed and the title becomes the
+commit subject, which drives the version bump and the changelog. It must be
+conventional — `fix(check): ...`, `feat(ui): ...` — and the scope comes from a
+closed allowlist enforced by CI. Put the component in the *scope*, never the
+type. `AGENTS.md` has the full list and the reasoning.
+
+## What makes a change likely to be merged
+
+hostveil's only real claim is that **its score is honest**. Most of the
+project's rules exist to protect that, and they are documented as invariants in
+`AGENTS.md` — worth reading before a first change. The two that come up most:
+
+- **"I couldn't look" must never score the same as "nothing there."** A checker
+  that cannot examine its ground reports `Available() = false` (skipped, axis
+  excluded) or returns a `check.PartialError` (degraded, axis flagged). It must
+  never return no findings and let that be read as clean.
+- **A fix is Auto only if it is safe to apply unattended.** That means
+  reversible, recoverable even if wrong (nothing that can cut off the
+  operator's own SSH access), and unambiguous. Anything else is Review, or
+  Manual. The full standard is the doc comment on `fix.Default()` in
+  `internal/fix/register.go`.
+
+New detection rules are welcome. A rule that fires on a correctly configured
+host is worse than no rule at all, so please include the case that must *not*
+trigger it alongside the case that must.
+
+## Reporting things
+
+- **A finding hostveil misses, or reports wrongly** — open an issue. Include
+  the relevant config and what you expected. These are the most useful reports
+  the project gets.
+- **A security vulnerability in hostveil itself** — see `SECURITY.md`; report
+  it privately rather than in an issue.
+
+## License
+
+Contributions are made under the GPL-3.0, the same license as the project.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ it continues in the same terminal. `version` and `help` never prompt.
 To run unprivileged (scripts/CI), set `HOSTVEIL_NO_SUDO=1`; the root-owned
 domains are then skipped with a clear message.
 
+### Using it as a CI or cron gate
+
+`hostveil scan` exits **1** when any unfixed finding is Critical or High, and
+**0** otherwise — so a scheduled check needs no output parsing:
+
+```bash
+HOSTVEIL_NO_SUDO=1 hostveil scan --json > report.json || echo "action needed"
+```
+
+Other commands exit 0 on success, 1 on failure, and 2 on a usage error.
+
 ## How fixing works
 
 Every finding is classified so the tool never mutates blindly:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report security issues **privately** through GitHub's
+[private vulnerability reporting](https://github.com/seolcu/hostveil/security/advisories/new)
+rather than opening a public issue.
+
+Include whatever you have: what you did, what happened, and what you expected.
+A proof of concept helps but is not required — a clear description of the flaw
+is enough to start.
+
+You should get an acknowledgement within a week. hostveil is maintained by a
+small team rather than a company with an on-call rotation, so please read that
+as a good-faith target and not a guarantee.
+
+## Supported versions
+
+Only the latest release gets fixes. hostveil is a single self-updating binary
+with no long-term support branches; if you are behind, upgrade first and check
+whether the issue still reproduces.
+
+## What is in scope
+
+hostveil runs as root on the machine it is auditing, so the interesting
+questions are about what it does with that privilege:
+
+- **A fix that damages a host.** Any input that makes an applied fix corrupt a
+  config file, write outside its declared path, or leave the file in a state
+  the checkpoint cannot restore.
+- **A fix that cannot be rolled back.** Apply order is backup → write →
+  checkpoint, and `applyEdit` refuses to write if the backup fails. A path
+  around that ordering is a vulnerability even if nothing is corrupted, because
+  reversibility is the promise the whole tool rests on.
+- **Command injection through scanned data.** Exec actions carry argv lists and
+  never a shell string. A container name, image tag, file path, or config value
+  that escapes into a command is in scope.
+- **Web dashboard escapes.** `internal/ui/web` binds to loopback and enforces a
+  Host allowlist (DNS-rebinding defense) plus same-origin checks on mutating
+  requests. Reaching it from another origin, or from a page in the user's
+  browser, is in scope.
+- **Leaking what it reads.** hostveil reads `/etc/shadow`, SSH keys, and
+  compose files containing secrets. Any path that writes those somewhere
+  world-readable, into a scan report, or off the host is in scope.
+- **Privilege escalation via auto-elevation.** `cmd/hostveil/elevate.go`
+  re-execs under sudo. Anything that redirects that to a binary the user did
+  not intend is in scope.
+
+## What is not in scope
+
+- **Findings hostveil misses, or reports wrongly.** Detection gaps and false
+  positives are real bugs and we want them — but as public issues, not private
+  advisories. They do not put anyone at risk by being discussed openly.
+- **The severity or score assigned to a finding.** That is a judgement call.
+  Argue with it in an issue.
+- **Vulnerabilities in the software hostveil audits.** If Docker or OpenSSH has
+  a flaw, report it to them.
+- **Anything requiring an attacker who already has root on the host.** At that
+  point hostveil is not the weakest link.
+
+## Supply chain
+
+Releases are built by GitHub Actions from a tag on `main` and carry checksums,
+SBOMs, and a provenance attestation. `scripts/install.sh` verifies the
+published checksum before installing.
+
+If you believe a published artifact does not match the source it claims to be
+built from, that is in scope and worth reporting privately.


### PR DESCRIPTION
A security tool with **no way to report a vulnerability in itself** was the most visible thing missing from this repository.

## SECURITY.md

Points at GitHub's private vulnerability reporting — which was **disabled**, and I've enabled it, so the link actually works and nobody has to publish a flaw in order to report it. (Easily reversible in repo settings if you'd rather it were off.)

The scope section is specific to what hostveil is, not boilerplate. It runs as root, so the questions worth asking are about what it does with that privilege:

- a fix that damages a host or writes outside its declared path
- **a fix that can't be rolled back** — a path around backup → write → checkpoint is a vulnerability even with no corruption, because reversibility is the promise the tool rests on
- scanned data (container name, image tag, config value) escaping into a command
- reaching the loopback dashboard from another origin
- leaking the `/etc/shadow`, SSH keys, and compose secrets it reads

Explicitly **out** of scope for private reporting: detection gaps, false positives, and score disagreements. Those are real bugs and the project wants them — as public issues. Discussing them openly puts nobody at risk.

## CONTRIBUTING.md

Setup, the demo VM (with the "don't run this against your own machine" warning), and the full CI gate written as `go run` commands so nothing needs installing.

It names the two invariants a first-time contributor is most likely to trip over — *"I couldn't look" must never score the same as "nothing there"*, and what makes a fix Auto — and asks for the case that must **not** trigger a new rule alongside the case that must. A rule that fires on a correctly configured host is worse than no rule.

Also covers PR title rules, since those drive versioning and have caught several PRs in this repo already.

## README

Documents the exit-status contract. `hostveil scan` exits 1 on any unfixed Critical/High — the thing that makes it usable as a CI gate — and that was written down nowhere.

## One thing to check

SECURITY.md says you'll acknowledge reports **within a week**, hedged as a good-faith target rather than a guarantee. That's a commitment I made on your behalf — change or drop it if it doesn't suit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)