### PR TITLE
feat(install): add an uninstall path and verify build provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ go install github.com/seolcu/hostveil/cmd/hostveil@latest
 
 Trivy is optional — install it any time to enable image CVE scanning.
 
+To **upgrade**, re-run the same command: the binary is replaced and your saved
+scans and rollback checkpoints are left alone. To **uninstall**:
+
+```bash
+curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --uninstall
+```
+
+That removes the binary and prints where the state directory is, without
+deleting it — those checkpoints are the backups of every file hostveil has
+edited on the host, and uninstalling is not a decision to give up the ability
+to undo them.
+
 Release archives are built by GitHub Actions and carry a signed build
 provenance attestation, so you can confirm a download really came from this
 repo's release workflow before running it:

--- a/cmd/sitegen/content/en/docs/installation.html
+++ b/cmd/sitegen/content/en/docs/installation.html
@@ -57,6 +57,11 @@
               </table>
             </div>
 
+            <h2 id="upgrade">Upgrading and uninstalling</h2>
+            <p>To upgrade, re-run the install command. The binary is replaced in place and your saved scans and rollback checkpoints are left alone.</p>
+            <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --uninstall</code></pre></div>
+            <p>Uninstalling removes <code>/usr/bin/hostveil</code> and prints where the state directory is — <strong>without deleting it</strong>. Those checkpoints are the backups of every file hostveil has edited on this host, and removing the tool is not a decision to give up the ability to undo its fixes. The command to delete them is printed if you want it. Trivy is left alone too: it is a general-purpose scanner that may predate hostveil or be used by something else.</p>
+
             <h2>Build from source</h2>
             <p>With a recent Go toolchain installed:</p>
             <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil

--- a/cmd/sitegen/content/ko/docs/installation.html
+++ b/cmd/sitegen/content/ko/docs/installation.html
@@ -57,6 +57,11 @@
               </table>
             </div>
 
+            <h2 id="upgrade">업그레이드와 제거</h2>
+            <p>업그레이드하려면 설치 명령을 다시 실행하세요. 바이너리만 교체되고, 저장된 스캔 기록과 롤백 체크포인트는 그대로 남습니다.</p>
+            <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --uninstall</code></pre></div>
+            <p>제거는 <code>/usr/bin/hostveil</code>을 삭제하고 상태 디렉터리의 위치를 알려주되, <strong>그 디렉터리는 지우지 않습니다</strong>. 그 안의 체크포인트는 hostveil이 이 호스트에서 수정한 모든 파일의 백업이며, 도구를 지운다는 것이 그 수정들을 되돌릴 능력을 포기하겠다는 뜻은 아니기 때문입니다. 지우고 싶다면 필요한 명령도 함께 출력됩니다. trivy도 건드리지 않습니다. 범용 스캐너라서 hostveil보다 먼저 설치되었거나 다른 용도로 쓰이고 있을 수 있습니다.</p>
+
             <h2>소스에서 빌드하기</h2>
             <p>최신 Go 툴체인이 설치되어 있다면:</p>
             <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,12 @@ VERSION=""
 VERSION_EXPLICIT=false
 SKIP_TRIVY=false
 FORCE=false
+UNINSTALL=false
+
+# The repository every release artifact is fetched from, and the one the
+# build provenance attestation must name. One constant so a URL and the
+# identity being verified can never drift apart.
+REPO="seolcu/hostveil"
 
 usage() {
   cat <<'EOF'
@@ -15,8 +21,63 @@ Options:
   --no-trivy         Skip the optional trivy (image CVE scanner) install
   --no-deps          Install hostveil only (same as --no-trivy)
   --yes, -y          Non-interactive mode (install optional dependencies)
+  --uninstall        Remove hostveil, and say where its saved state lives
   --help, -h         Show this help
+
+Re-running this script installs over an existing hostveil, which is the
+supported way to upgrade: the binary is replaced and your saved scans and
+rollback checkpoints are left alone.
 EOF
+}
+
+# uninstall removes what this script installed, and nothing else.
+#
+# It deliberately does not delete the state directory. That is where the
+# rollback checkpoints live — the backups of every file hostveil has edited
+# on this host — and removing hostveil is not a statement that the operator
+# no longer wants the ability to undo what it did. So the path is printed
+# with the command to remove it, and the decision stays theirs.
+#
+# trivy is likewise left in place: this script offers to install it, but it
+# is a general-purpose scanner that may well predate hostveil or be used by
+# something else, and silently removing another tool is not ours to do.
+uninstall() {
+  local removed=false
+
+  if [[ -e /usr/bin/hostveil ]]; then
+    sudo rm -f /usr/bin/hostveil
+    echo "  ✓ removed /usr/bin/hostveil"
+    removed=true
+  else
+    echo "  hostveil is not installed at /usr/bin/hostveil"
+  fi
+
+  local state
+  if [[ -d /var/lib/hostveil ]]; then
+    state=/var/lib/hostveil
+  elif [[ -d "${HOME}/.local/share/hostveil" ]]; then
+    state="${HOME}/.local/share/hostveil"
+  fi
+
+  if [[ -n "${state:-}" ]]; then
+    echo ""
+    echo "  Saved scans and rollback checkpoints are still in:"
+    echo "    ${state}"
+    echo "  Those checkpoints are the backups of every file hostveil edited here."
+    echo "  Delete them only if you no longer need to undo any of its fixes:"
+    echo "    sudo rm -rf ${state}"
+  fi
+
+  if command -v trivy >/dev/null 2>&1; then
+    echo ""
+    echo "  trivy is still installed. It is a general-purpose scanner, so this"
+    echo "  script does not remove it. To remove it: sudo rm -f \"$(command -v trivy)\""
+  fi
+
+  if [[ "$removed" == true ]]; then
+    echo ""
+    echo "  Done."
+  fi
 }
 
 while [[ $# -gt 0 ]]; do
@@ -34,6 +95,7 @@ while [[ $# -gt 0 ]]; do
     --no-trivy) SKIP_TRIVY=true; shift ;;
     --no-deps) SKIP_TRIVY=true; shift ;;
     --yes|-y) FORCE=true; shift ;;
+    --uninstall) UNINSTALL=true; shift ;;
     --help|-h) usage; exit 0 ;;
     *)
       echo "Unknown option: $1" >&2
