### PR TITLE
fix(tui): compose every mode through one frame layout

### DIFF
--- a/internal/ui/tui/frame.go
+++ b/internal/ui/tui/frame.go
@@ -1,0 +1,381 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// This file owns the shape of the screen: how a frame is assembled, how tall
+// each region is, and what happens when the terminal is too small for all of
+// it. No mode composes its own frame.
+//
+// It replaces a scheme where every view appended to a strings.Builder and the
+// two scrolling views worked out their row budget by counting the newlines of
+// chrome they had *already rendered* (`reserved := strings.Count(hdr, "\n") +
+// strings.Count(ftr, "\n") + 3`). That arithmetic was the direct cause of two
+// separate fixed bugs, because it had to be re-derived by hand every time the
+// chrome changed, and getting it wrong pushed the key hints off the bottom of
+// the alt screen with nothing to say they had gone. Here the chrome is
+// measured first and the body is *told* what it may use.
+
+// minBodyRows is how much room the findings list must keep for the full axes
+// strip to be worth drawing. Below it the header drops to the one-line tier:
+// a score breakdown is context, and context that leaves no room for the thing
+// it is context *for* is worse than no context.
+const minBodyRows = 6
+
+// Fallback terminal size, used until the first WindowSizeMsg arrives and by
+// every model built as a bare struct literal (which is how the layout tests
+// and several call sites build one). 80x24 is the floor every terminal meets.
+const (
+	fallbackWidth  = 80
+	fallbackHeight = 24
+)
+
+type headerKind int
+
+const (
+	hdrNone    headerKind = iota // no chrome above the body at all
+	hdrCompact                   // exactly one row, at every width
+	hdrFull                      // gauge + axes strip + delta line
+)
+
+// header is what a mode asks for. right fills the compact tier's third slot
+// with a mode marker ("FIX PREVIEW"); when it is empty the slot falls back to
+// naming the weakest axes, so the row is never wasted.
+type header struct {
+	kind  headerKind
+	right string
+}
+
+func noHeader() header                  { return header{kind: hdrNone} }
+func compactHeader(right string) header { return header{kind: hdrCompact, right: right} }
+func fullHeader() header                { return header{kind: hdrFull} }
+
+// compose renders one whole screen, and is the only place a frame is
+// assembled.
+//
+//	hdr    which header tier the mode wants. compose may downgrade hdrFull
+//	       when the screen is too short to spend the rows on it.
+//	title  extra chrome rows under the header — a modal's label. Already
+//	       styled.
+//	hint   key bindings for the footer, which is pinned to the last row.
+//	fill   draws the body. Called exactly once, with the number of rows it
+//	       may use. Returning fewer pads the bottom; returning more is cut.
+//
+// The result is exactly m.height lines with no trailing newline. The trailing
+// newline matters: the height test counts separators, so one stray "\n" makes
+// the frame h+1 rows and scrolls the alt screen.
+func (m *appModel) compose(hdr header, title []string, hint string, fill func(rows int) []string) string {
+	m.fitSize()
+	w, h := m.width, m.height
+
+	// The footer is costed first because it is the one region that must
+	// survive: it is where every key binding is documented, and a user who
+	// cannot see it has no way to find out what to press.
+	ftr := m.footerRows(hint)
+
+	top := m.headerRows(hdr, len(ftr))
+	top = append(top, title...)
+	if len(top) > 0 {
+		top = append(top, m.ruleRow())
+	}
+
+	// Shed chrome from the bottom of the header up — the rule first, then the
+	// delta line, then axis rows — rather than clipping the frame, so what is
+	// lost is always the least informative thing left.
+	for len(top)+len(ftr) > h && len(top) > 0 {
+		top = top[:len(top)-1]
+	}
+	if len(ftr) > h {
+		ftr = ftr[len(ftr)-h:] // keep the hints, drop the footer's rule
+	}
+
+	budget := h - len(top) - len(ftr)
+	body := fitRows(fill(budget), budget)
+
+	out := make([]string, 0, h)
+	out = append(out, top...)
+	out = append(out, body...)
+	out = append(out, ftr...)
+	for i := range out {
+		out[i] = clip(out[i], w)
+	}
+	return strings.Join(out, "\n")
+}
+
+// fitSize substitutes a usable terminal size for an unset one. Without it a
+// model that has not seen a WindowSizeMsg draws with width 0, which means
+// strings.Repeat with a negative count and a negative row budget.
+func (m *appModel) fitSize() {
+	if m.width <= 0 {
+		m.width = fallbackWidth
+	}
+	if m.height <= 0 {
+		m.height = fallbackHeight
+	}
+}
+
+// headerRows renders the requested tier, downgrading hdrFull when the axes
+// strip would not leave the body enough room. footerRows is how tall the
+// footer turned out to be; the decision needs it, and only compose knows.
+func (m *appModel) headerRows(hdr header, footerRows int) []string {
+	switch hdr.kind {
+	case hdrNone:
+		return nil
+	case hdrFull:
+		full := m.fullHeaderRows()
+		if m.height-len(full)-1-footerRows >= minBodyRows {
+			return full
+		}
+	}
+	return []string{m.topRow(hdr.right)}
+}
+
+// fullHeaderRows is the list's header: the brand and exposure gauge, the
+// per-axis bars, and what moved since the last scan.
+func (m *appModel) fullHeaderRows() []string {
+	s := m.sty()
+	out := []string{s.dim.Render("▚ ") + s.brand.Render("hostveil") + "   " +
+		m.gaugeRow(gaugeMeterWidth(m.width))}
+	if ax := m.axesLine(); ax != "" {
+		out = append(out, strings.Split(ax, "\n")...)
+	}
+	if d := m.deltaLine(); d != "" {
+		out = append(out, d)
+	}
+	return out
+}
+
+// topRow is the compact tier: one row, at every width, ever.
+//
+// Four segments joined by three spaces. When they do not fit, the meter is
+// squeezed before anything is dropped, and only then are segments dropped
+// right to left — the brand is what identifies the program and is never one
+// of them.
+func (m *appModel) topRow(right string) string {
+	s := m.sty()
+	brand := s.dim.Render("▚ ") + s.brand.Render("hostveil")
+
+	if right == "" {
+		right = m.axisDigest()
+	}
+	var segs []string
+	if right != "" {
+		segs = append(segs, s.dim.Render(right))
+	}
+	if d := m.deltaDigest(); d != "" {
+		segs = append(segs, d)
+	}
+
+	const gap = "   "
+	for n := len(segs); n >= 0; n-- {
+		for mw := 18; mw >= 4; mw -= 2 {
+			row := brand + gap + m.gaugeRow(mw)
+			for _, sg := range segs[:n] {
+				row += gap + sg
+			}
+			if lipgloss.Width(row) <= m.width {
+				return row
+			}
+		}
+	}
+	return brand // not even the gauge fits; clip() guards the rest
+}
+
+// gaugeRow is "SECURITY ▊▊▊░░ 62/100" with a meter of the given width. The
+// literal SECURITY is deliberate and load-bearing: it is how both header
+// tiers stay recognisably the same instrument.
+func (m *appModel) gaugeRow(meterW int) string {
+	s := m.sty()
+	sc := m.report.Score.Overall
+	return s.dim.Render("SECURITY ") + s.meter(sc, meterW, s.band(sc)) +
+		s.bone.Render(fmt.Sprintf(" %d", sc)) + s.dim.Render("/100")
+}
+
+// gaugeMeterWidth shrinks the full header's meter on a narrow terminal.
+// Everything around it is fixed width: "▚ " + "hostveil" + a three-space gap
+// + "SECURITY " + " NNN" + "/100".
+func gaugeMeterWidth(w int) int {
+	const chrome = 2 + 8 + 3 + 9 + 4 + 4
+	if w > 0 && w-chrome < 18 {
+		return max(4, w-chrome)
+	}
+	return 18
+}
+
+// axisDigest names the two weakest applicable axes. It is the compact tier's
+// stand-in for the strip: not the whole breakdown, but enough to say where
+// the score is being lost without spending nine rows saying it.
+func (m *appModel) axisDigest() string {
+	var ax []model.ScoreAxis
+	for _, a := range m.report.Score.Axes {
+		if a.Applicable {
+			ax = append(ax, a)
+		}
+	}
+	if len(ax) == 0 {
+		return ""
+	}
+	// Stable, so ties keep axisDefs order and the digest does not flicker
+	// between two equally weak domains.
+	sort.SliceStable(ax, func(i, j int) bool { return ax[i].Score < ax[j].Score })
+	if len(ax) > 2 {
+		ax = ax[:2]
+	}
+	parts := make([]string, 0, len(ax))
+	for _, a := range ax {
+		parts = append(parts, fmt.Sprintf("%s %d", a.ID, a.Score))
+	}
+	return "weakest " + strings.Join(parts, " · ")
+}
+
+// deltaDigest is deltaLine compressed into one field for the compact tier.
+func (m *appModel) deltaDigest() string {
+	if !m.delta.HasChanges() {
+		return ""
+	}
+	s := m.sty()
+	var parts []string
+	if n := len(m.delta.Resolved); n > 0 {
+		parts = append(parts, s.safe.Render(fmt.Sprintf("✓%d", n)))
+	}
+	if n := len(m.delta.New); n > 0 {
+		parts = append(parts, lipgloss.NewStyle().Foreground(s.cHigh).Render(fmt.Sprintf("+%d", n)))
+	}
+	if n := len(m.delta.Changed); n > 0 {
+		parts = append(parts, s.bone.Render(fmt.Sprintf("~%d", n)))
+	}
+	return strings.Join(parts, " ")
+}
+
+// footerRows is the pinned footer: a rule, then the key hints reflowed to the
+// terminal width. An empty hint pins nothing.
+func (m *appModel) footerRows(hint string) []string {
+	if hint == "" {
+		return nil
+	}
+	dim := m.sty().dim
+	out := []string{m.ruleRow()}
+	for _, line := range strings.Split(m.wrapHint(hint), "\n") {
+		out = append(out, dim.Render(line))
+	}
+	return out
+}
+
+func (m *appModel) ruleRow() string {
+	w := m.width
+	if w < 1 {
+		w = 1
+	}
+	return m.sty().track.Render(strings.Repeat("─", w))
+}
+
+// --- row plumbing ---
+
+// styledRows renders each line of a multi-line string separately, so the
+// result can be laid out by the frame rather than embedded as one blob. An
+// empty string is no rows at all, not one empty row — the difference is a
+// stray blank line in every frame that uses it.
+func styledRows(st lipgloss.Style, text string) []string {
+	if text == "" {
+		return nil
+	}
+	lines := strings.Split(text, "\n")
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		out[i] = st.Render(l)
+	}
+	return out
+}
+
+// fitRows pads with blank rows or cuts from the end so the result is exactly
+// n rows. Padding is "" rather than spaces: it satisfies the width invariant
+// for free, and the background is already painted by tea.View.
+func fitRows(rs []string, n int) []string {
+	if n <= 0 {
+		return nil
+	}
+	if len(rs) >= n {
+		return rs[:n]
+	}
+	out := make([]string, n)
+	copy(out, rs)
+	return out
+}
+
+// centerRows pads to n rows with the blanks split above and below, so a short
+// body sits in the middle of the frame instead of clinging to the top of it.
+func centerRows(rs []string, n int) []string {
+	if n <= 0 || len(rs) >= n {
+		return fitRows(rs, n)
+	}
+	out := make([]string, n)
+	copy(out[(n-len(rs))/2:], rs)
+	return out
+}
+
+// clipRows is fitRows for a body that may genuinely be longer than the frame.
+// The last kept row becomes an ellipsis, because a body cut without a mark
+// reads as the end of the text rather than the end of the screen.
+func (m *appModel) clipRows(rs []string, n int) []string {
+	if n <= 0 {
+		return nil
+	}
+	if len(rs) <= n {
+		return rs
+	}
+	out := make([]string, n)
+	copy(out, rs[:n])
+	out[n-1] = m.sty().dim.Render("  …")
+	return out
+}
+
+// clip hard-cuts one rendered row to w columns, counting printable cells and
+// copying escape sequences through at zero width. It is the frame's last-
+// resort width guarantee.
+//
+// truncate() cannot do this job: it measures runes and would count an SGR
+// sequence as a dozen columns, then cut through the middle of one. The two
+// are for different things — truncate shortens plain text before it is
+// styled, clip bounds a row that already is.
+func clip(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	var b strings.Builder
+	col, styled := 0, false
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			j := i
+			for j < len(s) && s[j] != 'm' {
+				j++
+			}
+			if j < len(s) {
+				j++
+			}
+			b.WriteString(s[i:j])
+			styled = true
+			i = j
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		rw := lipgloss.Width(string(r))
+		if col+rw > w {
+			if styled {
+				b.WriteString("\x1b[m") // never leave a colour open past the cut
+			}
+			return b.String()
+		}
+		b.WriteString(s[i : i+size])
+		col += rw
+		i += size
+	}
+	return s
+}

