### PR TITLE
fix(check): close three places where a partial scan reported as complete

### DIFF
--- a/internal/check/compose/compose.go
+++ b/internal/check/compose/compose.go
@@ -45,7 +45,7 @@ func (*Checker) Available(ctx context.Context, env platform.Env) (bool, string) 
 // object on the box could be published to 0.0.0.0, privileged, and mounting
 // the Docker socket while the axis scored it as if it were not there.
 func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
-	projects, err := compose.Discover(ctx, env.Runner)
+	projects, unparsed, err := compose.Discover(ctx, env.Runner)
 	if err != nil {
 		return nil, err
 	}
@@ -71,10 +71,24 @@ func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, e
 		return findings, &check.PartialError{
 			Reason:  "cannot inspect containers started outside Compose — audited compose projects only",
 			Covered: len(projects),
+			Total:   len(projects) + len(unparsed),
 		}
 	}
 	for _, c := range standalone {
 		findings = append(findings, auditContainer(c)...)
+	}
+
+	// A project docker knows about but whose file we could not parse is a
+	// stack this scan says nothing about. Reporting ScanDone over the rest
+	// would score the domain as if those services had been audited and found
+	// clean, which is the one thing a checker must never do.
+	if len(unparsed) > 0 {
+		return findings, &check.PartialError{
+			Reason: "cannot parse compose file(s): " + strings.Join(unparsed, ", ") +
+				" — services defined there were not audited",
+			Covered: len(projects),
+			Total:   len(projects) + len(unparsed),
+		}
 	}
 	return findings, nil
 }

--- a/internal/check/compose/unparsed_test.go
+++ b/internal/check/compose/unparsed_test.go
@@ -1,0 +1,101 @@
+package compose
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// lsRunner scripts a host whose compose projects are the given files and
+// which has no hand-started containers.
+type lsRunner struct{ lsJSON string }
+
+func (lsRunner) LookPath(name string) (string, error) { return "/usr/bin/" + name, nil }
+
+func (r lsRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	joined := strings.Join(args, " ")
+	switch {
+	case name == "docker" && joined == "version --format {{.Server.Version}}":
+		return []byte("27.0.3\n"), nil
+	case name == "docker" && joined == "compose ls --all --format json":
+		return []byte(r.lsJSON), nil
+	case name == "docker" && joined == "ps --quiet --no-trunc":
+		return []byte(""), nil
+	}
+	return nil, errors.New("unexpected command: " + name + " " + joined)
+}
+
+func writeCompose(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const goodStack = "services:\n  app:\n    image: myapp\n    privileged: true\n"
+
+// A project docker knows about but whose file cannot be parsed is a stack
+// this scan says nothing about. It used to be dropped with a bare `continue`
+// and the domain reported ScanDone over the rest — the only place in the
+// tree that let "I couldn't look" pass for "nothing there", which is
+// precisely what scores a never-audited stack as clean.
+func TestAnUnparseableProjectDegradesTheDomain(t *testing.T) {
+	dir := t.TempDir()
+	good := writeCompose(t, dir, "good.yml", goodStack)
+	bad := writeCompose(t, dir, "bad.yml", "services:\n  app:\n    ports: [ {{{ ]\n")
+
+	r := lsRunner{lsJSON: `[{"Name":"good","ConfigFiles":"` + good + `"},` +
+		`{"Name":"bad","ConfigFiles":"` + bad + `"}]`}
+	findings, err := (&Checker{}).Check(context.Background(), platform.Env{Runner: r})
+
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("expected a PartialError, got %v", err)
+	}
+	if !strings.Contains(partial.Reason, bad) {
+		t.Errorf("the reason should name the unparseable file: %q", partial.Reason)
+	}
+	if partial.Covered != 1 || partial.Total != 2 {
+		t.Errorf("coverage = %d/%d, want 1/2", partial.Covered, partial.Total)
+	}
+	// The stack that did parse is still audited — partial means incomplete,
+	// not failed.
+	var sawPrivileged bool
+	for _, f := range findings {
+		if f.ID == "compose.ds001" {
+			sawPrivileged = true
+		}
+	}
+	if !sawPrivileged {
+		t.Error("findings from the project that parsed must be kept")
+	}
+}
+
+// The flag must stay quiet when every project parses, or Degraded stops
+// meaning anything.
+func TestAllProjectsParsingIsNotDegraded(t *testing.T) {
+	dir := t.TempDir()
+	good := writeCompose(t, dir, "good.yml", goodStack)
+
+	r := lsRunner{lsJSON: `[{"Name":"good","ConfigFiles":"` + good + `"}]`}
+	if _, err := (&Checker{}).Check(context.Background(), platform.Env{Runner: r}); err != nil {
+		t.Errorf("a fully parseable host must not degrade: %v", err)
+	}
+}
+
+// docker sometimes lists a project with no config file at all. There is
+// nothing to audit and nothing we failed to read, so it must not degrade.
+func TestAProjectWithNoConfigFileIsNotPartialCoverage(t *testing.T) {
+	r := lsRunner{lsJSON: `[{"Name":"orphan","ConfigFiles":""}]`}
+	if _, err := (&Checker{}).Check(context.Background(), platform.Env{Runner: r}); err != nil {
+		t.Errorf("a project with no config file must not degrade: %v", err)
+	}
+}

