### PR TITLE
feat(check): audit shared pid/ipc namespaces and writable root filesystems in compose services

### DIFF
--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -100,11 +100,14 @@
                   <tr><td><code>compose.dr001</code></td><td>Container uses host network mode</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds017</code></td><td>Sensitive host path mounted read-write</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds005</code></td><td>Adds a dangerous Linux capability</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>compose.ds020</code></td><td>Shares the host PID namespace</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.dr005</code></td><td>Hardcoded secret in the environment</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds006</code></td><td>Missing no-new-privileges hardening</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>compose.ds021</code></td><td>Shares the host IPC namespace</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds009</code></td><td>Container runs as root</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.dr002</code></td><td>Port published on all interfaces</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>compose.ds008</code></td><td>No restart policy set</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>compose.ds022</code></td><td>Container filesystem is writable</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds010</code></td><td>No memory limit set</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
                   <tr><td><code>compose.ds012</code></td><td>No healthcheck defined</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.dr004</code></td><td>Loads secrets from an env_file</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -100,11 +100,14 @@
                   <tr><td><code>compose.dr001</code></td><td>컨테이너가 호스트 네트워킹 모드를 사용함</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds017</code></td><td>민감한 호스트 경로가 읽기-쓰기로 마운트됨</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds005</code></td><td>위험한 리눅스 capability를 추가함</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>compose.ds020</code></td><td>호스트 PID 네임스페이스를 공유함</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.dr005</code></td><td>환경 변수에 하드코딩된 비밀값</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds006</code></td><td>no-new-privileges 강화 설정 누락</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>compose.ds021</code></td><td>호스트 IPC 네임스페이스를 공유함</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds009</code></td><td>컨테이너가 root로 실행됨</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
                   <tr><td><code>compose.dr002</code></td><td>포트가 모든 인터페이스에 게시됨</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
                   <tr><td><code>compose.ds008</code></td><td>재시작 정책이 설정되지 않음</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>compose.ds022</code></td><td>컨테이너 파일시스템이 쓰기 가능함</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds010</code></td><td>메모리 제한이 설정되지 않음</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
                   <tr><td><code>compose.ds012</code></td><td>헬스체크가 정의되지 않음</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.dr004</code></td><td>env_file에서 비밀값을 불러옴</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>

