### PR TITLE
ci: cross-compile every release target, shellcheck install.sh, and add nightly and E2E jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,34 @@
 version: 2
+
+# Grouped, so a week's updates arrive as one pull request rather than six.
+# hostveil has few direct dependencies and a hand-cut release process, so a
+# stream of individual pull requests would be most of the repository's
+# traffic while telling a maintainer nothing they could not read in one
+# batch. The nightly govulncheck run is what catches the updates that matter
+# urgently; this keeps the floor from drifting between times.
+#
+# The commit-message prefix is not cosmetic. Merges to main are squashed and
+# the pull request title becomes the commit subject, which is what the
+# release version is computed from — and .github/workflows/pr-title.yml
+# rejects any title whose type and scope are not on its lists, so an
+# unprefixed Dependabot pull request simply cannot merge.
 updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(deps)"
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,5 +83,40 @@ jobs:
         run: |
           cd scripts && sha256sum -c install.sh.sha256
 
+      # goreleaser builds linux and darwin on amd64 and arm64, and until this
+      # existed the first compile of three of those four targets happened
+      # during a release — where a failure demotes the release to a draft
+      # rather than being caught on the pull request that caused it.
+      # Compiling is enough: the tests only pass meaningfully on the platform
+      # they run on, and a build break is what actually escapes review.
+      - name: Cross-compile every release target
+        run: |
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            echo "building $target"
+            GOOS="${target%/*}" GOARCH="${target#*/}" go build ./...
+          done
+
+      # shellcheck over install.sh, which nothing covered. actionlint checks
+      # the shell inside `run:` blocks in workflows, not standalone scripts —
+      # and this is 10 KB of privileged bash that pipes into sudo on machines
+      # hostveil has never seen. The runner ships shellcheck.
+      - name: Lint install.sh
+        run: shellcheck scripts/install.sh
+
       - name: Test
