### PR TITLE
feat(cmd): add HOSTVEIL_DEBUG command tracing and an operator troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ does not change the status; both are reported in the output instead.
 
 Other commands exit 0 on success, 1 on failure, and 2 on a usage error.
 
+### When something looks wrong
+
+Set `HOSTVEIL_DEBUG=1` to trace every command hostveil runs against the host —
+what ran, how long it took, and whether it failed — to stderr:
+
+```bash
+HOSTVEIL_DEBUG=1 hostveil scan
+```
+
+That is the right thing to attach to a bug report about a domain being skipped
+or a check reporting the wrong thing. Command *output* is deliberately never
+logged: `docker inspect` reports the resolved environment of every container,
+so a trace that included it would routinely be a credential leak.
+
+See [Troubleshooting](https://hostveil.seolcu.com/docs/troubleshooting) for what
+Degraded, a declined rollback, an empty history, and exit code 3 mean.
+
 ## How fixing works
 
 Every finding is classified so the tool never mutates blindly:

--- a/cmd/hostveil/app.go
+++ b/cmd/hostveil/app.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/seolcu/hostveil/internal/ai"
 	"github.com/seolcu/hostveil/internal/check"
 	accountscheck "github.com/seolcu/hostveil/internal/check/accounts"
@@ -14,6 +16,7 @@ import (
 	updatescheck "github.com/seolcu/hostveil/internal/check/updates"
 	"github.com/seolcu/hostveil/internal/core"
 	"github.com/seolcu/hostveil/internal/fix"
+	"github.com/seolcu/hostveil/internal/platform"
 )
 
 // buildEngine constructs the shared engine with every checker and the
@@ -36,10 +39,30 @@ func buildEngineWithAI(useAI bool) *core.Engine {
 			filepermscheck.New(),
 			agentcheck.New(),
 		),
-		Fixes: fix.Default(),
+		Fixes:  fix.Default(),
+		Runner: debugRunner(),
 	}
 	if useAI {
 		cfg.AI = ai.NewOllama()
 	}
 	return core.New(cfg)
+}
+
+// debugRunner returns the command runner the engine should use: the plain
+// one, or a tracing wrapper when HOSTVEIL_DEBUG is set.
+//
+// An environment variable rather than a flag, because it has to work for
+// every command without threading a flag through six of them — and because
+// the thing you tell someone in a bug report is one line they can paste:
+//
+//	HOSTVEIL_DEBUG=1 hostveil scan
+//
+// The trace goes to stderr, so `--json` and every redirect produce exactly
+// the bytes they did before. Returning nil leaves core.New to pick its own
+// default, which keeps the untraced path identical to what it was.
+func debugRunner() platform.CommandRunner {
+	if os.Getenv("HOSTVEIL_DEBUG") == "" {
+		return nil
+	}
+	return platform.NewTraceRunner(platform.DefaultRunner{}, os.Stderr)
 }

--- a/cmd/hostveil/main.go
+++ b/cmd/hostveil/main.go
@@ -198,6 +198,12 @@ Exit status:
   Other commands exit 0 on success, 1 on failure, and 2 on a usage error.
 
 Environment:
+  HOSTVEIL_DEBUG=1     Trace every command hostveil runs against the host, to
+                       stderr: what ran, how long it took, and whether it
+                       failed. This is what to attach to a bug report about a
+                       domain being skipped or a check reporting the wrong
+                       thing. Command output is deliberately not logged — it
+                       routinely contains environment variables.
   HOSTVEIL_NO_SUDO=1   Never re-exec under sudo (for scripts and CI)
   HOSTVEIL_THEME=NAME  Color theme for the TUI and the dashboard
   NO_COLOR=1           Disable colored output

--- a/cmd/hostveil/rollback.go
+++ b/cmd/hostveil/rollback.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/seolcu/hostveil/internal/core"
+	"github.com/seolcu/hostveil/internal/history"
 )
 
 func cmdRollback(ctx context.Context, args []string) int {
@@ -81,6 +82,7 @@ func cmdHistory(_ context.Context, args []string) int {
 	}
 	if len(cps) == 0 {
 		fmt.Println("No fixes have been applied yet.")
+		warnAboutStateDirectory()
 		return 0
 	}
 	fmt.Println("Applied fixes (newest first):")
@@ -93,4 +95,23 @@ func cmdHistory(_ context.Context, args []string) int {
 			cp.CreatedAt.Format("2006-01-02 15:04:05"), cp.FindingID, cp.Label, reversible)
 	}
 	return 0
+}
+
+// warnAboutStateDirectory explains an empty history that is not really
+// empty.
+//
+// Checkpoints live in /var/lib/hostveil when root and ~/.local/share/hostveil
+// otherwise, so a fix applied as root and a later unprivileged `hostveil
+// history` read different directories. The user is then told "No fixes have
+// been applied yet" about a host they fixed ten minutes ago, with nothing
+// pointing at the reason. Only shown when the history is empty *and* the run
+// is unprivileged, so it never nags anyone whose setup is fine.
+func warnAboutStateDirectory() {
+	if os.Geteuid() == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"\nhostveil: reading %s because this run is not root.\n"+
+			"Fixes applied as root are recorded in /var/lib/hostveil instead — re-run with sudo to see those.\n",
+		history.DefaultDir())
 }

--- a/cmd/sitegen/content/en/docs/contributing.html
+++ b/cmd/sitegen/content/en/docs/contributing.html
@@ -20,6 +20,6 @@ go test ./...</code></pre></div>
             <p><code>demo/</code> is a code-defined, deliberately vulnerable Ubuntu server; hostveil is built from your working tree <em>inside</em> the VM, so it always reflects your current code. Bring it up with <code>./run.sh up</code> and scan with <code>./run.sh scan</code>. Per-platform provider setup, the 5-minute demo script, the reset workflow, and troubleshooting all live in <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>.</p>
 
             <div class="docs-pager">
-              <a class="button secondary" href="faq">← FAQ</a>
+              <a class="button secondary" href="troubleshooting">← Troubleshooting</a>
               <a class="button primary" href="https://github.com/seolcu/hostveil">GitHub repository →</a>
             </div>

--- a/cmd/sitegen/content/en/docs/faq.html
+++ b/cmd/sitegen/content/en/docs/faq.html
@@ -28,5 +28,5 @@
 
             <div class="docs-pager">
               <a class="button secondary" href="cli">← CLI reference</a>
-              <a class="button primary" href="contributing">Contributing →</a>
+              <a class="button primary" href="troubleshooting">Troubleshooting →</a>
             </div>

