### PR TITLE
fix(history): give scan snapshots unique IDs and test the ordering for real

### DIFF
--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -245,8 +245,19 @@ func randomSuffix() string {
 }
 
 // NewScanID returns a sortable ID for a scan snapshot.
+//
+// It carries the same random suffix as NewID, and for the same reason: the
+// timestamp resolves to a millisecond, so two scans starting within one
+// wrote to the same filename and the second silently replaced the first.
+// The delta between scans is computed from the newest snapshot, so a lost
+// one makes the next scan compare against the wrong baseline.
+//
+// The timestamp stays the prefix, so scanFiles' lexical sort remains
+// chronological. Within a single millisecond the order becomes arbitrary,
+// which is the correct answer for two events at the same instant and is in
+// any case better than one of them not existing.
 func NewScanID() string {
-	return time.Now().UTC().Format("20060102-150405.000")
+	return time.Now().UTC().Format("20060102-150405.000") + "-" + randomSuffix()
 }
 
 // blobName returns a filesystem-safe name derived from a path.

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -145,8 +145,20 @@ func TestListIsNewestFirst(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, id := range []string{"ssh.rootlogin", "compose.ds006", "ssh.maxauthtries"} {
-		if _, err := store.Save(Checkpoint{ID: NewID(id), FindingID: id}, map[string][]byte{path: []byte("a\n")}); err != nil {
+	// Save does not stamp CreatedAt — the engine does, at fixflow.go:189 —
+	// so the test has to. Without it all three carried the zero time, the
+	// assertion below was vacuously true, and the ordering was actually
+	// being decided by the ID tiebreak. Flipping After to Before in List
+	// left the whole suite green.
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	want := []string{"newest", "middle", "oldest"}
+	for i, id := range []string{"oldest", "middle", "newest"} {
+		cp := Checkpoint{
+			ID:        NewID(id),
+			FindingID: id,
+			CreatedAt: base.Add(time.Duration(i) * time.Hour),
+		}
+		if _, err := store.Save(cp, map[string][]byte{path: []byte("a\n")}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -158,9 +170,91 @@ func TestListIsNewestFirst(t *testing.T) {
 	if len(cps) != 3 {
 		t.Fatalf("want 3 checkpoints, got %d", len(cps))
 	}
+	for i, wantID := range want {
+		if cps[i].FindingID != wantID {
+			t.Errorf("position %d = %q, want %q — List must be newest first (got order %v)",
+				i, cps[i].FindingID, wantID, findingIDs(cps))
+		}
+	}
 	for i := 1; i < len(cps); i++ {
 		if cps[i-1].CreatedAt.Before(cps[i].CreatedAt) {
 			t.Errorf("checkpoint %d is older than %d — List must be newest first", i-1, i)
 		}
+	}
+}
+
+func findingIDs(cps []Checkpoint) []string {
+	out := make([]string, len(cps))
+	for i, c := range cps {
+		out[i] = c.FindingID
+	}
+	return out
+}
+
+// NewScanID lacked the random suffix that NewID's own doc comment argues is
+// mandatory, twelve lines above it. The timestamp resolves to a millisecond,
+// so two scans starting within one produced the same filename and the second
+// silently replaced the first — and the delta is computed from the newest
+// snapshot, so a lost one makes the next scan compare against the wrong
+// baseline.
+func TestScanIDsAreUniqueWithinAMillisecond(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 2000; i++ {
+		id := NewScanID()
+		if seen[id] {
+			t.Fatalf("NewScanID collided after %d calls: %q", i, id)
+		}
+		seen[id] = true
+	}
+}
+
+// The timestamp must stay the prefix: scanFiles sorts lexically and treats
+// that order as chronological, so a suffix that disturbed it would make
+// LastReport return something other than the newest scan.
+func TestScanIDsSortChronologically(t *testing.T) {
+	first := NewScanID()
+	time.Sleep(2 * time.Millisecond)
+	second := NewScanID()
+	if first >= second {
+		t.Errorf("scan IDs must sort chronologically: %q should precede %q", first, second)
+	}
+}
+
+// Two snapshots written in the same millisecond must both survive.
+func TestConcurrentScanSnapshotsDoNotClobber(t *testing.T) {
+	store := NewStore(t.TempDir())
+	for i := 0; i < 5; i++ {
+		if err := store.SaveReport(NewScanID(), []byte(`{"n":1}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	names, err := scanFiles(store.scansDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 5 {
+		t.Errorf("wrote 5 snapshots, %d survived: %v", len(names), names)
+	}
+}
+
+// Retention is executed on every save but nothing asserted it works, so a
+// broken prune would grow the directory forever without a test noticing.
+func TestScanSnapshotsArePrunedToMaxScans(t *testing.T) {
+	store := NewStore(t.TempDir())
+	for i := 0; i < maxScans+15; i++ {
+		if err := store.SaveReport(NewScanID(), []byte(`{"n":1}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	names, err := scanFiles(store.scansDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != maxScans {
+		t.Errorf("retained %d snapshots, want the %d cap", len(names), maxScans)
+	}
+	// The newest must be the survivors, not an arbitrary subset.
+	if _, ok, err := store.LastReport(); err != nil || !ok {
+		t.Errorf("LastReport after pruning: ok=%v err=%v", ok, err)
 	}
 }


### PR DESCRIPTION
## A test that didn't test its own name

`TestListIsNewestFirst` built checkpoints with **no `CreatedAt`** — `Save` doesn't stamp it, the engine does at `fixflow.go:189`. So all three carried the zero time and this was vacuously true:

```go
if cps[i-1].CreatedAt.Before(cps[i].CreatedAt) {
```

Ordering was actually being decided by the `ID >` tiebreak. Inverting `After` to `Before` in `List` left **the entire suite green** while every UI's history list silently reversed — so "roll back the last thing I did" would restore the oldest change.

Now it sets distinct timestamps and asserts positions. Verified by mutation:

```
$ # After → Before in List
--- FAIL: TestListIsNewestFirst
    position 0 = "oldest", want "newest" — List must be newest first (got order [oldest middle newest])
```

I removed a duplicate I'd added for the same-timestamp tiebreak — `TestListOrderIsDeterministicWithinAMillisecond` already covers it, and better.

## `NewScanID` had no random suffix

Twelve lines *below* `NewID`'s doc comment arguing at length that the random component is **load-bearing, not decoration**:

```go
func NewScanID() string {
	return time.Now().UTC().Format("20060102-150405.000")   // ← no suffix
}
```

The timestamp resolves to a millisecond, so two scans starting within one wrote the same filename and the second silently replaced the first. The delta is computed from the newest snapshot, so a lost one makes the next scan compare against the **wrong baseline** — it reports changes that didn't happen and misses ones that did.

The timestamp stays the prefix so `scanFiles`' lexical sort remains chronological. Within a single millisecond the order becomes arbitrary, which is the correct answer for two events at the same instant and better than one of them not existing.

## Pruning was never asserted

`pruneScans` runs on every save and no test referenced `maxScans` or counted files. A broken prune would grow the directory forever with nothing noticing. Now pinned, including that `LastReport` still works afterwards.

## Note on the premise

An earlier audit flagged `internal/history` as the least-tested load-bearing package at 42.6%. That's the package-local figure; measured with `-coverpkg` across the repo it's **80.3%** — `scans.go` is exercised through `internal/core`. The package wasn't undertested overall. What was missing was concentrated in exactly these spots.

## Gate

`go build`/`vet`/`gofmt`/`go mod tidy`/`go test -race ./...` green, golangci-lint v2.12.2 **0 issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)