### PR TITLE
docs: add README screenshots, community health files, and a comparison

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Something hostveil did wrong — a crash, a bad fix, or a finding it got wrong or missed.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. If this is a **security
+        vulnerability in hostveil itself**, please don't use this form — report
+        it privately per [SECURITY.md](https://github.com/seolcu/hostveil/blob/main/SECURITY.md) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, what did hostveil do, and what did you expect instead?
+      placeholder: |
+        I ran `hostveil fix ssh.rootlogin` and ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which part
+      description: Roughly where the problem is. Pick the closest.
+      options:
+        - A finding is wrong or missing (false positive / false negative)
+        - A fix did the wrong thing, or couldn't be rolled back
+        - Scan / scoring
+        - TUI
+        - Web dashboard
+        - CLI / scripting
+        - Install / build
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: hostveil version
+      description: Output of `hostveil version`.
+      placeholder: v3.2.0
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / distribution
+      description: e.g. Ubuntu 24.04, Debian 12, Fedora 40.
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Relevant config and output
+      description: >
+        For a wrong or missing finding, the config that should (or should not)
+        have triggered it is the single most useful thing you can include — the
+        `sshd_config` snippet, the `docker-compose.yml` service, the `ss`/`ufw`
+        line. Paste `hostveil scan --json` output if it helps. Redact secrets.
+      render: text
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: This is not a security vulnerability in hostveil itself (those go through SECURITY.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability in hostveil
+    url: https://github.com/seolcu/hostveil/security/advisories/new
+    about: hostveil runs as root — please report vulnerabilities privately, not as a public issue. See SECURITY.md.
+  - name: Documentation and usage
+    url: https://hostveil.seolcu.com/docs/
+    about: How to install, run, and read the report.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request or new detection rule
+description: Suggest a capability, or a security check hostveil should add.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        New detection rules are welcome. A rule that fires on a correctly
+        configured host is worse than no rule at all — so if you're proposing a
+        check, please describe the case that must **not** trigger it too.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What gap or misconfiguration are you thinking about? Who does it affect?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you'd like hostveil to do
+      description: >
+        For a new check: what should it flag, at what severity, and is there a
+        safe automatic fix or is it Manual? For a feature: what should it look
+        like?
+    validations:
+      required: true
+  - type: textarea
+    id: must-not-trigger
+    attributes:
+      label: What must NOT trigger it
+      description: For a detection rule, the configuration that is fine and should stay silent.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--
+Title: conventional and with a scope from the allowlist — e.g. `fix(check): ...`,
+`feat(ui): ...`. The title becomes the squashed commit subject and drives the
+version bump and changelog, so put the component in the SCOPE, never the type.
+See AGENTS.md for the allowlist and the reasoning. CI enforces it.
+-->
+
+## What and why
+
+<!-- What does this change do, and what problem does it solve? Link any issue: Closes #123 -->
+
+## Checklist
+
+- [ ] Title is conventional with a valid scope (`type(scope): ...`).
+- [ ] Ran the CI gate locally and it passes:
+  ```
+  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
+  go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
+  go run ./cmd/sitegen && git diff --exit-code site/
+  ```
+- [ ] For a new or changed detection rule: added the case that must **not** trigger it, not just the one that must.
+- [ ] For a UI change: included a screenshot, or confirmed the TUI/web layering tests still pass.
+- [ ] The score stays honest — a checker that can't look reports skipped/degraded, it never passes "couldn't look" off as "nothing there" (see AGENTS.md invariants).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use hostveil in your work, please cite it using this metadata."
+title: hostveil
+abstract: >-
+  A single-binary guided hardening tool for self-hosted Linux servers. It scans
+  the host, its Docker/Compose stacks, and image CVEs, merges the findings into
+  one 0–100 score, explains them in plain language, and applies fixes with a
+  preview, a backup, and one-command rollback. Winner of the Grand Prize
+  (Development) at the 2026-1 Ajou University SoftCon.
+type: software
+authors:
+  - name: seolcu
+    alias: seolcu
+  - name: gkdms04
+    alias: gkdms04
+repository-code: "https://github.com/seolcu/hostveil"
+url: "https://hostveil.seolcu.com/"
+license: GPL-3.0-or-later
+keywords:
+  - security
+  - linux
+  - self-hosting
+  - hardening
+  - docker

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers responsible for enforcement privately. The quickest
+confidential channel is GitHub's
+[private vulnerability reporting](https://github.com/seolcu/hostveil/security/advisories/new);
+you may also contact a maintainer directly. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -9,8 +9,14 @@ One binary, no config file, no cloud account.
 [![Release](https://img.shields.io/github/v/release/seolcu/hostveil)](https://github.com/seolcu/hostveil/releases/latest)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/seolcu/hostveil)](go.mod)
 [![License: GPL-3.0](https://img.shields.io/github/license/seolcu/hostveil)](LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/seolcu/hostveil)](https://goreportcard.com/report/github.com/seolcu/hostveil)
 
 [Website](https://hostveil.seolcu.com/) · [Docs](https://hostveil.seolcu.com/docs/) · [Latest release](https://github.com/seolcu/hostveil/releases/latest)
+
+<p align="center">
+  <img src="site/assets/web.png" width="900"
+       alt="hostveil's web dashboard: a 0–100 security score, per-domain meters, and findings grouped by severity with one-click safe fixes">
+</p>
 
 ---
 
@@ -43,6 +49,12 @@ renormalized so you are never handed a misleadingly perfect result.
 
 ```bash
 curl -fsSL https://hostveil.seolcu.com/install.sh | bash
+```
+
+Or, if you have Go 1.26+ and would rather build it yourself:
+
+```bash
+go install github.com/seolcu/hostveil/cmd/hostveil@latest
 ```
 
 Trivy is optional — install it any time to enable image CVE scanning.
@@ -105,6 +117,11 @@ same engine, a fix applied anywhere is reversible.
 
 ## Interfaces
 
+<p align="center">
+  <img src="site/assets/tui.png" width="820"
+       alt="hostveil's terminal UI: the same score and per-domain meters over a keyboard-driven findings list">
+</p>
+
 - **TUI** — keyboard-driven, the default when you run `hostveil` on a terminal.
 - **Web** — `hostveil serve`, a localhost-bound dashboard. It prints a URL
   carrying a one-off access token; open that exact URL. Loopback keeps the
@@ -126,6 +143,28 @@ bar, or set it explicitly with `--theme nord` or `HOSTVEIL_THEME=nord`.
 LLM (Ollama by default), so nothing leaves your host. AI is strictly
 advisory — it never applies changes — and every explanation, score, and fix
 works with no AI at all.
+
+## How it compares
+
+Most server-hardening tools are auditors: they hand you a report and leave the
+fixing to you. hostveil is built to close that loop for people who aren't
+security experts.
+
+- **[Lynis](https://github.com/CISOfy/lynis)** is a thorough, expert-oriented
+  host auditor. It prints a long list of suggestions but doesn't apply them,
+  and reading the output assumes you already know which ones matter.
+- **[docker-bench-security](https://github.com/docker/docker-bench-security)**
+  checks a Docker host against the CIS benchmark. It's container-only, and it
+  reports rather than fixes.
+- **[Trivy](https://github.com/aquasecurity/trivy)** scans images and
+  filesystems for known CVEs and misconfigurations. It's excellent at that one
+  job — hostveil actually *runs* Trivy for its CVE domain — but it doesn't look
+  at your SSH config, firewall, or accounts.
+
+hostveil's angle is to merge the host, your containers, and image CVEs into a
+single 0–100 score, explain each finding in plain language, and then **apply
+the fix** — with a preview, a backup, and one-command rollback. One binary, and
+no report to interpret.
 
 ## Build from source
 


### PR DESCRIPTION
## What and why

The code and release tooling are already mature, but a few first-impression and contributor-facing pieces were missing. This rounds them out — no code changes.

- **README screenshots.** The README had no visuals despite the TUI and dashboard being the whole pitch. Wired in the existing `site/assets/web.png` and `tui.png` (already shipped and used as the site's `og:image`) as a hero and in the Interfaces section.
- **"How it compares" section.** Positions hostveil against Lynis, docker-bench-security, and Trivy — auditors that report, where hostveil closes the loop by applying and rolling back fixes.
- **Second install path + badge.** Documented `go install github.com/seolcu/hostveil/cmd/hostveil@latest` and added a Go Report Card badge.
- **Community health files** GitHub surfaces in its Community Standards checklist: `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), issue forms (bug report / feature-or-detection-rule, with a private security-contact link and a docs link), and a pull request template mirroring the CI gate and the conventional-title rule.
- **`CITATION.cff`.**

Two distribution paths I deliberately did **not** wire up, to avoid touching the release pipeline blindly:
- **Homebrew** would mean a `brews:` block in goreleaser, which needs a separate `homebrew-tap` repo and a token secret. Half-configured, it fails the release (and the pipeline demotes a failed release to a draft). Happy to add it once the tap repo and secret exist.
- **A Docker image** is a poor fit for a tool that audits the host as root — run in a container it would inspect the container, not the host — so I left it out rather than ship something misleading.

The two screenshots predate the recent brand-mark and TUI-spacing tweaks, but they're the full-demo-VM shots (every domain firing, 70 findings) and can't be reproduced at that richness outside the Vagrant demo — best refreshed there by a maintainer when convenient.

## Checklist

- [x] Title is conventional (`docs:`; scope is optional here and no package fits repo-meta).
- [x] Ran the relevant gate locally: `go build ./...`, `go test` for `internal/docs` and `cmd/sitegen`, and `go run ./cmd/sitegen && git diff --exit-code site/` — all clean. No Go changed.
- [x] Issue-form and CITATION.cff YAML validated as parseable.
- [ ] N/A — no detection-rule or UI code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_