--- a/cmd/sitegen/content/en/docs/troubleshooting.html
+++ b/cmd/sitegen/content/en/docs/troubleshooting.html
@@ -1,0 +1,37 @@
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / Troubleshooting</p>
+            <h1>Troubleshooting</h1>
+            <p class="lead">What the less obvious messages mean, and how to find out what hostveil actually did.</p>
+
+            <h2 id="debug">See every command hostveil runs</h2>
+            <p>Most questions about a wrong-looking result come down to one command answering differently than expected. Set <code>HOSTVEIL_DEBUG=1</code> to trace them:</p>
+            <pre><code>HOSTVEIL_DEBUG=1 hostveil scan</code></pre>
+            <p>Each line names the command, how long it took, and whether it failed — including the binary lookups that decide whether a domain runs at all. The trace goes to <strong>stderr</strong>, so <code>--json</code> and redirects are unaffected, and it is the right thing to attach to a bug report.</p>
+            <p>Command <em>output</em> is deliberately never logged. <code>docker inspect</code> reports the resolved environment of every container, so a trace that included it would routinely be a credential leak.</p>
+
+            <h2 id="degraded">A domain says “Degraded”</h2>
+            <p>The checker ran and covered <em>part</em> of its ground. The findings it reported are real and are scored; what it could not examine is named in the reason. Common causes: an <code>Include</code>d sshd config it cannot read, a compose file it cannot parse, images Trivy could not pull, or containers it could not enumerate.</p>
+            <p>Degraded is deliberately different from <strong>Skipped</strong> (a dependency is absent — the domain is excluded from scoring entirely, not given full marks) and from <strong>Error</strong> (the checker failed outright).</p>
+
+            <h2 id="declined">Rollback says the file was edited externally</h2>
+            <p>The file no longer matches anything hostveil recorded writing, so someone changed it after the fix ran. Rollback keeps no backup of its own, so restoring would discard those edits irreversibly — it declines instead.</p>
+            <p>If you are sure you want the backup back, <code>hostveil rollback &lt;id&gt; --force</code> overwrites. Note that <code>--force</code> will <em>not</em> push through a backup whose checksum does not match what was stored: there is nothing correct on the other side of a damaged backup.</p>
+
+            <h2 id="empty-history">“No fixes have been applied yet” after applying fixes</h2>
+            <p>Almost always the state directory. hostveil stores checkpoints in <code>/var/lib/hostveil</code> when running as root and <code>~/.local/share/hostveil</code> otherwise, so a fix applied under <code>sudo</code> is invisible to an unprivileged <code>hostveil history</code>. Re-run with <code>sudo</code>. This most often bites when <code>HOSTVEIL_NO_SUDO=1</code> is set, or on a host with no <code>sudo</code> installed.</p>
+
+            <h2 id="exit-codes">A scheduled scan exits 3</h2>
+            <p>A detection domain failed outright, so the scan covered less of the host than it should have — a result that looks clean but is not trustworthy. An unreachable Docker socket is the usual cause. A domain merely <em>skipped</em> for a missing dependency, or <em>degraded</em> to partial coverage, does not produce this. See <a href="cli#exit-codes">exit codes</a>.</p>
+
+            <h2 id="timeouts">A check reports that a command “did not respond”</h2>
+            <p>hostveil bounds every command it runs, so a daemon that accepts a connection and never answers — a wedged Docker is the everyday case — fails that check instead of hanging the scan. The affected domain is reported honestly rather than scored as clean. Check the daemon named in the message; <code>HOSTVEIL_DEBUG=1</code> shows exactly which call stalled.</p>
+
+            <h2 id="ssh-fix">An SSH fix refuses to apply</h2>
+            <p>Before writing, hostveil runs the config it would produce through <code>sshd -t</code>. If sshd rejects it, the fix is abandoned and your file is left untouched — nothing was written, so there is nothing to roll back. This exists because sshd keeps serving from the config it already loaded: a broken file would look like nothing at all until the next restart, when sshd refuses to start and repairing it needs the SSH access it just removed.</p>
+
+            <h2 id="interrupt">Ctrl-C does not seem to stop it</h2>
+            <p>The first interrupt cancels the work in progress and lets it wind down cleanly — stopping the commands a scan has running, draining the dashboard's in-flight requests. Press it a second time to exit immediately. A batch fix stops between fixes rather than during one, and tells you how many were never attempted; whatever did apply is in <code>hostveil history</code>.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="faq">← FAQ</a>
+              <a class="button primary" href="contributing">Contributing →</a>
+            </div>

--- a/cmd/sitegen/content/ko/docs/contributing.html
+++ b/cmd/sitegen/content/ko/docs/contributing.html
@@ -20,6 +20,6 @@ go test ./...</code></pre></div>
             <p><code>demo/</code>는 코드로 정의된, 의도적으로 취약하게 만든 Ubuntu 서버입니다. hostveil은 VM <em>내부</em>에서 여러분의 작업 트리로부터 빌드되므로 항상 현재 코드를 반영합니다. <code>./run.sh up</code>으로 띄우고 <code>./run.sh scan</code>으로 스캔하세요. 플랫폼별 프로바이더 설정, 5분 데모 스크립트, 초기화 절차, 문제 해결은 모두 <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>에 있습니다.</p>
 
             <div class="docs-pager">
-              <a class="button secondary" href="faq">← 자주 묻는 질문</a>
+              <a class="button secondary" href="troubleshooting">← 문제 해결</a>
               <a class="button primary" href="https://github.com/seolcu/hostveil">GitHub 저장소 →</a>
             </div>

--- a/cmd/sitegen/content/ko/docs/faq.html
+++ b/cmd/sitegen/content/ko/docs/faq.html
@@ -28,5 +28,5 @@
 
             <div class="docs-pager">
               <a class="button secondary" href="cli">← CLI 레퍼런스</a>
-              <a class="button primary" href="contributing">기여하기 →</a>
+              <a class="button primary" href="troubleshooting">문제 해결 →</a>
             </div>