--- a/internal/ui/tui/frame_test.go
+++ b/internal/ui/tui/frame_test.go
@@ -1,0 +1,160 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// modeModels builds one populated model per mode at the given size. Every
+// mode is represented, which the older per-mode assertions were not: the
+// theme test's mode list is a hand-written subset, so preview, history and
+// the rollback confirmation were never rendered by any assertion at all.
+func modeModels(w, h int) map[string]*appModel {
+	r := layoutReport()
+	cps := []model.Checkpoint{
+		{ID: "cp1", FindingID: "compose.ds018", Label: "Bind redis to loopback", Reversible: true,
+			Files: []string{"/opt/stacks/cloud/docker-compose.yml"}, RestartService: "redis",
+			Diff: "--- a\n+++ b\n-      - \"6379:6379\"\n+      - \"127.0.0.1:6379:6379\"\n"},
+		{ID: "cp2", FindingID: "firewall.inactive", Label: "Enable ufw", Reversible: false},
+	}
+	preview := model.FixPreview{
+		FindingID: "compose.ds018", Label: "Bind redis to loopback",
+		Actions: []model.ActionPreview{
+			{Index: 0, Label: "Publish on 127.0.0.1 only", Type: "edit", Path: "/opt/stacks/cloud/docker-compose.yml",
+				Diff: "--- a\n+++ b\n-      - \"6379:6379\"\n+      - \"127.0.0.1:6379:6379\"\n"},
+			{Index: 1, Label: "Remove the published port", Type: "exec",
+				Warning:  "This recreates the container and there is no rollback checkpoint.",
+				Commands: [][]string{{"docker", "compose", "up", "-d", "redis"}}},
+		},
+	}
+
+	out := map[string]*appModel{}
+	for name, md := range map[string]mode{
+		"scanning": modeScanning, "list": modeList, "detail": modeDetail,
+		"preview": modePreview, "message": modeMessage, "history": modeHistory,
+		"rollback": modeRollbackConfirm, "theme": modeTheme,
+	} {
+		m := &appModel{
+			mode: md, width: w, height: h, report: r, selected: map[string]bool{},
+			status: "Scanning…", checkpoints: cps, preview: preview,
+			delta: model.Delta{Resolved: r.Findings[:1], New: r.Findings[1:2]},
+		}
+		m.rebuildActive()
+		out[name] = m
+	}
+	return out
+}
+
+// The frame must be exactly the terminal, in both axes, in every mode. This
+// one table is the regression net for the whole composer: a mode that forgets
+// to pad, one that overruns its budget, and one that emits a trailing newline
+// all show up here rather than on someone's terminal.
+func TestEveryModeFillsExactlyTheTerminal(t *testing.T) {
+	sizes := []struct{ w, h int }{{200, 40}, {120, 34}, {100, 34}, {80, 24}, {60, 24}, {44, 20}}
+	for _, sz := range sizes {
+		for name, m := range modeModels(sz.w, sz.h) {
+			lines := strings.Split(m.View().Content, "\n")
+			if len(lines) != sz.h {
+				t.Errorf("%s %dx%d: frame is %d lines, want %d", name, sz.w, sz.h, len(lines), sz.h)
+			}
+			for i, line := range lines {
+				if got := visibleWidth(line); got > sz.w {
+					t.Errorf("%s %dx%d: line %d is %d columns:\n  %q", name, sz.w, sz.h, i, got, line)
+				}
+			}
+		}
+	}
+}
+
+// The key hints live on the last row, always. Content-sized modes used to end
+// wherever their content did, so on a short detail view the hints sat in the
+// middle of the screen with an empty third below them.
+func TestFooterIsPinned(t *testing.T) {
+	want := map[string]string{
+		"scanning": "ctrl+c quit", "list": "q quit", "detail": "q list",
+		"preview": "n cancel", "message": "continue", "history": "q list",
+		"rollback": "n cancel", "theme": "esc cancel",
+	}
+	for name, m := range modeModels(100, 34) {
+		lines := strings.Split(m.View().Content, "\n")
+		last := lines[len(lines)-1]
+		if !strings.Contains(last, want[name]) {
+			t.Errorf("%s: last row should end the key hints (%q), got %q", name, want[name], last)
+		}
+	}
+}
+
+// A model that has not seen a WindowSizeMsg has width and height 0. Drawing
+// into that meant strings.Repeat with a negative count and a negative row
+// budget; the fallback size is what keeps the first frame — and every model
+// built as a bare literal — renderable.
+func TestUnsetSizeRenders(t *testing.T) {
+	for _, md := range []mode{modeScanning, modeList} {
+		m := &appModel{mode: md}
+		lines := strings.Split(m.View().Content, "\n")
+		if len(lines) != fallbackHeight {
+			t.Errorf("mode %v: unsized frame is %d lines, want %d", md, len(lines), fallbackHeight)
+		}
+		for _, line := range lines {
+			if got := visibleWidth(line); got > fallbackWidth {
+				t.Errorf("mode %v: unsized line is %d columns: %q", md, got, line)
+			}
+		}
+	}
+}
+
+// The compact header is one row at every width — that is the whole point of
+// it. The full strip costs three to five rows and is worth it on the list;
+// repeating it over a detail view is what left an 80x24 terminal with half a
+// screen of chrome.
+func TestCompactHeaderIsOneRow(t *testing.T) {
+	for _, w := range []int{200, 100, 80, 44, 20} {
+		m := &appModel{mode: modeDetail, width: w, height: 30, report: layoutReport(), selected: map[string]bool{}}
+		row := m.topRow("FIX PREVIEW")
+		if strings.Contains(row, "\n") {
+			t.Errorf("width=%d: compact header spans several rows: %q", w, row)
+		}
+		if got := visibleWidth(row); got > w {
+			t.Errorf("width=%d: compact header is %d columns: %q", w, got, row)
+		}
+	}
+}
+
+// The full header earns its rows only while the list still has room to be a
+// list. On a short or narrow terminal the axes strip wraps to five or nine
+// rows, and keeping it there would leave the findings a couple of lines.
+func TestFullHeaderDowngradesOnASmallTerminal(t *testing.T) {
+	roomy := &appModel{mode: modeList, width: 100, height: 34, report: layoutReport(), selected: map[string]bool{}}
+	roomy.rebuildActive()
+	if n := len(roomy.headerRows(fullHeader(), 3)); n < 3 {
+		t.Errorf("100x34 should keep the axes strip, got %d header rows", n)
+	}
+
+	cramped := &appModel{mode: modeList, width: 44, height: 20, report: layoutReport(), selected: map[string]bool{}}
+	cramped.rebuildActive()
+	if n := len(cramped.headerRows(fullHeader(), 5)); n != 1 {
+		t.Errorf("44x20 should fall back to the one-row header, got %d rows", n)
+	}
+}
+
+// clip bounds a row that is already styled. truncate cannot: it measures
+// runes, so it would charge a dozen columns for one escape sequence and cut
+// through the middle of it.
+func TestClipCountsCellsNotBytes(t *testing.T) {
+	styled := "\x1b[38;2;255;0;0mhello\x1b[m world"
+	got := clip(styled, 5)
+	if visibleWidth(got) != 5 {
+		t.Errorf("clip to 5 gave %d columns: %q", visibleWidth(got), got)
+	}
+	if !strings.HasSuffix(got, "\x1b[m") {
+		t.Errorf("a cut through styled text must close the colour: %q", got)
+	}
+	if clip(styled, 100) != styled {
+		t.Error("clip must return its input untouched when it already fits")
+	}
+	if clip(styled, 0) != "" {
+		t.Error("clip to zero columns must render nothing")
+	}
+}

