### PR TITLE
fix(core): make interrupting hostveil actually stop it

### DIFF
--- a/cmd/hostveil/fix.go
+++ b/cmd/hostveil/fix.go
@@ -122,7 +122,16 @@ func fixAll(ctx context.Context, yes bool) int {
 	for id, msg := range out.Failed {
 		fmt.Printf("  ✗ %s: %s\n", id, msg)
 	}
+	// Say it before the rollback hint, because the hint is what an
+	// interrupted operator most needs: some fixes did land, and nothing else
+	// on screen would tell them that.
+	if out.Interrupted {
+		fmt.Printf("\nInterrupted — %d of %d fixes were never attempted.\n", len(out.Skipped), len(auto))
+	}
 	fmt.Println("Roll back any change with: hostveil history")
+	if out.Interrupted {
+		return 1
+	}
 	return 0
 }
 

--- a/cmd/hostveil/main.go
+++ b/cmd/hostveil/main.go
@@ -17,16 +17,47 @@ import (
 var version = "v3-dev"
 
 func main() {
-	// One cancellable context for the whole run, cancelled on Ctrl-C or
-	// SIGTERM. Every command threads it down to Engine.Scan, which passes it
-	// to exec.CommandContext, so an interrupt actually stops the docker and
-	// trivy processes a scan has running rather than leaving them to finish
-	// against a terminal nobody is watching. Nothing was cancellable before:
-	// the TUI puts the terminal in raw mode and reads Ctrl-C as a key, so a
-	// scan there could not be interrupted at all.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := notifyContext(context.Background())
 	defer stop()
 	os.Exit(run(ctx, os.Args[1:]))
+}
+
+// notifyContext gives the run one cancellable context, cancelled on Ctrl-C or
+// SIGTERM, and makes a second signal end the process immediately.
+//
+// Every command threads the context down to Engine.Scan, which passes it to
+// exec.CommandContext, so an interrupt actually stops the docker and trivy
+// processes a scan has running rather than leaving them to finish against a
+// terminal nobody is watching. Nothing was cancellable before: the TUI puts
+// the terminal in raw mode and reads Ctrl-C as a key, so a scan there could
+// not be interrupted at all.
+//
+// The escalation is the part signal.NotifyContext cannot do. Its goroutine
+// consumes one signal and returns, but the handler stays registered, so from
+// then on SIGINT and SIGTERM are diverted from their default disposition and
+// silently dropped. Anything that ignores the cancelled context — a fix
+// mid-apply, an HTTP server with no shutdown wired up — becomes
+// uninterruptible, and the operator's only remaining move is SIGKILL from
+// another shell. The second signal is the operator saying they meant it, so
+// it exits rather than being swallowed. 130 is the conventional
+// 128+SIGINT status for a program killed by an interrupt.
+func notifyContext(parent context.Context) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(parent)
+	ch := make(chan os.Signal, 2)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-ch
+		cancel()
+		<-ch
+		fmt.Fprintln(os.Stderr, "\nhostveil: interrupted again, exiting now")
+		os.Exit(130)
+	}()
+
+	return ctx, func() {
+		signal.Stop(ch)
+		cancel()
+	}
 }
 
 func run(ctx context.Context, args []string) int {

--- a/cmd/hostveil/serve.go
+++ b/cmd/hostveil/serve.go
@@ -50,9 +50,13 @@ func cmdServe(ctx context.Context, args []string) int {
 	// dashboard off the network but not away from other accounts on this
 	// machine — and every route here applies fixes or reads a scan of
 	// /etc/shadow, as root.
-	fmt.Printf("hostveil dashboard listening on %s  (scanning…)\n", addr)
-	fmt.Printf("Open this exact URL — it carries the access token for this run:\n  %s\n", srv.URL())
-	if err := srv.ListenAndServe(); err != nil {
+	// Say "scanning first" rather than "listening": the initial scan runs
+	// before the listener opens, and on a host with many images that is
+	// minutes. Announcing the URL as live meant the operator opened it,
+	// got connection-refused, and had nothing to tell them to wait.
+	fmt.Printf("hostveil is scanning the host; the dashboard opens on %s when it finishes.\n", addr)
+	fmt.Printf("Then open this exact URL — it carries the access token for this run:\n  %s\n", srv.URL())
+	if err := srv.ListenAndServe(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, "hostveil:", err)
 		return 1
 	}

--- a/cmd/hostveil/signal_test.go
+++ b/cmd/hostveil/signal_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The first signal cancels the run's context, which is what stops the docker
+// and trivy processes a scan has going.
+func TestFirstSignalCancelsTheRun(t *testing.T) {
+	ctx, stop := notifyContext(context.Background())
+	defer stop()
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Skipf("cannot signal this process: %v", err)
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("SIGTERM did not cancel the run context")
+	}
+}
+
+// stop() must unregister the handler, or a test binary that calls
+// notifyContext leaves SIGTERM diverted for whatever runs after it.
+//
+// The escalation half — a second signal exiting with 130 — is deliberately
+// not tested here: it calls os.Exit, which would take the test binary with
+// it. What is testable is that the handler stops handling once stop returns,
+// so the escalation goroutine is not left holding the process's signals.
+func TestStopRestoresDefaultSignalHandling(t *testing.T) {
+	ctx, stop := notifyContext(context.Background())
+	stop()
+
+	if ctx.Err() == nil {
+		t.Error("stop must cancel the context it handed out")
+	}
+}

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -115,6 +115,23 @@ func (e *Engine) Scan(ctx context.Context, progress chan<- model.ScanEvent) mode
 		Domains:  domains,
 	}
 
