### PR TITLE
feat(web): orient the user with an overview in the detail pane

### DIFF
--- a/internal/ui/web/assets/app.css
+++ b/internal/ui/web/assets/app.css
@@ -154,6 +154,28 @@ ul { list-style: none; margin: 0; padding: 0; }
 .detail p { max-width: 74ch; margin: 0 0 12px; }
 .detail .howto { color: var(--slate); text-transform: uppercase; font-size: 10px; letter-spacing: 1.5px; }
 
+/* ── overview (detail pane before a finding is selected) ── */
+.overview { max-width: 68ch; }
+.over-lead { color: var(--slate); }
+.over-sev { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 18px; }
+.over-chip { font-size: 11px; font-weight: 700; letter-spacing: .5px; padding: 4px 9px;
+  border: 1px solid var(--line-2); }
+.over-chip.sev-critical { color: var(--crit); border-color: var(--crit); }
+.over-chip.sev-high { color: var(--high); border-color: var(--high); }
+.over-chip.sev-medium { color: var(--med); }
+.over-chip.sev-low { color: var(--low); }
+.over-fixall { margin: 0 0 6px; }
+.over-note { color: var(--slate); font-size: 12px; margin: 0 0 20px; }
+.over-head { color: var(--slate); text-transform: uppercase; font-size: 10px; letter-spacing: 1.5px;
+  margin: 0 0 8px; padding-top: 14px; border-top: 1px solid var(--line); }
+.over-jump { list-style: none; margin: 0; padding: 0; }
+.over-jump-row { display: grid; grid-template-columns: auto 1fr auto; gap: 12px; align-items: baseline;
+  padding: 8px 4px; border-bottom: 1px solid var(--ink-2); cursor: pointer; }
+.over-jump-row:hover { background: var(--ink-2); }
+.over-jump-row .sev.crit { color: var(--crit); } .over-jump-row .sev.high { color: var(--high); }
+.over-jump-row .sev.medium { color: var(--med); } .over-jump-row .sev.low { color: var(--low); }
+.over-jump-title { color: var(--bone); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
 /* ── fix preview ── */
 .fixbox { margin-top: 18px; border: 1px solid var(--line); background: var(--ink-2); }
 .fixbox-head { padding: 10px 14px; border-bottom: 1px solid var(--line);

--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -252,6 +252,7 @@ function render() {
     return;
   }
 
+  const rows = new Map(); // finding key -> its <li>, so the overview can jump to one
   list.replaceChildren(
     ...items.map((f) => {
       const li = el("li", { class: "finding " + rowSevClass(f) + (isAuto(f) ? " pickable" : "") },
@@ -265,10 +266,73 @@ function render() {
       );
       li.onclick = () => selectFinding(f, li);
       if (selected && selected.id === f.id && selected.service === f.service) li.classList.add("active");
+      rows.set(f.id + "|" + (f.service || ""), li);
       return li;
     })
   );
   renderBatchbar();
+
+  // Orient the user in the detail pane instead of leaving it a blank "Select
+  // a finding". It stays until the first selection, and comes back on rescan.
+  if (!selected) renderOverview(all, items, rows);
+}
+
+// renderOverview fills the detail pane with a read of the whole scan: the
+// score in words, the severity mix, how many can be fixed unattended, and the
+// most severe findings as a jump list. The empty pane was wasted on the one
+// view every user sees first.
+function renderOverview(all, visible, rows) {
+  const counts = [0, 0, 0, 0];
+  for (const f of all) counts[f.severity]++;
+  const autos = all.filter(isAuto).length;
+  const s = report.score.overall;
+  const verdict = s >= 80 ? "in good shape" : s >= 50 ? "middling" : s >= 25 ? "exposed" : "wide open";
+
+  const d = document.getElementById("detail");
+  const box = el("div", { class: "overview" });
+  box.append(el("h3", {}, `This host is ${verdict}.`));
+  box.append(el("p", { class: "over-lead" },
+    `${all.length} unresolved finding${all.length === 1 ? "" : "s"} across the domains that ran.`));
+
+  // Severity chips, only for severities actually present.
+  const chips = el("div", { class: "over-sev" });
+  [["Critical", 0], ["High", 1], ["Medium", 2], ["Low", 3]].forEach(([name, i]) => {
+    if (counts[i] > 0) chips.append(el("span", { class: "over-chip sev-" + SEV[i] }, `${counts[i]} ${name}`));
+  });
+  box.append(chips);
+
+  // The one action that needs no per-finding decision.
+  if (autos > 0) {
+    const btn = el("button", { class: "primary over-fixall" },
+      `Fix all ${autos} safe finding${autos === 1 ? "" : "s"}`);
+    btn.onclick = () => document.getElementById("fixall").click();
+    box.append(btn);
+    box.append(el("p", { class: "over-note" },
+      "Each is previewed and backed up first, and reversible from History."));
+  }
+
+  // Jump list: the most severe handful, so the worst problems are one click
+  // away rather than a scroll-and-hunt.
+  const top = visible.slice(0, 6);
+  if (top.length) {
+    box.append(el("div", { class: "over-head" }, "Most severe"));
+    const ul = el("ul", { class: "over-jump" });
+    for (const f of top) {
+      const li = el("li", { class: "over-jump-row" },
+        el("span", { class: "sev " + rowSevClass(f) }, sevAbbr(f)),
+        el("span", { class: "over-jump-title" }, f.title),
+        f.service ? el("span", { class: "svc" }, f.service) : ""
+      );
+      li.onclick = () => {
+        const row = rows.get(f.id + "|" + (f.service || ""));
+        if (row) { row.scrollIntoView({ block: "nearest" }); selectFinding(f, row); }
+      };
+      ul.append(li);
+    }
+    box.append(ul);
+  }
+
+  d.replaceChildren(box);
 }
 
 function selectFinding(f, li) {

--- a/internal/ui/web/assets/index.html
+++ b/internal/ui/web/assets/index.html
@@ -30,7 +30,7 @@
       <ul id="findings"></ul>
     </section>
     <section class="detail" id="detail">
-      <p class="empty">Select a finding to inspect it.</p>
+      <p class="empty">Reading the scan…</p>
     </section>
   </main>
 


### PR DESCRIPTION
Found during a visual pass of the dashboard: the detail pane read *"Select a finding to inspect it."* and stayed that way until you clicked something — a large empty panel taking up half the screen on the **one view every user sees first**.

## Before / after

Before: half the screen is an instruction to click.

After, it reads the scan already in memory:

- **Verdict in words** — "This host is exposed." (good shape / middling / exposed / wide open, by score band)
- **Severity mix** as colour-coded chips: `18 Critical  20 High  20 Medium  24 Low`
- **`Fix all 26 safe findings`** — the one action needing no per-finding decision — with the note that each is previewed, backed up, and reversible from History
- **Most severe** — the top 6, each a click that selects the finding and scrolls it into view

The long-title case ellipsizes cleanly, and it matches the existing "Instrument" visual system (same chips, meters, mono, severity colours).

## Behaviour

- Shows whenever nothing is selected: on load, and again after a rescan.
- Replaced by the finding detail on the first click.
- No new endpoint and no new state — it reads `report`, which is already in memory. The jump list reuses the existing `selectFinding`.

## Verified on the demo VM

```
heading:  "This host is exposed."
chips:    ["18 Critical","20 High","20 Medium","24 Low"]
fixAll:   "Fix all 26 safe findings"
jumpRows: 6
after jump click: overview gone, detail shows the finding — no console errors
```

The apply → history → rollback cycle and the preview / filter / batch flows were all exercised in the same pass and had no bugs; this was the one clear UX gap.

## Note

`index.html`'s static placeholder — which the script replaces on load — now reads "Reading the scan…" so a slow first paint shows that rather than inviting a click on a list that hasn't rendered.

## Gate

`go build`/`vet`/`gofmt`/`go test -race ./...` green, golangci-lint v2.12.2 **0 issues**, sitegen clean. Assets are embedded, so `go:embed` picks them up on build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)