### PR TITLE
feat(cmd): add SARIF output and --output to scan

### DIFF
--- a/cmd/hostveil/main.go
+++ b/cmd/hostveil/main.go
@@ -157,6 +157,10 @@ Usage:
 Scan flags:
   -v, --verbose   Show each finding's description and fix guidance
   --json          Output the report as JSON
+  --sarif         Output the report as SARIF 2.1.0, the format CI systems
+                  and GitHub code scanning ingest
+  --output FILE   Write the report to FILE instead of stdout. The exit
+                  status is unchanged, so a CI gate still works.
   --no-color      Disable colored output
 
 Fix flags:

--- a/cmd/hostveil/scan.go
+++ b/cmd/hostveil/scan.go
@@ -14,36 +14,65 @@ import (
 func cmdScan(ctx context.Context, args []string) int {
 	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
 	var (
-		jsonOut bool
-		verbose bool
-		noColor bool
+		jsonOut  bool
+		sarifOut bool
+		verbose  bool
+		noColor  bool
+		output   string
 	)
 	fs.BoolVar(&jsonOut, "json", false, "output the report as JSON")
+	fs.BoolVar(&sarifOut, "sarif", false, "output the report as SARIF 2.1.0")
 	fs.BoolVar(&verbose, "verbose", false, "show descriptions and fix guidance")
 	fs.BoolVar(&verbose, "v", false, "show descriptions and fix guidance (shorthand)")
 	fs.BoolVar(&noColor, "no-color", false, "disable colored output")
+	fs.StringVar(&output, "output", "", "write the report to a file instead of stdout")
 	if code := parseFlags(fs, args); code >= 0 {
 		return code
+	}
+	if jsonOut && sarifOut {
+		fmt.Fprintln(os.Stderr, "hostveil: --json and --sarif are mutually exclusive")
+		return 2
 	}
 
 	engine := buildEngine()
 	report := scanWithProgress(ctx, engine)
 
-	if jsonOut {
+	var rendered string
+	switch {
+	case jsonOut:
 		out, err := clirender.JSON(report)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "hostveil:", err)
 			return 1
 		}
-		fmt.Println(out)
-		return exitCode(report)
+		rendered = out + "\n"
+	case sarifOut:
+		out, err := clirender.SARIF(report, version)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "hostveil:", err)
+			return 1
+		}
+		rendered = out + "\n"
+	default:
+		// A report written to a file is read later, without the terminal it
+		// was produced on — never color it.
+		opts := clirender.Options{Color: output == "" && !noColor && colorEnabled(), Verbose: verbose}
+		rendered = clirender.Text(report, opts)
+		if delta := engine.LastDelta(); delta.HasChanges() {
+			rendered += clirender.DeltaSummary(delta)
+		}
 	}
 
-	opts := clirender.Options{Color: !noColor && colorEnabled(), Verbose: verbose}
-	fmt.Print(clirender.Text(report, opts))
-	if delta := engine.LastDelta(); delta.HasChanges() {
-		fmt.Print(clirender.DeltaSummary(delta))
+	if output != "" {
+		if err := os.WriteFile(output, []byte(rendered), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "hostveil:", err)
+			return 1
+		}
+	} else {
+		fmt.Print(rendered)
 	}
+	// The exit code is the CI contract and does not vary by output format
+	// or destination.
 	return exitCode(report)
 }
 

--- a/cmd/sitegen/content/en/docs/cli.html
+++ b/cmd/sitegen/content/en/docs/cli.html
@@ -14,6 +14,8 @@
                 <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
                 <tbody>
                   <tr><td><code>--json</code></td><td><code>false</code></td><td>Output the report as JSON.</td></tr>
+                  <tr><td><code>--sarif</code></td><td><code>false</code></td><td>Output the report as SARIF 2.1.0, the format CI systems and GitHub code scanning ingest. Mutually exclusive with <code>--json</code>. Per-domain coverage rides in the run's properties, so a degraded scan is visible in the export too.</td></tr>
+                  <tr><td><code>--output FILE</code></td><td>—</td><td>Write the report to a file instead of stdout, in whichever format was chosen. The exit status is unchanged, so a CI gate keeps working.</td></tr>
                   <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>Show descriptions and fix guidance.</td></tr>
                   <tr><td><code>--no-color</code></td><td><code>false</code></td><td>Disable colored output.</td></tr>
                 </tbody>

--- a/cmd/sitegen/content/ko/docs/cli.html
+++ b/cmd/sitegen/content/ko/docs/cli.html
@@ -14,6 +14,8 @@
                 <thead><tr><th>플래그</th><th>기본값</th><th>설명</th></tr></thead>
                 <tbody>
                   <tr><td><code>--json</code></td><td><code>false</code></td><td>보고서를 JSON으로 출력합니다.</td></tr>