--- a/cmd/sitegen/content/ko/docs/troubleshooting.html
+++ b/cmd/sitegen/content/ko/docs/troubleshooting.html
@@ -1,0 +1,37 @@
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 문제 해결</p>
+            <h1>문제 해결</h1>
+            <p class="lead">덜 명확한 메시지들이 무슨 뜻인지, 그리고 hostveil이 실제로 무엇을 했는지 확인하는 방법.</p>
+
+            <h2 id="debug">hostveil이 실행하는 모든 명령 보기</h2>
+            <p>결과가 이상해 보이는 대부분의 경우, 원인은 어떤 명령 하나가 예상과 다르게 답했다는 것입니다. <code>HOSTVEIL_DEBUG=1</code>을 설정하면 그 명령들을 추적할 수 있습니다.</p>
+            <pre><code>HOSTVEIL_DEBUG=1 hostveil scan</code></pre>
+            <p>각 줄은 실행한 명령, 소요 시간, 실패 여부를 보여주며, 도메인 실행 여부를 결정하는 바이너리 조회도 포함됩니다. 추적은 <strong>stderr</strong>로 나가므로 <code>--json</code>이나 리다이렉트에 영향을 주지 않습니다. 버그 리포트에 첨부하기에 알맞습니다.</p>
+            <p>명령의 <em>출력</em>은 의도적으로 기록하지 않습니다. <code>docker inspect</code>는 모든 컨테이너의 환경 변수를 그대로 담고 있어서, 출력을 포함하면 추적 자체가 자격 증명 유출이 되기 때문입니다.</p>
+
+            <h2 id="degraded">도메인이 “Degraded”로 표시됩니다</h2>
+            <p>체커가 실행되었지만 검사 대상의 <em>일부만</em> 확인했다는 뜻입니다. 보고된 발견 항목은 실제이고 점수에 반영되며, 확인하지 못한 부분은 사유에 명시됩니다. 흔한 원인: 읽을 수 없는 <code>Include</code> sshd 설정, 파싱할 수 없는 compose 파일, Trivy가 받아오지 못한 이미지, 열거하지 못한 컨테이너.</p>
+            <p>Degraded는 <strong>Skipped</strong>(의존성 부재 — 만점을 주는 대신 점수 산정에서 아예 제외)나 <strong>Error</strong>(체커가 완전히 실패)와 의도적으로 구분됩니다.</p>
+
+            <h2 id="declined">롤백이 “외부에서 편집됨”이라고 거부합니다</h2>
+            <p>해당 파일이 hostveil이 기록한 어떤 내용과도 일치하지 않습니다. 즉 수정 적용 이후 누군가 파일을 바꿨다는 뜻입니다. 롤백은 자체 백업을 남기지 않으므로, 복원하면 그 편집분이 되돌릴 수 없게 사라집니다. 그래서 대신 거부합니다.</p>
+            <p>그래도 백업을 되돌리려면 <code>hostveil rollback &lt;id&gt; --force</code>를 사용하세요. 다만 <code>--force</code>도 체크섬이 맞지 않는 손상된 백업은 밀어붙이지 <em>않습니다</em>. 손상된 백업 너머에는 올바른 내용이 없기 때문입니다.</p>
+
+            <h2 id="empty-history">수정을 적용했는데 “아직 적용된 수정이 없습니다”라고 나옵니다</h2>
+            <p>거의 항상 상태 디렉터리 문제입니다. hostveil은 root로 실행될 때 <code>/var/lib/hostveil</code>에, 그렇지 않으면 <code>~/.local/share/hostveil</code>에 체크포인트를 저장합니다. 따라서 <code>sudo</code>로 적용한 수정은 권한 없이 실행한 <code>hostveil history</code>에서는 보이지 않습니다. <code>sudo</code>로 다시 실행하세요. <code>HOSTVEIL_NO_SUDO=1</code>이 설정되어 있거나 호스트에 <code>sudo</code>가 없을 때 자주 발생합니다.</p>
+
+            <h2 id="exit-codes">예약된 스캔이 3으로 종료됩니다</h2>
+            <p>탐지 도메인이 완전히 실패해서, 스캔이 호스트를 검사해야 할 범위보다 좁게 검사했다는 뜻입니다. 깨끗해 보이지만 믿을 수 없는 결과입니다. 보통 Docker 소켓에 접근할 수 없는 경우입니다. 의존성이 없어 <em>건너뛴</em> 도메인이나 부분 커버리지로 <em>강등된</em> 도메인은 여기에 해당하지 않습니다. <a href="cli#exit-codes">종료 코드</a>를 참고하세요.</p>
+
+            <h2 id="timeouts">검사가 명령이 “응답하지 않았다”고 보고합니다</h2>
+            <p>hostveil은 실행하는 모든 명령에 시간 제한을 둡니다. 연결은 받아들이지만 응답하지 않는 데몬 — 멈춘 Docker가 대표적입니다 — 은 스캔 전체를 멈추는 대신 해당 검사만 실패시킵니다. 영향받은 도메인은 깨끗하다고 점수를 매기지 않고 정직하게 보고됩니다. 메시지에 나온 데몬을 확인하세요. <code>HOSTVEIL_DEBUG=1</code>이 어떤 호출에서 멈췄는지 정확히 보여줍니다.</p>
+
+            <h2 id="ssh-fix">SSH 수정이 적용을 거부합니다</h2>
+            <p>파일을 쓰기 전에, hostveil은 만들어질 설정을 <code>sshd -t</code>로 검사합니다. sshd가 거부하면 수정을 포기하고 원본 파일은 그대로 둡니다. 아무것도 쓰지 않았으므로 되돌릴 것도 없습니다. sshd는 이미 로드한 설정으로 계속 동작하기 때문입니다. 깨진 파일은 다음 재시작 전까지 아무 문제 없어 보이다가, 그때 sshd가 시작을 거부하고, 그 파일을 고치려면 방금 사라진 SSH 접근이 필요해집니다.</p>
+
+            <h2 id="interrupt">Ctrl-C가 듣지 않는 것 같습니다</h2>
+            <p>첫 번째 인터럽트는 진행 중인 작업을 취소하고 깔끔하게 마무리합니다. 스캔이 실행 중인 명령을 멈추고, 대시보드의 처리 중인 요청을 마저 끝냅니다. 한 번 더 누르면 즉시 종료합니다. 일괄 수정은 하나의 수정 도중이 아니라 수정과 수정 사이에서 멈추며, 시도하지 못한 개수를 알려줍니다. 이미 적용된 것은 <code>hostveil history</code>에 남습니다.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="faq">← 자주 묻는 질문</a>
+              <a class="button primary" href="contributing">기여하기 →</a>
+            </div>

