### PR TITLE
fix(cmd): stop scan exiting 0 when it never actually looked

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,25 @@ domains are then skipped with a clear message.
 
 ### Using it as a CI or cron gate
 
-`hostveil scan` exits **1** when any unfixed finding is Critical or High, and
-**0** otherwise — so a scheduled check needs no output parsing:
+`hostveil scan` reports what it found in its exit status, so a scheduled
+check needs no output parsing:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The scan ran and found nothing Critical or High. |
+| `1` | At least one unfixed Critical or High finding. |
+| `3` | A detection domain failed outright, so the scan covered less of the host than it should have. |
 
 ```bash
 HOSTVEIL_NO_SUDO=1 hostveil scan --json > report.json || echo "action needed"
 ```
+
+Code **3** matters more than it looks. A failed domain contributes no
+findings, so without it an unreachable Docker socket silences the two
+heaviest axes and the pipeline sees a clean run — a blind scan and a healthy
+host are indistinguishable to the one consumer that never reads the output.
+A domain skipped for a missing dependency, or degraded to partial coverage,
+does not change the status; both are reported in the output instead.
 
 Other commands exit 0 on success, 1 on failure, and 2 on a usage error.
 

--- a/cmd/hostveil/cli_test.go
+++ b/cmd/hostveil/cli_test.go
@@ -52,6 +52,48 @@ func TestExitCode(t *testing.T) {
 	}
 }
 