@@ -42,6 +104,11 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ "$UNINSTALL" == true ]]; then
+  uninstall
+  exit 0
+fi
 
 if [[ "$VERSION_EXPLICIT" == true && -z "$VERSION" ]]; then
   echo "ERROR: --version requires a non-empty version (e.g. v2.6.0)" >&2
@@ -238,7 +305,7 @@ fi
 
 # ─── INSTALL HOSTVEIL ────────────────────────────────────────────────────
 if [[ -z "$VERSION" ]]; then
-  VERSION=$(github_latest_tag seolcu/hostveil) || true
+  VERSION=$(github_latest_tag "$REPO") || true
   if [[ -z "$VERSION" ]]; then
     echo "  ERROR: failed to determine latest hostveil version" >&2
     echo "  Try again later or specify a version with --version vX.Y.Z" >&2
@@ -248,7 +315,7 @@ fi
 
 echo "  • hostveil: downloading v${VERSION}..."
 TAR="hostveil-${OS}-${ARCH}.tar.gz"
-URL="https://github.com/seolcu/hostveil/releases/download/v${VERSION}/${TAR}"
+URL="https://github.com/${REPO}/releases/download/v${VERSION}/${TAR}"
 curl -fsSL --retry 3 "$URL" -o "${TMPDIR}/${TAR}" || {
   echo "  ERROR: download failed for ${URL}" >&2
   exit 1
@@ -263,7 +330,7 @@ curl -fsSL --retry 3 "$URL" -o "${TMPDIR}/${TAR}" || {
 # /usr/bin and run as root. There is no partial credit here: either the
 # artifact matches what the release published, or it does not get installed.
 echo "  • hostveil: verifying checksum..."
-CHECKSUM_URL="https://github.com/seolcu/hostveil/releases/download/v${VERSION}/hostveil-checksums.txt"
+CHECKSUM_URL="https://github.com/${REPO}/releases/download/v${VERSION}/hostveil-checksums.txt"
 if ! curl -fsSL --retry 3 "$CHECKSUM_URL" -o "${TMPDIR}/hostveil-checksums.txt"; then
   echo "  ERROR: could not download the checksums file for v${VERSION}" >&2
   echo "    ${CHECKSUM_URL}" >&2
@@ -285,6 +352,27 @@ if [[ "$EXPECTED" != "$ACTUAL" ]]; then
 fi
 echo "  ✓ checksum verified"
 
+# The checksums file comes from the same GitHub release as the tarball, so
+# matching it proves the download was not corrupted or partially swapped in
+# transit — not that the release itself is genuine. The release workflow
+# mints a signed build provenance attestation tying the archive to the
+# workflow run and commit that produced it, and that is the claim worth
+# checking. Verified when the tooling is present; skipped with a note when
+# it is not, because gh is not a dependency this installer can require.
+if command -v gh >/dev/null 2>&1; then
+  if gh attestation verify "${TMPDIR}/${TAR}" --repo "$REPO" >/dev/null 2>&1; then
+    echo "  ✓ build provenance verified (built by ${REPO}'s release workflow)"
+  else
+    echo "  ERROR: build provenance could not be verified for ${TAR}." >&2
+    echo "  The checksum matched, but nothing proves this archive came from" >&2
+    echo "  ${REPO}'s release workflow. Refusing to install." >&2
+    exit 1
+  fi
+else
+  echo "  · provenance not checked (install the GitHub CLI to enable it):"
+  echo "      gh attestation verify ${TAR} --repo ${REPO}"
+fi
+
 tar xzf "${TMPDIR}/${TAR}" -C "$TMPDIR" || {
   echo "  ERROR: extraction failed" >&2
   exit 1
@@ -302,3 +390,4 @@ fi
 echo ""
 echo "  hostveil v${VERSION} installed ($(hostveil --version))."
 echo "  Run: hostveil"
+echo "  Upgrade later by re-running this script; uninstall with: install.sh --uninstall"

--- a/scripts/install.sh.sha256
+++ b/scripts/install.sh.sha256
@@ -1,1 +1,1 @@
-3e69eb759f736875dca20ab8ac58fa6d2fe321bb43fa3301d0f9cc5ea0ca7477  install.sh
+6324f6fdc9ada8d16db08a7d38bcd93e886d5f74258abf19cf1337fbb2e4cbab  install.sh

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -143,6 +143,11 @@
               </table>
             </div>
 
+            <h2 id="upgrade">Upgrading and uninstalling</h2>
+            <p>To upgrade, re-run the install command. The binary is replaced in place and your saved scans and rollback checkpoints are left alone.</p>
+            <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --uninstall</code></pre></div>
+            <p>Uninstalling removes <code>/usr/bin/hostveil</code> and prints where the state directory is — <strong>without deleting it</strong>. Those checkpoints are the backups of every file hostveil has edited on this host, and removing the tool is not a decision to give up the ability to undo its fixes. The command to delete them is printed if you want it. Trivy is left alone too: it is a general-purpose scanner that may predate hostveil or be used by something else.</p>
+
             <h2>Build from source</h2>
             <p>With a recent Go toolchain installed:</p>
             <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil

--- a/site/ko/docs/installation.html
+++ b/site/ko/docs/installation.html
@@ -143,6 +143,11 @@
               </table>
             </div>
 
+            <h2 id="upgrade">업그레이드와 제거</h2>
+            <p>업그레이드하려면 설치 명령을 다시 실행하세요. 바이너리만 교체되고, 저장된 스캔 기록과 롤백 체크포인트는 그대로 남습니다.</p>
+            <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --uninstall</code></pre></div>
+            <p>제거는 <code>/usr/bin/hostveil</code>을 삭제하고 상태 디렉터리의 위치를 알려주되, <strong>그 디렉터리는 지우지 않습니다</strong>. 그 안의 체크포인트는 hostveil이 이 호스트에서 수정한 모든 파일의 백업이며, 도구를 지운다는 것이 그 수정들을 되돌릴 능력을 포기하겠다는 뜻은 아니기 때문입니다. 지우고 싶다면 필요한 명령도 함께 출력됩니다. trivy도 건드리지 않습니다. 범용 스캐너라서 hostveil보다 먼저 설치되었거나 다른 용도로 쓰이고 있을 수 있습니다.</p>
+
             <h2>소스에서 빌드하기</h2>
             <p>최신 Go 툴체인이 설치되어 있다면:</p>
             <div class="code-block"><pre><code>git clone https://github.com/seolcu/hostveil


### PR DESCRIPTION
## No way to uninstall, and no documented upgrade

`grep -i uninstall` across every `.sh`, `.md`, `.html`, and `.go` in the repo returned **nothing**. Nothing told a user how to remove `/usr/bin/hostveil`, and nothing said that re-running the installer is the supported upgrade path — which it is (a plain `sudo install -m 755` overwrite), just undocumented.

A tool that asks for root and edits system files owes an answer to "how do I get rid of this".

### `install.sh --uninstall`

Removes the binary, and **deliberately does not remove the state directory.**

That directory holds the rollback checkpoints — the backups of every file hostveil has edited on this host. Uninstalling the tool is not a decision to give up the ability to undo what it did, so the path is printed along with the command to delete it, and that stays the operator's call.

trivy is left alone for a similar reason: this script offers to install it, but it is a general-purpose scanner that may well predate hostveil or be used by something else. Silently removing another tool is not ours to do. Its path is printed too.

## The installer trusted a checksum it fetched from the same place as the file

`hostveil-checksums.txt` comes from the same GitHub release as the tarball. Matching it proves the download was not corrupted or partially swapped **in transit** — it says nothing about whether the release itself is genuine, because an attacker who can publish the release publishes both.

The release workflow already mints a signed build provenance attestation (`actions/attest-build-provenance`) tying each archive to the workflow run and commit that produced it. Nothing was checking it. The installer now does:

- **GitHub CLI present** → verified, and a mismatch **refuses to install**.
- **Not present** → skipped with a note and the exact command to run manually. `gh` is not a dependency an installer piped from curl can require, and failing closed on its absence would break every minimal server.

A `REPO` constant replaces three hardcoded `seolcu/hostveil` strings, so the URLs artifacts are fetched from and the identity being verified cannot drift apart.

## Verified

Ran the real script against the real v3.4.0 release inside a `debian:13` container — install, `hostveil --version`, and `--uninstall` all behave, including the state-directory notice. `bash -n` and shellcheck clean (shellcheck now gates CI, as of #578). Checksum regenerated.

Docs updated in README and the installation page (en + ko).

🤖 Generated with [Claude Code](https://claude.com/claude-code)