--- a/cmd/sitegen/pages.json
+++ b/cmd/sitegen/pages.json
@@ -187,6 +187,25 @@
       }
     },
     {
+      "slug": "troubleshooting",
+      "group": "reference",
+      "ogType": "article",
+      "en": {
+        "title": "Troubleshooting — hostveil docs",
+        "description": "What hostveil's less obvious messages mean and how to diagnose them: HOSTVEIL_DEBUG command tracing, Degraded domains, declined rollbacks, an empty history, exit code 3, and command timeouts.",
+        "ogTitle": "Troubleshooting — hostveil docs",
+        "ogDescription": "Diagnose a hostveil result: trace every command it runs, and read Degraded, declined rollback, empty history, and exit code 3.",
+        "nav": "Troubleshooting"
+      },
+      "ko": {
+        "title": "문제 해결 — hostveil 문서",
+        "description": "hostveil의 덜 명확한 메시지들이 무슨 뜻인지, 어떻게 진단하는지: HOSTVEIL_DEBUG 명령 추적, Degraded 도메인, 거부된 롤백, 빈 히스토리, 종료 코드 3, 명령 시간 초과.",
+        "ogTitle": "문제 해결 — hostveil 문서",
+        "ogDescription": "hostveil 결과 진단하기: 실행되는 모든 명령을 추적하고 Degraded, 거부된 롤백, 빈 히스토리, 종료 코드 3을 읽는 법.",
+        "nav": "문제 해결"
+      }
+    },
+    {
       "slug": "contributing",
       "group": "reference",
       "ogType": "article",

--- a/internal/platform/trace.go
+++ b/internal/platform/trace.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TraceRunner wraps a CommandRunner and writes a line per command to w.
+//
+// It exists because hostveil had no way at all to answer the commonest
+// support question there is: "it says my firewall is inactive, but it
+// isn't." Every claim the tool makes about a host comes from a command run
+// through this interface, so a log of what was run and what came back is
+// the whole diagnosis — and without it the only evidence was a domain's
+// Reason string, which collapses stderr to one line and truncates it to 200
+// runes.
+//
+// What it deliberately does not record is stdout. `docker inspect` alone
+// reaches megabytes, and the output frequently contains environment
+// variables — a trace an operator pastes into a bug report must not be a
+// credential leak. The command, how long it took, and whether it failed are
+// what identify the problem; the parse of a successful command is a
+// different kind of bug.
+type TraceRunner struct {
+	inner CommandRunner
+	mu    sync.Mutex // one whole line at a time; checkers run concurrently
+	w     io.Writer
+}
+
+// NewTraceRunner wraps r so every command is logged to w.
+func NewTraceRunner(r CommandRunner, w io.Writer) *TraceRunner {
+	return &TraceRunner{inner: r, w: w}
+}
+
+// Run executes the command and logs it with its duration and outcome.
+func (t *TraceRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	start := time.Now()
+	out, err := t.inner.Run(ctx, name, args...)
+	t.logf("run  %s (%s) %s", quoteArgv(name, args), time.Since(start).Round(time.Millisecond), outcome(err, len(out)))
+	return out, err
+}
+
+// LookPath resolves a binary and logs whether it was found. This is half of
+// every "checker skipped my domain" report: Available gates on it, and a
+// binary in /usr/sbin that is not on a non-login PATH looks exactly like a
+// binary that is not installed.
+func (t *TraceRunner) LookPath(name string) (string, error) {
+	path, err := t.inner.LookPath(name)
+	if err != nil {
+		t.logf("look %s → not found", name)
+	} else {
+		t.logf("look %s → %s", name, path)
+	}
+	return path, err
+}
+
+func (t *TraceRunner) logf(format string, a ...any) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	fmt.Fprintf(t.w, "hostveil[trace] "+format+"\n", a...)
+}
+
+func outcome(err error, n int) string {
+	if err != nil {
+		return "FAILED: " + err.Error()
+	}
+	return fmt.Sprintf("ok, %d bytes", n)
+}
+
+// quoteArgv renders a command the way a person would retype it, quoting only
+// the arguments that need it. A trace whose commands cannot be copied back
+// into a shell is half a diagnostic.
+func quoteArgv(name string, args []string) string {
+	var b strings.Builder
+	b.WriteString(shellQuote(name))
+	for _, a := range args {
+		b.WriteByte(' ')
+		b.WriteString(shellQuote(a))
+	}
+	return b.String()
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(s, " \t\n'\"\\$`|&;<>()*?[]{}!#~") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/platform/trace_test.go
+++ b/internal/platform/trace_test.go
@@ -1,0 +1,116 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type scriptRunner struct {
+	out     string
+	err     error
+	missing bool
+}
+
+func (s scriptRunner) LookPath(name string) (string, error) {
+	if s.missing {
+		return "", errors.New("not found")
+	}
+	return "/usr/bin/" + name, nil
+}
+
+func (s scriptRunner) Run(context.Context, string, ...string) ([]byte, error) {
+	return []byte(s.out), s.err
+}
+
+func trace(t *testing.T, inner CommandRunner, do func(CommandRunner)) string {
+	t.Helper()
+	var buf bytes.Buffer
+	do(NewTraceRunner(inner, &buf))
+	return buf.String()
+}
+
+// A failing command is the whole reason this exists: the domain Reason
+// string collapses stderr to one truncated line, so without a trace there
+// was no way to answer "it says my firewall is inactive, but it isn't".
+func TestTraceRecordsCommandsAndFailures(t *testing.T) {
+	got := trace(t, scriptRunner{err: errors.New("exit status 1: permission denied")}, func(r CommandRunner) {
+		_, _ = r.Run(context.Background(), "ufw", "status")
+	})
+	if !strings.Contains(got, "ufw status") {
+		t.Errorf("the trace should name the command: %q", got)
+	}
+	if !strings.Contains(got, "FAILED") || !strings.Contains(got, "permission denied") {
+		t.Errorf("the trace should carry the failure: %q", got)
+	}
+}
+
+// Half of every "my domain was skipped" report is a lookup: a binary in
+// /usr/sbin that is not on a non-login PATH looks exactly like one that is
+// not installed.
+func TestTraceRecordsLookups(t *testing.T) {
+	found := trace(t, scriptRunner{}, func(r CommandRunner) { _, _ = r.LookPath("docker") })
+	if !strings.Contains(found, "/usr/bin/docker") {
+		t.Errorf("a successful lookup should name the path: %q", found)
+	}
+	missing := trace(t, scriptRunner{missing: true}, func(r CommandRunner) { _, _ = r.LookPath("trivy") })
+	if !strings.Contains(missing, "not found") {
+		t.Errorf("a failed lookup should say so: %q", missing)
+	}
+}
+
+// Command output routinely contains environment variables — `docker
+// inspect` reports the resolved environment of every container. A trace an
+// operator pastes into a bug report must not be a credential leak.
+func TestTraceNeverLogsCommandOutput(t *testing.T) {
+	const secret = "AWS_SECRET_ACCESS_KEY=hunter2"
+	got := trace(t, scriptRunner{out: secret}, func(r CommandRunner) {
+		_, _ = r.Run(context.Background(), "docker", "inspect", "abc")
+	})
+	if strings.Contains(got, "hunter2") || strings.Contains(got, "AWS_SECRET") {
+		t.Fatalf("the trace leaked command output: %q", got)
+	}
+	if !strings.Contains(got, "bytes") {
+		t.Errorf("the size should still be reported: %q", got)
+	}
+}
+
+// Arguments must survive a round trip through a shell, or the trace is half
+// a diagnostic — nobody can rerun the command it describes.
+func TestTraceQuotesArgumentsThatNeedIt(t *testing.T) {
+	got := trace(t, scriptRunner{}, func(r CommandRunner) {
+		_, _ = r.Run(context.Background(), "docker", "version", "--format", "{{.Server.Version}}")
+	})
+	if !strings.Contains(got, `'{{.Server.Version}}'`) {
+		t.Errorf("braces need quoting to be re-runnable: %q", got)
+	}
+}
+
+// Checkers all run at once, so unsynchronised writes would interleave two
+// commands into one unreadable line.
+func TestTraceLinesAreNotInterleaved(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTraceRunner(scriptRunner{}, &buf)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = r.Run(context.Background(), "docker", "ps")
+		}()
+	}
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 50 {
+		t.Fatalf("got %d lines from 50 commands", len(lines))
+	}
+	for _, l := range lines {
+		if !strings.HasPrefix(l, "hostveil[trace] run  docker ps") {
+			t.Fatalf("a line was torn: %q", l)
+		}
+	}
+}

