### PR TITLE
feat(check): recognize Webmin and Proxmox in the exposed-admin-port table

### DIFF
--- a/internal/check/ports/ports.go
+++ b/internal/check/ports/ports.go
@@ -56,9 +56,15 @@ var datastorePorts = map[int]string{
 }
 
 // adminPorts maps well-known admin/management-UI ports to a human name.
+// Only single-purpose admin UIs whose default port is unambiguous belong
+// here — Cockpit's 9090 is absent because Prometheus claims the same port,
+// and a finding titled with the wrong product half the time teaches the
+// user to ignore the whole domain.
 var adminPorts = map[int]string{
-	9000: "Portainer",
-	9443: "Portainer (HTTPS)",
+	9000:  "Portainer",
+	9443:  "Portainer (HTTPS)",
+	10000: "Webmin",
+	8006:  "Proxmox VE",
 }
 
 // Check reads listening TCP sockets and flags non-loopback exposure.

--- a/internal/check/ports/ports_test.go
+++ b/internal/check/ports/ports_test.go
@@ -144,6 +144,24 @@ func TestAdminPanelFlagged(t *testing.T) {
 	}
 }
 
+func TestWebminAndProxmoxRecognizedAsAdminPanels(t *testing.T) {
+	ss := `LISTEN 0 128 0.0.0.0:10000 0.0.0.0:* users:(("miniserv",pid=42,fd=3))
+LISTEN 0 128 0.0.0.0:8006 0.0.0.0:* users:(("pveproxy",pid=43,fd=3))`
+	fs, err := New().Check(context.Background(), platform.Env{Runner: fakeRunner{ss: ss}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var admins int
+	for _, f := range fs {
+		if f.ID == "ports.exposed-admin" {
+			admins++
+		}
+	}
+	if admins != 2 {
+		t.Fatalf("expected 2 admin-panel findings (Webmin, Proxmox), got %d: %v", admins, fs)
+	}
+}
+
 func TestGenericExposedOnlyWithoutFirewall(t *testing.T) {
 	ss := `LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:(("sshd",pid=1,fd=3))
 LISTEN 0 128 0.0.0.0:8080 0.0.0.0:* users:(("myapp",pid=7,fd=3))`


### PR DESCRIPTION
Two additions with unambiguous default ports and real self-hosting
install bases: Webmin on 10000 and Proxmox VE on 8006. Cockpit's 9090
is deliberately absent — Prometheus claims the same port, and an admin
finding titled with the wrong product half the time teaches the user to
distrust the domain.

No new finding IDs, so no docs or fix-registry changes — table and
tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)