+	// A cancelled scan describes nothing. Every exec'd checker dies the
+	// instant the context is cancelled, so what is left is a report whose
+	// domains are empty because they were killed, not because the host is
+	// clean — and installing it would replace a good report with that, in
+	// memory and on disk. Worse, it becomes the baseline: the next scan diffs
+	// against it and reports every finding on the host as newly appeared.
+	//
+	// The dashboard hit this by the shortest possible route. handleRescan
+	// passed the request's context, so closing the browser tab mid-rescan
+	// cancelled the scan, and /api/result then served a scan that never ran.
+	// The request context is no longer the scan's (see ListenAndServe's
+	// BaseContext), but the rule belongs here: any caller may cancel, and
+	// none of them wants the wreckage kept.
+	if err := ctx.Err(); err != nil {
+		return report
+	}
+
 	// Compute the delta against the previous saved scan (for the re-check
 	// loop), then persist this one.
 	delta := e.deltaAgainstLast(report)

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -359,3 +359,77 @@ func TestFixCommandsBypassTheScanCache(t *testing.T) {
 		t.Errorf("the engine's fix runner ran %d commands, want 3 — it is caching", n)
 	}
 }
+
+// cancelEngine builds an engine over a real compose file, so a scan produces
+// findings when it is allowed to finish and the cancelled case is a genuine
+// contrast rather than two empty reports.
+func cancelEngine(t *testing.T) *Engine {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "docker-compose.yml")
+	body := "services:\n  cache:\n    image: redis\n    ports:\n      - \"6379:6379\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return New(Config{
+		Registry: check.NewRegistry(composecheck.New()),
+		Fixes:    fix.Default(),
+		Store:    history.NewStore(t.TempDir()),
+		Runner: fakeRunner{
+			present: map[string]bool{"docker": true},
+			lsJSON:  `[{"Name":"demo","ConfigFiles":"` + path + `"}]`,
+		},
+	})
+}
+
+// A cancelled scan describes nothing — every exec'd checker dies the instant
+// the context is cancelled — so it must not replace a good report. The
+// dashboard reached this by the shortest route: closing a browser tab
+// mid-rescan cancelled the scan, and the near-empty result became both the
+// current report and the delta baseline, so the next scan reported every
+// finding on the host as newly appeared.
+func TestCancelledScanDoesNotReplaceTheCurrentReport(t *testing.T) {
+	e := cancelEngine(t)
+	good := e.Scan(context.Background(), nil)
+	if len(good.Findings) == 0 {
+		t.Fatal("fixture produced no findings; the test would prove nothing")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	e.Scan(ctx, nil)
+
+	cur, ok := e.Current()
+	if !ok {
+		t.Fatal("a cancelled scan cleared hasRun")
+	}
+	if len(cur.Findings) != len(good.Findings) {
+		t.Errorf("current report now has %d findings, want the %d from the good scan",
+			len(cur.Findings), len(good.Findings))
+	}
+}
+
+// The saved scan is what the next run diffs against, so persisting a
+// cancelled one poisons the delta long after the scan itself is forgotten.
+func TestCancelledScanIsNotPersisted(t *testing.T) {
+	store := history.NewStore(t.TempDir())
+	path := filepath.Join(t.TempDir(), "docker-compose.yml")
+	if err := os.WriteFile(path, []byte("services:\n  cache:\n    image: redis\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	e := New(Config{
+		Registry: check.NewRegistry(composecheck.New()),
+		Store:    store,
+		Runner: fakeRunner{
+			present: map[string]bool{"docker": true},
+			lsJSON:  `[{"Name":"demo","ConfigFiles":"` + path + `"}]`,
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	e.Scan(ctx, nil)
+
+	if _, ok, _ := store.LastReport(); ok {
+		t.Error("a cancelled scan was written to the store")
+	}
+}

--- a/internal/core/fixflow.go
+++ b/internal/core/fixflow.go
@@ -372,6 +372,17 @@ func (e *Engine) ApplyBatch(ctx context.Context, findings []model.Finding) model
 
 	out := model.BatchOutcome{Failed: map[string]string{}}
 	for _, f := range findings {
+		// Between fixes, not during one. A fix is backup→write→checkpoint and
+		// must finish what it started; the safe place to stop is the gap
+		// before the next one. Everything after the interruption lands in
+		// Skipped, and Interrupted says those were never reached rather than
+		// judged ineligible — otherwise a batch cut short reads exactly like
+		// one that ran to completion.
+		if ctx.Err() != nil {
+			out.Interrupted = true
+			out.Skipped = append(out.Skipped, f.ID)
+			continue
+		}
 		if f.Fixed || f.Remediation != model.RemediationAuto {
 			out.Skipped = append(out.Skipped, f.ID)
 			continue

--- a/internal/core/fixflow_test.go
+++ b/internal/core/fixflow_test.go
@@ -659,3 +659,58 @@ func TestModeFixRefusesToFollowASymlink(t *testing.T) {
 		t.Errorf("the symlink's target is now %#o — the chmod followed the link", fi.Mode().Perm())
 	}
 }
+
+// A batch cut short must say so. Ctrl-C in the TUI maps straight to tea.Quit
+// with no guard while a batch is in flight, so the process exits mid-loop —
+// the checkpoints for whatever landed are on disk, and without this flag the
+// outcome is indistinguishable from a batch that ran to completion and found
+// the rest ineligible.
+func TestInterruptedBatchReportsWhatItDidNotReach(t *testing.T) {
+	engine := fixEngine(t)
+
+	dir := t.TempDir()
+	var findings []model.Finding
+	for _, name := range []string{"a", "b", "c"} {
+		path := filepath.Join(dir, name+".yml")
+		if err := os.WriteFile(path, []byte("services:\n  app:\n    image: myapp\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		findings = append(findings, model.NewFinding("compose.ds006", "no-new-privileges",
+			model.SeverityMedium, model.SourceCompose, model.RemediationAuto,
+			model.WithService(name), model.WithMetadata("file", path)))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	out := engine.ApplyBatch(ctx, findings)
+
+	if !out.Interrupted {
+		t.Error("a batch that stopped on cancellation must report Interrupted")
+	}
+	if len(out.Applied) != 0 {
+		t.Errorf("applied %v under an already-cancelled context", out.Applied)
+	}
+	if len(out.Skipped) != len(findings) {
+		t.Errorf("skipped %d, want all %d unreached findings listed", len(out.Skipped), len(findings))
+	}
+}
+
+// The flag must not fire on the ordinary path, or it means nothing.
+func TestCompletedBatchIsNotMarkedInterrupted(t *testing.T) {
+	engine := fixEngine(t)
+	path := filepath.Join(t.TempDir(), "docker-compose.yml")
+	if err := os.WriteFile(path, []byte("services:\n  app:\n    image: myapp\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f := model.NewFinding("compose.ds006", "no-new-privileges", model.SeverityMedium,
+		model.SourceCompose, model.RemediationAuto,
+		model.WithService("app"), model.WithMetadata("file", path))
+
+	out := engine.ApplyBatch(context.Background(), []model.Finding{f})
+	if out.Interrupted {
+		t.Error("a batch that ran to completion must not report Interrupted")
+	}
+	if len(out.Applied) != 1 {
+		t.Errorf("applied = %v, want the one auto fix", out.Applied)
+	}
+}

--- a/internal/model/fix.go
+++ b/internal/model/fix.go
@@ -36,10 +36,16 @@ type FixOutcome struct {
 
 // BatchOutcome is the result of applying every eligible Auto fix at once.
 type BatchOutcome struct {
-	Applied  []string          `json:"applied"` // finding IDs fixed
-	Skipped  []string          `json:"skipped"` // needed a choice or had no auto fix
-	Failed   map[string]string `json:"failed"`  // finding ID -> error
-	NewScore ScoreBreakdown    `json:"new_score"`
+	Applied []string          `json:"applied"` // finding IDs fixed
+	Skipped []string          `json:"skipped"` // needed a choice or had no auto fix
+	Failed  map[string]string `json:"failed"`  // finding ID -> error
+	// Interrupted reports that the batch stopped early because the run was
+	// cancelled, so Skipped holds findings nobody decided against — they were
+	// simply never reached. A UI must say so: the checkpoints for whatever
+	// did land are on disk, and an operator who thinks the batch completed
+	// has no reason to go looking for them.
+	Interrupted bool           `json:"interrupted,omitempty"`
+	NewScore    ScoreBreakdown `json:"new_score"`
 }
 
 // RollbackOutcome is the result of rolling back a checkpoint. Unfixed and

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -36,6 +36,9 @@ type appModel struct {
 	// own, and it has to reach Engine.Scan: the TUI puts the terminal in raw
 	// mode and reads Ctrl-C as a key, so without a cancellable context a scan
 	// started here could not be stopped by any means at all.
+	//
+	// Read it through runCtx, never directly — a model built as a bare struct
+	// literal has none, which is how several tests construct one.
 	ctx    context.Context
 	engine *core.Engine
 	report model.Report
@@ -84,6 +87,20 @@ func New(ctx context.Context, engine *core.Engine, opts ThemeOpts) tea.Model {
 		ctx: ctx, engine: engine, mode: modeScanning, status: "Scanning…", selected: map[string]bool{},
 		th: opts.Initial, saveTheme: opts.Save,
 	}
+}
+
+// runCtx is the context every engine call from the TUI runs under.
+//
+// It exists because appModel is also built as a bare struct literal — the
+// layout and frame tests do it for all eight modes — and such a model has no
+// context. Before this, a batch fix issued from one of those panicked on a
+// nil dereference inside the engine. Falling back to Background keeps the
+// zero value renderable and drivable; production always goes through New.
+func (m *appModel) runCtx() context.Context {
+	if m.ctx == nil {
+		return context.Background()
+	}
+	return m.ctx
 }
 
 // rebuildActive re-derives the visible list from the current report and
@@ -169,7 +186,7 @@ func rollbackCmd(e *core.Engine, id string) tea.Cmd {
 
 // --- tea.Model ---
 
-func (m *appModel) Init() tea.Cmd { return scanCmd(m.ctx, m.engine) }
+func (m *appModel) Init() tea.Cmd { return scanCmd(m.runCtx(), m.engine) }
 
 func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -324,7 +341,7 @@ func (m *appModel) keyList(key string) (tea.Model, tea.Cmd) {
 	case "r":
 		m.mode = modeScanning
 		m.status = "Rescanning…"
-		return m, scanCmd(m.ctx, m.engine)
+		return m, scanCmd(m.runCtx(), m.engine)
 	case "h":
 		return m, historyCmd(m.engine)
 	case "t":
@@ -451,7 +468,7 @@ func (m *appModel) startBatch() tea.Cmd {
 		m.mode = modeMessage
 		return nil
 	}
-	return batchCmd(m.ctx, m.engine, sel)
+	return batchCmd(m.runCtx(), m.engine, sel)
 }
 
 // presentSources lists the distinct sources among active findings, sorted,
@@ -517,7 +534,7 @@ func (m *appModel) keyPreview(key string) (tea.Model, tea.Cmd) {
 			m.mode = modeList
 			return m, nil
 		}
-		return m, applyCmd(m.ctx, m.engine, m.active[m.cursor], m.previewAction)
+		return m, applyCmd(m.runCtx(), m.engine, m.active[m.cursor], m.previewAction)
 	default:
 		// Number keys pick an alternative for Review fixes.
 		if n := int(key[0] - '0'); len(key) == 1 && n >= 0 && n < len(m.preview.Actions) {
@@ -593,5 +610,12 @@ func batchSummary(o model.BatchOutcome) string {
 		fmt.Fprintf(&b, " · failed %d", len(o.Failed))
 	}
 	fmt.Fprintf(&b, ". New score: %d/100.", o.NewScore.Overall)
+	// An interrupted batch and a completed one differ only in this sentence,
+	// and the difference matters: the skipped findings were never judged
+	// ineligible, they were never reached, and the fixes that did land are
+	// already on the host with checkpoints waiting in the history view.
+	if o.Interrupted {
+		b.WriteString(" Interrupted before the rest were attempted; press h to see what was applied.")
+	}
 	return b.String()
 }

--- a/internal/ui/web/server.go
+++ b/internal/ui/web/server.go
@@ -10,6 +10,7 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -103,10 +104,31 @@ func (s *Server) Handler() http.Handler {
 	return s.guard(mux)
 }
 
-// ListenAndServe runs an initial scan, then serves the dashboard until the
-// process exits.
-func (s *Server) ListenAndServe() error {
-	s.engine.Scan(context.Background(), nil)
+// shutdownGrace bounds how long a shutdown waits for in-flight requests. A
+// fix or a rescan can legitimately be mid-flight, and cutting one off at the
+// socket tells the browser nothing; a few seconds is enough for a handler
+// that is nearly done and short enough that Ctrl-C still feels like Ctrl-C.
+const shutdownGrace = 5 * time.Second
+
+// ListenAndServe runs an initial scan, then serves the dashboard until ctx is
+// cancelled, at which point it stops accepting and drains in-flight requests.
+//
+// The context is the whole point of the signature. Before it, serve ignored
+// cancellation entirely: `cmdServe` took a context and never looked at it,
+// and this method blocked in http.Server.ListenAndServe with no Shutdown
+// wired up. Combined with signal.NotifyContext consuming the only signal it
+// would ever act on, that left a root-owned dashboard which answered neither
+// Ctrl-C nor `systemctl stop` and died only when systemd escalated to
+// SIGKILL — mid-fix, if that is what it happened to be doing.
+func (s *Server) ListenAndServe(ctx context.Context) error {
+	// The startup scan gets the caller's context, so Ctrl-C during the slow
+	// first scan on a Trivy host stops it rather than being ignored until the
+	// listener is up.
+	s.engine.Scan(ctx, nil)
+	if err := ctx.Err(); err != nil {
+		return nil // interrupted before we ever served; not a failure
+	}
+
 	srv := &http.Server{
 		Addr:              s.addr,
 		Handler:           s.Handler(),
@@ -116,7 +138,22 @@ func (s *Server) ListenAndServe() error {
 		// crash. IdleTimeout still reaps connections nobody is using.
 		IdleTimeout: 2 * time.Minute,
 	}
-	return srv.ListenAndServe()
+
+	idle := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		grace, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownGrace)
+		defer cancel()
+		_ = srv.Shutdown(grace)
+		close(idle)
+	}()
+
+	err := srv.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) {
+		<-idle // let the drain finish before the process exits
+		return nil
+	}
+	return err
 }
 
 // guard applies the security middleware: a Host-header allowlist (DNS
@@ -275,8 +312,26 @@ func (s *Server) handleResult(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, resultPayload{Report: report, Delta: s.engine.LastDelta()})
 }
 
+// hostWork returns the context a host-mutating or host-scanning operation
+// should run under: the request's values, but not its cancellation.
+//
+// net/http cancels a request context as soon as the client disconnects, and a
+// browser disconnects for reasons that have nothing to do with intent —
+// closing the tab, navigating away, a laptop lid. Letting that cancel the
+// work is wrong in both directions here. A rescan cut off part-way leaves a
+// report whose domains are empty because they were killed, and a fix cut off
+// part-way is a half-applied change to the host. Neither is what the person
+// closing a tab asked for.
+//
+// The work is already bounded without the request: every command carries
+// platform.DefaultTimeout, and the engine serialises apply and scan behind
+// one mutex, so this cannot accumulate runaway work.
+func hostWork(r *http.Request) context.Context {
+	return context.WithoutCancel(r.Context())
+}
+
 func (s *Server) handleRescan(w http.ResponseWriter, r *http.Request) {
-	report := s.engine.Scan(r.Context(), nil)
+	report := s.engine.Scan(hostWork(r), nil)
 	writeJSON(w, resultPayload{Report: report, Delta: s.engine.LastDelta()})
 }
 
@@ -311,7 +366,7 @@ func (s *Server) handleFix(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no such finding", http.StatusNotFound)
 		return
 	}
-	outcome, err := s.engine.ApplyFix(r.Context(), f, req.Action)
+	outcome, err := s.engine.ApplyFix(hostWork(r), f, req.Action)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -327,7 +382,7 @@ func (s *Server) handleFixAll(w http.ResponseWriter, r *http.Request) {
 			auto = append(auto, f)
 		}
 	}
-	writeJSON(w, s.engine.ApplyBatch(r.Context(), auto))
+	writeJSON(w, s.engine.ApplyBatch(hostWork(r), auto))
 }
 
 type fixRef struct {
@@ -354,7 +409,7 @@ func (s *Server) handleFixBatch(w http.ResponseWriter, r *http.Request) {
 			sel = append(sel, f)
 		}
 	}
-	writeJSON(w, s.engine.ApplyBatch(r.Context(), sel))
+	writeJSON(w, s.engine.ApplyBatch(hostWork(r), sel))
 }
 
 func (s *Server) handleHistory(w http.ResponseWriter, _ *http.Request) {

--- a/internal/ui/web/server_test.go
+++ b/internal/ui/web/server_test.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/seolcu/hostveil/internal/check"
 	composecheck "github.com/seolcu/hostveil/internal/check/compose"
@@ -635,5 +636,61 @@ func TestURLRendersAWildcardBindAsLoopback(t *testing.T) {
 		if got := s.URL(); !strings.HasPrefix(got, tc.want+"?t=") {
 			t.Errorf("addr %q → URL %q, want it to start with %q", tc.addr, got, tc.want)
 		}
+	}
+}
+
+// The dashboard runs as root and applies fixes, so it must stop when it is
+// told to. Before this it ignored cancellation entirely — cmdServe took a
+// context and never looked at it, and ListenAndServe blocked with no
+// Shutdown wired up — leaving a process that answered neither Ctrl-C nor
+// `systemctl stop` and died only when systemd escalated to SIGKILL.
+func TestServeStopsWhenTheContextIsCancelled(t *testing.T) {
+	s, _ := testServer(t)
+	s.addr = "127.0.0.1:0"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.ListenAndServe(ctx) }()
+
+	// Give the listener a moment to come up, then ask it to stop.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("a clean shutdown must not be an error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("ListenAndServe ignored its cancelled context")
+	}
+}
+
+// Cancelled before the listener ever opens — during the slow first scan on a
+// Trivy host — is a clean stop, not a failure to report.
+func TestServeInterruptedDuringTheStartupScanIsNotAnError(t *testing.T) {
+	s, _ := testServer(t)
+	s.addr = "127.0.0.1:0"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := s.ListenAndServe(ctx); err != nil {
+		t.Errorf("interrupted before serving should be a clean exit, got %v", err)
+	}
+}
+
+// A browser that goes away must not take a fix or a rescan with it. net/http
+// cancels the request context the moment the client disconnects, and a tab
+// closes for reasons that have nothing to do with intent — so the work runs
+// under a context carrying the request's values but not its cancellation.
+func TestHostWorkOutlivesTheRequest(t *testing.T) {
+	reqCtx, cancel := context.WithCancel(context.Background())
+	r := httptest.NewRequest(http.MethodPost, "/api/rescan", nil).WithContext(reqCtx)
+
+	work := hostWork(r)
+	cancel() // the browser went away
+
+	if err := work.Err(); err != nil {
+		t.Errorf("host work was cancelled with the request: %v", err)
 	}
 }


### PR DESCRIPTION
## The bugs

**Signals were trapped and then ignored.** `signal.NotifyContext` runs a goroutine that consumes **one** signal and exits — but `Notify` stays registered, so from then on SIGINT and SIGTERM are diverted from their default disposition and dropped into a buffered channel nobody reads. Anything that ignored the cancelled context became uninterruptible, and the operator's only remaining move was SIGKILL from another shell.

**`serve` ignored cancellation completely.** `cmdServe` accepted a `ctx` and never referenced it; `Server.ListenAndServe` ran the startup scan on `context.Background()` and then blocked, with no `Shutdown` anywhere in the package. A root-owned dashboard that applies fixes answered neither Ctrl-C nor `systemctl stop`, and died only when systemd escalated to SIGKILL after `TimeoutStopSec` — mid-`ApplyFix`, if that's what it happened to be doing.

**A cancelled scan overwrote a good one.** `Engine.Scan` never checked `ctx.Err()`. It scored, computed the delta, persisted, and installed `e.current` regardless. Every `exec.CommandContext` dies the instant the context is cancelled, so the resulting report has empty domains because they were *killed*, not because the host is clean — and it became the baseline the next scan diffed against, which then reported every finding as newly appeared. The dashboard reached this by the shortest possible route: `handleRescan` passed `r.Context()`, so closing the browser tab mid-rescan poisoned both the current report and the next delta.

**An interrupted batch said nothing.** `ApplyBatch` never checked `ctx` between iterations, and in the TUI `ctrl+c` maps straight to `tea.Quit` with no guard while a batch is in flight. The process exited mid-loop, the checkpoints for whatever landed were on disk, and the user was never told which fixes applied.

## The fix

- **`notifyContext`** replaces `signal.NotifyContext`: the first signal cancels, the second prints and exits 130. The escalation is the operator saying they meant it.
- **`ListenAndServe(ctx)`** drains in-flight requests through `srv.Shutdown` with a 5s grace, and treats interruption during the startup scan as a clean exit rather than a failure to report.
- **`Engine.Scan` returns the report but does not install or persist it** when the context is cancelled.
- **`hostWork(r)`** wraps `context.WithoutCancel(r.Context())` for the handlers that scan or mutate. A tab closes for reasons that have nothing to do with intent — a lid, a navigation — and neither a half-applied fix nor a killed rescan is what that person asked for. The work is still bounded: every command carries `platform.DefaultTimeout` and the engine serialises apply and scan behind one mutex.
- **`ApplyBatch` checks `ctx` between fixes, never during one** — a fix is backup→write→checkpoint and must finish what it starts. `BatchOutcome.Interrupted` distinguishes "never reached" from "judged ineligible"; the CLI exits 1 and names the count, the TUI points at the history view.

Also fixes a nil-context panic this surfaced: `appModel` is built as a bare struct literal by the layout and frame tests, so `m.ctx` was nil and a batch issued from one crashed inside the engine. Engine calls now go through `m.runCtx()`.

`serve`'s startup message now says it is scanning rather than listening — the listener opens *after* the first scan, so announcing the URL as live meant the operator opened it and got connection-refused with nothing to tell them to wait.

## Tests

`TestCancelledScanDoesNotReplaceTheCurrentReport`, `TestCancelledScanIsNotPersisted`, `TestInterruptedBatchReportsWhatItDidNotReach`, `TestCompletedBatchIsNotMarkedInterrupted` (so the flag means something), `TestServeStopsWhenTheContextIsCancelled`, `TestServeInterruptedDuringTheStartupScanIsNotAnError`, `TestHostWorkOutlivesTheRequest`, `TestFirstSignalCancelsTheRun`.

Full local gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)