--- a/site/docs/ai.html
+++ b/site/docs/ai.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI reference</a></li>
               <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI reference</a></li>
               <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli" class="active">CLI reference</a></li>
               <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI reference</a></li>
               <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing" class="active">Contributing</a></li>
             </ul>
           </div>
@@ -105,7 +106,7 @@ go test ./...</code></pre></div>
             <p><code>demo/</code> is a code-defined, deliberately vulnerable Ubuntu server; hostveil is built from your working tree <em>inside</em> the VM, so it always reflects your current code. Bring it up with <code>./run.sh up</code> and scan with <code>./run.sh scan</code>. Per-platform provider setup, the 5-minute demo script, the reset workflow, and troubleshooting all live in <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>.</p>
 
             <div class="docs-pager">
-              <a class="button secondary" href="faq">← FAQ</a>
+              <a class="button secondary" href="troubleshooting">← Troubleshooting</a>
               <a class="button primary" href="https://github.com/seolcu/hostveil">GitHub repository →</a>
             </div>
           </article>

--- a/site/docs/faq.html
+++ b/site/docs/faq.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI reference</a></li>
               <li><a href="faq" class="active">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>
@@ -113,7 +114,7 @@
 
             <div class="docs-pager">
               <a class="button secondary" href="cli">← CLI reference</a>
-              <a class="button primary" href="contributing">Contributing →</a>
+              <a class="button primary" href="troubleshooting">Troubleshooting →</a>
             </div>
           </article>
         </main>

--- a/site/docs/fixing.html
+++ b/site/docs/fixing.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI reference</a></li>
               <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI reference</a></li>
               <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI reference</a></li>
               <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>

--- a/site/docs/interfaces.html
+++ b/site/docs/interfaces.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI reference</a></li>
               <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI reference</a></li>
               <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting">Troubleshooting</a></li>
               <li><a href="contributing">Contributing</a></li>
             </ul>
           </div>

--- a/site/docs/troubleshooting.html
+++ b/site/docs/troubleshooting.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Troubleshooting — hostveil docs</title>
+    <meta name="description" content="What hostveil's less obvious messages mean and how to diagnose them: HOSTVEIL_DEBUG command tracing, Degraded domains, declined rollbacks, an empty history, exit code 3, and command timeouts.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="Troubleshooting — hostveil docs">
+    <meta property="og:description" content="Diagnose a hostveil result: trace every command it runs, and read Degraded, declined rollback, empty history, and exit code 3.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/docs/troubleshooting">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <link rel="canonical" href="https://hostveil.seolcu.com/docs/troubleshooting">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/troubleshooting">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/troubleshooting">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/troubleshooting">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../docs.css">
+    <script src="../docs.js" defer></script>
+    <script src="../lang-suggest.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="Primary navigation">
+        <a class="brand" href="../" aria-label="hostveil home">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">Docs</a>
+          <a href="../#features">Features</a>
+          <a href="../#install">Install</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/ko/docs/troubleshooting" lang="ko" hreflang="ko">한국어</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        Documentation menu
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="Search the docs…" aria-label="Search documentation"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="Search results" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>Getting started</p>
+            <ul>
+              <li><a href="./">Introduction</a></li>
+              <li><a href="installation">Installation</a></li>
+              <li><a href="quickstart">Quick start</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Guide</p>
+            <ul>
+              <li><a href="checks">What it checks</a></li>
+              <li><a href="fixing">Fixing &amp; rollback</a></li>
+              <li><a href="interfaces">Interfaces</a></li>
+              <li><a href="ai">AI explanations</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>Reference</p>
+            <ul>
+              <li><a href="cli">CLI reference</a></li>
+              <li><a href="faq">FAQ</a></li>
+              <li><a href="troubleshooting" class="active">Troubleshooting</a></li>
+              <li><a href="contributing">Contributing</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">Docs</a> / Troubleshooting</p>
+            <h1>Troubleshooting</h1>
+            <p class="lead">What the less obvious messages mean, and how to find out what hostveil actually did.</p>
+
+            <h2 id="debug">See every command hostveil runs</h2>
+            <p>Most questions about a wrong-looking result come down to one command answering differently than expected. Set <code>HOSTVEIL_DEBUG=1</code> to trace them:</p>
+            <pre><code>HOSTVEIL_DEBUG=1 hostveil scan</code></pre>
+            <p>Each line names the command, how long it took, and whether it failed — including the binary lookups that decide whether a domain runs at all. The trace goes to <strong>stderr</strong>, so <code>--json</code> and redirects are unaffected, and it is the right thing to attach to a bug report.</p>
+            <p>Command <em>output</em> is deliberately never logged. <code>docker inspect</code> reports the resolved environment of every container, so a trace that included it would routinely be a credential leak.</p>
+
+            <h2 id="degraded">A domain says “Degraded”</h2>
+            <p>The checker ran and covered <em>part</em> of its ground. The findings it reported are real and are scored; what it could not examine is named in the reason. Common causes: an <code>Include</code>d sshd config it cannot read, a compose file it cannot parse, images Trivy could not pull, or containers it could not enumerate.</p>
+            <p>Degraded is deliberately different from <strong>Skipped</strong> (a dependency is absent — the domain is excluded from scoring entirely, not given full marks) and from <strong>Error</strong> (the checker failed outright).</p>
+
+            <h2 id="declined">Rollback says the file was edited externally</h2>
+            <p>The file no longer matches anything hostveil recorded writing, so someone changed it after the fix ran. Rollback keeps no backup of its own, so restoring would discard those edits irreversibly — it declines instead.</p>
+            <p>If you are sure you want the backup back, <code>hostveil rollback &lt;id&gt; --force</code> overwrites. Note that <code>--force</code> will <em>not</em> push through a backup whose checksum does not match what was stored: there is nothing correct on the other side of a damaged backup.</p>
+
+            <h2 id="empty-history">“No fixes have been applied yet” after applying fixes</h2>
+            <p>Almost always the state directory. hostveil stores checkpoints in <code>/var/lib/hostveil</code> when running as root and <code>~/.local/share/hostveil</code> otherwise, so a fix applied under <code>sudo</code> is invisible to an unprivileged <code>hostveil history</code>. Re-run with <code>sudo</code>. This most often bites when <code>HOSTVEIL_NO_SUDO=1</code> is set, or on a host with no <code>sudo</code> installed.</p>
+
+            <h2 id="exit-codes">A scheduled scan exits 3</h2>
+            <p>A detection domain failed outright, so the scan covered less of the host than it should have — a result that looks clean but is not trustworthy. An unreachable Docker socket is the usual cause. A domain merely <em>skipped</em> for a missing dependency, or <em>degraded</em> to partial coverage, does not produce this. See <a href="cli#exit-codes">exit codes</a>.</p>
+
+            <h2 id="timeouts">A check reports that a command “did not respond”</h2>
+            <p>hostveil bounds every command it runs, so a daemon that accepts a connection and never answers — a wedged Docker is the everyday case — fails that check instead of hanging the scan. The affected domain is reported honestly rather than scored as clean. Check the daemon named in the message; <code>HOSTVEIL_DEBUG=1</code> shows exactly which call stalled.</p>
+
+            <h2 id="ssh-fix">An SSH fix refuses to apply</h2>
+            <p>Before writing, hostveil runs the config it would produce through <code>sshd -t</code>. If sshd rejects it, the fix is abandoned and your file is left untouched — nothing was written, so there is nothing to roll back. This exists because sshd keeps serving from the config it already loaded: a broken file would look like nothing at all until the next restart, when sshd refuses to start and repairing it needs the SSH access it just removed.</p>
+
+            <h2 id="interrupt">Ctrl-C does not seem to stop it</h2>
+            <p>The first interrupt cancels the work in progress and lets it wind down cleanly — stopping the commands a scan has running, draining the dashboard's in-flight requests. Press it a second time to exit immediately. A batch fix stops between fixes rather than during one, and tells you how many were never attempted; whatever did apply is in <code>hostveil history</code>.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="faq">← FAQ</a>
+              <a class="button primary" href="contributing">Contributing →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>Guided security hardening for self-hosted Linux servers.</p>
+        </div>
+        <nav aria-label="Footer links">
+          <a href="./">Docs</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">Releases</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/ko/docs/ai.html
+++ b/site/ko/docs/ai.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI 레퍼런스</a></li>
               <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing">기여하기</a></li>
             </ul>
           </div>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI 레퍼런스</a></li>
               <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing">기여하기</a></li>
             </ul>
           </div>