+                  <tr><td><code>--sarif</code></td><td><code>false</code></td><td>보고서를 CI 시스템과 GitHub code scanning이 읽는 SARIF 2.1.0 형식으로 출력합니다. <code>--json</code>과 함께 쓸 수 없습니다. 도메인별 커버리지가 run 속성에 함께 실리므로, 일부만 점검된 스캔은 내보내기에서도 그대로 보입니다.</td></tr>
+                  <tr><td><code>--output FILE</code></td><td>—</td><td>선택한 형식 그대로 보고서를 stdout 대신 파일에 씁니다. 종료 코드는 그대로이므로 CI 게이트는 계속 동작합니다.</td></tr>
                   <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>설명과 수정 안내를 표시합니다.</td></tr>
                   <tr><td><code>--no-color</code></td><td><code>false</code></td><td>색상 출력을 비활성화합니다.</td></tr>
                 </tbody>

--- a/internal/clirender/sarif.go
+++ b/internal/clirender/sarif.go
@@ -1,0 +1,165 @@
+package clirender
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// SARIF renders the report as a SARIF 2.1.0 log, the interchange format CI
+// systems (GitHub code scanning among them) ingest. The mapping is one run,
+// one rule per distinct finding ID, one result per unfixed finding.
+//
+// Findings have no source-file location in SARIF's sense — they describe a
+// host — so results carry a logical location (the service, or "host") and a
+// stable partialFingerprint built from Finding.Key(), which is what lets a
+// consumer track a finding across scans. Score and per-domain coverage ride
+// in the run's properties so a Degraded or Skipped domain survives export:
+// a SARIF file with zero results from a scan that could not look is the
+// same lie the score model refuses to tell.
+func SARIF(r model.Report, version string) (string, error) {
+	type text struct {
+		Text string `json:"text"`
+	}
+	type rule struct {
+		ID               string            `json:"id"`
+		ShortDescription text              `json:"shortDescription"`
+		FullDescription  *text             `json:"fullDescription,omitempty"`
+		Help             *text             `json:"help,omitempty"`
+		Properties       map[string]string `json:"properties,omitempty"`
+	}
+	type logicalLocation struct {
+		FullyQualifiedName string `json:"fullyQualifiedName"`
+	}
+	type location struct {
+		LogicalLocations []logicalLocation `json:"logicalLocations"`
+	}
+	type result struct {
+		RuleID              string            `json:"ruleId"`
+		Level               string            `json:"level"`
+		Message             text              `json:"message"`
+		Locations           []location        `json:"locations"`
+		PartialFingerprints map[string]string `json:"partialFingerprints"`
+	}
+
+	var rules []rule
+	ruleIndex := map[string]bool{}
+	var results []result
+	for _, f := range r.Findings {
+		if f.Fixed {
+			continue
+		}
+		if !ruleIndex[f.ID] {
+			ruleIndex[f.ID] = true
+			ru := rule{
+				ID:               f.ID,
+				ShortDescription: text{f.Title},
+				Properties:       map[string]string{"security-severity": securitySeverity(f.Severity)},
+			}
+			if f.Description != "" {
+				ru.FullDescription = &text{f.Description}
+			}
+			if f.HowToFix != "" {
+				ru.Help = &text{f.HowToFix}
+			}
+			rules = append(rules, ru)
+		}
+		where := f.Service
+		if where == "" {
+			where = "host"
+		}
+		msg := f.Title
+		if f.Service != "" {
+			msg = fmt.Sprintf("%s (%s)", f.Title, f.Service)
+		}
+		results = append(results, result{
+			RuleID:    f.ID,
+			Level:     sarifLevel(f.Severity),
+			Message:   text{msg},
+			Locations: []location{{LogicalLocations: []logicalLocation{{FullyQualifiedName: where}}}},
+			PartialFingerprints: map[string]string{
+				"hostveil/findingKey": f.Key(),
+			},
+		})
+	}
+	// A run with no results still must carry a non-null, empty array —
+	// `"results": null` is invalid SARIF and some ingesters reject it.
+	if results == nil {
+		results = []result{}
+	}
+	if rules == nil {
+		rules = []rule{}
+	}
+
+	domains := map[string]any{}
+	for _, d := range r.Domains {
+		domains[d.Source.String()] = map[string]any{
+			"state":  d.State.String(),
+			"reason": d.Reason,
+		}
+	}
+	axes := map[string]any{}
+	for _, ax := range r.Score.Axes {
+		axes[ax.ID] = map[string]any{
+			"score":      ax.Score,
+			"applicable": ax.Applicable,
+			"degraded":   ax.Degraded,
+		}
+	}
+
+	log := map[string]any{
+		"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+		"version": "2.1.0",
+		"runs": []any{map[string]any{
+			"tool": map[string]any{
+				"driver": map[string]any{
+					"name":           "hostveil",
+					"version":        version,
+					"informationUri": "https://github.com/seolcu/hostveil",
+					"rules":          rules,
+				},
+			},
+			"results": results,
+			"properties": map[string]any{
+				"score":           r.Score.Overall,
+				"scoreApplicable": r.Score.Applicable,
+				"axes":            axes,
+				"domains":         domains,
+			},
+		}},
+	}
+	out, err := json.MarshalIndent(log, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// sarifLevel maps severities onto SARIF's three levels.
+func sarifLevel(s model.Severity) string {
+	switch s {
+	case model.SeverityCritical, model.SeverityHigh:
+		return "error"
+	case model.SeverityMedium:
+		return "warning"
+	default:
+		return "note"
+	}
+}
+
+// securitySeverity is the 0–10 scale GitHub code scanning ranks by; the
+// values put Critical/High/Medium/Low into its critical/high/medium/low
+// buckets respectively.
+func securitySeverity(s model.Severity) string {
+	switch s {
+	case model.SeverityCritical:
+		return "9.5"
+	case model.SeverityHigh:
+		return "8.0"
+	case model.SeverityMedium:
+		return "5.5"
+	default:
+		return "3.0"
+	}
+}

--- a/internal/clirender/sarif_test.go
+++ b/internal/clirender/sarif_test.go
@@ -1,0 +1,123 @@
+package clirender
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+func sarifOf(t *testing.T, r model.Report) map[string]any {
+	t.Helper()
+	out, err := SARIF(r, "v-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var log map[string]any
+	if err := json.Unmarshal([]byte(out), &log); err != nil {
+		t.Fatalf("SARIF output is not valid JSON: %v", err)
+	}
+	return log
+}
+
+func sarifRun(t *testing.T, log map[string]any) map[string]any {
+	t.Helper()
+	runs, ok := log["runs"].([]any)
+	if !ok || len(runs) != 1 {
+		t.Fatalf("want exactly one run, got %v", log["runs"])
+	}
+	return runs[0].(map[string]any)
+}
+
+func TestSARIFMapsFindingsToResultsAndRules(t *testing.T) {
+	f1 := model.NewFinding("ssh.rootlogin", "Root login allowed", model.SeverityHigh,
+		model.SourceSSH, model.RemediationReview,
+		model.WithDescription("desc"), model.WithHowToFix("how"))
+	f2 := model.NewFinding("compose.ds018", "Datastore exposed", model.SeverityCritical,
+		model.SourceCompose, model.RemediationAuto, model.WithService("cache"))
+	f3 := model.NewFinding("compose.ds018", "Datastore exposed", model.SeverityCritical,
+		model.SourceCompose, model.RemediationAuto, model.WithService("db"))
+	fixed := model.NewFinding("ssh.x11forwarding", "X11 on", model.SeverityLow,
+		model.SourceSSH, model.RemediationAuto)
+	fixed.Fixed = true
+
+	report := model.Report{Findings: []model.Finding{f1, f2, f3, fixed}}
+	run := sarifRun(t, sarifOf(t, report))
+
+	results := run["results"].([]any)
+	if len(results) != 3 {
+		t.Fatalf("want 3 results (fixed finding excluded), got %d", len(results))
+	}
+	first := results[0].(map[string]any)
+	if first["ruleId"] != "ssh.rootlogin" || first["level"] != "error" {
+		t.Errorf("first result = %v, want ssh.rootlogin at error", first)
+	}
+	fp := first["partialFingerprints"].(map[string]any)
+	if fp["hostveil/findingKey"] != f1.Key() {
+		t.Errorf("fingerprint = %v, want %s", fp, f1.Key())
+	}
+
+	// One rule per distinct ID, even with two ds018 results.
+	driver := run["tool"].(map[string]any)["driver"].(map[string]any)
+	rules := driver["rules"].([]any)
+	if len(rules) != 2 {
+		t.Fatalf("want 2 rules for 2 distinct IDs, got %d", len(rules))
+	}
+	if driver["version"] != "v-test" {
+		t.Errorf("driver version = %v", driver["version"])
+	}
+
+	// Same-ID results stay distinguishable through the logical location.
+	second := results[1].(map[string]any)
+	loc := second["locations"].([]any)[0].(map[string]any)["logicalLocations"].([]any)[0].(map[string]any)
+	if loc["fullyQualifiedName"] != "cache" {
+		t.Errorf("logical location = %v, want the service name", loc)
+	}
+}
+
+func TestSARIFSeverityLevels(t *testing.T) {
+	cases := map[model.Severity]string{
+		model.SeverityCritical: "error",
+		model.SeverityHigh:     "error",
+		model.SeverityMedium:   "warning",
+		model.SeverityLow:      "note",
+	}
+	for sev, want := range cases {
+		if got := sarifLevel(sev); got != want {
+			t.Errorf("sarifLevel(%v) = %q, want %q", sev, got, want)
+		}
+	}
+}
+
+// An empty scan must produce `"results": []`, not `"results": null` —
+// null is invalid SARIF and some ingesters reject the whole file.
+func TestSARIFEmptyReportHasEmptyArrays(t *testing.T) {
+	out, err := SARIF(model.Report{}, "v-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, `"results": null`) || strings.Contains(out, `"rules": null`) {
+		t.Errorf("null arrays in empty SARIF output:\n%s", out)
+	}
+}
+
+// Degradation must survive export: a SARIF file with zero results from a
+// scan that could not look would otherwise read as a clean host.
+func TestSARIFCarriesDomainCoverage(t *testing.T) {
+	report := model.Report{
+		Domains: []model.DomainResult{
+			{Source: model.SourceCVE, State: model.ScanSkipped, Reason: "trivy not installed"},
+		},
+	}
+	run := sarifRun(t, sarifOf(t, report))
+	props := run["properties"].(map[string]any)
+	domains := props["domains"].(map[string]any)
+	cve := domains["cve"].(map[string]any)
+	if cve["reason"] != "trivy not installed" {
+		t.Errorf("domain coverage lost in export: %v", cve)
+	}
+	if _, ok := props["scoreApplicable"]; !ok {
+		t.Error("scoreApplicable missing from run properties")
+	}
+}

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -100,6 +100,8 @@
                 <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
                 <tbody>
                   <tr><td><code>--json</code></td><td><code>false</code></td><td>Output the report as JSON.</td></tr>
+                  <tr><td><code>--sarif</code></td><td><code>false</code></td><td>Output the report as SARIF 2.1.0, the format CI systems and GitHub code scanning ingest. Mutually exclusive with <code>--json</code>. Per-domain coverage rides in the run's properties, so a degraded scan is visible in the export too.</td></tr>
+                  <tr><td><code>--output FILE</code></td><td>—</td><td>Write the report to a file instead of stdout, in whichever format was chosen. The exit status is unchanged, so a CI gate keeps working.</td></tr>
                   <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>Show descriptions and fix guidance.</td></tr>
                   <tr><td><code>--no-color</code></td><td><code>false</code></td><td>Disable colored output.</td></tr>
                 </tbody>

--- a/site/ko/docs/cli.html
+++ b/site/ko/docs/cli.html
@@ -100,6 +100,8 @@
                 <thead><tr><th>플래그</th><th>기본값</th><th>설명</th></tr></thead>
                 <tbody>
                   <tr><td><code>--json</code></td><td><code>false</code></td><td>보고서를 JSON으로 출력합니다.</td></tr>
+                  <tr><td><code>--sarif</code></td><td><code>false</code></td><td>보고서를 CI 시스템과 GitHub code scanning이 읽는 SARIF 2.1.0 형식으로 출력합니다. <code>--json</code>과 함께 쓸 수 없습니다. 도메인별 커버리지가 run 속성에 함께 실리므로, 일부만 점검된 스캔은 내보내기에서도 그대로 보입니다.</td></tr>
+                  <tr><td><code>--output FILE</code></td><td>—</td><td>선택한 형식 그대로 보고서를 stdout 대신 파일에 씁니다. 종료 코드는 그대로이므로 CI 게이트는 계속 동작합니다.</td></tr>
                   <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>설명과 수정 안내를 표시합니다.</td></tr>
                   <tr><td><code>--no-color</code></td><td><code>false</code></td><td>색상 출력을 비활성화합니다.</td></tr>
                 </tbody>


### PR DESCRIPTION
scan grows `--sarif` (mutually exclusive with `--json`) and
`--output FILE`. The renderer lives in internal/clirender like the
other two formats: one run, one rule per distinct finding ID, one
result per unfixed finding, with the service as a logical location and
`Finding.Key()` as a partialFingerprint so a consumer can track
findings across scans. security-severity properties put findings into
GitHub code scanning's ranking buckets.

Score and per-domain coverage ride in the run's properties — a SARIF
file with zero results from a scan that could not look would otherwise
read as a clean host, the exact lie the score model refuses to tell.
Empty runs serialize as `[]` rather than `null`, which some ingesters
reject.

`--output` writes whichever format was chosen; text written to a file
is never colored. The exit status (0/1/3) is the CI contract and does
not vary by format or destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)