### PR TITLE
feat(ui): add a brand mark and favicon, tighten TUI axis spacing

### DIFF
--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -210,17 +210,19 @@ func (m *appModel) deltaLine() string {
 	return s.dim.Render("since last scan  ") + strings.Join(parts, s.dim.Render("   "))
 }
 
-// axisCell is the rendered width of one axis: a 9-column id, an 8-column
-// meter, and a 4-column value. axisGap separates two of them.
+// axisCell is the rendered width of one axis: a 10-column id, an 8-column
+// meter, and a 4-column value. axisGap separates two of them. The id is
+// 10 wide, not 9, so the longest ids ("container", "fileperms") keep a
+// space before the meter instead of butting straight against it.
 const (
-	axisCell = 9 + 8 + 4
+	axisCell = 10 + 8 + 4
 	axisGap  = 3
 )
 
 // axesLine renders the score axes, wrapped to the terminal width.
 //
 // It used to join every axis into a single row. With nine domains that is
-// 9*21 + 8*3 = 213 columns, so on any ordinary 80- or 120-column terminal the
+// 9*22 + 8*3 = 222 columns, so on any ordinary 80- or 120-column terminal the
 // row was far wider than the screen — and in alt-screen mode a wrapped line
 // does not merely look wrong, it pushes every row below it down and off the
 // bottom of the frame, taking the findings list with it.
@@ -228,7 +230,7 @@ func (m *appModel) axesLine() string {
 	s := m.sty()
 	var cells []string
 	for _, ax := range m.report.Score.Axes {
-		label := s.dim.Render(fmt.Sprintf("%-9s", ax.ID))
+		label := s.dim.Render(fmt.Sprintf("%-10s", ax.ID))
 		switch {
 		case !ax.Applicable:
 			cells = append(cells, label+s.track.Render(strings.Repeat("░", 8))+s.dim.Render(" N/A"))

--- a/internal/ui/web/assets/app.css
+++ b/internal/ui/web/assets/app.css
@@ -29,9 +29,12 @@ body {
    ran clean off the right edge — unreachable — on every viewport between the
    560px mobile breakpoint and ~880px (tablets, split-screen, small laptops).
    Wrapping drops .actions to its own right-aligned row instead. */
-.brand { font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; white-space: nowrap; }
+.brand { display: inline-flex; align-items: center; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; white-space: nowrap; }
 .brand b { color: var(--bone); }
-.brand::before { content: "▚"; color: var(--slate); margin-right: 8px; }
+/* The tile-less mark, so it dissolves into any theme's status bar and only the
+   veil slats and revealed core show. (The favicon carries a tile instead, for
+   the neutral background of a browser tab.) */
+.brand::before { content: ""; width: 20px; height: 20px; margin-right: 9px; background: url(/mark.svg) center / contain no-repeat; }
 .actions { margin-left: auto; display: flex; gap: 8px; }
 
 button {

--- a/internal/ui/web/assets/favicon.svg
+++ b/internal/ui/web/assets/favicon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="hostveil">
+  <!-- The hostveil mark. The rounded tile is the host; the three bone slats
+       are the veil drawn over it; the teal panel is the hardened core the
+       scan reveals as the veil is drawn aside. Bone dominates and teal is
+       the one meaningful accent, matching the Instrument palette. Kept as a
+       static two-tone mark because a browser tab icon is requested before
+       any theme is known. Bone #e7e3d8, Safe teal #46c69a, Ink2 tile #12151b. -->
+  <rect width="32" height="32" rx="7" fill="#12151b"/>
+  <clipPath id="veil"><rect x="6" y="6" width="20" height="20" rx="2.5"/></clipPath>
+  <g clip-path="url(#veil)">
+    <rect x="18.5" y="6" width="7.5" height="20" fill="#46c69a"/>
+    <g fill="#e7e3d8">
+      <rect x="6" y="6" width="3.4" height="20"/>
+      <rect x="11" y="6" width="3.4" height="20"/>
+      <rect x="16" y="6" width="3.4" height="20"/>
+    </g>
+  </g>
+</svg>

--- a/internal/ui/web/assets/index.html
+++ b/internal/ui/web/assets/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>hostveil</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <!-- Generated from internal/ui/theme: the palettes, then the layout that
        draws from them. theme.js is blocking and in <head> on purpose — it
        restores the saved theme before the first paint, and the page's CSP

--- a/internal/ui/web/assets/mark.svg
+++ b/internal/ui/web/assets/mark.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="hostveil">
+  <!-- The status-bar mark: the same veil-and-reveal figure as the favicon, but
+       with no tile behind it so it dissolves into whatever theme paints the
+       bar and only the veil slats and the revealed core show. The favicon
+       keeps its tile because a browser tab has no known background. Teal is the
+       constant safety accent across every theme, so it is not themed here. -->
+  <clipPath id="veil"><rect x="2" y="2" width="28" height="28" rx="6"/></clipPath>
+  <g clip-path="url(#veil)">
+    <rect x="18" y="2" width="12" height="28" fill="#46c69a"/>
+    <g fill="#e7e3d8">
+      <rect x="2" y="2" width="4.6" height="28"/>
+      <rect x="8" y="2" width="4.6" height="28"/>
+      <rect x="14" y="2" width="4.6" height="28"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Ran hostveil end-to-end against a docker-reproduced demo (the vulnerable compose stacks brought up as real containers, 48 findings across the compose/firewall/updates domains) and checked the CLI, TUI, and web dashboard for visual problems. CLI, TUI, and web all worked — scan, explain, fix preview + apply, rescan-with-resolved-tracking, history, rollback, live theme switching, and the token gate. Two visual issues turned up, both fixed here.

## Changes

**Brand mark + favicon (web).** The dashboard had no favicon, so the browser logged a `/favicon.ico` 404 on every load and the tab icon was blank. Added a proper mark instead of a throwaway icon: a rounded tile (the host) with three bone "veil" slats parting to reveal a teal hardened core — the thing the scan does, and it reads down to 16px.
- `favicon.svg` — opaque tile, for the neutral background of a browser tab.
- `mark.svg` — a tile-less variant for the status bar, so it dissolves into whatever theme paints the bar and only the slats and revealed core show (an opaque tile stood out as a mismatched dark box on the warmer/cooler themes).
- The status bar now renders this mark in place of the plain `▚` glyph.
- Bone dominates and teal is the single accent, matching the Instrument palette; teal is the constant safety color across all five themes, so the mark is not themed.

**TUI axis spacing.** The score-axis id column was 9 wide, exactly the length of the two longest ids (`container`, `fileperms`), so their meter bars butted straight against the label with no separating space. Widened the id column to 10 (and the `axisCell` width + comments that track it) so every label keeps a gap before its meter.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .`, and `go test -race ./...` all pass. Verified the favicon and status-bar mark render (HTTP 200, no console errors, clean across all five themes) and the widened TUI column with real terminal captures.

golangci-lint could not be run locally: the pinned `v2.12.2` is built with go1.25 and refuses the repo's go1.26 target in this environment. The change is a printf width bump, a comment, and static SVG/HTML/CSS assets — nothing staticcheck/ineffassign/misspell would flag — and CI runs the linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_