--- a/site/ko/docs/cli.html
+++ b/site/ko/docs/cli.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli" class="active">CLI 레퍼런스</a></li>
               <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing">기여하기</a></li>
             </ul>
           </div>

--- a/site/ko/docs/contributing.html
+++ b/site/ko/docs/contributing.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI 레퍼런스</a></li>
               <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing" class="active">기여하기</a></li>
             </ul>
           </div>
@@ -105,7 +106,7 @@ go test ./...</code></pre></div>
             <p><code>demo/</code>는 코드로 정의된, 의도적으로 취약하게 만든 Ubuntu 서버입니다. hostveil은 VM <em>내부</em>에서 여러분의 작업 트리로부터 빌드되므로 항상 현재 코드를 반영합니다. <code>./run.sh up</code>으로 띄우고 <code>./run.sh scan</code>으로 스캔하세요. 플랫폼별 프로바이더 설정, 5분 데모 스크립트, 초기화 절차, 문제 해결은 모두 <a href="https://github.com/seolcu/hostveil/blob/main/demo/README.md"><code>demo/README.md</code></a>에 있습니다.</p>
 
             <div class="docs-pager">
-              <a class="button secondary" href="faq">← 자주 묻는 질문</a>
+              <a class="button secondary" href="troubleshooting">← 문제 해결</a>
               <a class="button primary" href="https://github.com/seolcu/hostveil">GitHub 저장소 →</a>
             </div>
           </article>

--- a/site/ko/docs/faq.html
+++ b/site/ko/docs/faq.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI 레퍼런스</a></li>
               <li><a href="faq" class="active">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing">기여하기</a></li>
             </ul>
           </div>
@@ -113,7 +114,7 @@
 
             <div class="docs-pager">
               <a class="button secondary" href="cli">← CLI 레퍼런스</a>
-              <a class="button primary" href="contributing">기여하기 →</a>
+              <a class="button primary" href="troubleshooting">문제 해결 →</a>
             </div>
           </article>
         </main>

--- a/site/ko/docs/fixing.html
+++ b/site/ko/docs/fixing.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI 레퍼런스</a></li>
               <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing">기여하기</a></li>
             </ul>
           </div>

--- a/site/ko/docs/index.html
+++ b/site/ko/docs/index.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI 레퍼런스</a></li>
               <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing">기여하기</a></li>
             </ul>
           </div>

--- a/site/ko/docs/installation.html
+++ b/site/ko/docs/installation.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI 레퍼런스</a></li>
               <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing">기여하기</a></li>
             </ul>
           </div>

--- a/site/ko/docs/interfaces.html
+++ b/site/ko/docs/interfaces.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI 레퍼런스</a></li>
               <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing">기여하기</a></li>
             </ul>
           </div>

--- a/site/ko/docs/quickstart.html
+++ b/site/ko/docs/quickstart.html
@@ -76,6 +76,7 @@
             <ul>
               <li><a href="cli">CLI 레퍼런스</a></li>
               <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting">문제 해결</a></li>
               <li><a href="contributing">기여하기</a></li>
             </ul>
           </div>