--- a/internal/ui/tui/layout_test.go
+++ b/internal/ui/tui/layout_test.go
@@ -84,24 +84,34 @@ func TestFrameFitsTerminalWidth(t *testing.T) {
 	}
 }
 
-// The rows drawn plus the chrome around them must not exceed the terminal
-// height, or the footer — which is where every key binding is documented —
-// scrolls off the bottom.
+// The frame is exactly as tall as the terminal — not merely no taller.
+//
+// "No taller" was the old assertion, and it let the footer float: a short
+// list drew its key hints directly under the last row and left the bottom
+// third of the alt screen empty, which reads as a half-drawn program. Exact
+// height is what pins the footer to the last line, so the composer pads the
+// body rather than stopping early.
+//
+// It also has to stay exact from the other direction: the count is
+// separators + 1, so a single trailing newline makes the frame h+1 rows and
+// scrolls the alt screen by one.
 func TestFrameFitsTerminalHeight(t *testing.T) {
 	r := layoutReport()
-	for _, h := range []int{40, 30, 24, 20} {
-		for _, withDelta := range []bool{false, true} {
-			m := &appModel{
-				mode: modeList, width: 80, height: h,
-				report: r, selected: map[string]bool{},
-			}
-			if withDelta {
-				m.delta = model.Delta{Resolved: r.Findings[:1]}
-			}
-			m.active = m.report.Select(m.filter)
-			got := strings.Count(m.View().Content, "\n") + 1
-			if got > h {
-				t.Errorf("height=%d delta=%v: frame is %d lines", h, withDelta, got)
+	for _, w := range []int{120, 80, 60, 44} {
+		for _, h := range []int{40, 30, 24, 20} {
+			for _, withDelta := range []bool{false, true} {
+				m := &appModel{
+					mode: modeList, width: w, height: h,
+					report: r, selected: map[string]bool{},
+				}
+				if withDelta {
+					m.delta = model.Delta{Resolved: r.Findings[:1]}
+				}
+				m.active = m.report.Select(m.filter)
+				got := strings.Count(m.View().Content, "\n") + 1
+				if got != h {
+					t.Errorf("%dx%d delta=%v: frame is %d lines, want %d", w, h, withDelta, got, h)
+				}
 			}
 		}
 	}
@@ -145,13 +155,11 @@ func TestPreviewAndHistoryFitTerminalWidth(t *testing.T) {
 				t.Errorf("%s width=%d: line is %d columns:\n  %q", name, m.width, got, line)
 			}
 		}
-		// The history list sizes itself to the terminal, so a wrong header
-		// reservation makes it draw more rows than fit and the frame runs past
-		// the bottom. (The preview is content-sized and not height-bounded.)
-		if name == "history" {
-			if got := strings.Count(content, "\n") + 1; got > m.height {
-				t.Errorf("history height=%d: frame is %d lines", m.height, got)
-			}
+		// Both are height-bounded now. The preview used to be content-sized,
+		// which is why its key hints appeared wherever the diff happened to
+		// end; every mode goes through the same composer and fills the frame.
+		if got := strings.Count(content, "\n") + 1; got != m.height {
+			t.Errorf("%s height=%d: frame is %d lines", name, m.height, got)
 		}
 	}
 }

--- a/internal/ui/tui/snapshot_test.go
+++ b/internal/ui/tui/snapshot_test.go
@@ -1,0 +1,159 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// dumpEveryMode writes one .ans per screen into dir, in the order a user
+// meets them. Reached from TestSnapshotDump when HOSTVEIL_SNAPSHOT names a
+// directory; see that test for why there is only the one hook.
+//
+// The fixture is deliberately a plausible host rather than a minimal one: a
+// full nine domains, one of them degraded, findings at every severity, a
+// couple marked, and enough of them to scroll. A layout only misbehaves when
+// there is something in it.
+func dumpEveryMode(t *testing.T, dir string) {
+	t.Helper()
+	const W, H = 100, 34
+
+	findings := []model.Finding{
+		model.NewFinding("compose.ds018", "Datastore exposed on all network interfaces", model.SeverityCritical, model.SourceCompose, model.RemediationAuto, model.WithService("cloud/redis"),
+			model.WithDescription("The redis container publishes port 6379 on 0.0.0.0, so anything that can reach this host can reach the datastore. Redis has no authentication enabled by default, which means a full read and write of everything the service keeps there."),
+			model.WithHowToFix("Bind the published port to 127.0.0.1 so only this host can connect, and reach it from other containers over the compose network instead.")),
+		model.NewFinding("compose.ds016", "Docker socket mounted into container", model.SeverityCritical, model.SourceCompose, model.RemediationManual, model.WithService("ops/portainer"),
+			model.WithDescription("Mounting /var/run/docker.sock gives the container full control of the Docker daemon, which is equivalent to root on the host.")),
+		model.NewFinding("cve.outdated-image", "12 fixable vulnerabilities in nextcloud:27.1.3", model.SeverityCritical, model.SourceCVE, model.RemediationReview, model.WithService("cloud/nextcloud")),
+		model.NewFinding("ssh.rootlogin", "SSH permits root login with a password", model.SeverityHigh, model.SourceSSH, model.RemediationReview,
+			model.WithDescription("PermitRootLogin is set to yes, so anyone who guesses the root password is root on this host."),
+			model.WithHowToFix("Set PermitRootLogin prohibit-password after confirming you have a working key-based login for a non-root user.")),
+		model.NewFinding("ports.database", "PostgreSQL is listening on a public interface", model.SeverityHigh, model.SourcePorts, model.RemediationManual, model.WithService("postgres")),
+		model.NewFinding("compose.ds019", "Admin panel exposed on all network interfaces", model.SeverityHigh, model.SourceCompose, model.RemediationManual, model.WithService("ops/portainer")),
+		model.NewFinding("accounts.nopasswd", "A sudoers rule grants NOPASSWD to a human account", model.SeverityHigh, model.SourceAccounts, model.RemediationManual, model.WithService("deploy")),
+		model.NewFinding("compose.ds006", "Missing no-new-privileges hardening", model.SeverityMedium, model.SourceCompose, model.RemediationAuto, model.WithService("cloud/nextcloud")),
+		model.NewFinding("updates.disabled", "Automatic security updates are not enabled", model.SeverityMedium, model.SourceUpdates, model.RemediationAuto),
+		model.NewFinding("firewall.inactive", "ufw is installed but not enabled", model.SeverityMedium, model.SourceFirewall, model.RemediationReview),
+		model.NewFinding("fileperms.envfile", "An .env file is world-readable", model.SeverityMedium, model.SourceFilePerms, model.RemediationAuto, model.WithService("cloud")),
+		model.NewFinding("agent.toolsopen", "An AI agent config allows unattended shell access", model.SeverityMedium, model.SourceAgent, model.RemediationManual, model.WithService("opencode")),
+		model.NewFinding("compose.ds008", "No restart policy set", model.SeverityLow, model.SourceCompose, model.RemediationAuto, model.WithService("cloud/collabora")),
+		model.NewFinding("compose.ds002", "Container runs as root", model.SeverityLow, model.SourceCompose, model.RemediationReview, model.WithService("ops/watchtower")),
+		model.NewFinding("ssh.maxauth", "MaxAuthTries is higher than necessary", model.SeverityLow, model.SourceSSH, model.RemediationAuto),
+	}
+	states := map[model.Source]model.ScanState{
+		model.SourceCompose: model.ScanDone, model.SourceSSH: model.ScanDone,
+		model.SourceFirewall: model.ScanDone, model.SourceUpdates: model.ScanDone,
+		model.SourcePorts: model.ScanDegraded, model.SourceAccounts: model.ScanDone,
+		model.SourceFilePerms: model.ScanDone, model.SourceAgent: model.ScanDone,
+		model.SourceCVE: model.ScanDone,
+	}
+	rep := model.Report{Findings: findings, Score: model.ScoreReport(findings, states)}
+	delta := model.Delta{Resolved: findings[:2], New: findings[2:3], StillPresent: 12}
+
+	newModel := func(md mode) *appModel {
+		m := &appModel{mode: md, width: W, height: H, report: rep, delta: delta,
+			selected: map[string]bool{}, status: "Scanning…"}
+		m.rebuildActive()
+		return m
+	}
+	dump := func(name string, m *appModel) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name+".ans"), []byte(m.View().Content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dump("01-scanning", newModel(modeScanning))
+
+	list := newModel(modeList)
+	list.cursor = 3
+	for _, f := range list.active {
+		if f.Remediation == model.RemediationAuto && len(list.selected) < 3 {
+			list.selected[f.Key()] = true
+		}
+	}
+	dump("02-list", list)
+
+	filtered := newModel(modeList)
+	sev := model.SeverityHigh
+	filtered.filter = model.Filter{MinSeverity: &sev, FixableOnly: true}
+	filtered.rebuildActive()
+	filtered.cursor = 1
+	dump("03-list-filtered", filtered)
+
+	dump("04-detail", newModel(modeDetail))
+
+	pv := newModel(modePreview)
+	pv.preview = model.FixPreview{
+		FindingID: "compose.ds018", Label: "Bind redis to loopback", Kind: model.RemediationAuto,
+		Actions: []model.ActionPreview{{Index: 0, Label: "Publish on 127.0.0.1 only", Type: "edit",
+			Path: "/opt/stacks/cloud/docker-compose.yml",
+			Diff: "--- /opt/stacks/cloud/docker-compose.yml\n" +
+				"+++ /opt/stacks/cloud/docker-compose.yml\n" +
+				"@@ -14,7 +14,7 @@\n" +
+				"   redis:\n     image: redis:7-alpine\n     ports:\n" +
+				"-      - \"6379:6379\"\n+      - \"127.0.0.1:6379:6379\"\n" +
+				"     restart: unless-stopped\n"}},
+	}
+	dump("05-preview-edit", pv)
+
+	pv2 := newModel(modePreview)
+	pv2.preview = model.FixPreview{
+		FindingID: "cve.outdated-image", Label: "Update the image for nextcloud", Kind: model.RemediationReview,
+		Actions: []model.ActionPreview{
+			{Index: 0, Label: "Pull the new image and recreate nextcloud now", Type: "exec",
+				Warning: "This recreates the container: the service goes down briefly and comes back on a different image. There is no rollback checkpoint — exec fixes are not file-backed, so hostveil cannot undo this.",
+				Commands: [][]string{
+					{"docker", "compose", "-f", "/opt/stacks/cloud/docker-compose.yml", "pull", "nextcloud"},
+					{"docker", "compose", "-f", "/opt/stacks/cloud/docker-compose.yml", "up", "-d", "nextcloud"}}},
+			{Index: 1, Label: "Download the image only, recreate it yourself later", Type: "exec",
+				Commands: [][]string{{"docker", "compose", "-f", "/opt/stacks/cloud/docker-compose.yml", "pull", "nextcloud"}}},
+		},
+	}
+	dump("06-preview-exec", pv2)
+
+	msg := newModel(modeMessage)
+	msg.status = "✓ Fix applied. Press h to undo it. New score: 61/100. You may need to restart 'redis'."
+	dump("07-message", msg)
+
+	// A fixed date: the history rows show a timestamp, and time.Now() would
+	// make every dump differ from the last for no reason anyone cares about.
+	base := time.Date(2026, 7, 26, 14, 3, 0, 0, time.Local)
+	cps := []model.Checkpoint{
+		{ID: "cp7", FindingID: "compose.ds018", Label: "Bind redis to loopback", CreatedAt: base, Reversible: true,
+			Files: []string{"/opt/stacks/cloud/docker-compose.yml"}, RestartService: "redis",
+			Diff: "--- /opt/stacks/cloud/docker-compose.yml\n+++ /opt/stacks/cloud/docker-compose.yml\n@@ -14,7 +14,7 @@\n   redis:\n     image: redis:7-alpine\n     ports:\n-      - \"6379:6379\"\n+      - \"127.0.0.1:6379:6379\"\n     restart: unless-stopped\n"},
+		{ID: "cp6", FindingID: "compose.ds006", Label: "Add no-new-privileges to nextcloud", CreatedAt: base.Add(-42 * time.Minute), Reversible: true},
+		{ID: "cp5", FindingID: "updates.disabled", Label: "Enable unattended-upgrades", CreatedAt: base.Add(-3 * time.Hour), Reversible: true},
+		{ID: "cp4", FindingID: "firewall.inactive", Label: "Enable ufw with the current ports allowed", CreatedAt: base.Add(-26 * time.Hour), Reversible: false},
+		{ID: "cp3", FindingID: "fileperms.envfile", Label: "Restrict /opt/stacks/cloud/.env to the owner", CreatedAt: base.Add(-50 * time.Hour), Reversible: true},
+		{ID: "cp2", FindingID: "ssh.maxauth", Label: "Set MaxAuthTries to 3", CreatedAt: base.Add(-74 * time.Hour), Reversible: true},
+	}
+
+	hist := newModel(modeHistory)
+	hist.checkpoints = cps
+	dump("08-history", hist)
+
+	rb := newModel(modeRollbackConfirm)
+	rb.checkpoints = cps
+	dump("09-rollback", rb)
+
+	th := newModel(modeTheme)
+	th.openThemePicker()
+	th.mode = modeTheme
+	dump("10-theme", th)
+
+	clean := &appModel{mode: modeList, width: W, height: H, selected: map[string]bool{},
+		report: model.Report{Score: model.ScoreReport(nil, states)}}
+	clean.rebuildActive()
+	dump("11-clean", clean)
+
+	// The size every layout regression shows up at first.
+	narrow := newModel(modeList)
+	narrow.width, narrow.height = 80, 24
+	narrow.cursor = 2
+	dump("12-narrow", narrow)
+}

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -64,13 +64,23 @@ func send(m tea.Model, msg tea.Msg) tea.Model {
 	return next
 }
 
-// TestSnapshotDump writes the rendered TUI frame to the path in
-// HOSTVEIL_SNAPSHOT when set, for generating documentation screenshots. It
-// is a no-op in normal test runs.
+// TestSnapshotDump writes rendered TUI frames to HOSTVEIL_SNAPSHOT when it is
+// set, and is a no-op in normal test runs. It is how the frames in the
+// documentation are produced, and how a layout change is reviewed without a
+// terminal in front of you.
+//
+// A file path gets the one frame the website uses (site/assets/tui.png, at
+// its published 96x34); a directory gets every mode, one .ans per screen, for
+// eyeballing a change across the whole interface. There is deliberately one
+// hook rather than two — a second dumper drifts out of step with the first.
 func TestSnapshotDump(t *testing.T) {
 	path := os.Getenv("HOSTVEIL_SNAPSHOT")
 	if path == "" {
-		t.Skip("set HOSTVEIL_SNAPSHOT to dump a frame")
+		t.Skip("set HOSTVEIL_SNAPSHOT to dump a frame (a file for the site frame, a directory for every mode)")
+	}
+	if fi, err := os.Stat(path); err == nil && fi.IsDir() {
+		dumpEveryMode(t, path)
+		return
 	}
 	findings := []model.Finding{
 		model.NewFinding("compose.ds018", "Datastore exposed on all network interfaces", model.SeverityCritical, model.SourceCompose, model.RemediationAuto, model.WithService("cache")),
@@ -414,7 +424,7 @@ func TestRollbackFlowThroughEngine(t *testing.T) {
 	if len(hm.checkpoints) != 1 {
 		t.Fatalf("want 1 checkpoint, got %d", len(hm.checkpoints))
 	}
-	if view := m.(*appModel).viewHistory(); !strings.Contains(view, "compose.ds018") {
+	if view := m.(*appModel).View().Content; !strings.Contains(view, "compose.ds018") {
 		t.Errorf("history view should name the finding:\n%s", view)
 	}
 

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -113,6 +113,9 @@ func (s *styles) band(v uint8) color.Color {
 
 // meter renders a segmented bar: filled blocks in c, empty in the track.
 func (s *styles) meter(pct uint8, width int, c color.Color) string {
+	if width < 0 {
+		width = 0 // strings.Repeat panics on a negative count
+	}
 	filled := int(pct) * width / 100
 	if filled > width {
 		filled = width
@@ -122,27 +125,61 @@ func (s *styles) meter(pct uint8, width int, c color.Color) string {
 	return on + off
 }
 
+// View draws the whole screen. Every mode goes through compose (see
+// frame.go), so all of them are exactly as tall as the terminal, with the key
+// hints pinned to the last row.
 func (m *appModel) View() tea.View {
 	s := m.sty()
+	m.fitSize()
+
 	var content string
 	switch m.mode {
 	case modeScanning:
-		content = "\n  " + s.dim.Render(m.status) + "\n"
+		content = m.compose(noHeader(), nil, "ctrl+c quit", m.scanningRows)
+
 	case modeList:
-		content = m.viewList()
+		hint := listHint
+		if len(m.active) == 0 {
+			hint = emptyListHint
+		}
+		content = m.compose(fullHeader(), nil, hint, m.listRows)
+
 	case modeDetail:
-		content = m.viewDetail()
+		hint := "esc back   q list"
+		if len(m.active) > 0 && m.active[m.cursor].IsFixable() {
+			hint = "f apply fix   " + hint
+		}
+		content = m.compose(compactHeader(""), nil, hint,
+			func(n int) []string { return m.clipRows(m.detailRows(), n) })
+
 	case modePreview:
-		content = m.viewPreview()
+		content = m.compose(compactHeader("FIX PREVIEW"),
+			[]string{s.brand.Render(m.preview.Label)}, "y apply   n cancel",
+			func(n int) []string { return m.clipRows(m.previewRows(), n) })
+
 	case modeMessage:
-		content = m.viewMessage()
+		content = m.compose(compactHeader(""), nil, "press any key to continue",
+			func(n int) []string {
+				return centerRows(styledRows(s.bone, "  "+wrap(m.status, min(m.width-4, 78))), n)
+			})
+
 	case modeHistory:
-		content = m.viewHistory()
+		content = m.compose(compactHeader(""), nil, historyHint, m.historyRows)
+
 	case modeRollbackConfirm:
-		content = m.viewRollbackConfirm()
+		var title []string
+		if len(m.checkpoints) > 0 {
+			title = []string{s.brand.Render(m.checkpoints[m.cpCursor].Label)}
+		}
+		content = m.compose(compactHeader("ROLL BACK"), title, "y roll back   n cancel",
+			func(n int) []string { return m.clipRows(m.rollbackRows(), n) })
+
 	case modeTheme:
-		content = m.viewTheme()
+		content = m.compose(compactHeader("THEME"),
+			[]string{s.brand.Render(m.th.Name)}, themeHint,
+			func(n int) []string { return m.clipRows(m.themeRows(), n) })
 	}
+
 	// Paint the terminal background too. Without it a theme only recolors the
 	// text and the terminal's own background shows through every gap, which
 	// reads as a broken palette rather than a chosen one. Bubble Tea resets
@@ -150,41 +187,6 @@ func (m *appModel) View() tea.View {
 	// terminal whose background was itself set by an earlier escape sequence
 	// comes back to its default rather than to that value.
 	return tea.View{Content: content, AltScreen: true, BackgroundColor: s.cInk}
-}
-
-func (m *appModel) rule() string {
-	w := m.width
-	if w < 1 {
-		w = 1
-	}
-	return m.sty().track.Render(strings.Repeat("─", w))
-}
-
-// header renders the status bar: brand + the exposure gauge (SECURITY
-// meter + score), then the per-axis bars.
-func (m *appModel) header() string {
-	s := m.sty()
-	var b strings.Builder
-	sc := m.report.Score.Overall
-	b.WriteString(s.dim.Render("▚ ") + s.brand.Render("hostveil"))
-	// Everything but the meter is fixed width: "▚ " + "hostveil" + a
-	// three-space gap + "SECURITY " + " NNN" + "/100". The meter absorbs
-	// whatever is left, so the gauge shrinks with the terminal instead of
-	// running off the end of a narrow one.
-	const gaugeChrome = 2 + 8 + 3 + 9 + 4 + 4
-	meterW := 18
-	if m.width > 0 && m.width-gaugeChrome < meterW {
-		meterW = max(4, m.width-gaugeChrome)
-	}
-	b.WriteString("   " + s.dim.Render("SECURITY ") + s.meter(sc, meterW, s.band(sc)) +
-		s.bone.Render(fmt.Sprintf(" %d", sc)) + s.dim.Render("/100"))
-	b.WriteString("\n")
-	b.WriteString(m.axesLine())
-	b.WriteString("\n")
-	if line := m.deltaLine(); line != "" {
-		b.WriteString(line + "\n")
-	}
-	return b.String()
 }
 
 // deltaLine summarises what moved since the previous scan. The CLI prints
@@ -260,85 +262,87 @@ func (m *appModel) axesLine() string {
 	}
 
 	gap := s.dim.Render(strings.Repeat(" ", axisGap))
-	var rows []string
+	var out []string
 	for i := 0; i < len(cells); i += perRow {
 		end := min(i+perRow, len(cells))
-		rows = append(rows, strings.Join(cells[i:end], gap))
+		out = append(out, strings.Join(cells[i:end], gap))
 	}
-	return strings.Join(rows, "\n")
+	return strings.Join(out, "\n")
 }
 
-const listHint = "↑/↓ move   enter details   f fix   space select   a fix marked\n" +
-	"s severity   d domain   x fixable   c clear   h history   t theme   r rescan   q quit"
+const (
+	listHint = "↑/↓ move   enter details   f fix   space select   a fix marked\n" +
+		"s severity   d domain   x fixable   c clear   h history   t theme   r rescan   q quit"
+	emptyListHint = "c clear   t theme   r rescan   q quit"
+	historyHint   = "↑/↓ move   enter roll back   esc back   q list"
+	themeHint     = "↑/↓ preview   enter keep   esc cancel"
+)
 
-func (m *appModel) viewList() string {
+// scanningRows is the whole scan screen: one status line, held in the middle
+// of an otherwise empty frame.
+func (m *appModel) scanningRows(n int) []string {
+	return centerRows(styledRows(m.sty().dim, "  "+m.status), n)
+}
+
+// listRows draws the findings list into the rows the frame gave it. The head
+// and filter lines are drawn from that same budget rather than reserved
+// outside it, so there is exactly one place the arithmetic happens.
+func (m *appModel) listRows(budget int) []string {
 	s := m.sty()
-	var b strings.Builder
-	hdr := m.header()
-	b.WriteString(hdr)
-	b.WriteString(m.rule() + "\n")
+	if budget <= 0 {
+		return nil
+	}
 
 	fl := m.filterLine()
 
 	// Empty list: distinguish a clean host from a too-narrow filter.
 	if len(m.active) == 0 {
+		var body []string
 		if fl != "" {
-			b.WriteString(fl + "\n")
-			b.WriteString("\n" + s.dim.Render("  No findings match the filter.") + "\n")
+			body = append(body, fl, "", s.dim.Render("  No findings match the filter."))
 		} else {
-			b.WriteString("\n" + s.safe.Render("  No problems found. Clean.") + "\n")
+			body = append(body, s.safe.Render("  No problems found. Clean."))
 		}
-		b.WriteString(m.footer("c clear   t theme   r rescan   q quit"))
-		return b.String()
+		return centerRows(body, budget)
 	}
 
-	// Measure the header rather than assuming its height. It used to be a
-	// constant 8, which silently assumed a two-line header — one brand line
-	// and one axes line. That was already one short whenever a delta line was
-	// present, and the axes strip now wraps to several rows on a narrow
-	// terminal. Reserving too little makes the list draw more rows than fit,
-	// pushing the footer and its key hints off the bottom of the frame.
-	//
-	// The footer is measured too, since its hint now reflows. The remaining
-	// 3 is what viewList draws itself: the rule under the header, the count
-	// line, and the footer's leading blank.
-	ftr := m.footer(listHint)
-	reserved := strings.Count(hdr, "\n") + strings.Count(ftr, "\n") + 3
+	chrome := 1
 	if fl != "" {
-		reserved++
+		chrome = 2
 	}
-	visible := m.height - reserved
+	visible := budget - chrome
 	if visible < 1 {
-		visible = 1
+		// Findings beat labels: on a frame this short the list itself is the
+		// only thing worth drawing.
+		chrome, visible = 0, budget
 	}
+
 	m.offset = scrollOffset(m.cursor, len(m.active), visible, m.offset)
-	end := m.offset + visible
-	if end > len(m.active) {
-		end = len(m.active)
-	}
+	end := min(m.offset+visible, len(m.active))
 
-	// Head: shown[/total] · selected · scroll range.
-	count := fmt.Sprintf("FINDINGS · %d", len(m.active))
-	if total := m.activeTotal(); total != len(m.active) {
-		count = fmt.Sprintf("FINDINGS · %d/%d", len(m.active), total)
+	var out []string
+	if chrome > 0 {
+		// Head: shown[/total] · selected · scroll range.
+		count := fmt.Sprintf("FINDINGS · %d", len(m.active))
+		if total := m.activeTotal(); total != len(m.active) {
+			count = fmt.Sprintf("FINDINGS · %d/%d", len(m.active), total)
+		}
+		head := s.dim.Render(count)
+		if n := len(m.selected); n > 0 {
+			head += s.safe.Render(fmt.Sprintf("   ✓ %d marked", n))
+		}
+		if len(m.active) > visible {
+			head += s.dim.Render(fmt.Sprintf("      %d–%d", m.offset+1, end))
+		}
+		out = append(out, head)
+		if chrome == 2 {
+			out = append(out, fl)
+		}
 	}
-	head := s.dim.Render(count)
-	if n := len(m.selected); n > 0 {
-		head += s.safe.Render(fmt.Sprintf("   ✓ %d marked", n))
-	}
-	if len(m.active) > visible {
-		head += s.dim.Render(fmt.Sprintf("      %d–%d", m.offset+1, end))
-	}
-	b.WriteString(head + "\n")
-	if fl != "" {
-		b.WriteString(fl + "\n")
-	}
-
 	for i := m.offset; i < end; i++ {
-		b.WriteString(m.findingRow(m.active[i], i == m.cursor) + "\n")
+		out = append(out, m.findingRow(m.active[i], i == m.cursor))
 	}
-	b.WriteString(ftr)
-	return b.String()
+	return out
 }
 
 // activeTotal counts findings that are not fixed, ignoring the filter — the
@@ -464,52 +468,50 @@ func (m *appModel) serviceSuffix(f model.Finding) string {
 	return m.sty().dim.Render("  (" + f.Service + ")")
 }
 
-func (m *appModel) viewDetail() string {
+func (m *appModel) detailRows() []string {
+	if len(m.active) == 0 {
+		return nil
+	}
 	s := m.sty()
 	f := m.active[m.cursor]
-	var b strings.Builder
-	b.WriteString(m.header())
-	b.WriteString(m.rule() + "\n\n")
-	b.WriteString(lipgloss.NewStyle().Foreground(s.severityColor(f.Severity)).Bold(true).Render(strings.ToUpper(f.Severity.String())) +
-		"  " + s.brand.Render(f.Title) + "\n")
+
+	out := []string{"",
+		lipgloss.NewStyle().Foreground(s.severityColor(f.Severity)).Bold(true).Render(strings.ToUpper(f.Severity.String())) +
+			"  " + s.brand.Render(f.Title)}
 	meta := strings.ToUpper(f.ID + "  ·  " + f.Remediation.String())
 	if f.Service != "" {
 		meta += "  ·  SERVICE: " + f.Service
 	}
-	b.WriteString(s.dim.Render(meta) + "\n\n")
-	b.WriteString(s.bone.Render(wrap(f.Description, min(m.width-4, 78))) + "\n\n")
+	out = append(out, s.dim.Render(meta), "")
+	out = append(out, styledRows(s.bone, wrap(f.Description, min(m.width-4, 78)))...)
 	if f.HowToFix != "" {
-		b.WriteString(s.dim.Render("HOW TO FIX") + "\n")
-		b.WriteString(s.bone.Render(wrap(f.HowToFix, min(m.width-4, 78))) + "\n")
+		out = append(out, "", s.dim.Render("HOW TO FIX"))
+		out = append(out, styledRows(s.bone, wrap(f.HowToFix, min(m.width-4, 78)))...)
 	}
-	hint := "esc back   q list"
-	if f.IsFixable() {
-		hint = "f apply fix   " + hint
-	}
-	b.WriteString(m.footer(hint))
-	return b.String()
+	return out
 }
 
-func (m *appModel) viewPreview() string {
+func (m *appModel) previewRows() []string {
+	if len(m.preview.Actions) == 0 {
+		return nil
+	}
 	s := m.sty()
-	var b strings.Builder
-	b.WriteString(s.dim.Render("FIX PREVIEW") + "\n")
-	b.WriteString(s.brand.Render(m.preview.Label) + "\n")
-	b.WriteString(m.rule() + "\n\n")
+	idx := clamp(m.previewAction, 0, len(m.preview.Actions)-1)
 
+	out := []string{""}
 	if len(m.preview.Actions) > 1 {
-		b.WriteString(s.dim.Render("Alternatives (press a number):") + "\n")
+		out = append(out, s.dim.Render("Alternatives (press a number):"))
 		for _, a := range m.preview.Actions {
 			marker := "  "
-			if a.Index == m.previewAction {
+			if a.Index == idx {
 				marker = lipgloss.NewStyle().Foreground(s.cBone).Render("› ")
 			}
-			b.WriteString(marker + s.bone.Render(fmt.Sprintf("[%d] %s", a.Index, a.Label)) + "\n")
+			out = append(out, marker+s.bone.Render(fmt.Sprintf("[%d] %s", a.Index, a.Label)))
 		}
-		b.WriteString("\n")
+		out = append(out, "")
 	}
 
-	a := m.preview.Actions[m.previewAction]
+	a := m.preview.Actions[idx]
 	if a.Warning != "" {
 		// Wrap the warning. It is the one place the preview explains what
 		// cannot be undone, and unwrapped it ran past the terminal edge and
@@ -517,70 +519,64 @@ func (m *appModel) viewPreview() string {
 		// rollback" with the reason that follows lost. The "⚠  " prefix is
 		// two columns plus a space, so the continuation lines are indented to
 		// sit under the text rather than the marker.
-		warn := wrap(a.Warning, min(m.width-4, 78))
-		warn = strings.ReplaceAll(warn, "\n", "\n   ")
-		b.WriteString(lipgloss.NewStyle().Foreground(s.cHigh).Render("⚠  "+warn) + "\n\n")
+		warn := lipgloss.NewStyle().Foreground(s.cHigh)
+		for i, l := range strings.Split(wrap(a.Warning, min(m.width-4, 78)), "\n") {
+			if i == 0 {
+				out = append(out, warn.Render("⚠  "+l))
+			} else {
+				out = append(out, warn.Render("   "+l))
+			}
+		}
+		out = append(out, "")
 	}
+
 	switch a.Type {
 	case "edit", "mode":
-		b.WriteString(s.renderDiff(a.Diff))
+		out = append(out, s.diffRows(a.Diff)...)
 	case "exec":
-		b.WriteString(s.dim.Render("These commands will run:") + "\n")
+		out = append(out, s.dim.Render("These commands will run:"))
 		for _, cmd := range a.Commands {
-			b.WriteString(s.dim.Render("  $ "+strings.Join(cmd, " ")) + "\n")
+			out = append(out, s.dim.Render("  $ "+strings.Join(cmd, " ")))
 		}
 	default:
 		// Never leave the apply/cancel footer with an empty body above it.
-		b.WriteString(s.dim.Render("(no preview available for action type "+a.Type+")") + "\n")
+		out = append(out, s.dim.Render("(no preview available for action type "+a.Type+")"))
 	}
-	b.WriteString(m.footer("y apply   n cancel"))
-	return b.String()
+	return out
 }
 
-// viewHistory lists every applied fix, newest first, so a fix applied here
+// historyRows lists every applied fix, newest first, so a fix applied here
 // can be undone here rather than only from the CLI. Non-reversible
 // (command) fixes are dimmed: they are part of the record but there is
 // nothing file-backed to restore.
-func (m *appModel) viewHistory() string {
+func (m *appModel) historyRows(budget int) []string {
 	s := m.sty()
-	var b strings.Builder
-	hdr := m.header()
-	b.WriteString(hdr)
-	b.WriteString(m.rule() + "\n")
+	if budget <= 0 || len(m.checkpoints) == 0 {
+		return nil
+	}
 
-	// Measure the header rather than assuming 8 lines. viewList was corrected
-	// this way when the axes strip started wrapping; this view had the same
-	// hardcoded reservation and the same bug — on a narrow terminal the extra
-	// header rows pushed the checkpoint list past the footer. The 6 is the
-	// chrome viewHistory draws around the rows (matching viewList): the rule
-	// under the header, the count line, and the footer's blank, rule, and two
-	// hint lines.
-	ftr := m.footer(historyHint)
-	reserved := strings.Count(hdr, "\n") + strings.Count(ftr, "\n") + 3
-	visible := m.height - reserved
+	chrome := 1
+	visible := budget - chrome
 	if visible < 1 {
-		visible = 1
+		chrome, visible = 0, budget
 	}
+
 	m.cpOffset = scrollOffset(m.cpCursor, len(m.checkpoints), visible, m.cpOffset)
-	end := m.cpOffset + visible
-	if end > len(m.checkpoints) {
-		end = len(m.checkpoints)
-	}
+	end := min(m.cpOffset+visible, len(m.checkpoints))
 
-	head := s.dim.Render(fmt.Sprintf("APPLIED FIXES · %d", len(m.checkpoints)))
-	if len(m.checkpoints) > visible {
-		head += s.dim.Render(fmt.Sprintf("      %d–%d", m.cpOffset+1, end))
+	var out []string
+	if chrome > 0 {
+		head := s.dim.Render(fmt.Sprintf("APPLIED FIXES · %d", len(m.checkpoints)))
+		if len(m.checkpoints) > visible {
+			head += s.dim.Render(fmt.Sprintf("      %d–%d", m.cpOffset+1, end))
+		}
+		out = append(out, head)
 	}
-	b.WriteString(head + "\n")
-
 	for i := m.cpOffset; i < end; i++ {
-		b.WriteString(m.checkpointRow(m.checkpoints[i], i == m.cpCursor) + "\n")
+		out = append(out, m.checkpointRow(m.checkpoints[i], i == m.cpCursor))
 	}
-	b.WriteString(ftr)
-	return b.String()
+	return out
 }
-
-const historyHint = "↑/↓ move   enter roll back   esc back   q list"
 
 func (m *appModel) checkpointRow(cp model.Checkpoint, cursor bool) string {
 	s := m.sty()
@@ -597,18 +593,13 @@ func (m *appModel) checkpointRow(cp model.Checkpoint, cursor bool) string {
 		s.bone.Render(label)
 }
 
-const themeHint = "↑/↓ preview   enter keep   esc cancel"
-
-// viewTheme is the color-theme picker. Moving the cursor restyles the whole
+// themeRows is the color-theme picker. Moving the cursor restyles the whole
 // frame on the spot rather than showing a swatch and a name: a palette is
 // only judgeable against the meters, severity gutters and diffs it will
 // actually be drawn with.
-func (m *appModel) viewTheme() string {
+func (m *appModel) themeRows() []string {
 	s := m.sty()
-	var b strings.Builder
-	b.WriteString(s.dim.Render("THEME") + "\n")
-	b.WriteString(s.brand.Render(m.th.Name) + "\n")
-	b.WriteString(m.rule() + "\n\n")
+	out := []string{""}
 
 	all := theme.All()
 	// A row is "› " + an 18-column name + a two-space gap + five two-column
@@ -631,13 +622,13 @@ func (m *appModel) viewTheme() string {
 		if showSwatch {
 			row += "  " + swatch(t)
 		}
-		b.WriteString(row + "\n")
+		out = append(out, row)
 	}
 
-	b.WriteString("\n" + s.dim.Render(wrap("Colors mean the same thing in every theme: the four severity "+
-		"steps and safety. Everything else is chrome.", min(m.width-2, 78))) + "\n")
-	b.WriteString(m.footer(themeHint))
-	return b.String()
+	out = append(out, "")
+	out = append(out, styledRows(s.dim, wrap("Colors mean the same thing in every theme: the four severity "+
+		"steps and safety. Everything else is chrome.", min(m.width-2, 78)))...)
+	return out
 }
 
 // swatch previews the five colors that carry meaning, in that theme's own
@@ -650,43 +641,29 @@ func swatch(t theme.Theme) string {
 	return b.String()
 }
 
-// viewRollbackConfirm mirrors viewPreview's y/n gesture, showing the diff
-// the rollback would revert so the decision is made on evidence.
-func (m *appModel) viewRollbackConfirm() string {
+// rollbackRows mirrors previewRows' y/n gesture, showing the diff the
+// rollback would revert so the decision is made on evidence.
+func (m *appModel) rollbackRows() []string {
+	if len(m.checkpoints) == 0 {
+		return nil
+	}
 	s := m.sty()
 	cp := m.checkpoints[m.cpCursor]
-	var b strings.Builder
-	b.WriteString(s.dim.Render("ROLL BACK") + "\n")
-	b.WriteString(s.brand.Render(cp.Label) + "\n")
-	b.WriteString(m.rule() + "\n\n")
-	b.WriteString(s.dim.Render("Restores:") + "\n")
+
+	out := []string{"", s.dim.Render("Restores:")}
 	for _, p := range cp.Files {
-		b.WriteString(s.bone.Render("  "+p) + "\n")
+		out = append(out, s.bone.Render("  "+p))
 	}
-	b.WriteString("\n")
+	out = append(out, "")
 	if cp.RestartService != "" {
-		b.WriteString(lipgloss.NewStyle().Foreground(s.cHigh).
-			Render("⚠  You may need to restart '"+cp.RestartService+"' afterwards.") + "\n\n")
+		out = append(out, lipgloss.NewStyle().Foreground(s.cHigh).
+			Render("⚠  You may need to restart '"+cp.RestartService+"' afterwards."), "")
 	}
 	if cp.Diff != "" {
-		b.WriteString(s.dim.Render("This change will be reverted:") + "\n")
-		b.WriteString(s.renderDiff(cp.Diff))
+		out = append(out, s.dim.Render("This change will be reverted:"))
+		out = append(out, s.diffRows(cp.Diff)...)
 	}
-	b.WriteString(m.footer("y roll back   n cancel"))
-	return b.String()
-}
-
-func (m *appModel) viewMessage() string {
-	s := m.sty()
-	var b strings.Builder
-	b.WriteString(m.header())
-	b.WriteString(m.rule() + "\n\n  " + s.bone.Render(m.status) + "\n")
-	b.WriteString(m.footer("press any key to continue"))
-	return b.String()
-}
-
-func (m *appModel) footer(hint string) string {
-	return "\n" + m.rule() + "\n" + m.sty().dim.Render(m.wrapHint(hint))
+	return out
 }
 
 // wrapHint reflows a key-binding hint onto as many lines as the terminal
@@ -721,19 +698,19 @@ func (m *appModel) wrapHint(hint string) string {
 	return strings.Join(out, "\n")
 }
 
-func (s *styles) renderDiff(diff string) string {
-	var b strings.Builder
+func (s *styles) diffRows(diff string) []string {
+	var out []string
 	for _, line := range strings.Split(strings.TrimRight(diff, "\n"), "\n") {
 		switch {
 		case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
-			b.WriteString(s.safe.Render(line) + "\n")
+			out = append(out, s.safe.Render(line))
 		case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---"):
-			b.WriteString(lipgloss.NewStyle().Foreground(s.cCrit).Render(line) + "\n")
+			out = append(out, lipgloss.NewStyle().Foreground(s.cCrit).Render(line))
 		default:
-			b.WriteString(s.dim.Render(line) + "\n")
+			out = append(out, s.dim.Render(line))
 		}
 	}
-	return b.String()
+	return out
 }
 
 // scrollOffset returns a new window start that keeps cursor within the
@@ -756,6 +733,10 @@ func scrollOffset(cursor, total, visible, offset int) int {
 
 // truncate shortens s to at most max columns, marking the cut with an
 // ellipsis when there is room for one.
+//
+// It is for plain text, before it is styled: it measures runes, so an ANSI
+// escape would cost it a dozen columns and it would happily cut through the
+// middle of one. Bounding a row that is already styled is clip()'s job.
 //
 // The old guard returned s unchanged whenever max < 4, which inverted the
 // function exactly where it was needed. findingRow passes m.width-46, so on a


### PR DESCRIPTION
## What

Routes all eight TUI modes through a single frame composer (`internal/ui/tui/frame.go`). `compose(hdr, title, hint, fill)` measures the chrome first and passes the body its exact row budget, replacing the old scheme where each view counted the newlines of chrome it had already rendered to derive its budget by hand.

## Why

That hand-derived arithmetic was the direct cause of the two viewport overflow bugs fixed in 3.3.0/3.4.0 (#557, #559): every change to the chrome required re-deriving the count in several places, and getting it wrong silently pushed the key hints off the bottom of the alt screen. This lands the structural fix so the class of bug can't recur.

Along the way:

- Three header tiers (`none` / one-row compact / full gauge+axes strip), with graceful downgrade when the terminal is too short — chrome is shed before content.
- A fallback 80x24 size so a model that never saw a `WindowSizeMsg` still renders.
- `styles.meter` clamps a negative width (`strings.Repeat` panics on a negative count).
- Cell-accurate `clip()` that counts printable columns and passes ANSI escapes through at zero width, closing any open colour at the cut.

## Tests

- `TestEveryModeFillsExactlyTheTerminal`: all 8 modes × 6 sizes (200x40 down to 44x20) must produce exactly `h` lines with no line wider than `w`. The old per-mode assertions were a hand-written subset that never rendered preview, history, or the rollback confirmation at all.
- `TestFooterIsPinned`, `TestUnsetSizeRenders`, `TestCompactHeaderIsOneRow`, `TestFullHeaderDowngradesOnASmallTerminal`, `TestClipCountsCellsNotBytes`.
- `HOSTVEIL_SNAPSHOT` now accepts a directory and dumps all 12 mode frames for docs screenshots.

Full local gate passes: build, vet, gofmt, tidy, `go test -race ./...`, golangci-lint, govulncheck, sitegen drift, install.sh checksum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)