### PR TITLE
feat(check): extend the sshd audit with grace time, gateway ports, host-based and keyboard-interactive auth

### DIFF
--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -81,7 +81,11 @@
                   <tr><td><code>ssh.emptypasswords</code></td><td>Empty passwords are permitted</td><td><span class="sev critical">Critical</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>ssh.rootlogin</code></td><td>Root login with a password is allowed</td><td><span class="sev high">High</span></td><td>Review</td></tr>
                   <tr><td><code>ssh.passwordauth</code></td><td>Password authentication is allowed</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>ssh.gatewayports</code></td><td>Remote-forwarded ports are exposed to the network</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>ssh.hostbasedauth</code></td><td>Host-based authentication is enabled</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>ssh.kbdinteractive</code></td><td>Interactive password prompts survive PasswordAuthentication no</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
                   <tr><td><code>ssh.maxauthtries</code></td><td>Too many auth attempts per connection</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>ssh.logingracetime</code></td><td>Unauthenticated connections are held open too long</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>ssh.x11forwarding</code></td><td>X11 forwarding is enabled</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
                 </tbody>
               </table>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -81,7 +81,11 @@
                   <tr><td><code>ssh.emptypasswords</code></td><td>빈 비밀번호가 허용됨</td><td><span class="sev critical">심각</span></td><td>자동 수정</td></tr>
                   <tr><td><code>ssh.rootlogin</code></td><td>비밀번호를 사용한 root 로그인이 허용됨</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
                   <tr><td><code>ssh.passwordauth</code></td><td>비밀번호 인증이 허용됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>ssh.gatewayports</code></td><td>원격 포워딩 포트가 네트워크에 노출됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>ssh.hostbasedauth</code></td><td>호스트 기반 인증이 활성화됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>ssh.kbdinteractive</code></td><td>PasswordAuthentication no 이후에도 대화형 비밀번호 입력이 살아 있음</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
                   <tr><td><code>ssh.maxauthtries</code></td><td>연결당 인증 시도 횟수가 너무 많음</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>ssh.logingracetime</code></td><td>미인증 연결을 너무 오래 열어 둠</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>ssh.x11forwarding</code></td><td>X11 포워딩이 활성화됨</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
                 </tbody>
               </table>

--- a/internal/check/ssh/ssh.go
+++ b/internal/check/ssh/ssh.go
@@ -295,7 +295,92 @@ func auditConfig(cfg sshdConfig, path string) []model.Finding {
 			configFor(cfg, path, "X11Forwarding")))
 	}
 