--- a/site/ko/docs/troubleshooting.html
+++ b/site/ko/docs/troubleshooting.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>문제 해결 — hostveil 문서</title>
+    <meta name="description" content="hostveil의 덜 명확한 메시지들이 무슨 뜻인지, 어떻게 진단하는지: HOSTVEIL_DEBUG 명령 추적, Degraded 도메인, 거부된 롤백, 빈 히스토리, 종료 코드 3, 명령 시간 초과.">
+    <meta name="theme-color" content="#07100f">
+    <meta property="og:title" content="문제 해결 — hostveil 문서">
+    <meta property="og:description" content="hostveil 결과 진단하기: 실행되는 모든 명령을 추적하고 Degraded, 거부된 롤백, 빈 히스토리, 종료 코드 3을 읽는 법.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://hostveil.seolcu.com/ko/docs/troubleshooting">
+    <meta property="og:image" content="https://hostveil.seolcu.com/assets/web.png">
+    <meta property="og:locale" content="ko_KR">
+    <link rel="canonical" href="https://hostveil.seolcu.com/ko/docs/troubleshooting">
+    <link rel="alternate" hreflang="en" href="https://hostveil.seolcu.com/docs/troubleshooting">
+    <link rel="alternate" hreflang="ko" href="https://hostveil.seolcu.com/ko/docs/troubleshooting">
+    <link rel="alternate" hreflang="x-default" href="https://hostveil.seolcu.com/docs/troubleshooting">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2307100f'/%3E%3Crect x='8' y='7' width='16' height='18' fill='%23d2bc74'/%3E%3Crect x='13' y='18' width='10' height='4' fill='%2307100f' transform='rotate(-45 18 20)'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../docs.css">
+    <script src="../../docs.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 건너뛰기</a>
+
+    <header class="site-header">
+      <nav class="nav container" aria-label="주요 내비게이션">
+        <a class="brand" href="../" aria-label="hostveil 홈">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>hostveil</span>
+        </a>
+        <div class="nav-links">
+          <a href="./">문서</a>
+          <a href="../#features">기능</a>
+          <a href="../#install">설치</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a class="lang-switch" href="/docs/troubleshooting" lang="en" hreflang="en">English</a>
+        </div>
+      </nav>
+    </header>
+
+    <div class="docs-container">
+      <button class="docs-sidebar-toggle" type="button" aria-expanded="false" aria-controls="docs-sidebar">
+        문서 메뉴
+      </button>
+
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar" aria-label="문서 내비게이션">
+          <form class="docs-search" role="search" autocomplete="off">
+            <input type="search" id="docs-search-input" class="docs-search-input"
+                   placeholder="문서 검색…" aria-label="문서 검색"
+                   role="combobox" aria-expanded="false" aria-controls="docs-search-results"
+                   aria-autocomplete="list">
+            <ul class="docs-search-results" id="docs-search-results" role="listbox" aria-label="검색 결과" hidden></ul>
+          </form>
+          <div class="docs-nav-group">
+            <p>시작하기</p>
+            <ul>
+              <li><a href="./">소개</a></li>
+              <li><a href="installation">설치</a></li>
+              <li><a href="quickstart">빠른 시작</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>가이드</p>
+            <ul>
+              <li><a href="checks">점검 항목</a></li>
+              <li><a href="fixing">수정 및 롤백</a></li>
+              <li><a href="interfaces">인터페이스</a></li>
+              <li><a href="ai">AI 설명</a></li>
+            </ul>
+          </div>
+          <div class="docs-nav-group">
+            <p>레퍼런스</p>
+            <ul>
+              <li><a href="cli">CLI 레퍼런스</a></li>
+              <li><a href="faq">자주 묻는 질문</a></li>
+              <li><a href="troubleshooting" class="active">문제 해결</a></li>
+              <li><a href="contributing">기여하기</a></li>
+            </ul>
+          </div>
+        </aside>
+
+        <main class="docs-content" id="main">
+          <article class="docs-prose">
+            <p class="docs-breadcrumb"><a href="../">hostveil</a> / <a href="./">문서</a> / 문제 해결</p>
+            <h1>문제 해결</h1>
+            <p class="lead">덜 명확한 메시지들이 무슨 뜻인지, 그리고 hostveil이 실제로 무엇을 했는지 확인하는 방법.</p>
+
+            <h2 id="debug">hostveil이 실행하는 모든 명령 보기</h2>
+            <p>결과가 이상해 보이는 대부분의 경우, 원인은 어떤 명령 하나가 예상과 다르게 답했다는 것입니다. <code>HOSTVEIL_DEBUG=1</code>을 설정하면 그 명령들을 추적할 수 있습니다.</p>
+            <pre><code>HOSTVEIL_DEBUG=1 hostveil scan</code></pre>
+            <p>각 줄은 실행한 명령, 소요 시간, 실패 여부를 보여주며, 도메인 실행 여부를 결정하는 바이너리 조회도 포함됩니다. 추적은 <strong>stderr</strong>로 나가므로 <code>--json</code>이나 리다이렉트에 영향을 주지 않습니다. 버그 리포트에 첨부하기에 알맞습니다.</p>
+            <p>명령의 <em>출력</em>은 의도적으로 기록하지 않습니다. <code>docker inspect</code>는 모든 컨테이너의 환경 변수를 그대로 담고 있어서, 출력을 포함하면 추적 자체가 자격 증명 유출이 되기 때문입니다.</p>
+
+            <h2 id="degraded">도메인이 “Degraded”로 표시됩니다</h2>
+            <p>체커가 실행되었지만 검사 대상의 <em>일부만</em> 확인했다는 뜻입니다. 보고된 발견 항목은 실제이고 점수에 반영되며, 확인하지 못한 부분은 사유에 명시됩니다. 흔한 원인: 읽을 수 없는 <code>Include</code> sshd 설정, 파싱할 수 없는 compose 파일, Trivy가 받아오지 못한 이미지, 열거하지 못한 컨테이너.</p>
+            <p>Degraded는 <strong>Skipped</strong>(의존성 부재 — 만점을 주는 대신 점수 산정에서 아예 제외)나 <strong>Error</strong>(체커가 완전히 실패)와 의도적으로 구분됩니다.</p>
+
+            <h2 id="declined">롤백이 “외부에서 편집됨”이라고 거부합니다</h2>
+            <p>해당 파일이 hostveil이 기록한 어떤 내용과도 일치하지 않습니다. 즉 수정 적용 이후 누군가 파일을 바꿨다는 뜻입니다. 롤백은 자체 백업을 남기지 않으므로, 복원하면 그 편집분이 되돌릴 수 없게 사라집니다. 그래서 대신 거부합니다.</p>
+            <p>그래도 백업을 되돌리려면 <code>hostveil rollback &lt;id&gt; --force</code>를 사용하세요. 다만 <code>--force</code>도 체크섬이 맞지 않는 손상된 백업은 밀어붙이지 <em>않습니다</em>. 손상된 백업 너머에는 올바른 내용이 없기 때문입니다.</p>
+
+            <h2 id="empty-history">수정을 적용했는데 “아직 적용된 수정이 없습니다”라고 나옵니다</h2>
+            <p>거의 항상 상태 디렉터리 문제입니다. hostveil은 root로 실행될 때 <code>/var/lib/hostveil</code>에, 그렇지 않으면 <code>~/.local/share/hostveil</code>에 체크포인트를 저장합니다. 따라서 <code>sudo</code>로 적용한 수정은 권한 없이 실행한 <code>hostveil history</code>에서는 보이지 않습니다. <code>sudo</code>로 다시 실행하세요. <code>HOSTVEIL_NO_SUDO=1</code>이 설정되어 있거나 호스트에 <code>sudo</code>가 없을 때 자주 발생합니다.</p>
+
+            <h2 id="exit-codes">예약된 스캔이 3으로 종료됩니다</h2>
+            <p>탐지 도메인이 완전히 실패해서, 스캔이 호스트를 검사해야 할 범위보다 좁게 검사했다는 뜻입니다. 깨끗해 보이지만 믿을 수 없는 결과입니다. 보통 Docker 소켓에 접근할 수 없는 경우입니다. 의존성이 없어 <em>건너뛴</em> 도메인이나 부분 커버리지로 <em>강등된</em> 도메인은 여기에 해당하지 않습니다. <a href="cli#exit-codes">종료 코드</a>를 참고하세요.</p>
+
+            <h2 id="timeouts">검사가 명령이 “응답하지 않았다”고 보고합니다</h2>
+            <p>hostveil은 실행하는 모든 명령에 시간 제한을 둡니다. 연결은 받아들이지만 응답하지 않는 데몬 — 멈춘 Docker가 대표적입니다 — 은 스캔 전체를 멈추는 대신 해당 검사만 실패시킵니다. 영향받은 도메인은 깨끗하다고 점수를 매기지 않고 정직하게 보고됩니다. 메시지에 나온 데몬을 확인하세요. <code>HOSTVEIL_DEBUG=1</code>이 어떤 호출에서 멈췄는지 정확히 보여줍니다.</p>
+
+            <h2 id="ssh-fix">SSH 수정이 적용을 거부합니다</h2>
+            <p>파일을 쓰기 전에, hostveil은 만들어질 설정을 <code>sshd -t</code>로 검사합니다. sshd가 거부하면 수정을 포기하고 원본 파일은 그대로 둡니다. 아무것도 쓰지 않았으므로 되돌릴 것도 없습니다. sshd는 이미 로드한 설정으로 계속 동작하기 때문입니다. 깨진 파일은 다음 재시작 전까지 아무 문제 없어 보이다가, 그때 sshd가 시작을 거부하고, 그 파일을 고치려면 방금 사라진 SSH 접근이 필요해집니다.</p>
+
+            <h2 id="interrupt">Ctrl-C가 듣지 않는 것 같습니다</h2>
+            <p>첫 번째 인터럽트는 진행 중인 작업을 취소하고 깔끔하게 마무리합니다. 스캔이 실행 중인 명령을 멈추고, 대시보드의 처리 중인 요청을 마저 끝냅니다. 한 번 더 누르면 즉시 종료합니다. 일괄 수정은 하나의 수정 도중이 아니라 수정과 수정 사이에서 멈추며, 시도하지 못한 개수를 알려줍니다. 이미 적용된 것은 <code>hostveil history</code>에 남습니다.</p>
+
+            <div class="docs-pager">
+              <a class="button secondary" href="faq">← 자주 묻는 질문</a>
+              <a class="button primary" href="contributing">기여하기 →</a>
+            </div>
+          </article>
+        </main>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="../"><span class="brand-mark" aria-hidden="true"></span><span>hostveil</span></a>
+          <p>셀프호스팅 리눅스 서버를 위한 가이드형 보안 강화.</p>
+        </div>
+        <nav aria-label="푸터 링크">
+          <a href="./">문서</a>
+          <a href="https://github.com/seolcu/hostveil">GitHub</a>
+          <a href="https://github.com/seolcu/hostveil/releases/latest">릴리스</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## The gap