--- a/internal/check/compose/compose.go
+++ b/internal/check/compose/compose.go
@@ -96,8 +96,8 @@ func (*Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, e
 // runtimeOnlyRules are the rules that mean the same thing for a container
 // the daemon describes as they do for a service a compose file describes.
 //
-// Two of the fifteen are deliberately absent, both because the daemon's
-// record cannot support the claim the rule would make:
+// Two rules are deliberately absent, both because the daemon's record
+// cannot support the claim the rule would make:
 //
 //   - dr005 (hardcoded secret in the environment) — `docker inspect` reports
 //     the resolved environment, which merges the image's own ENV defaults and
@@ -119,6 +119,8 @@ var runtimeOnlyRules = []rule{
 	ruleExposedDatastore,
 	ruleExposedAdminPanel,
 	ruleHostNetwork,
+	ruleHostPid,
+	ruleHostIpc,
 	ruleSensitiveHostMount,
 	ruleDangerousCaps,
 	ruleNoNewPrivileges,
@@ -127,6 +129,7 @@ var runtimeOnlyRules = []rule{
 	ruleNoRestart,
 	ruleNoHealthcheck,
 	ruleNoResourceLimits,
+	ruleWritableRootFS,
 }
 
 // auditContainer audits a container with no compose file behind it.
@@ -188,12 +191,17 @@ type rule func(compose.Service) (model.Finding, bool)
 
 // rules is the ordered set of compose checks. Each returns a finding when
 // the service trips it. IDs preserve the v2 ds/dr naming for continuity.
+// userns_mode is parsed but deliberately has no rule: `userns_mode: host` is
+// a no-op unless the daemon enables userns-remap, which a static file audit
+// cannot see, so flagging it would accuse configs that change nothing.
 var rules = []rule{
 	rulePrivileged,
 	ruleDockerSocket,
 	ruleExposedDatastore,
 	ruleExposedAdminPanel,
 	ruleHostNetwork,
+	ruleHostPid,
+	ruleHostIpc,
 	ruleSensitiveHostMount,
 	ruleDangerousCaps,
 	ruleNoNewPrivileges,
@@ -202,6 +210,7 @@ var rules = []rule{
 	ruleNoRestart,
 	ruleNoHealthcheck,
 	ruleNoResourceLimits,
+	ruleWritableRootFS,
 	ruleInlineSecret,
 	ruleEnvFile,
 }
@@ -289,6 +298,26 @@ func ruleHostNetwork(s compose.Service) (model.Finding, bool) {
 	return f("dr001", "Container uses host network mode", model.SeverityHigh, model.RemediationReview, s.Name,
 		model.WithDescription("`network_mode: host` removes network isolation: the container shares the host's interfaces and can bind any port, bypassing Docker's published-port controls and your firewall assumptions."),
 		model.WithHowToFix("Remove `network_mode: host` and publish only the specific ports the service needs."),
+	), true
+}
+
+func ruleHostPid(s compose.Service) (model.Finding, bool) {
+	if s.Pid != "host" {
+		return model.Finding{}, false
+	}
+	return f("ds020", "Container shares the host PID namespace", model.SeverityHigh, model.RemediationManual, s.Name,
+		model.WithDescription("`pid: host` lets the container see and signal every process on the host. A compromised container can read other processes' command lines and environment — which often carry credentials — and kill arbitrary services."),
+		model.WithHowToFix("Remove `pid: host` unless the service is a monitoring agent that genuinely needs to observe host processes. If it only needs to see one other container, use `pid: \"service:NAME\"` instead."),
+	), true
+}
+
+func ruleHostIpc(s compose.Service) (model.Finding, bool) {
+	if s.Ipc != "host" {
+		return model.Finding{}, false
+	}
+	return f("ds021", "Container shares the host IPC namespace", model.SeverityMedium, model.RemediationManual, s.Name,
+		model.WithDescription("`ipc: host` shares the host's inter-process communication (shared memory, semaphores) with the container. A compromised container can read or tamper with shared memory used by host processes, including other containers' databases."),
+		model.WithHowToFix("Remove `ipc: host`. If two containers need to share memory with each other, use `ipc: \"service:NAME\"` to share between just those two instead of with the whole host."),
 	), true
 }
 
@@ -410,6 +439,16 @@ func ruleNoResourceLimits(s compose.Service) (model.Finding, bool) {
 	return f("ds010", "No memory limit set", model.SeverityLow, model.RemediationReview, s.Name,
 		model.WithDescription("Without a memory limit, one runaway or attacker-triggered container can exhaust host RAM and take every other service down with it."),
 		model.WithHowToFix("Set a memory limit, e.g. `mem_limit: 512m` (Compose v2) or under `deploy.resources.limits.memory`."),
+	), true
+}
+
+func ruleWritableRootFS(s compose.Service) (model.Finding, bool) {
+	if s.ReadOnly {
+		return model.Finding{}, false
+	}
+	return f("ds022", "Container filesystem is writable", model.SeverityLow, model.RemediationManual, s.Name,
+		model.WithDescription("Without `read_only: true`, a compromised process can modify the container's own binaries and drop tools anywhere in its filesystem, making an intrusion easier to deepen and harder to spot."),
+		model.WithHowToFix("Add `read_only: true` and mount `tmpfs` for the paths the service writes to (commonly /tmp and /run). Which paths those are depends on the app, so hostveil does not change this automatically."),
 	), true
 }
 

--- a/internal/check/compose/compose_test.go
+++ b/internal/check/compose/compose_test.go
@@ -120,6 +120,59 @@ func TestHardenedServiceIsClean(t *testing.T) {
 	}
 }
 
+func TestHostNamespaceSharingDetected(t *testing.T) {
+	got := findingsFor(t, `services:
+  monitor:
+    image: myapp
+    pid: host
+    ipc: host`)
+	if f, ok := got["compose.ds020"]; !ok {
+		t.Errorf("expected compose.ds020 for pid: host, got %v", keys(got))
+	} else if f.Severity != model.SeverityHigh {
+		t.Errorf("ds020 severity = %v, want high", f.Severity)
+	}
+	if f, ok := got["compose.ds021"]; !ok {
+		t.Errorf("expected compose.ds021 for ipc: host, got %v", keys(got))
+	} else if f.Severity != model.SeverityMedium {
+		t.Errorf("ds021 severity = %v, want medium", f.Severity)
+	}
+}
+
+func TestServiceScopedNamespacesNotFlagged(t *testing.T) {
+	got := findingsFor(t, `services:
+  app:
+    image: myapp
+    pid: "service:db"
+    ipc: "service:db"`)
+	if _, ok := got["compose.ds020"]; ok {
+		t.Error("pid scoped to another service should not be flagged")
+	}
+	if _, ok := got["compose.ds021"]; ok {
+		t.Error("ipc scoped to another service should not be flagged")
+	}
+}
+
+func TestWritableRootFilesystemDetected(t *testing.T) {
+	got := findingsFor(t, `services:
+  app:
+    image: myapp`)
+	f, ok := got["compose.ds022"]
+	if !ok {
+		t.Fatalf("expected compose.ds022 for a service without read_only, got %v", keys(got))
+	}
+	if f.Severity != model.SeverityLow {
+		t.Errorf("ds022 severity = %v, want low", f.Severity)
+	}
+
+	clean := findingsFor(t, `services:
+  app:
+    image: myapp
+    read_only: true`)
+	if _, ok := clean["compose.ds022"]; ok {
+		t.Error("read_only: true should not be flagged")
+	}
+}
+
 func TestInlineSecretDetected(t *testing.T) {
 	got := findingsFor(t, `services:
   db:

--- a/internal/check/compose/container_test.go
+++ b/internal/check/compose/container_test.go
@@ -150,6 +150,45 @@ func TestResolvedEnvironmentIsNotScannedForSecrets(t *testing.T) {
 	}
 }
 
+// The daemon reports namespace modes and the root-filesystem flag directly,
+// so `docker run --pid=host --ipc=host` is as visible as the compose keys —
+// and a `--read-only` container must not be accused of a writable rootfs.
+func TestHostNamespacesAuditedForStandaloneContainers(t *testing.T) {
+	shared := `[{
+	 "Name": "/monitor",
+	 "Config": {"Image": "myapp", "User": "1000", "Labels": {}},
+	 "HostConfig": {
+	   "PidMode": "host",
+	   "IpcMode": "host",
+	   "ReadonlyRootfs": false,
+	   "RestartPolicy": {"Name": "always"}
+	 }
+	}]`
+	fs := check2(t, runRunner{inspect: shared})
+	for _, id := range []string{"compose.ds020", "compose.ds021", "compose.ds022"} {
+		if _, ok := has(fs, id); !ok {
+			t.Errorf("%s not reported for a hand-started container", id)
+		}
+	}
+
+	private := `[{
+	 "Name": "/app",
+	 "Config": {"Image": "myapp", "User": "1000", "Labels": {}},
+	 "HostConfig": {
+	   "PidMode": "private",
+	   "IpcMode": "private",
+	   "ReadonlyRootfs": true,
+	   "RestartPolicy": {"Name": "always"}
+	 }
+	}]`
+	fs = check2(t, runRunner{inspect: private})
+	for _, id := range []string{"compose.ds020", "compose.ds021", "compose.ds022"} {
+		if _, ok := has(fs, id); ok {
+			t.Errorf("%s reported for a container with private namespaces and a read-only rootfs", id)
+		}
+	}
+}
+
 // Losing the ability to enumerate containers is a smaller blind spot than a
 // failed scan, but it is still one: the domain covered compose only and has
 // to say so rather than report a clean result.
@@ -175,6 +214,7 @@ func TestWellConfiguredStandaloneContainerIsClean(t *testing.T) {
 	 "HostConfig": {
 	   "Privileged": false,
 	   "NetworkMode": "bridge",
+	   "ReadonlyRootfs": true,
 	   "SecurityOpt": ["no-new-privileges:true"],
 	   "Binds": ["/srv/app/data:/data:rw"],
 	   "Memory": 536870912,

--- a/internal/compose/inspect.go
+++ b/internal/compose/inspect.go
@@ -69,16 +69,17 @@ type dockerContainer struct {
 		} `json:"Healthcheck"`
 	} `json:"Config"`
 	HostConfig struct {
-		Privileged    bool                `json:"Privileged"`
-		NetworkMode   string              `json:"NetworkMode"`
-		PidMode       string              `json:"PidMode"`
-		IpcMode       string              `json:"IpcMode"`
-		CapAdd        []string            `json:"CapAdd"`
-		SecurityOpt   []string            `json:"SecurityOpt"`
-		Binds         []string            `json:"Binds"`
-		Memory        int64               `json:"Memory"`
-		PortBindings  map[string][]hostIP `json:"PortBindings"`
-		RestartPolicy struct {
+		Privileged     bool                `json:"Privileged"`
+		NetworkMode    string              `json:"NetworkMode"`
+		PidMode        string              `json:"PidMode"`
+		IpcMode        string              `json:"IpcMode"`
+		ReadonlyRootfs bool                `json:"ReadonlyRootfs"`
+		CapAdd         []string            `json:"CapAdd"`
+		SecurityOpt    []string            `json:"SecurityOpt"`
+		Binds          []string            `json:"Binds"`
+		Memory         int64               `json:"Memory"`
+		PortBindings   map[string][]hostIP `json:"PortBindings"`
+		RestartPolicy  struct {
 			Name string `json:"Name"`
 		} `json:"RestartPolicy"`
 	} `json:"HostConfig"`
@@ -120,6 +121,7 @@ func (e dockerContainer) toService(name string) Service {
 		NetworkMode: e.HostConfig.NetworkMode,
 		Pid:         e.HostConfig.PidMode,
 		Ipc:         e.HostConfig.IpcMode,
+		ReadOnly:    e.HostConfig.ReadonlyRootfs,
 		User:        e.Config.User,
 		Restart:     e.HostConfig.RestartPolicy.Name,
 		CapAdd:      e.HostConfig.CapAdd,

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -113,6 +113,9 @@ func TestKnownUnregisteredFindings(t *testing.T) {
 		"compose.ds001":       "removal-shaped: hostveil cannot tell a needless privileged flag from a load-bearing one",
 		"compose.ds005":       "removal-shaped: same, for cap_add",
 		"compose.dr001":       "removing host networking without knowing which ports to publish leaves the service unreachable",
+		"compose.ds020":       "removal-shaped: a monitoring agent legitimately needs the host PID namespace, and hostveil cannot tell that from a cargo-culted one",
+		"compose.ds021":       "removal-shaped: deliberate host-IPC sharing breaks silently when the line is deleted",
+		"compose.ds022":       "read_only: true breaks any image that writes to its own filesystem, and the audit cannot infer the tmpfs mounts that would make it safe",
 		"compose.dr005":       "a two-file change where Action carries one Path, and the real remediation is rotating the leaked secret",
 
 		// Every agent.* config-key finding. OpenClaw's config is JSON5 and

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -116,6 +116,19 @@ package fix
 //     from a load-bearing one. dr001 is the clearest: removing host
 //     networking without knowing which ports to publish in its place
 //     leaves the service unreachable, and the finding does not carry them.
+//   - compose.ds020, compose.ds021 — removal-shaped like the three above:
+//     delete `pid: host`, delete `ipc: host`. Both are settings nobody types
+//     by accident — a monitoring agent needs the host PID namespace, a pair
+//     of processes sharing memory needs the IPC one — and hostveil cannot
+//     tell that deployment from a cargo-culted one. Deleting the line breaks
+//     the legitimate case silently: the service starts fine and stops seeing
+//     what it existed to see.
+//   - compose.ds022 — the one mechanical remediation, `read_only: true`,
+//     breaks any image that writes inside its own filesystem, which is most
+//     of them (/tmp, /run, log directories). Making it work needs tmpfs
+//     mounts for exactly the paths the service writes, and a static audit
+//     cannot learn which paths those are. A fix that takes the service down
+//     to improve the score is worse than no fix.
 //   - compose.dr005 — moving a value into an env_file is a two-file change
 //     where Action carries one Path, and a move that does not delete the
 //     original improves nothing. More to the point, by the time the secret

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -186,11 +186,14 @@
                   <tr><td><code>compose.dr001</code></td><td>Container uses host network mode</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds017</code></td><td>Sensitive host path mounted read-write</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds005</code></td><td>Adds a dangerous Linux capability</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>compose.ds020</code></td><td>Shares the host PID namespace</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.dr005</code></td><td>Hardcoded secret in the environment</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds006</code></td><td>Missing no-new-privileges hardening</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>compose.ds021</code></td><td>Shares the host IPC namespace</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds009</code></td><td>Container runs as root</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.dr002</code></td><td>Port published on all interfaces</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>compose.ds008</code></td><td>No restart policy set</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>compose.ds022</code></td><td>Container filesystem is writable</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.ds010</code></td><td>No memory limit set</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
                   <tr><td><code>compose.ds012</code></td><td>No healthcheck defined</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
                   <tr><td><code>compose.dr004</code></td><td>Loads secrets from an env_file</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -186,11 +186,14 @@
                   <tr><td><code>compose.dr001</code></td><td>컨테이너가 호스트 네트워킹 모드를 사용함</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds017</code></td><td>민감한 호스트 경로가 읽기-쓰기로 마운트됨</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds005</code></td><td>위험한 리눅스 capability를 추가함</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>compose.ds020</code></td><td>호스트 PID 네임스페이스를 공유함</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.dr005</code></td><td>환경 변수에 하드코딩된 비밀값</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds006</code></td><td>no-new-privileges 강화 설정 누락</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>compose.ds021</code></td><td>호스트 IPC 네임스페이스를 공유함</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds009</code></td><td>컨테이너가 root로 실행됨</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
                   <tr><td><code>compose.dr002</code></td><td>포트가 모든 인터페이스에 게시됨</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
                   <tr><td><code>compose.ds008</code></td><td>재시작 정책이 설정되지 않음</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>compose.ds022</code></td><td>컨테이너 파일시스템이 쓰기 가능함</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.ds010</code></td><td>메모리 제한이 설정되지 않음</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
                   <tr><td><code>compose.ds012</code></td><td>헬스체크가 정의되지 않음</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
                   <tr><td><code>compose.dr004</code></td><td>env_file에서 비밀값을 불러옴</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>


### PR DESCRIPTION
Three new compose rules consuming fields the parser already carried:
`ds020` (`pid: host`, High), `ds021` (`ipc: host`, Medium), `ds022` (no
`read_only`, Low). All three are Manual and pinned unfixed — the first two
are removal-shaped, and `read_only: true` breaks images without the tmpfs
mounts a static audit cannot infer.

`docker inspect`'s `ReadonlyRootfs` now maps onto `Service.ReadOnly` so a
`--read-only` container is not accused of a writable rootfs; ds020/ds021
join the runtime rules as-is since PidMode/IpcMode carry "host" verbatim.
`userns_mode` stays unaudited on purpose: it is a no-op without daemon-side
userns-remap, which a file audit cannot see.

Docs rows added in both languages; `TestKnownUnregisteredFindings` pins the
three unfixed decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)