+	// sshd's own default is 120 seconds, so this fires on an untouched
+	// config — deliberately, like ssh.passwordauth. The fix is Auto because
+	// shortening the window cannot lock anyone out: it only bounds how long
+	// an unauthenticated connection may sit there. 0 means no limit at all.
+	grace := effective(cfg, "LoginGraceTime", "120")
+	if secs, ok := parseSSHDuration(grace); ok && (secs == 0 || secs > 60) {
+		out = append(out, model.NewFinding("ssh.logingracetime", "SSH keeps unauthenticated connections open too long",
+			model.SeverityLow, model.SourceSSH, model.RemediationAuto,
+			model.WithDescription("LoginGraceTime is how long sshd waits for a connection to authenticate before dropping it. A long (or unlimited) window lets scanning bots hold many half-open connections and gives every brute-force attempt more room."),
+			model.WithHowToFix("Set `LoginGraceTime 60` or lower."),
+			model.WithEvidence("value", grace), configFor(cfg, path, "LoginGraceTime")))
+	}
+
+	if v := effective(cfg, "GatewayPorts", "no"); v == "yes" || v == "clientspecified" {
+		out = append(out, model.NewFinding("ssh.gatewayports", "SSH exposes remote-forwarded ports to the network",
+			model.SeverityMedium, model.SourceSSH, model.RemediationReview,
+			model.WithDescription("With GatewayPorts enabled, a port forwarded with `ssh -R` listens on all interfaces instead of loopback, so anyone who can reach this host can use the tunnel — effectively publishing whatever the tunnel reaches."),
+			model.WithHowToFix("Set `GatewayPorts no` so remote-forwarded ports bind to loopback only. If a tunnel genuinely must be public, front it with a reverse proxy that authenticates."),
+			model.WithEvidence("value", v), configFor(cfg, path, "GatewayPorts")))
+	}
+
+	if effective(cfg, "HostbasedAuthentication", "no") == "yes" {
+		out = append(out, model.NewFinding("ssh.hostbasedauth", "SSH trusts other hosts' identities for login",
+			model.SeverityMedium, model.SourceSSH, model.RemediationReview,
+			model.WithDescription("Host-based authentication lets users log in because of which machine they connect from, without any per-user credential. Compromising one trusted host then opens this one."),
+			model.WithHowToFix("Set `HostbasedAuthentication no` and use per-user SSH keys instead."),
+			configFor(cfg, path, "HostbasedAuthentication")))
+	}
+
+	// The contradiction case only: PasswordAuthentication no is meant to end
+	// password guessing, but keyboard-interactive runs the same PAM password
+	// prompt through a different door. KbdInteractiveAuthentication defaults
+	// to yes, and ChallengeResponseAuthentication is its pre-8.7 alias — an
+	// operator who disabled either one has already closed the door.
+	kbdKey := "KbdInteractiveAuthentication"
+	kbd := effective(cfg, kbdKey, "")
+	if kbd == "" {
+		if v := effective(cfg, "ChallengeResponseAuthentication", ""); v != "" {
+			kbdKey = "ChallengeResponseAuthentication"
+			kbd = v
+		} else {
+			kbd = "yes"
+		}
+	}
+	if kbd == "yes" && effective(cfg, "PasswordAuthentication", "yes") == "no" {
+		out = append(out, model.NewFinding("ssh.kbdinteractive", "SSH still accepts interactive password prompts",
+			model.SeverityMedium, model.SourceSSH, model.RemediationReview,
+			model.WithDescription("PasswordAuthentication is off, but keyboard-interactive authentication is still on — and on most systems it asks PAM for the very same password. The brute-force protection you configured is not actually in force."),
+			model.WithHowToFix("Set `KbdInteractiveAuthentication no`. Careful: PAM-based one-time codes (2FA prompts) also use this mechanism, so keep it if your logins go through one."),
+			model.WithEvidence("directive", kbdKey), configFor(cfg, path, kbdKey)))
+	}
+
 	return out