`grep -rn '"log"\|log\.\|slog'` over `internal/` and `cmd/` returned nothing but the word "log" in comments. There was no `--debug`, no log file, no command trace — no observability of any kind.

So the entire evidence available for the commonest support question there is — *"it says my firewall is inactive, but it isn't"* — was the domain's `Reason` string, which `platform.cleanStderr` collapses to one line and truncates to 200 runes. Nothing recorded which commands ran, which binaries were found, or which call was the one that answered wrong.

## The fix

`HOSTVEIL_DEBUG=1` wraps the engine's runner in `platform.TraceRunner`, which writes one line per command and per binary lookup:

```
hostveil[trace] look ufw → not found
hostveil[trace] look firewall-cmd → /usr/bin/firewall-cmd
hostveil[trace] run  systemctl is-enabled dnf-automatic.timer (12ms) FAILED: exit status 4
hostveil[trace] run  docker version --format '{{.Server.Version}}' (50ms) ok, 7 bytes
```

Every claim hostveil makes about a host comes from a command through `CommandRunner`, so this is the diagnosis. Lookups are traced because they are half of every "my domain was skipped" report — a binary in `/usr/sbin` that is not on a non-login PATH looks exactly like one that is not installed.

**An environment variable, not a flag.** It works for every subcommand without threading a flag through six of them, and what you tell a reporter is one line they can paste. Output goes to **stderr**, so `--json` and every redirect produce exactly the bytes they did before.

**Command output is deliberately never logged.** `docker inspect` reports the resolved environment of every container, so a trace an operator pastes into a public issue would routinely be a credential leak. The command, its duration, and its outcome identify the problem; a wrong parse of a *successful* command is a different kind of bug. There's a test pinning this.

Arguments are shell-quoted so a traced command can be copied back into a terminal, and writes are serialised because the nine checkers run concurrently.

## Docs

Adds the operator-facing **Troubleshooting** page the docs never had (en + ko). The existing FAQ is eight pre-purchase questions — nothing on what Degraded means, why a rollback declined, or where the history went. The new page covers: `HOSTVEIL_DEBUG`, Degraded vs Skipped vs Error, declined rollback (and why `--force` still won't restore a damaged backup), the empty-history state-directory trap, exit code 3, command timeouts, why an SSH fix can refuse, and what two Ctrl-Cs do.

`hostveil history` now explains itself: when the list is empty *and* the run is unprivileged, it says which directory it read and that root's checkpoints live elsewhere. Fixes applied under `sudo` were otherwise invisible, reading as "No fixes have been applied yet" on a host fixed ten minutes ago.

## Tests

`TestTraceNeverLogsCommandOutput` (with a credential-shaped payload), `TestTraceRecordsCommandsAndFailures`, `TestTraceRecordsLookups`, `TestTraceQuotesArgumentsThatNeedIt`, and `TestTraceLinesAreNotInterleaved` under `-race` with 50 concurrent commands.

Full local gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)