### PR TITLE
fix(tui): wrap the fix-preview warning and measure history's header

### DIFF
--- a/internal/ui/tui/layout_test.go
+++ b/internal/ui/tui/layout_test.go
@@ -106,3 +106,52 @@ func TestFrameFitsTerminalHeight(t *testing.T) {
 		}
 	}
 }
+
+// The preview warning is the one place a fix says what it cannot undo, and it
+// was rendered as a single unwrapped line. On a terminal narrower than the
+// warning it ran off the edge and was clipped mid-sentence — in the exec case
+// exactly at "There is no rollback", losing the reason that follows. Every
+// line of every mode must fit the width it is drawn into.
+func TestPreviewAndHistoryFitTerminalWidth(t *testing.T) {
+	longWarn := "This recreates the container: the service goes down briefly and comes " +
+		"back on a different image. There is no rollback checkpoint: exec fixes are " +
+		"not file-backed, so hostveil cannot undo this."
+
+	preview := &appModel{
+		mode: modePreview, width: 80, height: 30, selected: map[string]bool{},
+		preview: model.FixPreview{
+			Label: "Update the image for nextcloud",
+			Actions: []model.ActionPreview{
+				{Index: 0, Label: "Pull the new image and recreate nextcloud now", Warning: longWarn,
+					Type: "exec", Commands: [][]string{{"docker", "compose", "-f", "/opt/stacks/cloud/docker-compose.yml", "pull", "nextcloud"}}},
+				{Index: 1, Label: "Download only", Warning: longWarn, Type: "exec",
+					Commands: [][]string{{"docker", "compose", "pull", "nextcloud"}}},
+			},
+		},
+	}
+
+	cps := make([]model.Checkpoint, 20)
+	for i := range cps {
+		cps[i] = model.Checkpoint{
+			ID: "cp", FindingID: "compose.ds018", Label: "Bind redis to loopback", Reversible: true,
+		}
+	}
+	history := &appModel{mode: modeHistory, width: 72, height: 20, checkpoints: cps, report: layoutReport(), selected: map[string]bool{}}
+
+	for name, m := range map[string]*appModel{"preview": preview, "history": history} {
+		content := m.View().Content
+		for _, line := range strings.Split(content, "\n") {
+			if got := visibleWidth(line); got > m.width {
+				t.Errorf("%s width=%d: line is %d columns:\n  %q", name, m.width, got, line)
+			}
+		}
+		// The history list sizes itself to the terminal, so a wrong header
+		// reservation makes it draw more rows than fit and the frame runs past
+		// the bottom. (The preview is content-sized and not height-bounded.)
+		if name == "history" {
+			if got := strings.Count(content, "\n") + 1; got > m.height {
+				t.Errorf("history height=%d: frame is %d lines", m.height, got)
+			}
+		}
+	}
+}

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -442,7 +442,15 @@ func (m *appModel) viewPreview() string {
 
 	a := m.preview.Actions[m.previewAction]
 	if a.Warning != "" {
-		b.WriteString(lipgloss.NewStyle().Foreground(cHigh).Render("⚠  "+a.Warning) + "\n\n")
+		// Wrap the warning. It is the one place the preview explains what
+		// cannot be undone, and unwrapped it ran past the terminal edge and
+		// was clipped mid-sentence — cut, in the exec case, at "There is no
+		// rollback" with the reason that follows lost. The "⚠  " prefix is
+		// two columns plus a space, so the continuation lines are indented to
+		// sit under the text rather than the marker.
+		warn := wrap(a.Warning, min(m.width-4, 78))
+		warn = strings.ReplaceAll(warn, "\n", "\n   ")
+		b.WriteString(lipgloss.NewStyle().Foreground(cHigh).Render("⚠  "+warn) + "\n\n")
 	}
 	switch a.Type {
 	case "edit", "mode":
@@ -466,10 +474,19 @@ func (m *appModel) viewPreview() string {
 // nothing file-backed to restore.
 func (m *appModel) viewHistory() string {
 	var b strings.Builder
-	b.WriteString(m.header())
+	hdr := m.header()
+	b.WriteString(hdr)
 	b.WriteString(m.rule() + "\n")
 
-	reserved := 8
+	// Measure the header rather than assuming 8 lines. viewList was corrected
+	// this way when the axes strip started wrapping; this view had the same
+	// hardcoded reservation and the same bug — on a narrow terminal the extra
+	// header rows pushed the checkpoint list past the footer. The 6 is the
+	// chrome viewHistory draws around the rows (matching viewList): the rule
+	// under the header, the count line, and the footer's blank, rule, and two
+	// hint lines.
+	ftr := m.footer(historyHint)
+	reserved := strings.Count(hdr, "\n") + strings.Count(ftr, "\n") + 3
 	visible := m.height - reserved
 	if visible < 1 {
 		visible = 1
@@ -489,9 +506,11 @@ func (m *appModel) viewHistory() string {
 	for i := m.cpOffset; i < end; i++ {
 		b.WriteString(m.checkpointRow(m.checkpoints[i], i == m.cpCursor) + "\n")
 	}
-	b.WriteString(m.footer("↑/↓ move   enter roll back   esc back   q list"))
+	b.WriteString(ftr)
 	return b.String()
 }
+
+const historyHint = "↑/↓ move   enter roll back   esc back   q list"
 
 func (m *appModel) checkpointRow(cp model.Checkpoint, cursor bool) string {
 	when := cp.CreatedAt.Local().Format("01-02 15:04")


### PR DESCRIPTION
Found by driving the TUI through a real terminal (tmux, sending keystrokes, capturing the rendered screen) rather than snapshotting `View()`.

## The warning was clipped mid-sentence

The fix-preview warning rendered as **one unwrapped line**. On any terminal narrower than the warning it ran off the right edge and was clipped. For an exec fix, the cut landed exactly here:

```
⚠  This recreates the container: ... comes back on a different image. There is no rollback
```

Everything after was gone — **"checkpoint: exec fixes are not file-backed, so hostveil cannot undo this."** The one line in the whole preview that tells the user a change *can't be undone* was the one being truncated.

After, at 100 columns:

```
⚠  This recreates the container: the service goes down briefly and comes back on
   a different image. There is no rollback checkpoint: exec fixes are not
   file-backed, so hostveil cannot undo this. Note the current image ID (`docker
   compose -f /opt/stacks/cloud/docker-compose.yml images`) before applying, so
   you can pin it back if the new one misbehaves.
```

It reuses the same `wrap` the detail view already uses for descriptions; continuation lines are indented to sit under the text, not the `⚠`.

## A second bug next to it

`viewHistory` still had `reserved := 8` — a hardcoded assumption of a two-line header. `viewList` was fixed this way in #557 when the axes strip started wrapping (nine domains is three or four header rows on a normal terminal). `viewHistory` had the same latent bug: on a wrapped header it draws more checkpoint rows than fit and pushes the footer — where the roll-back key hints live — off the bottom. It now measures the header and footer, exactly as `viewList` does.

## The test was lying at first

`TestPreviewAndHistoryFitTerminalWidth` pins both. Two ways my first version failed to catch the history fix, both worth recording:

1. The mutation harness rewrote the **first** `reserved :=` in the file — which is `viewList`'s, not `viewHistory`'s. Mutating the correct line is what finally showed CAUGHT.
2. The history test model had no `report`, so its axes header was empty and never wrapped — the bug couldn't manifest. Giving it a nine-axis report (the realistic case: you can't reach history without a scan) makes it real.

That's the third time this session a green mutation-check turned out to prove nothing until the harness itself was corrected. Both fixes are now independently verified.

## Gate

`go build`/`vet`/`gofmt`/`go test -race ./...` green, golangci-lint v2.12.2 **0 issues**. Warning wrap confirmed live on the demo VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)