--- a/internal/check/cve/cve.go
+++ b/internal/check/cve/cve.go
@@ -54,7 +54,7 @@ func (*Checker) Available(ctx context.Context, env platform.Env) (bool, string) 
 // but mean opposite things. Some images unscannable is Degraded; all of them
 // is an outright error, which drops the axis from scoring entirely.
 func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
-	projects, err := compose.Discover(ctx, env.Runner)
+	projects, unparsed, err := compose.Discover(ctx, env.Runner)
 	if err != nil {
 		return nil, err
 	}
@@ -95,6 +95,18 @@ func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, e
 	// zero and the clean case must win.
 	switch failed {
 	case 0:
+		// A compose file we could not parse is a set of images we never even
+		// knew to scan, so it degrades the axis exactly like a failed
+		// enumeration does — the images are absent from `attempted`, and
+		// without this the axis would score as if they did not exist.
+		if len(unparsed) > 0 {
+			return findings, &check.PartialError{
+				Reason: "cannot parse compose file(s): " + strings.Join(unparsed, ", ") +
+					" — images defined there were not scanned",
+				Covered: attempted,
+				Total:   attempted + len(unparsed),
+			}
+		}
 		if enumErr != nil {
 			// Every image we knew about scanned, but we could not find out
 			// which containers exist outside Compose — so the axis covered

--- a/internal/check/ssh/ssh.go
+++ b/internal/check/ssh/ssh.go
@@ -125,8 +125,28 @@ type includeParser struct {
 	stopped bool // hit a Match block; everything after it is conditional
 }
 
+// parse reads one config file's directives into the effective config.
+//
+// A scanner error — in practice bufio.ErrTooLong, a line over 64 KiB — stops
+// the read partway with no error returned anywhere, so every directive after
+// that point read as unset and the compiled-in default silently won the
+// audit. PermitRootLogin is the one that matters: unset audits as the
+// default, so a truncated parse could report a hardened host as exposed, or
+// an exposed one as fine, depending on which side of the long line the
+// directive sat. It is recorded as a file we could not fully read, which is
+// what it is, and rides the same PartialError the unreadable-include case
+// already uses.
 func (p *includeParser) parse(data []byte, path string, depth int) {
 	sc := bufio.NewScanner(bytes.NewReader(data))
+	defer func() {
+		if sc.Err() != nil {
+			// The caller counted this file as read before handing it over;
+			// take that back, so Covered/Total describes what was actually
+			// covered rather than crediting a file we only half-parsed.
+			p.cfg.filesRead--
+			p.unread = append(p.unread, path)
+		}
+	}()
 	for sc.Scan() {
 		if p.stopped {
 			return

--- a/internal/check/ssh/ssh_test.go
+++ b/internal/check/ssh/ssh_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/seolcu/hostveil/internal/check"
@@ -265,5 +266,57 @@ func TestSSHAvailability(t *testing.T) {
 	}
 	if _, ok := idsOf(fs)["ssh.rootlogin"]; !ok {
 		t.Error("Check should flag root login from the real file")
+	}
+}
+
+// bufio.Scanner stops at a line over 64 KiB and reports it only through
+// Err(), which nothing checked. The parse ended silently partway, every
+// directive after that point read as unset, and the compiled-in default won
+// the audit — so PermitRootLogin's verdict depended on which side of the
+// long line it sat, with nothing saying the file had been truncated.
+func TestAnOverlongLineDegradesRatherThanTruncatingSilently(t *testing.T) {
+	dir := t.TempDir()
+	main := filepath.Join(dir, "sshd_config")
+	body := "PermitRootLogin no\n" +
+		"# " + strings.Repeat("x", 128*1024) + "\n" +
+		"PasswordAuthentication no\n"
+	if err := os.WriteFile(main, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, unread, err := parseConfigFile(main)
+	if err != nil {
+		t.Fatalf("parseConfigFile: %v", err)
+	}
+	if len(unread) != 1 || unread[0] != main {
+		t.Errorf("a truncated parse must be reported as unread, got %v", unread)
+	}
+	// What was read before the long line is still valid and worth keeping.
+	if cfg.values["permitrootlogin"] != "no" {
+		t.Errorf("directives before the long line should survive, got %q", cfg.values["permitrootlogin"])
+	}
+
+	c := &Checker{ConfigPath: main}
+	findings, err := c.Check(context.Background(), platform.Env{})
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("expected a PartialError, got %v", err)
+	}
+	if !strings.Contains(partial.Reason, main) {
+		t.Errorf("the reason should name the file: %q", partial.Reason)
+	}
+	// Findings gathered before the truncation are real and must be kept.
+	_ = findings
+}
+
+// The ordinary file must not be reported as truncated, or the flag means
+// nothing.
+func TestANormalConfigIsNotReportedAsUnread(t *testing.T) {
+	main := filepath.Join(t.TempDir(), "sshd_config")
+	if err := os.WriteFile(main, []byte("PermitRootLogin no\nPasswordAuthentication no\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, unread, err := parseConfigFile(main); err != nil || len(unread) != 0 {
+		t.Errorf("unread = %v, err = %v; want neither", unread, err)
 	}
 }

--- a/internal/check/updates/updates.go
+++ b/internal/check/updates/updates.go
@@ -118,29 +118,50 @@ func (c *Checker) auditDnf(ctx context.Context, env platform.Env) ([]model.Findi
 			"Install and enable dnf-automatic: `dnf install dnf-automatic` then `systemctl enable --now dnf-automatic.timer` (configure it to apply security updates)."))
 	}
 
+	// Reasons accumulate rather than returning at the first one. Both probes
+	// below are independent questions about this domain, and answering only
+	// the first used to mean the second was never asked: on a stock minimal
+	// Fedora or Rocky there is no needs-restarting (it ships in dnf-utils),
+	// so the reboot check came back unknown, the function returned, and
+	// pending security updates went uncounted on every such host — while the
+	// domain reported only that a reboot could not be determined.
+	var reasons []string
+
 	// `needs-restarting -r` exits non-zero precisely when a reboot IS
 	// required, so the exit status cannot be read as success or failure here.
 	// Its stdout is unambiguous and is still captured on a non-zero exit, so
 	// the text is the signal — and a reply matching neither phrase means the
 	// command did not answer, which must not be read as "no reboot needed".
-	rebootOut, _ := env.Runner.Run(ctx, "needs-restarting", "-r")
-	switch reboot := classifyNeedsRestarting(string(rebootOut)); reboot {
-	case rebootRequired:
-		findings = append(findings, rebootFinding("sudo reboot"))
-	case rebootUnknown:
-		return findings, &check.PartialError{
-			Reason: "cannot tell whether a reboot is pending — checked that automatic updates are configured, but not whether they have taken effect",
+	switch {
+	case !platform.Has(env.Runner, "needs-restarting"):
+		reasons = append(reasons, "cannot tell whether a reboot is pending — needs-restarting is not installed (`dnf install dnf-utils`)")
+	default:
+		rebootOut, _ := env.Runner.Run(ctx, "needs-restarting", "-r")
+		switch classifyNeedsRestarting(string(rebootOut)) {
+		case rebootRequired:
+			findings = append(findings, rebootFinding("sudo reboot"))
+		case rebootUnknown:
+			reasons = append(reasons, "cannot tell whether a reboot is pending")
 		}
 	}
 
 	secOut, err := env.Runner.Run(ctx, "dnf", "-q", "updateinfo", "list", "security")
-	if err != nil {
-		return findings, &check.PartialError{
-			Reason: "cannot list pending security updates — checked that automatic updates are configured, but not whether they have caught up",
+	switch {
+	case err != nil:
+		reasons = append(reasons, "cannot list pending security updates")
+	default:
+		if n := countDnfSecurityAdvisories(string(secOut)); n > 0 {
+			findings = append(findings, pendingFinding(n, "sudo dnf upgrade --security"))
 		}
 	}
-	if n := countDnfSecurityAdvisories(string(secOut)); n > 0 {
-		findings = append(findings, pendingFinding(n, "sudo dnf upgrade --security"))
+
+	if len(reasons) > 0 {
+		return findings, &check.PartialError{
+			Reason: strings.Join(reasons, "; ") +
+				" — checked that automatic updates are configured, but not whether they have caught up",
+			Covered: 2 - len(reasons),
+			Total:   2,
+		}
 	}
 	return findings, nil
 }

--- a/internal/check/updates/updates_test.go
+++ b/internal/check/updates/updates_test.go
@@ -15,9 +15,17 @@ import (
 
 type fakeRunner struct {
 	outputs map[string]string
+	// missing names binaries this host does not have, so a checker's
+	// platform.Has gate can be exercised. The zero value has none.
+	missing map[string]bool
 }
 
-func (fakeRunner) LookPath(name string) (string, error) { return "/usr/bin/" + name, nil }
+func (f fakeRunner) LookPath(name string) (string, error) {
+	if f.missing[name] {
+		return "", errors.New("not found: " + name)
+	}
+	return "/usr/bin/" + name, nil
+}
 
 func (f fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
 	key := strings.TrimSpace(name + " " + strings.Join(args, " "))
@@ -299,5 +307,56 @@ func TestCheckRejectsUnsupportedPackageManager(t *testing.T) {
 		if len(fs) != 0 {
 			t.Errorf("%q: Check returned findings %v alongside the error", pm, fs)
 		}
+	}
+}
+
+// needs-restarting ships in dnf-utils, which a stock minimal Fedora, RHEL,
+// or Rocky does not install. The reboot probe then came back unknown, the
+// function returned right there, and `dnf updateinfo list security` never
+// ran — so pending security updates went uncounted on every such host, while
+// the domain reported only that a reboot could not be determined.
+func TestMissingNeedsRestartingStillCountsSecurityUpdates(t *testing.T) {
+	out := dnfClean()
+	out["dnf -q updateinfo list security"] = `FEDORA-2026-aaaa Important/Sec. openssl-3.2.1-1.fc41.x86_64
+FEDORA-2026-bbbb Moderate/Sec.  curl-8.6.0-1.fc41.x86_64
+`
+	env := platform.Env{
+		PackageManager: platform.PMDnf,
+		Runner:         fakeRunner{outputs: out, missing: map[string]bool{"needs-restarting": true}},
+	}
+
+	fs, err := New().Check(context.Background(), env)
+
+	// Still degraded — a reboot genuinely cannot be determined.
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want a PartialError, got %v", err)
+	}
+	if !strings.Contains(partial.Reason, "dnf-utils") {
+		t.Errorf("the reason should name the missing package: %q", partial.Reason)
+	}
+	// But the second probe ran, which is the whole point.
+	find(t, fs, "updates.pending-security")
+}
+
+// Both probes failing must read as both failing, not just the first.
+func TestBothDnfProbesFailingAreBothReported(t *testing.T) {
+	out := dnfClean()
+	delete(out, "dnf -q updateinfo list security") // the fake errors on an unknown key
+	env := platform.Env{
+		PackageManager: platform.PMDnf,
+		Runner:         fakeRunner{outputs: out, missing: map[string]bool{"needs-restarting": true}},
+	}
+
+	_, err := New().Check(context.Background(), env)
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want a PartialError, got %v", err)
+	}
+	if !strings.Contains(partial.Reason, "reboot") || !strings.Contains(partial.Reason, "security updates") {
+		t.Errorf("both failures should be named: %q", partial.Reason)
+	}
+	if partial.Covered != 0 || partial.Total != 2 {
+		t.Errorf("coverage = %d/%d, want 0/2", partial.Covered, partial.Total)
 	}
 }

--- a/internal/compose/discover.go
+++ b/internal/compose/discover.go
@@ -4,19 +4,26 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/seolcu/hostveil/internal/platform"
 )
 
 // Discover lists the compose projects docker knows about via
-// `docker compose ls --format json` and parses each project's config
-// file. Projects that fail to parse are skipped rather than aborting the
-// whole discovery.
-func Discover(ctx context.Context, r platform.CommandRunner) ([]Project, error) {
+// `docker compose ls --format json` and parses each project's config file.
+//
+// A project that fails to parse is skipped rather than aborting the whole
+// discovery — one broken stack must not blind the checker to the other
+// twelve. The paths of those projects are returned as the second value, and
+// callers must not drop it: a skipped project is ground the scan did not
+// cover, and reporting ScanDone over a subset is how "I couldn't look"
+// becomes "nothing there". A compose file the scan cannot read, or one whose
+// ports the typed model rejects, is enough to trigger it.
+func Discover(ctx context.Context, r platform.CommandRunner) ([]Project, []string, error) {
 	out, err := r.Run(ctx, "docker", "compose", "ls", "--all", "--format", "json")
 	if err != nil {
-		return nil, fmt.Errorf("list compose projects: %w", err)
+		return nil, nil, fmt.Errorf("list compose projects: %w", err)
 	}
 	return parseDiscovery(out)
 }
@@ -26,27 +33,32 @@ type dockerProject struct {
 	ConfigFiles string `json:"ConfigFiles"`
 }
 
-func parseDiscovery(out []byte) ([]Project, error) {
+func parseDiscovery(out []byte) ([]Project, []string, error) {
 	var entries []dockerProject
 	if err := json.Unmarshal(out, &entries); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var projects []Project
+	var skipped []string
 	for _, e := range entries {
 		path := firstConfigFile(e.ConfigFiles)
 		if path == "" {
+			// docker knows the project but names no config file for it, so
+			// there is nothing to audit and nothing we failed to read either.
 			continue
 		}
 		proj, err := ParseFile(path)
 		if err != nil {
-			continue // a single unreadable project must not fail discovery
+			skipped = append(skipped, path)
+			continue
 		}
 		if e.Name != "" {
 			proj.Name = e.Name
 		}
 		projects = append(projects, proj)
 	}
-	return projects, nil
+	sort.Strings(skipped) // stable evidence across runs
+	return projects, skipped, nil
 }
 
 // firstConfigFile returns the first path from docker's comma-separated


### PR DESCRIPTION
## The theme

Three bugs in three packages, all the same invariant breaking: *a checker must never let "I couldn't look" pass for "nothing there."* The two score identically and mean opposite things.

## 1. An unparseable compose project vanished silently

`compose.Discover` did `continue` on a `ParseFile` error and returned no counter, so `internal/check/compose` reported `ScanDone` for a **subset** of the host's stacks. This was the only place left in the tree that broke the rule — every other blind spot already produces a `check.PartialError`, and the package doc comments repeatedly say why.

Triggers are ordinary: a compose file the scan cannot read, or any file the typed model rejects (`Port.UnmarshalYAML` returning an error kills the whole project).

`Discover` now returns the skipped paths. Both callers degrade on them — and for the CVE checker those are images it never even knew to scan, so they are absent from `attempted` and the axis would otherwise score as though they were not on the host.

## 2. sshd_config truncated silently on a long line

`internal/check/ssh` parses with `bufio.Scanner` and never checked `sc.Err()`. A line over 64 KiB (`bufio.ErrTooLong`) stops the parse mid-file; `parseConfigFile` returned the partial config with no error and `Check` returned `ScanDone`. Every directive after that point was treated as unset, so the compiled-in default won the audit.

`PermitRootLogin` is the one that matters: unset audits as the default, so a truncated parse could report a hardened host as exposed or an exposed one as fine, depending purely on which side of the long line the directive sat — with nothing saying the file had been cut.

A truncated read now joins the existing `unread` list, which already flows into the `PartialError` the unreadable-include case uses. The file also stops being counted as covered, so `Covered/Total` describes what was actually read.

## 3. Minimal dnf hosts never counted security updates

`needs-restarting -r` ran with no `platform.Has` gate. That binary ships in `dnf-utils`, which a stock minimal Fedora, RHEL, or Rocky does not install. Missing binary → empty stdout → `rebootUnknown` → **early return**, so `dnf -q updateinfo list security` never executed. The domain reported "cannot tell whether a reboot is pending" while quietly never counting pending security updates at all.

The two probes are independent questions about the domain. Both now run, and their reasons accumulate into one `PartialError` with honest `Covered/Total`. The missing-binary case names the package to install.

## Tests

Each fix has a positive and a negative case, so the Degraded flag keeps meaning something:

- `TestAnUnparseableProjectDegradesTheDomain` (findings from the project that *did* parse are kept), `TestAllProjectsParsingIsNotDegraded`, `TestAProjectWithNoConfigFileIsNotPartialCoverage`.
- `TestAnOverlongLineDegradesRatherThanTruncatingSilently` (directives before the long line survive), `TestANormalConfigIsNotReportedAsUnread`.
- `TestMissingNeedsRestartingStillCountsSecurityUpdates`, `TestBothDnfProbesFailingAreBothReported`.

The updates test fake gained a `missing` set so `platform.Has` gates can be exercised; the zero value has none, so existing tests are unchanged.

Full local gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)