### PR TITLE
fix(check): stop a local user turning the agent audit against the host

### DIFF
--- a/internal/check/agent/agent.go
+++ b/internal/check/agent/agent.go
@@ -114,7 +114,10 @@ func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding,
 			}
 		}
 
-		b, err := os.ReadFile(in.path(in.rt.Config)) //nolint:gosec // path from the runtime registry
+		// The registry supplies the relative path, but everything under the
+		// home is the account's to shape, so the read must not follow a
+		// symlink, block on a FIFO, or swallow something unbounded.
+		b, err := platform.ReadFileNoFollow(in.path(in.rt.Config), maxAgentFileBytes)
 		switch {
 		case err != nil && os.IsNotExist(err):
 			// Installed but never configured. Nothing to read, nothing lost.
@@ -157,16 +160,26 @@ func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding,
 
 // modeFindings flags registry paths whose permissions are looser than the
 // runtime's own hardened baseline.
+//
+// Lstat, never Stat. These paths belong to the account being audited, and a
+// finding here carries an Auto chmod fix — following a symlink would let any
+// user point their "config file" at /etc/passwd, collect a finding about its
+// 0644 mode, and have root tighten it for them, which on /etc/passwd is a
+// host-wide denial of service. A symlink or any other non-regular file is not
+// the layout the registry describes, so it is skipped, not judged.
 func modeFindings(s scan) []model.Finding {
 	var out []model.Finding
 	for _, rule := range s.in.rt.Modes {
 		path := s.in.path(rule.Rel)
-		fi, err := os.Stat(path)
+		fi, err := os.Lstat(path)
 		if err != nil {
 			continue // a path the user never created is not a finding
 		}
 		if fi.IsDir() != rule.Dir {
 			continue // the layout is not what the registry describes; do not guess
+		}
+		if !rule.Dir && !fi.Mode().IsRegular() {
+			continue // a symlink, FIFO, or device is not the registry's layout
 		}
 		perm := fi.Mode().Perm()
 		if perm&^rule.Max == 0 {

--- a/internal/check/agent/config.go
+++ b/internal/check/agent/config.go
@@ -3,13 +3,13 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/seolcu/hostveil/internal/platform"
 	"github.com/seolcu/hostveil/internal/secretkey"
 )
 
@@ -196,10 +196,16 @@ type envFile struct {
 	SecretKeys []string
 }
 
+// maxAgentFileBytes bounds every read under a user's home. The largest real
+// config is a few hundred kilobytes of commented JSON5; a megabyte of headroom
+// keeps any legitimate file readable while a symlink at /dev/zero stays a
+// bounded error instead of an allocation that never ends.
+const maxAgentFileBytes = 1 << 20
+
 // loadEnvFile parses a KEY=value file. safeKeys names the variables whose
 // values the caller needs; every other variable is reported by presence only.
 func loadEnvFile(path string, safeKeys []string) (envFile, error) {
-	b, err := os.ReadFile(path) //nolint:gosec // path comes from the runtime registry
+	b, err := platform.ReadFileNoFollow(path, maxAgentFileBytes)
 	if err != nil {
 		return envFile{}, err
 	}

--- a/internal/check/agent/hostile_test.go
+++ b/internal/check/agent/hostile_test.go
@@ -1,0 +1,139 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The paths this checker reads live inside other people's home directories,
+// and it reads them as root. Everything here is one account arranging its own
+// home so that a routine audit does something on its behalf.
+
+// The worst of the three: a symlink where the config file should be, pointing
+// at a file the attacker does not own. Following it would let any user collect
+// an agent.config-perms finding *about /etc/passwd* — carrying an Auto chmod
+// fix — and have `fix --all` tighten the password database to 0600, which
+// breaks logins, sudo, and every getpwnam on the host.
+func TestSymlinkedConfigProducesNoModeFinding(t *testing.T) {
+	h := newHost(t, "mallory")
+	victim := filepath.Join(t.TempDir(), "passwd")
+	if err := os.WriteFile(victim, []byte("root:x:0:0::/root:/bin/bash\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(h.homes["mallory"], ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatal(err)
+	}
+
+	fs, _ := h.checker().Check(context.Background(), envNoFirewall(""))
+	for _, f := range fs {
+		if f.ID == "agent.config-perms" || f.ID == "agent.secret-exposed" {
+			t.Fatalf("a symlinked config produced %s with evidence %v — "+
+				"root would chmod %s on the strength of it", f.ID, f.Evidence, victim)
+		}
+	}
+	if fi, _ := os.Stat(victim); fi.Mode().Perm() != 0o644 {
+		t.Errorf("the checker changed the link target's mode to %#o", fi.Mode().Perm())
+	}
+}
+
+// Same trick against the credentials path, which is the Secret rule and the
+// higher-severity finding. Reading through the link would also mean parsing
+// the victim's contents looking for API keys.
+func TestSymlinkedSecretFileProducesNoFinding(t *testing.T) {
+	h := newHost(t, "mallory")
+	victim := filepath.Join(t.TempDir(), "shadow")
+	if err := os.WriteFile(victim, []byte("API_KEY=sk-not-really-a-key-but-literal\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(h.homes["mallory"], ".hermes", ".env")
+	if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatal(err)
+	}
+
+	fs, _ := h.checker().Check(context.Background(), envNoFirewall(""))
+	for _, f := range fs {
+		if f.ID == "agent.secret-exposed" {
+			t.Fatalf("a symlinked secret file produced %s: %v", f.ID, f.Evidence)
+		}
+	}
+}
+
+// A FIFO in place of a config file used to park the scan inside open(2)
+// forever: it blocks until a writer appears, and the attacker simply never
+// writes. There is no timeout on a file read, so the whole scan hangs.
+func TestFIFOConfigDoesNotHangTheScan(t *testing.T) {
+	h := newHost(t, "mallory")
+	p := filepath.Join(h.homes["mallory"], ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Skipf("mkfifo: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = h.checker().Check(context.Background(), envNoFirewall(""))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Check blocked on a FIFO left where a config file should be")
+	}
+}
+
+// A symlink to /dev/zero reads forever and allocates while it does. The size
+// cap turns it into an ordinary unreadable-config degradation.
+func TestUnboundedDeviceConfigIsBounded(t *testing.T) {
+	if _, err := os.Stat("/dev/zero"); err != nil {
+		t.Skip("no /dev/zero")
+	}
+	h := newHost(t, "mallory")
+	p := filepath.Join(h.homes["mallory"], ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/dev/zero", p); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = h.checker().Check(context.Background(), envNoFirewall(""))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Check did not bound a read of /dev/zero")
+	}
+}
+
+// The defence must not cost the ordinary case. A real config, read normally,
+// still yields its findings.
+func TestARealConfigIsStillRead(t *testing.T) {
+	h := newHost(t, "alice")
+	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o644)
+
+	fs, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if _, ok := findByID(fs, "agent.config-perms"); !ok {
+		t.Error("a genuinely world-readable config must still be reported")
+	}
+}

--- a/internal/core/fixflow.go
+++ b/internal/core/fixflow.go
@@ -14,6 +14,7 @@ import (
 	"github.com/seolcu/hostveil/internal/fix"
 	"github.com/seolcu/hostveil/internal/history"
 	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
 )
 
 // PreviewFix returns, per available action, exactly what the fix would
@@ -90,12 +91,21 @@ type modeChange struct {
 // A stat failure aborts the whole plan rather than skipping the file: a fix
 // that silently tightened three of four files would report success while
 // leaving the fourth exposed.
+//
+// Lstat plus a type check, never Stat. Mode fixes reach into user homes
+// (agent.config-perms), where the path is the account's to shape: a symlink
+// left where the config file was would send root's chmod to whatever the
+// link points at. Refusing loudly rather than skipping keeps the no-silent-
+// partial-success rule above.
 func planModes(a fix.Action) ([]modeChange, error) {
 	var changes []modeChange
 	for _, p := range a.Paths {
-		fi, err := os.Stat(p)
+		fi, err := os.Lstat(p)
 		if err != nil {
 			return nil, err
+		}
+		if m := fi.Mode(); !m.IsRegular() && !m.IsDir() {
+			return nil, fmt.Errorf("%s is not a regular file or directory (%v); refusing to change its mode", p, m.Type())
 		}
 		cur := fi.Mode()
 		next := a.Mode(cur)
@@ -316,7 +326,10 @@ func (e *Engine) applyMode(f model.Finding, fx fix.Fix, a fix.Action) (model.Fix
 	}
 
 	for _, c := range changes {
-		if err := os.Chmod(c.path, c.to); err != nil {
+		// Through the descriptor, not the path: planModes vetted the type,
+		// but the file can be swapped for a symlink between the plan and this
+		// line, and os.Chmod would follow it.
+		if err := platform.ChmodNoFollow(c.path, c.to); err != nil {
 			return model.FixOutcome{}, err
 		}
 	}

--- a/internal/core/fixflow_test.go
+++ b/internal/core/fixflow_test.go
@@ -621,3 +621,41 @@ func TestCurrentIsASnapshot(t *testing.T) {
 		t.Error("markFixed did not reach the engine's own report")
 	}
 }
+
+// A mode fix must not chmod through a symlink. fileperms and agent findings
+// both carry paths, and the agent ones point into a user's home where that
+// account decides what the path is. A symlink there aimed at /etc/passwd
+// would turn "tighten your agent config" into root breaking the host's
+// account database.
+//
+// The fix refuses rather than skipping, because a mode fix that silently
+// tightened some of its paths would report success over a file it left
+// exposed.
+func TestModeFixRefusesToFollowASymlink(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "passwd")
+	if err := os.WriteFile(victim, []byte("root:x:0:0::/root:/bin/bash\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "shadow")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatal(err)
+	}
+
+	f := model.NewFinding("fileperms.shadow", "over-permissive", model.SeverityHigh,
+		model.SourceFilePerms, model.RemediationAuto,
+		model.WithEvidence("paths", link),
+		model.WithEvidence("expected", "0640"),
+	)
+
+	engine := fixEngine(t)
+	if _, err := engine.PreviewFix(f); err == nil {
+		t.Error("previewing a mode fix on a symlink must fail, not report a plan")
+	}
+	if _, err := engine.ApplyFix(context.Background(), f, 0); err == nil {
+		t.Fatal("applying a mode fix to a symlink must fail")
+	}
+	if fi, _ := os.Stat(victim); fi.Mode().Perm() != 0o644 {
+		t.Errorf("the symlink's target is now %#o — the chmod followed the link", fi.Mode().Perm())
+	}
+}

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -156,6 +156,17 @@ package fix
 // ships these paths at 0600/0700, so that arrangement is a deviation rather
 // than a design, and the finding's how-to-fix names it explicitly.
 //
+// A path under a home carries one more obligation that /etc never did: the
+// account that owns it can shape it, so "safe to apply unattended" must hold
+// against an adversarial layout, not just a mistaken one. Every step from
+// detection to apply therefore refuses to follow a symlink — the checker
+// Lstats and skips non-regular files, planModes re-vets the type, and the
+// chmod itself goes through a descriptor opened O_NOFOLLOW — because a
+// symlink at ~/.openclaw/openclaw.json pointing at /etc/passwd would
+// otherwise turn `fix --all` into root tightening the password database off
+// the host. Any future Auto fix whose target another account can influence
+// owes the same discipline.
+//
 // # The one CVE finding that does have a fix
 //
 // cve.outdated-image, the per-image rollup, IS registered, because its

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -16,6 +16,8 @@ import (
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/seolcu/hostveil/internal/platform"
 )
 
 // BackedFile records one file captured in a checkpoint.
@@ -401,7 +403,12 @@ func (s *Store) rollback(id string, force bool) (Checkpoint, error) {
 		// file, so restoring the mode of a file that still exists needs an
 		// explicit chmod. Without this the Mode recorded on every checkpoint
 		// was never applied to anything.
-		if err := os.Chmod(bf.Path, bf.Mode); err != nil {
+		//
+		// No-follow, because mode-only checkpoints point into user homes
+		// (agent.config-perms) and the account that owns the path can have
+		// replaced it with a symlink since the fix ran — os.Chmod would carry
+		// root's chmod through to the link's target.
+		if err := platform.ChmodNoFollow(bf.Path, bf.Mode); err != nil {
 			return cp, err
 		}
 	}

--- a/internal/platform/safefile.go
+++ b/internal/platform/safefile.go
@@ -1,0 +1,64 @@
+package platform
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+// This file holds the file operations hostveil uses on paths another account
+// can shape — anything under a user's home. Plain os.ReadFile, os.Stat, and
+// os.Chmod all follow symlinks, and hostveil runs as root, so on such paths
+// each is a confused deputy: a user who replaces their own config file with a
+// symlink to /etc/passwd turns a routine permission fix into root chmod'ing
+// the password database, and one who replaces it with a FIFO parks the whole
+// scan inside an open(2) that never returns.
+
+// ReadFileNoFollow reads a regular file, refusing symlinks in the final path
+// component, refusing anything that is not a regular file, never blocking on
+// open, and reading at most limit bytes.
+//
+// O_NONBLOCK is what makes the FIFO case safe: without it, opening a FIFO for
+// reading blocks until a writer appears, which for an attacker's FIFO is
+// never. On a regular file the flag is meaningless and the read proceeds
+// normally. The fstat check happens on the open descriptor, so there is no
+// gap for the file to be swapped between the check and the read.
+func ReadFileNoFollow(path string, limit int64) ([]byte, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s: not a regular file (%v)", path, fi.Mode().Type())
+	}
+
+	b, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > limit {
+		return nil, fmt.Errorf("%s: larger than %d bytes", path, limit)
+	}
+	return b, nil
+}
+
+// ChmodNoFollow changes a file's or directory's permission bits without ever
+// following a symlink: the path is opened with O_NOFOLLOW and the mode is
+// applied through the descriptor, so the bits land on the inode that was
+// opened and nothing else. A symlink at path fails with ELOOP rather than
+// chmod'ing its target.
+func ChmodNoFollow(path string, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return f.Chmod(mode)
+}

--- a/internal/platform/safefile_test.go
+++ b/internal/platform/safefile_test.go
@@ -1,0 +1,112 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestReadFileNoFollowReadsARegularFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(p, []byte(`{"ok":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	b, err := ReadFileNoFollow(p, 1<<20)
+	if err != nil {
+		t.Fatalf("ReadFileNoFollow: %v", err)
+	}
+	if string(b) != `{"ok":true}` {
+		t.Errorf("read %q", b)
+	}
+}
+
+func TestReadFileNoFollowRefusesASymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFileNoFollow(link, 1<<20); err == nil {
+		t.Fatal("a symlink must be refused, not followed")
+	}
+}
+
+// The FIFO case is the one that used to hang: open(2) on a FIFO with no
+// writer blocks until one appears, which for an attacker's FIFO is never.
+// The read runs in a goroutine so a regression shows up as a test failure
+// with a message rather than a suite that never finishes.
+func TestReadFileNoFollowDoesNotBlockOnAFIFO(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "fifo")
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Skipf("mkfifo: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := ReadFileNoFollow(p, 1<<20)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a FIFO must be an error, not content")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("error should name the file type: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReadFileNoFollow blocked on a FIFO")
+	}
+}
+
+func TestReadFileNoFollowCapsTheSize(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "big")
+	if err := os.WriteFile(p, make([]byte, 100), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFileNoFollow(p, 99); err == nil {
+		t.Fatal("a file over the limit must be an error, not a truncated read")
+	}
+	if b, err := ReadFileNoFollow(p, 100); err != nil || len(b) != 100 {
+		t.Fatalf("a file exactly at the limit must read whole: %d bytes, %v", len(b), err)
+	}
+}
+
+func TestChmodNoFollowChangesARegularFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ChmodNoFollow(p, 0o600); err != nil {
+		t.Fatalf("ChmodNoFollow: %v", err)
+	}
+	fi, _ := os.Stat(p)
+	if fi.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %#o, want 0600", fi.Mode().Perm())
+	}
+}
+
+func TestChmodNoFollowRefusesASymlink(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "victim")
+	if err := os.WriteFile(victim, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := ChmodNoFollow(link, 0o600); err == nil {
+		t.Fatal("a symlink must be refused, not chmod'ed through")
+	}
+	fi, _ := os.Stat(victim)
+	if fi.Mode().Perm() != 0o644 {
+		t.Errorf("the symlink's target changed mode to %#o — the chmod followed the link", fi.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## The bug

The agent checker reads config files inside **other accounts' home directories, as root**, and emits an Auto chmod fix for the ones whose permissions are loose. Every step of that path used a symlink-following call, so the account being audited controlled where it landed.

A normal unprivileged user could:

```sh
rm ~/.openclaw/openclaw.json
ln -s /etc/passwd ~/.openclaw/openclaw.json
```

The scan then reports a real `agent.config-perms` finding — about `/etc/passwd`'s `0644` mode — carrying `RemediationAuto`. `hostveil fix --all` chmods the password database to `0600`, which breaks logins, `sudo`, and every `getpwnam` on the host. `tighten` is subtractive so it's a denial of service rather than an escalation, but it is root-initiated, host-wide, and triggered by the one command that's meant to be safe unattended.

Two more shapes of the same trick:

- **FIFO** in place of a config file: `os.ReadFile` blocks inside `open(2)` until a writer appears, and no writer is coming. File reads have no timeout, so the whole scan hangs.
- **Symlink to `/dev/zero`**: an unbounded read.

## The fix

New `internal/platform/safefile.go` with `ReadFileNoFollow` and `ChmodNoFollow` — `O_NOFOLLOW` (a symlink is `ELOOP`, not a redirect) plus `O_NONBLOCK` (a FIFO never blocks), a regular-file check on the *open descriptor* rather than the path, and a size cap.

Routed through every step, so no single check is load-bearing:

- `internal/check/agent` — `Lstat` and skip non-regular files; config and env reads go through `ReadFileNoFollow` with a 1 MiB cap.
- `internal/core.planModes` — `Lstat` plus a type check, and it *refuses* rather than skipping, keeping the existing "a mode fix must not silently tighten some of its paths" rule.
- `internal/core.applyMode` and `internal/history.rollback` — chmod through the descriptor, so a swap between plan and apply cannot win the race.

`internal/fix/register.go`'s doc comment now records the obligation any future Auto fix aimed at an attacker-influenced path inherits.

## Tests

`internal/check/agent/hostile_test.go` and `internal/platform/safefile_test.go` cover each attack: symlinked config, symlinked secret file, FIFO (with a timeout so a regression fails rather than hangs), `/dev/zero`, plus that an ordinary world-readable config is still reported. `TestModeFixRefusesToFollowASymlink` covers the apply path directly and asserts the victim file's mode is unchanged.

Verified they catch the bug: reverting the `Lstat`/`ReadFileNoFollow` changes makes `TestSymlinkedConfigProducesNoModeFinding` fail with the finding it would have produced, and `TestUnboundedDeviceConfigIsBounded` time out.

Full local gate passes, including a `GOOS=darwin` cross-compile for the new syscall use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)