+}
+
+// parseSSHDuration parses sshd's time format: a bare number is seconds, and
+// qualified values chain quantity[unit] pairs ("90", "2m", "1h30m"). It
+// returns false for anything else, and a false parse produces no finding —
+// sshd -t is the authority on validity, not this checker.
+func parseSSHDuration(s string) (seconds int, ok bool) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return 0, false
+	}
+	total, num, haveDigits := 0, 0, false
+	for i := range len(s) {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9':
+			num = num*10 + int(c-'0')
+			haveDigits = true
+		case c == 's' || c == 'm' || c == 'h' || c == 'd' || c == 'w':
+			if !haveDigits {
+				return 0, false
+			}
+			mult := map[byte]int{'s': 1, 'm': 60, 'h': 3600, 'd': 86400, 'w': 604800}[c]
+			total += num * mult
+			num, haveDigits = 0, false
+		default:
+			return 0, false
+		}
+	}
+	if haveDigits {
+		total += num
+	}
+	return total, true
 }
 
 func atoiDefault(s string, def int) int {

--- a/internal/check/ssh/ssh_test.go
+++ b/internal/check/ssh/ssh_test.go
@@ -74,12 +74,98 @@ X11Forwarding yes
 func TestSSHHardenedConfigIsClean(t *testing.T) {
 	cfg := `PermitRootLogin prohibit-password
 PasswordAuthentication no
+KbdInteractiveAuthentication no
 PermitEmptyPasswords no
 MaxAuthTries 3
+LoginGraceTime 30
 `
 	got := auditConfig(parseConfig([]byte(cfg)), "x")
 	if len(got) != 0 {
 		t.Errorf("hardened config produced findings: %v", got)
+	}
+}
+
+func TestGraceTimeGatewayAndHostbasedRules(t *testing.T) {
+	cfg := `LoginGraceTime 2m
+GatewayPorts clientspecified
+HostbasedAuthentication yes
+`
+	got := idsOf(auditConfig(parseConfig([]byte(cfg)), "x"))
+	for _, want := range []string{"ssh.logingracetime", "ssh.gatewayports", "ssh.hostbasedauth"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("expected %s, got %v", want, got)
+		}
+	}
+	if got["ssh.logingracetime"].Evidence["value"] != "2m" {
+		t.Errorf("grace-time evidence = %q, want the configured value", got["ssh.logingracetime"].Evidence["value"])
+	}
+}
+
+func TestUnlimitedGraceTimeIsFlagged(t *testing.T) {
+	got := idsOf(auditConfig(parseConfig([]byte("LoginGraceTime 0\n")), "x"))
+	if _, ok := got["ssh.logingracetime"]; !ok {
+		t.Error("LoginGraceTime 0 means no limit and must be flagged")
+	}
+}
+
+// The finding exists for the contradiction only: an operator who left
+// PasswordAuthentication on has not been misled about what is in force.
+func TestKbdInteractiveFlaggedOnlyWhenPasswordsAreOff(t *testing.T) {
+	got := idsOf(auditConfig(parseConfig([]byte("PasswordAuthentication no\n")), "x"))
+	f, ok := got["ssh.kbdinteractive"]
+	if !ok {
+		t.Fatal("default KbdInteractiveAuthentication (yes) with PasswordAuthentication no should be flagged")
+	}
+	if f.Evidence["directive"] != "KbdInteractiveAuthentication" {
+		t.Errorf("directive evidence = %q, want the modern keyword", f.Evidence["directive"])
+	}
+
+	got = idsOf(auditConfig(parseConfig([]byte("PasswordAuthentication yes\n")), "x"))
+	if _, ok := got["ssh.kbdinteractive"]; ok {
+		t.Error("with passwords still allowed there is no contradiction to report")
+	}
+}
+
+// ChallengeResponseAuthentication is the pre-8.7 alias for the same option,
+// and sshd keeps the first value it sees for either keyword. The finding
+// must respect an alias-based opt-out, and when the alias is the keyword in
+// force, name it so the fix edits the directive that actually wins.
+func TestChallengeResponseAliasIsRespected(t *testing.T) {
+	got := idsOf(auditConfig(parseConfig([]byte("PasswordAuthentication no\nChallengeResponseAuthentication no\n")), "x"))
+	if _, ok := got["ssh.kbdinteractive"]; ok {
+		t.Error("disabling the old alias closes the same door; nothing to report")
+	}
+
+	got = idsOf(auditConfig(parseConfig([]byte("PasswordAuthentication no\nChallengeResponseAuthentication yes\n")), "x"))
+	f, ok := got["ssh.kbdinteractive"]
+	if !ok {
+		t.Fatal("an explicit yes through the alias should be flagged")
+	}
+	if f.Evidence["directive"] != "ChallengeResponseAuthentication" {
+		t.Errorf("directive evidence = %q, want the alias in force", f.Evidence["directive"])
+	}
+}
+
+func TestParseSSHDuration(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"120", 120, true},
+		{"2m", 120, true},
+		{"1h30m", 5400, true},
+		{"90s", 90, true},
+		{"0", 0, true},
+		{"", 0, false},
+		{"none", 0, false},
+		{"m5", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := parseSSHDuration(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("parseSSHDuration(%q) = (%d, %v), want (%d, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
 	}
 }
 

--- a/internal/fix/ssh.go
+++ b/internal/fix/ssh.go
@@ -14,6 +14,37 @@ func registerSSH(r *Registry) {
 	r.Register("ssh.passwordauth", buildSSHAuto("PasswordAuthentication", "no", "Disable password authentication",
 		"Make sure key-based login works BEFORE applying this, or you may lock yourself out of SSH."))
 	r.Register("ssh.rootlogin", buildRootLogin)
+	r.Register("ssh.logingracetime", buildSSHAuto("LoginGraceTime", "60", "Lower LoginGraceTime to 60 seconds", ""))
+	r.Register("ssh.gatewayports", buildSSHAuto("GatewayPorts", "no", "Bind remote-forwarded ports to loopback only",
+		"If you rely on `ssh -R` tunnels being reachable from other machines, this closes them to loopback."))
+	r.Register("ssh.hostbasedauth", buildSSHAuto("HostbasedAuthentication", "no", "Disable host-based authentication",
+		"If any user logs in via host-based trust rather than their own key, this removes that path."))
+	r.Register("ssh.kbdinteractive", buildKbdInteractive)
+}
+
+// buildKbdInteractive disables keyboard-interactive authentication by
+// setting whichever keyword is actually in force. The checker records it in
+// the finding: sshd treats ChallengeResponseAuthentication as an alias for
+// KbdInteractiveAuthentication and keeps the first value it sees for either,
+// so writing the modern keyword into a file where the old alias already
+// appears earlier would change nothing while claiming to have fixed it.
+func buildKbdInteractive(f model.Finding) (Fix, error) {
+	path, err := sshConfigPath(f)
+	if err != nil {
+		return Fix{}, err
+	}
+	key := f.Evidence["directive"]
+	if key == "" {
+		key = "KbdInteractiveAuthentication"
+	}
+	label := "Disable keyboard-interactive authentication"
+	return Fix{
+		Label: label,
+		Kind:  model.RemediationAuto,
+		Actions: []Action{sshEdit(path, label,
+			"PAM-based one-time codes (2FA prompts) also use this mechanism — keep it enabled if your logins go through one.",
+			key, "no")},
+	}, nil
 }
 
 func sshConfigPath(f model.Finding) (string, error) {

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -167,7 +167,11 @@
                   <tr><td><code>ssh.emptypasswords</code></td><td>Empty passwords are permitted</td><td><span class="sev critical">Critical</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>ssh.rootlogin</code></td><td>Root login with a password is allowed</td><td><span class="sev high">High</span></td><td>Review</td></tr>
                   <tr><td><code>ssh.passwordauth</code></td><td>Password authentication is allowed</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>ssh.gatewayports</code></td><td>Remote-forwarded ports are exposed to the network</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>ssh.hostbasedauth</code></td><td>Host-based authentication is enabled</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>ssh.kbdinteractive</code></td><td>Interactive password prompts survive PasswordAuthentication no</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
                   <tr><td><code>ssh.maxauthtries</code></td><td>Too many auth attempts per connection</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>ssh.logingracetime</code></td><td>Unauthenticated connections are held open too long</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>ssh.x11forwarding</code></td><td>X11 forwarding is enabled</td><td><span class="sev low">Low</span></td><td>Auto-fix</td></tr>
                 </tbody>
               </table>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -167,7 +167,11 @@
                   <tr><td><code>ssh.emptypasswords</code></td><td>빈 비밀번호가 허용됨</td><td><span class="sev critical">심각</span></td><td>자동 수정</td></tr>
                   <tr><td><code>ssh.rootlogin</code></td><td>비밀번호를 사용한 root 로그인이 허용됨</td><td><span class="sev high">높음</span></td><td>검토</td></tr>
                   <tr><td><code>ssh.passwordauth</code></td><td>비밀번호 인증이 허용됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>ssh.gatewayports</code></td><td>원격 포워딩 포트가 네트워크에 노출됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>ssh.hostbasedauth</code></td><td>호스트 기반 인증이 활성화됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>ssh.kbdinteractive</code></td><td>PasswordAuthentication no 이후에도 대화형 비밀번호 입력이 살아 있음</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
                   <tr><td><code>ssh.maxauthtries</code></td><td>연결당 인증 시도 횟수가 너무 많음</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>ssh.logingracetime</code></td><td>미인증 연결을 너무 오래 열어 둠</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>ssh.x11forwarding</code></td><td>X11 포워딩이 활성화됨</td><td><span class="sev low">낮음</span></td><td>자동 수정</td></tr>
                 </tbody>
               </table>


### PR DESCRIPTION
Four new sshd directives audited through the existing first-value-wins
parser, each with a registered fix carrying `sshd -t` verification:

- `ssh.logingracetime` (Low, Auto): LoginGraceTime above 60s or 0 (no
  limit). Fires on sshd's own 120s default on purpose, like
  `ssh.passwordauth` — shortening the window cannot lock anyone out.
- `ssh.gatewayports` (Medium, Review): remote-forwarded ports listening
  on all interfaces instead of loopback.
- `ssh.hostbasedauth` (Medium, Review): machine-trust logins with no
  per-user credential.
- `ssh.kbdinteractive` (Medium, Review): fires only on the contradiction
  — `PasswordAuthentication no` while keyboard-interactive still runs the
  same PAM password prompt. Respects the pre-8.7
  `ChallengeResponseAuthentication` alias in both directions: an
  alias-based opt-out silences it, and when the alias is the keyword in
  force the fix edits that keyword, since sshd keeps the first value it
  sees for either.

Deliberately not audited, with reasons recorded in the commit:
`AllowTcpForwarding` (hostveil's own remediation text tells users to
reach admin panels over SSH tunnels), `AllowAgentForwarding` (defaults
to yes with routine legitimate use), `ClientAlive*` (weak signal), and
cipher/MAC/kex lists (distro crypto-policy territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)