+// A failed domain contributes no findings, so before this an unreachable
+// Docker socket silenced the two heaviest axes and the pipeline saw exit 0.
+// A blind scan and a clean host must not look the same to the one consumer
+// that never reads the output.
+func TestExitCodeReflectsDomainState(t *testing.T) {
+	domain := func(st model.ScanState) model.DomainResult {
+		return model.DomainResult{Source: model.SourceCompose, State: st}
+	}
+	for _, tc := range []struct {
+		name    string
+		fs      []model.Finding
+		domains []model.DomainResult
+		want    int
+	}{
+		{"a failed domain is not a clean host", nil, []model.DomainResult{domain(model.ScanError)}, 3},
+		{"a skipped domain is ordinary", nil, []model.DomainResult{domain(model.ScanSkipped)}, 0},
+		{"a degraded domain is reported, not gated", nil, []model.DomainResult{domain(model.ScanDegraded)}, 0},
+		{"everything ran and found nothing", nil, []model.DomainResult{domain(model.ScanDone)}, 0},
+		{
+			// Findings win: the gate exists to answer "is this host exposed",
+			// and a domain that also failed does not make that less true.
+			"findings outrank an incomplete scan",
+			[]model.Finding{finding(model.SeverityCritical, false)},
+			[]model.DomainResult{domain(model.ScanError)},
+			1,
+		},
+		{
+			"one failed domain among healthy ones still counts",
+			nil,
+			[]model.DomainResult{domain(model.ScanDone), domain(model.ScanError), domain(model.ScanSkipped)},
+			3,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := exitCode(model.Report{Findings: tc.fs, Domains: tc.domains})
+			if got != tc.want {
+				t.Errorf("exitCode = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 // -h is a request, not a mistake. Go's flag package reports it as
 // flag.ErrHelp after printing usage, and treating that as a parse failure
 // made `hostveil scan --help` exit 2. The top-level form was fixed in #520

--- a/cmd/hostveil/main.go
+++ b/cmd/hostveil/main.go
@@ -188,9 +188,14 @@ other accounts on this machine, and serve runs as root. Open the printed URL;
 the token then becomes a session cookie for that browser.
 
 Exit status:
-  hostveil scan exits 1 when any unfixed finding is Critical or High, and 0
-  otherwise — useful as a CI or cron gate. Other commands exit 0 on success,
-  1 on failure, and 2 on a usage error.
+  hostveil scan is a CI or cron gate:
+    0  the scan ran and found nothing Critical or High
+    1  at least one unfixed Critical or High finding
+    3  a detection domain failed outright, so the scan covered less of the
+       host than it should have — a clean-looking result you cannot trust
+  A domain skipped for a missing dependency, or degraded to partial coverage,
+  does not change the status; both are reported in the output instead.
+  Other commands exit 0 on success, 1 on failure, and 2 on a usage error.
 
 Environment:
   HOSTVEIL_NO_SUDO=1   Never re-exec under sudo (for scripts and CI)

--- a/cmd/hostveil/scan.go
+++ b/cmd/hostveil/scan.go
@@ -72,18 +72,45 @@ func scanWithProgress(ctx context.Context, engine *core.Engine) model.Report {
 	return report
 }
 
-// exitCode returns 1 when any unfixed high-or-critical finding was
-// detected, so scripts and CI can gate on it; 0 otherwise.
+// Exit codes for scan. These are the CI and cron contract, so they are
+// named rather than written as bare integers at the return sites.
+const (
+	exitClean      = 0 // the scan ran and found nothing serious
+	exitFindings   = 1 // unfixed Critical or High findings
+	exitIncomplete = 3 // a domain failed outright; the result describes less than the host
+)
+
+// exitCode is what a CI or cron gate reads.
+//
+// Findings come first: an unfixed Critical or High is the answer the gate
+// exists for, and it stays 1 whatever else happened.
+//
+// A domain in ScanError is the second answer, and it used to have none.
+// The code was derived from findings alone, and a failed domain contributes
+// zero findings — so an unreachable Docker socket silenced the two heaviest
+// axes and the pipeline saw exit 0. A blind scan and a clean host were
+// indistinguishable to the one consumer that cannot look at the output.
+//
+// Skipped and Degraded deliberately do not qualify. Skipped is the ordinary
+// state of a host that has no Docker or no Trivy, and failing every such
+// pipeline would train people to ignore the code. Degraded means the checker
+// covered part of its ground and said so, and those findings are real and
+// scored; it is reported in the output, not in the exit status.
 func exitCode(r model.Report) int {
 	for _, f := range r.Findings {
 		if f.Fixed {
 			continue
 		}
 		if f.Severity == model.SeverityCritical || f.Severity == model.SeverityHigh {
-			return 1
+			return exitFindings
 		}
 	}
-	return 0
+	for _, d := range r.Domains {
+		if d.State == model.ScanError {
+			return exitIncomplete
+		}
+	}
+	return exitClean
 }
 
 // colorEnabled reports whether to emit ANSI color: honored only when

--- a/cmd/sitegen/content/en/docs/cli.html
+++ b/cmd/sitegen/content/en/docs/cli.html
@@ -106,6 +106,7 @@ hostveil fix --all [flags]</code></pre></div>
                   <tr><td><code>0</code></td><td>Success (and, for <code>scan</code>, no unfixed Critical/High findings).</td></tr>
                   <tr><td><code>1</code></td><td><code>scan</code> found unfixed Critical or High findings, or a command failed.</td></tr>
                   <tr><td><code>2</code></td><td>Usage error — unknown command or missing required argument.</td></tr>
+                  <tr><td><code>3</code></td><td><code>scan</code> had a detection domain fail outright, so it covered less of the host than it should have. A domain skipped for a missing dependency, or degraded to partial coverage, does <em>not</em> produce this — both are reported in the output instead.</td></tr>
                 </tbody>
               </table>
             </div>

--- a/cmd/sitegen/content/ko/docs/cli.html
+++ b/cmd/sitegen/content/ko/docs/cli.html
@@ -106,6 +106,7 @@ hostveil fix --all [flags]</code></pre></div>
                   <tr><td><code>0</code></td><td>성공(<code>scan</code>의 경우, 수정되지 않은 심각/높음 발견 항목이 없음).</td></tr>
                   <tr><td><code>1</code></td><td><code>scan</code>이 수정되지 않은 심각 또는 높음 발견 항목을 찾았거나, 명령이 실패했습니다.</td></tr>
                   <tr><td><code>2</code></td><td>사용법 오류 — 알 수 없는 명령이거나 필수 인자가 누락되었습니다.</td></tr>
+                  <tr><td><code>3</code></td><td><code>scan</code> 중 탐지 도메인이 완전히 실패해, 호스트를 검사해야 할 범위보다 좁게 검사했습니다. 의존성이 없어 건너뛴 도메인이나 부분 커버리지로 강등된 도메인은 여기에 해당하지 <em>않으며</em>, 둘 다 출력에 표시됩니다.</td></tr>
                 </tbody>
               </table>
             </div>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -191,6 +191,7 @@ hostveil fix --all [flags]</code></pre></div>
                   <tr><td><code>0</code></td><td>Success (and, for <code>scan</code>, no unfixed Critical/High findings).</td></tr>
                   <tr><td><code>1</code></td><td><code>scan</code> found unfixed Critical or High findings, or a command failed.</td></tr>
                   <tr><td><code>2</code></td><td>Usage error — unknown command or missing required argument.</td></tr>
+                  <tr><td><code>3</code></td><td><code>scan</code> had a detection domain fail outright, so it covered less of the host than it should have. A domain skipped for a missing dependency, or degraded to partial coverage, does <em>not</em> produce this — both are reported in the output instead.</td></tr>
                 </tbody>
               </table>
             </div>

--- a/site/ko/docs/cli.html
+++ b/site/ko/docs/cli.html
@@ -191,6 +191,7 @@ hostveil fix --all [flags]</code></pre></div>
                   <tr><td><code>0</code></td><td>성공(<code>scan</code>의 경우, 수정되지 않은 심각/높음 발견 항목이 없음).</td></tr>
                   <tr><td><code>1</code></td><td><code>scan</code>이 수정되지 않은 심각 또는 높음 발견 항목을 찾았거나, 명령이 실패했습니다.</td></tr>
                   <tr><td><code>2</code></td><td>사용법 오류 — 알 수 없는 명령이거나 필수 인자가 누락되었습니다.</td></tr>
+                  <tr><td><code>3</code></td><td><code>scan</code> 중 탐지 도메인이 완전히 실패해, 호스트를 검사해야 할 범위보다 좁게 검사했습니다. 의존성이 없어 건너뛴 도메인이나 부분 커버리지로 강등된 도메인은 여기에 해당하지 <em>않으며</em>, 둘 다 출력에 표시됩니다.</td></tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
## The bug

`exitCode` computed the status from findings alone. Domain state was never consulted, and a domain in `ScanError` contributes zero findings — so:

- Docker socket unreachable → compose + CVE (the two heaviest axes) produce nothing → **exit 0**.
- Every exec'd checker killed by a CI timeout → **exit 0**.

`main.go` documents this code as the CI and cron contract. A blind scan and a clean host were indistinguishable to the one consumer that never reads the output, which is exactly the consumer the exit code exists for.

## The fix

`scan` exits **3** when any domain is in `ScanError`.

Findings still take precedence: an unfixed Critical or High is `1` whatever else happened, because that is the question the gate was asked.

`Skipped` and `Degraded` deliberately do not qualify:

- **Skipped** is the ordinary state of a host with no Docker or no Trivy installed. Failing every such pipeline would train people to ignore the code, which costs more than it buys.
- **Degraded** means the checker covered part of its ground *and said so*; those findings are real and scored. It belongs in the output, not the exit status.

Docs updated in all three places the contract is written down — `printUsage`, `README.md`, and the CLI reference (en + ko). `clidocs_test.go` and the sitegen drift check enforce that they agree with the code.

## Tests

`TestExitCodeReflectsDomainState` covers each state, plus the two orderings that matter: findings outrank an incomplete scan, and one failed domain among healthy ones still counts. The existing `TestExitCode` table is untouched, so the findings contract is pinned unchanged.

Full local gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)