### PR TITLE
feat(core): domain selection for scan (--only/--skip)

### DIFF
--- a/cmd/hostveil/main.go
+++ b/cmd/hostveil/main.go
@@ -161,6 +161,10 @@ Scan flags:
                   and GitHub code scanning ingest
   --output FILE   Write the report to FILE instead of stdout. The exit
                   status is unchanged, so a CI gate still works.
+  --only LIST     Scan only these domains (comma-separated, e.g.
+                  --only ssh,firewall). A partial scan is not saved as the
+                  last-scan baseline and reports no delta.
+  --skip LIST     Scan every domain except these (comma-separated)
   --no-color      Disable colored output
 
 Fix flags:

--- a/cmd/hostveil/scan.go
+++ b/cmd/hostveil/scan.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/seolcu/hostveil/internal/clirender"
 	"github.com/seolcu/hostveil/internal/core"
@@ -19,6 +20,8 @@ func cmdScan(ctx context.Context, args []string) int {
 		verbose  bool
 		noColor  bool
 		output   string
+		only     string
+		skip     string
 	)
 	fs.BoolVar(&jsonOut, "json", false, "output the report as JSON")
 	fs.BoolVar(&sarifOut, "sarif", false, "output the report as SARIF 2.1.0")
@@ -26,6 +29,8 @@ func cmdScan(ctx context.Context, args []string) int {
 	fs.BoolVar(&verbose, "v", false, "show descriptions and fix guidance (shorthand)")
 	fs.BoolVar(&noColor, "no-color", false, "disable colored output")
 	fs.StringVar(&output, "output", "", "write the report to a file instead of stdout")
+	fs.StringVar(&only, "only", "", "scan only these domains (comma-separated); a partial scan is not saved as the last-scan baseline")
+	fs.StringVar(&skip, "skip", "", "scan every domain except these (comma-separated); a partial scan is not saved as the last-scan baseline")
 	if code := parseFlags(fs, args); code >= 0 {
 		return code
 	}
@@ -33,9 +38,14 @@ func cmdScan(ctx context.Context, args []string) int {
 		fmt.Fprintln(os.Stderr, "hostveil: --json and --sarif are mutually exclusive")
 		return 2
 	}
+	scanOpts, errMsg := scanSelection(only, skip)
+	if errMsg != "" {
+		fmt.Fprintln(os.Stderr, "hostveil:", errMsg)
+		return 2
+	}
 
 	engine := buildEngine()
-	report := scanWithProgress(ctx, engine)
+	report := scanWithProgress(ctx, engine, scanOpts)
 
 	var rendered string
 	switch {
@@ -83,9 +93,9 @@ func cmdScan(ctx context.Context, args []string) int {
 // a redirect, and a cron run all produce exactly the bytes they did before.
 // When there is nowhere useful to draw, the scan runs with a nil channel and
 // no goroutine — the same path as before this existed.
-func scanWithProgress(ctx context.Context, engine *core.Engine) model.Report {
+func scanWithProgress(ctx context.Context, engine *core.Engine, opts core.ScanOptions) model.Report {
 	if !isCharDevice(os.Stderr) {
-		return engine.Scan(ctx, nil)
+		return engine.ScanWith(ctx, nil, opts)
 	}
 
 	events := make(chan model.ScanEvent, clirender.ProgressBufferSize)
@@ -95,10 +105,60 @@ func scanWithProgress(ctx context.Context, engine *core.Engine) model.Report {
 		clirender.Progress(os.Stderr, events)
 	}()
 
-	report := engine.Scan(ctx, events)
+	report := engine.ScanWith(ctx, events, opts)
 	close(events)
 	<-done // let the renderer clear its line before the report is printed
 	return report
+}
+
+// scanSelection turns --only/--skip into ScanOptions, validating domain
+// names against the real source set so a typo is a usage error naming the
+// valid choices rather than a silently empty scan.
+func scanSelection(only, skip string) (core.ScanOptions, string) {
+	if only != "" && skip != "" {
+		return core.ScanOptions{}, "--only and --skip are mutually exclusive"
+	}
+	list := only
+	if skip != "" {
+		list = skip
+	}
+	if list == "" {
+		return core.ScanOptions{}, ""
+	}
+
+	byName := map[string]model.Source{}
+	var names []string
+	for _, s := range model.AllSources() {
+		byName[s.String()] = s
+		names = append(names, s.String())
+	}
+
+	selected := map[model.Source]bool{}
+	for _, name := range strings.Split(list, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		src, ok := byName[name]
+		if !ok {
+			return core.ScanOptions{}, fmt.Sprintf("unknown domain %q (valid: %s)", name, strings.Join(names, ", "))
+		}
+		selected[src] = true
+	}
+	if len(selected) == 0 {
+		return core.ScanOptions{}, "no domains named"
+	}
+
+	var out []model.Source
+	for _, s := range model.AllSources() {
+		if selected[s] == (only != "") {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return core.ScanOptions{}, "--skip removes every domain; nothing would be scanned"
+	}
+	return core.ScanOptions{Only: out}, ""
 }
 
 // Exit codes for scan. These are the CI and cron contract, so they are

--- a/cmd/hostveil/scanselection_test.go
+++ b/cmd/hostveil/scanselection_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+func TestScanSelectionOnly(t *testing.T) {
+	opts, msg := scanSelection("ssh,firewall", "")
+	if msg != "" {
+		t.Fatalf("unexpected error: %s", msg)
+	}
+	if !opts.Partial() || len(opts.Only) != 2 ||
+		!slices.Contains(opts.Only, model.SourceSSH) || !slices.Contains(opts.Only, model.SourceFirewall) {
+		t.Errorf("opts = %+v, want ssh+firewall", opts)
+	}
+}
+
+func TestScanSelectionSkipIsTheComplement(t *testing.T) {
+	opts, msg := scanSelection("", "cve")
+	if msg != "" {
+		t.Fatalf("unexpected error: %s", msg)
+	}
+	if len(opts.Only) != len(model.AllSources())-1 {
+		t.Errorf("skip of one domain should select all others, got %v", opts.Only)
+	}
+	if slices.Contains(opts.Only, model.SourceCVE) {
+		t.Error("the skipped domain must not be selected")
+	}
+}
+
+func TestScanSelectionErrors(t *testing.T) {
+	if _, msg := scanSelection("ssh", "cve"); msg == "" {
+		t.Error("--only and --skip together should be a usage error")
+	}
+	if _, msg := scanSelection("bogus", ""); msg == "" || !strings.Contains(msg, "bogus") || !strings.Contains(msg, "ssh") {
+		t.Errorf("an unknown domain should be named alongside the valid ones, got %q", msg)
+	}
+
+	var names []string
+	for _, s := range model.AllSources() {
+		names = append(names, s.String())
+	}
+	if _, msg := scanSelection("", strings.Join(names, ",")); msg == "" {
+		t.Error("skipping every domain should be a usage error, not an empty scan")
+	}
+}
+
+func TestScanSelectionZeroValueIsAFullScan(t *testing.T) {
+	opts, msg := scanSelection("", "")
+	if msg != "" || opts.Partial() {
+		t.Errorf("no flags should mean a full scan, got %+v (%s)", opts, msg)
+	}
+}

--- a/cmd/sitegen/content/en/docs/cli.html
+++ b/cmd/sitegen/content/en/docs/cli.html
@@ -16,6 +16,8 @@
                   <tr><td><code>--json</code></td><td><code>false</code></td><td>Output the report as JSON.</td></tr>
                   <tr><td><code>--sarif</code></td><td><code>false</code></td><td>Output the report as SARIF 2.1.0, the format CI systems and GitHub code scanning ingest. Mutually exclusive with <code>--json</code>. Per-domain coverage rides in the run's properties, so a degraded scan is visible in the export too.</td></tr>
                   <tr><td><code>--output FILE</code></td><td>—</td><td>Write the report to a file instead of stdout, in whichever format was chosen. The exit status is unchanged, so a CI gate keeps working.</td></tr>
+                  <tr><td><code>--only LIST</code></td><td>—</td><td>Scan only these domains, comma-separated (e.g. <code>--only ssh,firewall</code>). Domains not scanned show as N/A, never as 100. A partial scan is not saved as the last-scan baseline and reports no delta — otherwise the next full scan would announce every finding from the skipped domains as new.</td></tr>
+                  <tr><td><code>--skip LIST</code></td><td>—</td><td>Scan every domain except these, comma-separated. Mutually exclusive with <code>--only</code>; the same partial-scan rules apply.</td></tr>
                   <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>Show descriptions and fix guidance.</td></tr>
                   <tr><td><code>--no-color</code></td><td><code>false</code></td><td>Disable colored output.</td></tr>
                 </tbody>

--- a/cmd/sitegen/content/ko/docs/cli.html
+++ b/cmd/sitegen/content/ko/docs/cli.html
@@ -16,6 +16,8 @@
                   <tr><td><code>--json</code></td><td><code>false</code></td><td>보고서를 JSON으로 출력합니다.</td></tr>
                   <tr><td><code>--sarif</code></td><td><code>false</code></td><td>보고서를 CI 시스템과 GitHub code scanning이 읽는 SARIF 2.1.0 형식으로 출력합니다. <code>--json</code>과 함께 쓸 수 없습니다. 도메인별 커버리지가 run 속성에 함께 실리므로, 일부만 점검된 스캔은 내보내기에서도 그대로 보입니다.</td></tr>
                   <tr><td><code>--output FILE</code></td><td>—</td><td>선택한 형식 그대로 보고서를 stdout 대신 파일에 씁니다. 종료 코드는 그대로이므로 CI 게이트는 계속 동작합니다.</td></tr>
+                  <tr><td><code>--only LIST</code></td><td>—</td><td>지정한 도메인만 스캔합니다. 쉼표로 구분합니다 (예: <code>--only ssh,firewall</code>). 스캔하지 않은 도메인은 100이 아니라 N/A로 표시됩니다. 부분 스캔은 마지막 스캔 기준선으로 저장되지 않고 변화 요약도 만들지 않습니다 — 저장하면 다음 전체 스캔이 건너뛴 도메인의 모든 발견 항목을 새로 생긴 것으로 보고하게 됩니다.</td></tr>
+                  <tr><td><code>--skip LIST</code></td><td>—</td><td>지정한 도메인을 제외한 모든 도메인을 스캔합니다. <code>--only</code>와 함께 쓸 수 없으며, 같은 부분 스캔 규칙이 적용됩니다.</td></tr>
                   <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>설명과 수정 안내를 표시합니다.</td></tr>
                   <tr><td><code>--no-color</code></td><td><code>false</code></td><td>색상 출력을 비활성화합니다.</td></tr>
                 </tbody>

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -71,11 +71,33 @@ func New(cfg Config) *Engine {
 	return &Engine{registry: cfg.Registry, fixes: cfg.Fixes, store: store, runner: runner, ai: explainer}
 }
 
+// ScanOptions narrows what a scan covers. The zero value is a full scan.
+type ScanOptions struct {
+	// Only limits the scan to these domains. Empty means every registered
+	// checker runs.
+	Only []model.Source
+}
+
+// Partial reports whether the options describe less than a full scan.
+func (o ScanOptions) Partial() bool { return len(o.Only) > 0 }
+
 // Scan runs every checker concurrently, scores the merged findings, stores
 // the result as the engine's current report, and returns it. progress may
 // be nil; if non-nil it receives a ScanEvent as each checker starts and
 // finishes.
 func (e *Engine) Scan(ctx context.Context, progress chan<- model.ScanEvent) model.Report {
+	return e.ScanWith(ctx, progress, ScanOptions{})
+}
+
+// ScanWith is Scan with domain selection.
+//
+// A partial scan is never persisted and computes no delta. Saving it would
+// make the partial report the baseline: the next full scan would announce
+// every finding from the skipped domains as newly appeared, and the
+// operator's last complete report on disk would have been overwritten by a
+// narrower one. The in-memory current report is still replaced, so a fix
+// in the same process works on what was just scanned.
+func (e *Engine) ScanWith(ctx context.Context, progress chan<- model.ScanEvent, opts ScanOptions) model.Report {
 	// A scan replaces the current report wholesale, so it must not overlap a
 	// fix: the replacement would drop the Fixed flag the fix had just set,
 	// and the scan would be reading files another goroutine is mid-write on.
@@ -89,7 +111,17 @@ func (e *Engine) Scan(ctx context.Context, progress chan<- model.ScanEvent) mode
 	// not replace e.runner: fixes run through the uncached one, because an
 	// exec fix mutates the host and must never be served from a cache.
 	env := platform.Detect(ctx, platform.NewScanCache(e.runner))
-	results := e.registry.Run(ctx, env, progress)
+	registry := e.registry
+	if opts.Partial() {
+		var subset []check.Checker
+		for _, c := range e.registry.Checkers() {
+			if slices.Contains(opts.Only, c.Source()) {
+				subset = append(subset, c)
+			}
+		}
+		registry = check.NewRegistry(subset...)
+	}
+	results := registry.Run(ctx, env, progress)
 
 	var findings []model.Finding
 	states := make(map[model.Source]model.ScanState, len(results))
@@ -133,9 +165,13 @@ func (e *Engine) Scan(ctx context.Context, progress chan<- model.ScanEvent) mode
 	}
 
 	// Compute the delta against the previous saved scan (for the re-check
-	// loop), then persist this one.
-	delta := e.deltaAgainstLast(report)
-	e.persist(report)
+	// loop), then persist this one. A partial scan does neither — see
+	// ScanWith.
+	var delta model.Delta
+	if !opts.Partial() {
+		delta = e.deltaAgainstLast(report)
+		e.persist(report)
+	}
 
 	e.mu.Lock()
 	e.current = report

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/seolcu/hostveil/internal/check"
 	composecheck "github.com/seolcu/hostveil/internal/check/compose"
 	cvecheck "github.com/seolcu/hostveil/internal/check/cve"
+	filepermscheck "github.com/seolcu/hostveil/internal/check/fileperms"
 	"github.com/seolcu/hostveil/internal/fix"
 	"github.com/seolcu/hostveil/internal/history"
 	"github.com/seolcu/hostveil/internal/model"
@@ -110,6 +111,57 @@ func TestEngineScanEndToEnd(t *testing.T) {
 	// Current() should return the stored report.
 	if cur, ran := engine.Current(); !ran || len(cur.Findings) != len(report.Findings) {
 		t.Error("Current() did not return the stored report")
+	}
+}
+
+// A partial scan must not become the baseline: persisting it would make
+// the next full scan report every finding from the skipped domains as
+// newly appeared, and it would overwrite the operator's last complete
+// report on disk. The unselected axes must come out N/A, never 100.
+func TestPartialScanIsNotPersistedAndExcludesUnselectedAxes(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	if err := os.WriteFile(composePath, []byte("services:\n  app:\n    image: myapp\n    privileged: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := fakeRunner{
+		present: map[string]bool{"docker": true},
+		lsJSON:  `[{"Name":"p","ConfigFiles":"` + composePath + `"}]`,
+	}
+	store := history.NewStore(t.TempDir())
+	engine := New(Config{
+		Registry: check.NewRegistry(composecheck.New(), filepermscheck.New()),
+		Runner:   runner,
+		Store:    store,
+	})
+
+	report := engine.ScanWith(context.Background(), nil, ScanOptions{Only: []model.Source{model.SourceCompose}})
+
+	for _, ax := range report.Score.Axes {
+		switch ax.Source {
+		case model.SourceCompose:
+			if !ax.Applicable {
+				t.Error("the selected axis should have been scanned and scored")
+			}
+		case model.SourceFilePerms:
+			if ax.Applicable {
+				t.Error("an unselected axis must be N/A, never scored as if it ran clean")
+			}
+		}
+	}
+	if len(report.Domains) != 1 {
+		t.Errorf("only the selected domain should report, got %v", report.Domains)
+	}
+	if _, ok, err := store.LastReport(); err != nil || ok {
+		t.Errorf("a partial scan must not be persisted (ok=%v, err=%v)", ok, err)
+	}
+	if cur, ran := engine.Current(); !ran || len(cur.Findings) != len(report.Findings) {
+		t.Error("the in-memory current report should still be replaced so fix works")
+	}
+
+	engine.Scan(context.Background(), nil)
+	if _, ok, _ := store.LastReport(); !ok {
+		t.Error("a full scan should still be persisted")
 	}
 }
 

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -102,6 +102,8 @@
                   <tr><td><code>--json</code></td><td><code>false</code></td><td>Output the report as JSON.</td></tr>
                   <tr><td><code>--sarif</code></td><td><code>false</code></td><td>Output the report as SARIF 2.1.0, the format CI systems and GitHub code scanning ingest. Mutually exclusive with <code>--json</code>. Per-domain coverage rides in the run's properties, so a degraded scan is visible in the export too.</td></tr>
                   <tr><td><code>--output FILE</code></td><td>—</td><td>Write the report to a file instead of stdout, in whichever format was chosen. The exit status is unchanged, so a CI gate keeps working.</td></tr>
+                  <tr><td><code>--only LIST</code></td><td>—</td><td>Scan only these domains, comma-separated (e.g. <code>--only ssh,firewall</code>). Domains not scanned show as N/A, never as 100. A partial scan is not saved as the last-scan baseline and reports no delta — otherwise the next full scan would announce every finding from the skipped domains as new.</td></tr>
+                  <tr><td><code>--skip LIST</code></td><td>—</td><td>Scan every domain except these, comma-separated. Mutually exclusive with <code>--only</code>; the same partial-scan rules apply.</td></tr>
                   <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>Show descriptions and fix guidance.</td></tr>
                   <tr><td><code>--no-color</code></td><td><code>false</code></td><td>Disable colored output.</td></tr>
                 </tbody>

--- a/site/ko/docs/cli.html
+++ b/site/ko/docs/cli.html
@@ -102,6 +102,8 @@
                   <tr><td><code>--json</code></td><td><code>false</code></td><td>보고서를 JSON으로 출력합니다.</td></tr>
                   <tr><td><code>--sarif</code></td><td><code>false</code></td><td>보고서를 CI 시스템과 GitHub code scanning이 읽는 SARIF 2.1.0 형식으로 출력합니다. <code>--json</code>과 함께 쓸 수 없습니다. 도메인별 커버리지가 run 속성에 함께 실리므로, 일부만 점검된 스캔은 내보내기에서도 그대로 보입니다.</td></tr>
                   <tr><td><code>--output FILE</code></td><td>—</td><td>선택한 형식 그대로 보고서를 stdout 대신 파일에 씁니다. 종료 코드는 그대로이므로 CI 게이트는 계속 동작합니다.</td></tr>
+                  <tr><td><code>--only LIST</code></td><td>—</td><td>지정한 도메인만 스캔합니다. 쉼표로 구분합니다 (예: <code>--only ssh,firewall</code>). 스캔하지 않은 도메인은 100이 아니라 N/A로 표시됩니다. 부분 스캔은 마지막 스캔 기준선으로 저장되지 않고 변화 요약도 만들지 않습니다 — 저장하면 다음 전체 스캔이 건너뛴 도메인의 모든 발견 항목을 새로 생긴 것으로 보고하게 됩니다.</td></tr>
+                  <tr><td><code>--skip LIST</code></td><td>—</td><td>지정한 도메인을 제외한 모든 도메인을 스캔합니다. <code>--only</code>와 함께 쓸 수 없으며, 같은 부분 스캔 규칙이 적용됩니다.</td></tr>
                   <tr><td><code>--verbose</code>, <code>-v</code></td><td><code>false</code></td><td>설명과 수정 안내를 표시합니다.</td></tr>
                   <tr><td><code>--no-color</code></td><td><code>false</code></td><td>색상 출력을 비활성화합니다.</td></tr>
                 </tbody>


### PR DESCRIPTION
`Engine.ScanWith` takes `ScanOptions{Only}`; `Scan` delegates with the
zero value. Selection filters the checker registry, so scoring needs no
new machinery: a domain absent from the states map already comes out
`Applicable=false` and renders N/A — never 100.

A partial scan is not persisted and computes no delta. Saving it would
make the partial report the baseline (the next full scan would announce
every finding from the skipped domains as newly appeared) and would
overwrite the operator's last complete report on disk. The in-memory
current report is still replaced so a fix in the same process works.

The CLI grows `--only ssh,firewall` / `--skip cve`, mutually exclusive,
validated against the real source names — a typo is a usage error
naming the valid choices, not a silently empty scan. Skipping every
domain is refused. Exit-code semantics are unchanged over what ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)