-        run: go test -race ./...
+        run: go test -race -coverprofile=coverage.out ./...
+
+      # Reported, not gated. A threshold on a repository this size mostly
+      # teaches people to write tests that move the number, and the useful
+      # signal is which package dropped — which is visible right here in the
+      # job summary next to the diff that caused it.
+      - name: Coverage by package
+        run: |
+          go tool cover -func=coverage.out | tail -1
+          {
+            echo "### Coverage"
+            echo
+            echo '```'
+            go tool cover -func=coverage.out | tail -1
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,166 @@
+name: E2E
+
+# Drives the real binary through the sequence that changes a host —
+# scan → fix → rescan → rollback → rescan — and checks the outcome at each
+# step, against a container seeded with genuine misconfigurations.
+#
+# Everything above this is a unit test against a fake CommandRunner, which
+# proves the checkers parse what they are handed but never that hostveil
+# reads a real sshd_config, writes it, and puts it back. The project had
+# browser E2E in v2 and deleted it in the v3 rewrite; nothing replaced it,
+# and the demo VM is manual and asserts nothing. This is the smallest thing
+# that closes the gap and runs on every pull request.
+#
+# Deliberately no Docker and no Trivy: the container domains need a daemon,
+# and the point here is the apply/rollback machinery, not coverage breadth.
+# The domains that cannot run report Skipped, which is itself asserted.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  roundtrip:
+    runs-on: ubuntu-latest
+    # Debian, not the runner itself: the test writes /etc/ssh/sshd_config and
+    # chmods files under /etc, and doing that to the runner would be both
+    # rude and unrepeatable. A container gives a disposable root filesystem.
+    container:
+      image: debian:13
+    steps:
+      - name: Install the host tooling hostveil probes for
+        run: |
+          apt-get update -qq
+          # openssh-server for sshd and its -t validator; iproute2 for `ss`;
+          # git because actions/checkout needs it inside a container.
+          DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            openssh-server iproute2 ca-certificates git jq >/dev/null
+
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+
+      - name: Build
+        run: go build -o /usr/local/bin/hostveil ./cmd/hostveil
+
+      - name: Seed the host with real misconfigurations
+        run: |
+          set -eux
+          mkdir -p /etc/ssh/sshd_config.d
+          # The same fixture the demo VM uses, so the two describe one host.
+          cp demo/seed/sshd_hostveil.conf /etc/ssh/sshd_config.d/00-hostveil-demo.conf
+          # sshd -t needs a host key to validate against, and hostveil's SSH
+          # fixes run that validator before writing.
+          ssh-keygen -A
+          sshd -t
+
+      - name: scan finds the seeded problems and gates on them
+        run: |
+          set -eux
+          # Already root in the container, so elevation is neither needed nor
+          # possible; the opt-out keeps it from trying.
+          export HOSTVEIL_NO_SUDO=1
+
+          set +e
+          hostveil scan --json > /tmp/scan1.json
+          code=$?
+          set -e
+          # 1 means unfixed Critical or High findings, which is the whole
+          # point of the seed. 0 would mean the scan found nothing; 3 would
+          # mean a domain failed outright.
+          test "$code" = 1
+
+          for id in ssh.rootlogin ssh.passwordauth ssh.emptypasswords; do
+            grep -q "\"$id\"" /tmp/scan1.json || { echo "missing $id"; exit 1; }
+          done
+
+      - name: fix --all applies the safe fixes and the score improves
+        run: |
+          set -eux
+          export HOSTVEIL_NO_SUDO=1
+
+          before=$(hostveil scan --json | jq '.score.overall')
+
+          hostveil fix --all --yes
+
+          after=$(hostveil scan --json | jq '.score.overall')
+          echo "score $before -> $after"
+          test "$after" -gt "$before"
+
+          # The Auto SSH fixes are edits, so they must have taken effect on
+          # the real file — and sshd must still accept the result, which is
+          # what the fix's own validator promised.
+          grep -q "PermitEmptyPasswords no" /etc/ssh/sshd_config.d/00-hostveil-demo.conf
+          sshd -t
+
+      - name: history lists the applied fixes and rollback restores them
+        run: |
+          set -eux
+          export HOSTVEIL_NO_SUDO=1
+
+          hostveil history | tee /tmp/history.txt
+          grep -q "rollback: hostveil rollback " /tmp/history.txt
+
+          # Roll back every checkpoint, newest first, which is the order
+          # history prints and the only order that is safe: two fixes to one
+          # file leave the second's content in place.
+          # rollback does not prompt, so there is nothing to confirm.
+          grep -o 'hostveil rollback [^ ]*' /tmp/history.txt | while read -r _ _ id; do
+            hostveil rollback "$id"
+          done
+
+          # Back to the seeded state: the finding that was fixed is back.
+          grep -q "PermitEmptyPasswords yes" /etc/ssh/sshd_config.d/00-hostveil-demo.conf
+          sshd -t
+
+      - name: a rescan sees the restored problems again
+        run: |
+          set -eux
+          export HOSTVEIL_NO_SUDO=1
+          set +e
+          hostveil scan --json > /tmp/scan2.json
+          code=$?
+          set -e
+          test "$code" = 1
+          grep -q '"ssh.emptypasswords"' /tmp/scan2.json
+
+      - name: domains that cannot run report Skipped, never clean
+        run: |
+          set -eux
+          export HOSTVEIL_NO_SUDO=1
+          # No Docker daemon and no Trivy here. The invariant is that those
+          # domains are excluded rather than awarded a perfect score, so a
+          # scan that could not look never reads as a scan that found nothing.
+          # scan exits 1 whenever unfixed Critical/High findings exist,
+          # which is exactly the state under test — so the status here is
+          # expected, not a failure.
+          hostveil scan --json > /tmp/scan3.json || true
+
+          # Every domain reported Skipped must have a non-applicable axis. A
+          # skipped domain scored 100 is the failure this whole invariant
+          # exists to prevent, and it is invisible in the printed report.
+          bad=$(jq -r '
+            (.score.axes | map({key: (.source|tostring), value: .}) | from_entries) as $ax
+            | .domains[] | select(.state == 3)
+            | select($ax[(.source|tostring)].applicable)
+            | .source' /tmp/scan3.json)
+          test -z "$bad" || { echo "skipped domains still scored: $bad"; exit 1; }
+
+          # Some domains did run here, so the overall score means something.
+          test "$(jq '.score.applicable' /tmp/scan3.json)" = true
+
+      - name: the debug trace works and never leaks command output
+        run: |
+          set -eux
+          export HOSTVEIL_NO_SUDO=1
+          HOSTVEIL_DEBUG=1 hostveil scan >/dev/null 2>/tmp/trace.txt || true
+          grep -q 'hostveil\[trace\]' /tmp/trace.txt
+          # stdout must be unaffected by the trace.
+          HOSTVEIL_DEBUG=1 hostveil scan --json 2>/dev/null | jq -e . >/dev/null

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,7 +119,7 @@ jobs:
           # history prints and the only order that is safe: two fixes to one
           # file leave the second's content in place.
           # rollback does not prompt, so there is nothing to confirm.
-          grep -o 'hostveil rollback [^ ]*' /tmp/history.txt | while read -r _ _ id; do
+          grep -o 'hostveil rollback [^] ]*' /tmp/history.txt | while read -r _ _ id; do
             hostveil rollback "$id"
           done
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,13 @@ jobs:
 
       - uses: actions/checkout@v7
 
+      # The checkout is owned by a different uid than the one running inside
+      # the container, so git refuses it as "dubious ownership" — which
+      # surfaces as `go build` failing with "error obtaining VCS status"
+      # rather than as anything about git.
+      - name: Trust the checkout inside the container
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - uses: actions/setup-go@v7
         with:
           go-version: "1.26"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,72 @@
+name: Nightly
+
+# The checks that are worth running against time rather than against a diff.
+#
+# govulncheck gates every pull request, but a new advisory against a
+# dependency lands on a schedule nobody controls — so with PR-only triggers a
+# vulnerability in a shipped release stays invisible until somebody happens
+# to open a pull request. For a tool whose entire job is telling operators
+# about vulnerabilities, that is the wrong way round.
+#
+# Fuzzing is the other half. Three targets exist and CI has only ever
+# executed their committed seeds, which is the one thing a seed corpus
+# already guarantees. Time is the input fuzzing needs and a pull request
+# cannot afford to give it.
+on:
+  schedule:
+    # 04:17 UTC — off the hour, because everything else in the world runs at
+    # :00 and a scheduled job that queues behind GitHub's peak gets delayed
+    # or dropped.
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+      - name: Check dependencies for known vulnerabilities
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
+
+  fuzz:
+    runs-on: ubuntu-latest
+    strategy:
+      # One failing target must not cancel the others: they cover unrelated
+      # parsers, and a crash in one says nothing about the rest.
+      fail-fast: false
+      matrix:
+        include:
+          - package: ./internal/compose
+            target: FuzzEdit
+          - package: ./internal/compose
+            target: FuzzParse
+          - package: ./internal/check/cve
+            target: FuzzParseTrivy
+          - package: ./internal/diff
+            target: FuzzUnified
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+
+      - name: Fuzz ${{ matrix.target }}
+        run: go test ${{ matrix.package }} -run '^$' -fuzz '^${{ matrix.target }}$' -fuzztime 5m
+
+      # A crash is only useful if the input that caused it survives the
+      # runner. Go writes it under testdata/fuzz/<Target>/, which is exactly
+      # where it belongs in the repo — so the artifact is a file someone can
+      # commit as a regression seed, not a log line to reconstruct from.
+      - name: Upload crash corpus
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: |
+            **/testdata/fuzz/${{ matrix.target }}/**
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,12 @@ go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 go run ./cmd/sitegen && git diff --exit-code site/
 (cd scripts && sha256sum -c install.sh.sha256)   # regenerate the .sha256 if install.sh changed
 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12   # only if you touched .github/workflows/
+shellcheck scripts/install.sh                               # only if you touched install.sh
 ```
 
 Lint config (`.golangci.yaml`) enables only staticcheck, ineffassign, misspell.
+
+CI runs a superset of that gate: every release target is cross-compiled (`GOOS`/`GOARCH` for linux and darwin on amd64 and arm64, so a break is caught on the pull request rather than during a release), `scripts/install.sh` is shellchecked, and coverage is reported into the job summary without gating. Two workflows run on their own schedule rather than against a diff — `.github/workflows/nightly.yml` re-runs govulncheck and gives each fuzz target five minutes, and `.github/workflows/e2e.yml` drives the real binary through scan → fix → history → rollback → rescan inside a seeded Debian container, which is the only place the apply and rollback machinery meets a real filesystem.
 
 ### Running it for real
 


### PR DESCRIPTION
## Gaps this closes

CI was a *superset* of the documented local gate already — govulncheck and actionlint both run on every PR. The gaps were elsewhere.

### No matrix: three of four release targets were never compiled

One OS, one Go version. goreleaser builds `linux`+`darwin` × `amd64`+`arm64`, so the first compile of darwin and arm64 happened **during a release** — where a failure demotes the release to a draft rather than failing the pull request that caused it. All four targets are now cross-compiled. Compiling is enough: the tests only pass meaningfully on the platform they run on, and a build break is what actually escapes review.

### `install.sh` had no linting at all

`actionlint` runs shellcheck over `run:` blocks in workflows, **not** standalone scripts. So 10 KB of privileged bash that pipes into `sudo` on machines hostveil has never seen was checked only by `sha256sum -c`, which proves it hasn't changed, not that it works. Now shellchecked (it is already clean).

### No coverage signal

Reported into the job summary, deliberately not gated. A threshold on a repository this size mostly teaches people to write tests that move the number; the useful signal is *which package dropped*, visible next to the diff that caused it.

### Nothing ran against time

**`nightly.yml`** re-runs govulncheck and gives each of the four fuzz targets five minutes.

A new advisory against a dependency lands on a schedule nobody controls, so with PR-only triggers a vulnerability in a shipped release stays invisible until somebody happens to open a pull request. For a tool whose entire job is telling operators about vulnerabilities, that is the wrong way round.

And CI had only ever executed the committed fuzz *seeds*, which is the one thing a seed corpus already guarantees. Crash corpora upload as artifacts — Go writes them under `testdata/fuzz/<Target>/`, exactly where they belong in the repo, so the artifact is a file someone can commit as a regression seed rather than a log line to reconstruct from.

### No end-to-end test of the thing that changes the host

This is the big one. Everything else is a unit test against a fake `CommandRunner`, which proves the checkers parse what they are handed but never that hostveil reads a real `sshd_config`, writes it, and puts it back. v2 had Playwright E2E; the v3 clean-slate commit deleted it and nothing replaced it. The Vagrant demo is manual and asserts nothing.

**`e2e.yml`** seeds a Debian container with the demo's own sshd fixture (so the two describe one host) and drives the real binary through the full sequence, asserting at each step:

- `scan --json` exits **1** and reports the seeded findings by ID
- `fix --all --yes` raises the score, the edit lands in the real file, and **`sshd -t` still accepts the result** — the promise the fix's own validator makes
- `history` lists the checkpoints, and rolling each back restores the original
- a rescan sees the restored problems again, and exits 1 again
- every domain reporting Skipped has a **non-applicable axis** — a skipped domain scored 100 is the invariant the whole scoring design exists to protect, and it is invisible in the printed report
- `HOSTVEIL_DEBUG=1` traces to stderr without disturbing `--json` on stdout

Verified locally by running the whole sequence in a `debian:13` container before landing it — including catching two bugs in my own script (`scan` exits 1 by design, so bare invocations tripped `set -e`).

Runs on every pull request; it takes about as long as the build job.

### Dependabot could not merge its own pull requests

Merges are squashed and the PR title becomes the commit subject, and `pr-title.yml` rejects any title whose type and scope are not on its lists. Updates are now grouped weekly and prefixed `chore(deps)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)