### PR TITLE
feat(check): add a kernel/sysctl hardening domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ The central rule: **one engine, three thin UIs.** `internal/core.Engine` owns al
 
 This is enforced structurally: `internal/ui/tui/layering_test.go` and `internal/ui/web/layering_test.go` parse imports and fail if production UI code imports `internal/fix`, `internal/history`, `internal/check`, or `internal/compose`. UIs may import only `core` and `model`. (v2's duplicated-fix-logic failure is what these tests exist to prevent.)
 
-Flow: `cmd/hostveil/app.go` builds the one engine (all nine checkers + `fix.Default()`) → `Engine.Scan` detects `platform.Env`, runs the checker registry concurrently, validates and classifies findings, scores, diffs against the last saved scan, persists.
+Flow: `cmd/hostveil/app.go` builds the one engine (all ten checkers + `fix.Default()`) → `Engine.Scan` detects `platform.Env`, runs the checker registry concurrently, validates and classifies findings, scores, diffs against the last saved scan, persists.
 
 ### Key seams
 

--- a/cmd/hostveil/app.go
+++ b/cmd/hostveil/app.go
@@ -13,6 +13,7 @@ import (
 	firewallcheck "github.com/seolcu/hostveil/internal/check/firewall"
 	portscheck "github.com/seolcu/hostveil/internal/check/ports"
 	sshcheck "github.com/seolcu/hostveil/internal/check/ssh"
+	sysctlcheck "github.com/seolcu/hostveil/internal/check/sysctl"
 	updatescheck "github.com/seolcu/hostveil/internal/check/updates"
 	"github.com/seolcu/hostveil/internal/core"
 	"github.com/seolcu/hostveil/internal/fix"
@@ -38,6 +39,7 @@ func buildEngineWithAI(useAI bool) *core.Engine {
 			accountscheck.New(),
 			filepermscheck.New(),
 			agentcheck.New(),
+			sysctlcheck.New(),
 		),
 		Fixes:  fix.Default(),
 		Runner: debugRunner(),

--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -43,15 +43,16 @@
               <table>
                 <thead><tr><th>Axis</th><th>Weight</th></tr></thead>
                 <tbody>
-                  <tr><td>Container exposure</td><td>18</td></tr>
-                  <tr><td>SSH hardening</td><td>17</td></tr>
-                  <tr><td>Vulnerabilities</td><td>13</td></tr>
-                  <tr><td>Host firewall</td><td>12</td></tr>
+                  <tr><td>Container exposure</td><td>17</td></tr>
+                  <tr><td>SSH hardening</td><td>16</td></tr>
+                  <tr><td>Vulnerabilities</td><td>12</td></tr>
+                  <tr><td>Host firewall</td><td>11</td></tr>
                   <tr><td>Exposed services</td><td>10</td></tr>
                   <tr><td>AI agent runtimes</td><td>10</td></tr>
-                  <tr><td>Account hygiene</td><td>8</td></tr>
+                  <tr><td>Account hygiene</td><td>7</td></tr>
                   <tr><td>Auto-updates</td><td>7</td></tr>
                   <tr><td>File permissions</td><td>5</td></tr>
+                  <tr><td>Kernel hardening</td><td>5</td></tr>
                 </tbody>
               </table>
             </div>
@@ -178,6 +179,25 @@
                   <tr><td><code>fileperms.group</code></td><td><code>/etc/group</code> is writable by non-root users</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>fileperms.hostkey</code></td><td>An SSH host private key is readable beyond root</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>fileperms.sshd-config</code></td><td><code>sshd_config</code> is writable by non-root users</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="sysctl">Kernel hardening <code>sysctl.</code></h2>
+            <p>Read directly from <code>/proc/sys</code> — no <code>sysctl</code> binary needed. These are the quiet knobs whose safe value is the same on essentially every server: none of them is the hole an attacker comes in through, each is what stops a foothold from becoming root or a spoofed packet from becoming a route. A parameter this kernel does not have (Yama not built in, say) is simply skipped.</p>
+            <p>Every finding here is Manual for now: making a value stick means creating an <code>/etc/sysctl.d</code> drop-in that does not exist yet, and applying it live takes <code>sysctl --system</code> — so each finding carries the exact line and the exact command instead of a button. <code>net.ipv4.ip_forward</code> is deliberately not audited: Docker, WireGuard, Tailscale exit nodes, and virtualization hosts all legitimately enable it, and hostveil cannot tell those apart from an accident.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>sysctl.ptrace-scope</code></td><td>Any process can debug its siblings and read their memory</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN-flood protection is off</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP redirects can rewrite this host's routing</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.protected-links</code></td><td>Symlink/hardlink race protections are disabled</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.kptr-restrict</code></td><td>Kernel pointer addresses are visible to all users</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>Any user can read the kernel log</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq is fully enabled</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.rp-filter</code></td><td>Source-address spoofing filter is off (strict and loose both pass)</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
                 </tbody>
               </table>
             </div>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -43,15 +43,16 @@
               <table>
                 <thead><tr><th>축</th><th>가중치</th></tr></thead>
                 <tbody>
-                  <tr><td>컨테이너 노출</td><td>18</td></tr>
-                  <tr><td>SSH 하드닝</td><td>17</td></tr>
-                  <tr><td>취약점</td><td>13</td></tr>
-                  <tr><td>호스트 방화벽</td><td>12</td></tr>
+                  <tr><td>컨테이너 노출</td><td>17</td></tr>
+                  <tr><td>SSH 하드닝</td><td>16</td></tr>
+                  <tr><td>취약점</td><td>12</td></tr>
+                  <tr><td>호스트 방화벽</td><td>11</td></tr>
                   <tr><td>노출된 서비스</td><td>10</td></tr>
                   <tr><td>AI 에이전트 런타임</td><td>10</td></tr>
-                  <tr><td>계정 위생</td><td>8</td></tr>
+                  <tr><td>계정 위생</td><td>7</td></tr>
                   <tr><td>자동 업데이트</td><td>7</td></tr>
                   <tr><td>파일 권한</td><td>5</td></tr>
+                  <tr><td>커널 하드닝</td><td>5</td></tr>
                 </tbody>
               </table>
             </div>
@@ -178,6 +179,25 @@
                   <tr><td><code>fileperms.group</code></td><td><code>/etc/group</code>이 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>fileperms.hostkey</code></td><td>SSH 호스트 개인 키를 root 외 사용자가 읽을 수 있음</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>fileperms.sshd-config</code></td><td><code>sshd_config</code>가 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="sysctl">커널 하드닝 <code>sysctl.</code></h2>
+            <p><code>/proc/sys</code>에서 직접 읽습니다 — <code>sysctl</code> 바이너리가 필요 없습니다. 이 항목들은 사실상 모든 서버에서 안전한 값이 같은 조용한 손잡이들입니다. 공격자가 들어오는 구멍은 아니지만, 각각은 발판이 root가 되는 것과 위조된 패킷이 경로가 되는 것을 막아 줍니다. 이 커널에 없는 파라미터(예: Yama가 빌드되지 않은 경우)는 그냥 건너뜁니다.</p>
+            <p>여기의 모든 발견 항목은 지금은 수동입니다. 값을 유지하려면 아직 존재하지 않는 <code>/etc/sysctl.d</code> 드롭인 파일을 만들어야 하고, 즉시 적용하려면 <code>sysctl --system</code>이 필요합니다 — 그래서 버튼 대신 정확한 설정 줄과 명령을 발견 항목이 직접 알려줍니다. <code>net.ipv4.ip_forward</code>는 의도적으로 점검하지 않습니다. Docker, WireGuard, Tailscale 종료 노드, 가상화 호스트가 모두 정당하게 켜는 값이고, hostveil은 그것을 실수와 구별할 수 없습니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>sysctl.ptrace-scope</code></td><td>아무 프로세스나 형제 프로세스를 디버깅해 메모리를 읽을 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN 플러드 보호가 꺼져 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP 리다이렉트가 이 호스트의 라우팅을 바꿀 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.protected-links</code></td><td>심볼릭/하드 링크 경쟁 보호가 비활성화됨</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.kptr-restrict</code></td><td>커널 포인터 주소가 모든 사용자에게 보임</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>아무 사용자나 커널 로그를 읽을 수 있음</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq가 전부 활성화됨</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.rp-filter</code></td><td>출발지 주소 위조 필터가 꺼져 있음 (strict와 loose 모두 통과)</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
                 </tbody>
               </table>
             </div>

--- a/internal/check/sysctl/sysctl.go
+++ b/internal/check/sysctl/sysctl.go
@@ -1,0 +1,242 @@
+// Package sysctl implements a kernel-hardening checker over the runtime
+// values in /proc/sys. It audits a small, defensible set of parameters
+// whose safe value is the same on essentially every self-hosted server —
+// the quiet knobs that stop a local foothold from becoming root and a
+// spoofed packet from becoming a route.
+//
+// net.ipv4.ip_forward is deliberately not audited. Docker, WireGuard,
+// Tailscale exit nodes, libvirt, LXD, and Kubernetes all legitimately
+// enable it, none of that is detectable from here, and a rule that accuses
+// most self-hosters' routers erodes trust in the whole domain.
+package sysctl
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// Rule audits one kernel parameter (or a small set that shares one
+// remediation). Flagged decides from the values that exist on this kernel;
+// a key whose /proc/sys file is absent simply is not in the map — the knob
+// does not exist on this kernel, so there is nothing to harden.
+type Rule struct {
+	ID      string
+	Title   string
+	Sev     model.Severity
+	Desc    string
+	Keys    []string // dotted sysctl names, e.g. "kernel.kptr_restrict"
+	Want    string   // the sysctl.d line(s) the how-to-fix recommends
+	Flagged func(vals map[string]int64) bool
+}
+
+// Checker reports weak kernel-parameter values.
+type Checker struct {
+	// Root is the /proc/sys mount to read; overridable for tests.
+	Root string
+	// Rules is the parameter set to audit; overridable for tests.
+	Rules []Rule
+}
+
+// New returns a sysctl checker with the default rule set.
+func New() *Checker { return &Checker{Root: "/proc/sys", Rules: defaultRules()} }
+
+func defaultRules() []Rule {
+	return []Rule{
+		{
+			ID: "sysctl.ptrace-scope", Title: "Any process can debug its siblings",
+			Sev:  model.SeverityMedium,
+			Desc: "kernel.yama.ptrace_scope is 0, so every process can attach a debugger to any other process of the same user and read its memory — including the session tokens inside a running agent, browser, or password manager. Setting it to 1 limits attaching to direct children.",
+			Keys: []string{"kernel.yama.ptrace_scope"},
+			Want: "kernel.yama.ptrace_scope = 1",
+			Flagged: func(v map[string]int64) bool {
+				val, ok := v["kernel.yama.ptrace_scope"]
+				return ok && val == 0
+			},
+		},
+		{
+			ID: "sysctl.syncookies", Title: "TCP SYN-flood protection is off",
+			Sev:  model.SeverityMedium,
+			Desc: "net.ipv4.tcp_syncookies lets listening services survive a SYN-flood denial of service. It costs nothing in normal operation and only activates under attack, which is why every mainstream distribution ships it on.",
+			Keys: []string{"net.ipv4.tcp_syncookies"},
+			Want: "net.ipv4.tcp_syncookies = 1",
+			Flagged: func(v map[string]int64) bool {
+				val, ok := v["net.ipv4.tcp_syncookies"]
+				return ok && val != 1
+			},
+		},
+		{
+			ID: "sysctl.accept-redirects", Title: "ICMP redirects are accepted",
+			Sev:  model.SeverityMedium,
+			Desc: "Accepting ICMP redirect messages lets a machine on the same network rewrite this host's routing decisions — a classic man-in-the-middle primitive. A server has no use for them.",
+			Keys: []string{"net.ipv4.conf.all.accept_redirects"},
+			Want: "net.ipv4.conf.all.accept_redirects = 0 (and net.ipv6.conf.all.accept_redirects = 0)",
+			Flagged: func(v map[string]int64) bool {
+				val, ok := v["net.ipv4.conf.all.accept_redirects"]
+				return ok && val != 0
+			},
+		},
+		{
+			ID: "sysctl.protected-links", Title: "Symlink and hardlink protections are disabled",
+			Sev:  model.SeverityMedium,
+			Desc: "fs.protected_symlinks and fs.protected_hardlinks close a family of /tmp link races that local attackers use to trick privileged processes into overwriting files of the attacker's choosing. Every mainstream distribution ships both enabled.",
+			Keys: []string{"fs.protected_symlinks", "fs.protected_hardlinks"},
+			Want: "fs.protected_symlinks = 1 and fs.protected_hardlinks = 1",
+			Flagged: func(v map[string]int64) bool {
+				for _, k := range []string{"fs.protected_symlinks", "fs.protected_hardlinks"} {
+					if val, ok := v[k]; ok && val == 0 {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			ID: "sysctl.kptr-restrict", Title: "Kernel pointer addresses are visible to all users",
+			Sev:  model.SeverityLow,
+			Desc: "With kernel.kptr_restrict at 0, /proc exposes raw kernel pointers to any local user. Those addresses defeat kernel address-space randomization, handing a local exploit the memory layout it needs.",
+			Keys: []string{"kernel.kptr_restrict"},
+			Want: "kernel.kptr_restrict = 1",
+			Flagged: func(v map[string]int64) bool {
+				val, ok := v["kernel.kptr_restrict"]
+				return ok && val < 1
+			},
+		},
+		{
+			ID: "sysctl.dmesg-restrict", Title: "Any user can read the kernel log",
+			Sev:  model.SeverityLow,
+			Desc: "The kernel log leaks addresses, hardware details, and stack traces that make local privilege-escalation exploits easier to build. With kernel.dmesg_restrict at 0, every account can read it.",
+			Keys: []string{"kernel.dmesg_restrict"},
+			Want: "kernel.dmesg_restrict = 1",
+			Flagged: func(v map[string]int64) bool {
+				val, ok := v["kernel.dmesg_restrict"]
+				return ok && val != 1
+			},
+		},
+		{
+			ID: "sysctl.sysrq", Title: "Magic SysRq is fully enabled",
+			Sev:  model.SeverityLow,
+			Desc: "kernel.sysrq = 1 enables every SysRq function, letting anyone with console, serial, or IPMI access kill processes, remount filesystems, or crash the machine with a keystroke. Distributions default to 0 or a restricted bitmask for a reason.",
+			Keys: []string{"kernel.sysrq"},
+			Want: "kernel.sysrq = 0 (or a restricted bitmask such as 176)",
+			// Only the fully-enabled value is flagged: anything else is
+			// either off or a deliberate restricted mask.
+			Flagged: func(v map[string]int64) bool {
+				val, ok := v["kernel.sysrq"]
+				return ok && val == 1
+			},
+		},
+		{
+			ID: "sysctl.rp-filter", Title: "Source-address spoofing filter is off",
+			Sev:  model.SeverityLow,
+			Desc: "Reverse-path filtering drops packets whose source address could not be reached back through the interface they arrived on — cheap protection against spoofed traffic. Strict (1) and loose (2) both count; loose is the right setting for VPN and multi-homed hosts.",
+			Keys: []string{"net.ipv4.conf.all.rp_filter"},
+			Want: "net.ipv4.conf.all.rp_filter = 1 (or 2 on VPN/multi-homed hosts)",
+			Flagged: func(v map[string]int64) bool {
+				val, ok := v["net.ipv4.conf.all.rp_filter"]
+				return ok && val == 0
+			},
+		},
+	}
+}
+
+// Source identifies the sysctl domain.
+func (*Checker) Source() model.Source { return model.SourceSysctl }
+
+// Available requires a readable /proc/sys. Its absence (non-Linux test
+// environments, heavily sandboxed containers) is a clean skip: there are no
+// kernel parameters to audit, not an error to report.
+func (c *Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
+	fi, err := os.Stat(filepath.Join(c.Root, "kernel"))
+	if err != nil || !fi.IsDir() {
+		return false, "/proc/sys is not readable — kernel parameters cannot be audited"
+	}
+	return true, ""
+}
+
+// Check reads each rule's parameters and flags weak values. A parameter
+// whose file does not exist is a knob this kernel does not have (Yama not
+// built, IPv4 disabled) and is silently fine; one that exists but cannot be
+// read is ground not covered, and the domain says so with a PartialError
+// rather than letting "could not look" pass for "nothing there".
+func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, error) {
+	var findings []model.Finding
+	var unreadable []string
+	covered := 0
+	for _, r := range c.Rules {
+		vals := map[string]int64{}
+		failed := false
+		for _, key := range r.Keys {
+			v, err := c.readKey(key)
+			switch {
+			case err == nil:
+				vals[key] = v
+			case os.IsNotExist(err):
+				// absent knob — nothing to audit
+			default:
+				unreadable = append(unreadable, key)
+				failed = true
+			}
+		}
+		if failed {
+			continue
+		}
+		covered++
+		if !r.Flagged(vals) {
+			continue
+		}
+		findings = append(findings, model.NewFinding(r.ID, r.Title, r.Sev,
+			model.SourceSysctl, model.RemediationManual,
+			model.WithDescription(r.Desc),
+			model.WithHowToFix(fmt.Sprintf("Add `%s` to a file under /etc/sysctl.d (e.g. 99-hardening.conf), then run `sysctl --system` to apply it without a reboot.", r.Want)),
+			model.WithEvidence("value", evidenceFor(r.Keys, vals)),
+		))
+	}
+	if len(unreadable) > 0 {
+		return findings, &check.PartialError{
+			Reason:  "cannot read " + strings.Join(unreadable, ", ") + " — those kernel parameters were not audited",
+			Covered: covered,
+			Total:   len(c.Rules),
+		}
+	}
+	return findings, nil
+}
+
+// readKey reads one dotted sysctl key from Root and parses its first field
+// as an integer. All audited parameters are single integers; anything else
+// is treated as unreadable rather than guessed at.
+func (c *Checker) readKey(key string) (int64, error) {
+	path := filepath.Join(c.Root, strings.ReplaceAll(key, ".", "/"))
+	data, err := os.ReadFile(path) //nolint:gosec // paths are the fixed rule table under /proc/sys
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("%s: empty value", key)
+	}
+	n, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", key, err)
+	}
+	return n, nil
+}
+
+// evidenceFor renders the observed values in rule-key order, so evidence is
+// stable across scans and a repeat scan produces no delta nobody caused.
+func evidenceFor(keys []string, vals map[string]int64) string {
+	var parts []string
+	for _, k := range keys {
+		if v, ok := vals[k]; ok {
+			parts = append(parts, fmt.Sprintf("%s=%d", k, v))
+		}
+	}
+	return strings.Join(parts, model.EvidenceSeparator)
+}

--- a/internal/check/sysctl/sysctl_test.go
+++ b/internal/check/sysctl/sysctl_test.go
@@ -1,0 +1,173 @@
+package sysctl
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// writeKeys lays out a fake /proc/sys under a temp dir.
+func writeKeys(t *testing.T, keys map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for key, val := range keys {
+		path := filepath.Join(root, strings.ReplaceAll(key, ".", "/"))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(val+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func checkerFor(root string) *Checker {
+	c := New()
+	c.Root = root
+	return c
+}
+
+func idsOf(fs []model.Finding) map[string]model.Finding {
+	m := map[string]model.Finding{}
+	for _, f := range fs {
+		m[f.ID] = f
+	}
+	return m
+}
+
+// weakHost is every audited parameter at its weak value.
+var weakHost = map[string]string{
+	"kernel.kptr_restrict":               "0",
+	"kernel.dmesg_restrict":              "0",
+	"kernel.sysrq":                       "1",
+	"kernel.yama.ptrace_scope":           "0",
+	"net.ipv4.tcp_syncookies":            "0",
+	"net.ipv4.conf.all.accept_redirects": "1",
+	"net.ipv4.conf.all.rp_filter":        "0",
+	"fs.protected_symlinks":              "0",
+	"fs.protected_hardlinks":             "1",
+}
+
+func TestWeakValuesAreFlagged(t *testing.T) {
+	fs, err := checkerFor(writeKeys(t, weakHost)).Check(context.Background(), platform.Env{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := idsOf(fs)
+	for _, want := range []string{
+		"sysctl.kptr-restrict", "sysctl.dmesg-restrict", "sysctl.sysrq",
+		"sysctl.ptrace-scope", "sysctl.syncookies", "sysctl.accept-redirects",
+		"sysctl.rp-filter", "sysctl.protected-links",
+	} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("expected %s, got %v", want, fs)
+		}
+	}
+	for _, f := range fs {
+		if err := f.Validate(); err != nil {
+			t.Errorf("%s: invalid finding: %v", f.ID, err)
+		}
+		if f.Remediation != model.RemediationManual {
+			t.Errorf("%s: remediation = %v, want Manual", f.ID, f.Remediation)
+		}
+		if !strings.Contains(f.HowToFix, "/etc/sysctl.d") || !strings.Contains(f.HowToFix, "sysctl --system") {
+			t.Errorf("%s: how-to-fix must carry the drop-in path and apply command: %q", f.ID, f.HowToFix)
+		}
+	}
+	if ev := got["sysctl.protected-links"].Evidence["value"]; !strings.Contains(ev, "fs.protected_symlinks=0") {
+		t.Errorf("protected-links evidence should name the weak key, got %q", ev)
+	}
+}
+
+func TestHardenedHostIsClean(t *testing.T) {
+	fs, err := checkerFor(writeKeys(t, map[string]string{
+		"kernel.kptr_restrict":               "1",
+		"kernel.dmesg_restrict":              "1",
+		"kernel.sysrq":                       "176", // restricted bitmask, not fully enabled
+		"kernel.yama.ptrace_scope":           "1",
+		"net.ipv4.tcp_syncookies":            "1",
+		"net.ipv4.conf.all.accept_redirects": "0",
+		"net.ipv4.conf.all.rp_filter":        "2", // loose counts too
+		"fs.protected_symlinks":              "1",
+		"fs.protected_hardlinks":             "1",
+	})).Check(context.Background(), platform.Env{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("hardened host produced findings: %v", fs)
+	}
+}
+
+// A knob this kernel does not have (Yama not built, IPv4 disabled) is not a
+// finding and not an error: there is nothing to harden.
+func TestAbsentKeysAreSilentlyFine(t *testing.T) {
+	fs, err := checkerFor(writeKeys(t, map[string]string{
+		"kernel.kptr_restrict": "1",
+	})).Check(context.Background(), platform.Env{})
+	if err != nil {
+		t.Fatalf("absent keys must not error: %v", err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("absent keys must not produce findings, got %v", fs)
+	}
+}
+
+// A key that exists but cannot be read is ground not covered, and the
+// domain must say so — "could not look" never passes for "nothing there".
+func TestUnreadableKeyIsPartial(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits do not bind root")
+	}
+	root := writeKeys(t, weakHost)
+	locked := filepath.Join(root, "net/ipv4/tcp_syncookies")
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := checkerFor(root).Check(context.Background(), platform.Env{})
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want PartialError for an unreadable key, got %v", err)
+	}
+	if !strings.Contains(partial.Reason, "net.ipv4.tcp_syncookies") {
+		t.Errorf("reason should name the unread key: %q", partial.Reason)
+	}
+	if len(fs) == 0 {
+		t.Error("the readable keys should still have been audited")
+	}
+	if _, ok := idsOf(fs)["sysctl.syncookies"]; ok {
+		t.Error("an unread key must not be guessed into a finding")
+	}
+}
+
+func TestAvailability(t *testing.T) {
+	c := checkerFor(t.TempDir()) // no kernel/ subdir
+	if ok, reason := c.Available(context.Background(), platform.Env{}); ok || reason == "" {
+		t.Errorf("empty root should be a clean skip with a reason, got ok=%v reason=%q", ok, reason)
+	}
+	c = checkerFor(writeKeys(t, map[string]string{"kernel.kptr_restrict": "1"}))
+	if ok, _ := c.Available(context.Background(), platform.Env{}); !ok {
+		t.Error("a readable /proc/sys/kernel should be available")
+	}
+}
+
+// A non-integer value is unreadable ground, not a guess.
+func TestGarbageValueIsPartialNotGuessed(t *testing.T) {
+	root := writeKeys(t, map[string]string{"kernel.kptr_restrict": "banana"})
+	fs, err := checkerFor(root).Check(context.Background(), platform.Env{})
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want PartialError for an unparseable value, got %v", err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("no finding should be invented from garbage, got %v", fs)
+	}
+}

--- a/internal/docs/findings_test.go
+++ b/internal/docs/findings_test.go
@@ -30,7 +30,7 @@ import (
 // findingID matches a namespaced finding ID. The namespace must be one of
 // the real sources, so incidental dotted strings in the check packages
 // (config filenames, config keys like net.bindIp) do not masquerade as IDs.
-var findingID = regexp.MustCompile(`^(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent)\.[a-z0-9][a-z0-9.\-]*$`)
+var findingID = regexp.MustCompile(`^(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent|sysctl)\.[a-z0-9][a-z0-9.\-]*$`)
 
 // composeRuleID matches compose's bare rule IDs, which reach NewFinding
 // through a helper that prefixes them: f("ds016", …) → "compose.ds016".

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -129,6 +129,20 @@ func TestKnownUnregisteredFindings(t *testing.T) {
 		"agent.sandbox-off":          "same JSON5 edit problem, and enabling a sandbox can break tools the operator relies on",
 		"agent.control-ui-insecure":  "same JSON5 edit problem",
 		"agent.ssrf-private-network": "same JSON5 edit problem",
+
+		// Every sysctl.* finding, one shared reason: the /etc/sysctl.d
+		// drop-in does not exist and edit actions cannot create files;
+		// applying the live value is exec (never Auto); and a
+		// write-then-apply pair is sequential steps, not the independent
+		// alternatives Review requires.
+		"sysctl.kptr-restrict":    "edit actions cannot create the missing sysctl.d drop-in, and sysctl --system is exec",
+		"sysctl.dmesg-restrict":   "same drop-in problem",
+		"sysctl.sysrq":            "same drop-in problem",
+		"sysctl.ptrace-scope":     "same drop-in problem",
+		"sysctl.syncookies":       "same drop-in problem",
+		"sysctl.accept-redirects": "same drop-in problem",
+		"sysctl.rp-filter":        "same drop-in problem",
+		"sysctl.protected-links":  "same drop-in problem",
 	}
 	r := Default()
 	for id, why := range declined {

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -150,6 +150,16 @@ package fix
 //     requires. agent.gateway-exposed fails the recoverability test on top
 //     of all that: rebinding a gateway to loopback can cut an operator off
 //     from the agent they administer remotely.
+//   - sysctl.* (every kernel-hardening finding) — one shared reason.
+//     Persisting a value means writing an /etc/sysctl.d drop-in that does
+//     not exist, and edit actions cannot create files: previewEdit and
+//     applyEdit both read the target before doing anything. Making it live
+//     needs `sysctl --system`, which is exec and so never Auto; and
+//     "write the drop-in, then apply it" is sequential steps, exactly what
+//     Review's independent-alternatives shape forbids. Each finding's
+//     how-to-fix carries the exact line and command instead. Revisit if
+//     Action ever grows a create-if-missing mode, at which point these
+//     become natural Review fixes.
 //
 // # Auto fixes that touch a user's home
 //

--- a/internal/model/score.go
+++ b/internal/model/score.go
@@ -64,16 +64,21 @@ type axisDef struct {
 // user — but it applies to far fewer hosts, and it is N/A-excluded entirely
 // on any host with no agent runtime installed. So the generous cap costs a
 // typical host nothing and carries real weight where it applies.
+//
+// "sysctl" ties with "fileperms" deliberately too: both are quiet local-
+// hardening backstops — neither is the hole an attacker comes in through,
+// each is what stops a foothold from becoming root.
 var axisDefs = []axisDef{
-	{"container", "Container exposure", SourceCompose, 18},
-	{"ssh", "SSH hardening", SourceSSH, 17},
-	{"firewall", "Host firewall", SourceFirewall, 12},
+	{"container", "Container exposure", SourceCompose, 17},
+	{"ssh", "SSH hardening", SourceSSH, 16},
+	{"firewall", "Host firewall", SourceFirewall, 11},
 	{"updates", "Auto-updates", SourceUpdates, 7},
-	{"cve", "Vulnerabilities", SourceCVE, 13},
+	{"cve", "Vulnerabilities", SourceCVE, 12},
 	{"ports", "Exposed services", SourcePorts, 10},
-	{"accounts", "Account hygiene", SourceAccounts, 8},
+	{"accounts", "Account hygiene", SourceAccounts, 7},
 	{"fileperms", "File permissions", SourceFilePerms, 5},
 	{"agent", "AI agent runtimes", SourceAgent, 10},
+	{"sysctl", "Kernel hardening", SourceSysctl, 5},
 }
 
 // criticalHalves is the anchor of the whole penalty model: one Critical

--- a/internal/model/source.go
+++ b/internal/model/source.go
@@ -21,6 +21,7 @@ const (
 	SourceAccounts
 	SourceFilePerms
 	SourceAgent
+	SourceSysctl
 )
 
 // String returns the stable lowercase domain name, also used as the
@@ -45,6 +46,8 @@ func (s Source) String() string {
 		return "fileperms"
 	case SourceAgent:
 		return "agent"
+	case SourceSysctl:
+		return "sysctl"
 	default:
 		return "unset"
 	}
@@ -57,13 +60,13 @@ func (s Source) String() string {
 // finding from the new domain fails Validate() and is dropped after the
 // scan, so the domain reports clean rather than reporting nothing.
 func (s Source) Valid() bool {
-	return s >= SourceCompose && s <= SourceAgent
+	return s >= SourceCompose && s <= SourceSysctl
 }
 
 // AllSources lists every real detection domain in scan/report order.
 func AllSources() []Source {
 	return []Source{
 		SourceCompose, SourceSSH, SourceFirewall, SourceUpdates, SourceCVE,
-		SourcePorts, SourceAccounts, SourceFilePerms, SourceAgent,
+		SourcePorts, SourceAccounts, SourceFilePerms, SourceAgent, SourceSysctl,
 	}
 }

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -129,15 +129,16 @@
               <table>
                 <thead><tr><th>Axis</th><th>Weight</th></tr></thead>
                 <tbody>
-                  <tr><td>Container exposure</td><td>18</td></tr>
-                  <tr><td>SSH hardening</td><td>17</td></tr>
-                  <tr><td>Vulnerabilities</td><td>13</td></tr>
-                  <tr><td>Host firewall</td><td>12</td></tr>
+                  <tr><td>Container exposure</td><td>17</td></tr>
+                  <tr><td>SSH hardening</td><td>16</td></tr>
+                  <tr><td>Vulnerabilities</td><td>12</td></tr>
+                  <tr><td>Host firewall</td><td>11</td></tr>
                   <tr><td>Exposed services</td><td>10</td></tr>
                   <tr><td>AI agent runtimes</td><td>10</td></tr>
-                  <tr><td>Account hygiene</td><td>8</td></tr>
+                  <tr><td>Account hygiene</td><td>7</td></tr>
                   <tr><td>Auto-updates</td><td>7</td></tr>
                   <tr><td>File permissions</td><td>5</td></tr>
+                  <tr><td>Kernel hardening</td><td>5</td></tr>
                 </tbody>
               </table>
             </div>
@@ -264,6 +265,25 @@
                   <tr><td><code>fileperms.group</code></td><td><code>/etc/group</code> is writable by non-root users</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>fileperms.hostkey</code></td><td>An SSH host private key is readable beyond root</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>fileperms.sshd-config</code></td><td><code>sshd_config</code> is writable by non-root users</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="sysctl">Kernel hardening <code>sysctl.</code></h2>
+            <p>Read directly from <code>/proc/sys</code> — no <code>sysctl</code> binary needed. These are the quiet knobs whose safe value is the same on essentially every server: none of them is the hole an attacker comes in through, each is what stops a foothold from becoming root or a spoofed packet from becoming a route. A parameter this kernel does not have (Yama not built in, say) is simply skipped.</p>
+            <p>Every finding here is Manual for now: making a value stick means creating an <code>/etc/sysctl.d</code> drop-in that does not exist yet, and applying it live takes <code>sysctl --system</code> — so each finding carries the exact line and the exact command instead of a button. <code>net.ipv4.ip_forward</code> is deliberately not audited: Docker, WireGuard, Tailscale exit nodes, and virtualization hosts all legitimately enable it, and hostveil cannot tell those apart from an accident.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>sysctl.ptrace-scope</code></td><td>Any process can debug its siblings and read their memory</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN-flood protection is off</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP redirects can rewrite this host's routing</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.protected-links</code></td><td>Symlink/hardlink race protections are disabled</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.kptr-restrict</code></td><td>Kernel pointer addresses are visible to all users</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>Any user can read the kernel log</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq is fully enabled</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.rp-filter</code></td><td>Source-address spoofing filter is off (strict and loose both pass)</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
                 </tbody>
               </table>
             </div>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -129,15 +129,16 @@
               <table>
                 <thead><tr><th>축</th><th>가중치</th></tr></thead>
                 <tbody>
-                  <tr><td>컨테이너 노출</td><td>18</td></tr>
-                  <tr><td>SSH 하드닝</td><td>17</td></tr>
-                  <tr><td>취약점</td><td>13</td></tr>
-                  <tr><td>호스트 방화벽</td><td>12</td></tr>
+                  <tr><td>컨테이너 노출</td><td>17</td></tr>
+                  <tr><td>SSH 하드닝</td><td>16</td></tr>
+                  <tr><td>취약점</td><td>12</td></tr>
+                  <tr><td>호스트 방화벽</td><td>11</td></tr>
                   <tr><td>노출된 서비스</td><td>10</td></tr>
                   <tr><td>AI 에이전트 런타임</td><td>10</td></tr>
-                  <tr><td>계정 위생</td><td>8</td></tr>
+                  <tr><td>계정 위생</td><td>7</td></tr>
                   <tr><td>자동 업데이트</td><td>7</td></tr>
                   <tr><td>파일 권한</td><td>5</td></tr>
+                  <tr><td>커널 하드닝</td><td>5</td></tr>
                 </tbody>
               </table>
             </div>
@@ -264,6 +265,25 @@
                   <tr><td><code>fileperms.group</code></td><td><code>/etc/group</code>이 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>fileperms.hostkey</code></td><td>SSH 호스트 개인 키를 root 외 사용자가 읽을 수 있음</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>fileperms.sshd-config</code></td><td><code>sshd_config</code>가 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h2 id="sysctl">커널 하드닝 <code>sysctl.</code></h2>
+            <p><code>/proc/sys</code>에서 직접 읽습니다 — <code>sysctl</code> 바이너리가 필요 없습니다. 이 항목들은 사실상 모든 서버에서 안전한 값이 같은 조용한 손잡이들입니다. 공격자가 들어오는 구멍은 아니지만, 각각은 발판이 root가 되는 것과 위조된 패킷이 경로가 되는 것을 막아 줍니다. 이 커널에 없는 파라미터(예: Yama가 빌드되지 않은 경우)는 그냥 건너뜁니다.</p>
+            <p>여기의 모든 발견 항목은 지금은 수동입니다. 값을 유지하려면 아직 존재하지 않는 <code>/etc/sysctl.d</code> 드롭인 파일을 만들어야 하고, 즉시 적용하려면 <code>sysctl --system</code>이 필요합니다 — 그래서 버튼 대신 정확한 설정 줄과 명령을 발견 항목이 직접 알려줍니다. <code>net.ipv4.ip_forward</code>는 의도적으로 점검하지 않습니다. Docker, WireGuard, Tailscale 종료 노드, 가상화 호스트가 모두 정당하게 켜는 값이고, hostveil은 그것을 실수와 구별할 수 없습니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>sysctl.ptrace-scope</code></td><td>아무 프로세스나 형제 프로세스를 디버깅해 메모리를 읽을 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN 플러드 보호가 꺼져 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP 리다이렉트가 이 호스트의 라우팅을 바꿀 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.protected-links</code></td><td>심볼릭/하드 링크 경쟁 보호가 비활성화됨</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.kptr-restrict</code></td><td>커널 포인터 주소가 모든 사용자에게 보임</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>아무 사용자나 커널 로그를 읽을 수 있음</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq가 전부 활성화됨</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.rp-filter</code></td><td>출발지 주소 위조 필터가 꺼져 있음 (strict와 loose 모두 통과)</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
A tenth checker reading /proc/sys directly: eight parameters whose safe
value is the same on essentially every server — ptrace_scope,
tcp_syncookies, accept_redirects, protected_symlinks/hardlinks,
kptr_restrict, dmesg_restrict, sysrq, rp_filter. A knob this kernel
does not have is silently fine; one that exists but cannot be read
degrades the axis via PartialError rather than passing for clean.

`net.ipv4.ip_forward` is deliberately not audited — Docker, WireGuard,
Tailscale exit nodes, libvirt, and k8s all legitimately enable it and
none of that is detectable from here.

Every finding is Manual and pinned unfixed for one shared reason: the
/etc/sysctl.d drop-in does not exist and edit actions cannot create
files (previewEdit/applyEdit read the target first); `sysctl --system`
is exec, never Auto; and write-then-apply is sequential steps, not the
independent alternatives Review requires. Each finding carries the
exact line and command instead. Revisit if Action grows a
create-if-missing mode.

New axis **Kernel hardening** (cap 5), funded by one point each from
the five largest non-tied axes: container 17, ssh 16, cve 12,
firewall 11, accounts 7. Preserves the container > ssh ordering and the
documented ports = agent tie; sysctl = fileperms is a new deliberate
pairing of the two quiet local-hardening backstops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)