### PR TITLE
feat(web): live rescan progress in the dashboard

### DIFF
--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -577,14 +577,34 @@ async function whileBusy(el, label, fn) {
   }
 }
 
+// A rescan is started, not awaited: the server answers 202 immediately and
+// the scan runs in the background, so the page polls the status route and
+// narrates which domains are still working instead of freezing a button
+// for minutes. A 409 means a scan is already running — poll that one.
 const rescanBtn = document.getElementById("rescan");
 rescanBtn.onclick = () => whileBusy(rescanBtn, "Rescanning…", async () => {
   flash("Rescanning…");
   marked.clear();
-  report = await api("/api/rescan", { method: "POST", headers: { "Content-Type": "application/json" } });
+  const res = await fetch("/api/rescan", { method: "POST", headers: { "Content-Type": "application/json" } });
+  if (!res.ok && res.status !== 409) throw new Error((await res.text()) || res.statusText);
+  await pollRescan();
+  report = await api("/api/result");
   render();
   flash("Rescan complete.");
 });
+
+// pollRescan resolves when the running scan finishes, updating the status
+// line with the per-domain picture roughly once a second.
+async function pollRescan() {
+  for (;;) {
+    const st = await api("/api/rescan/status");
+    if (!st.running) return;
+    const working = (st.domains || []).filter((d) => d.state === "running").map((d) => d.source);
+    const done = (st.domains || []).filter((d) => d.state !== "running" && d.state !== "pending").length;
+    flash("Rescanning… " + (working.length ? "checking " + working.join(", ") : done + " domain(s) finished"));
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}
 
 const fixallBtn = document.getElementById("fixall");
 fixallBtn.onclick = () => {

--- a/internal/ui/web/progress.go
+++ b/internal/ui/web/progress.go
@@ -1,0 +1,72 @@
+package web
+
+import (
+	"sync"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// progressTracker keeps a per-domain snapshot of the scan in flight.
+//
+// The engine's progress emit is deliberately lossy — a full channel buffer
+// drops events rather than stall a checker — so the consumer keeps
+// latest-state-per-domain instead of replaying a stream. A dropped event is
+// invisible as long as a later one lands, and each domain's final event
+// always does because the drain goroutine empties the channel faster than
+// checkers finish.
+type progressTracker struct {
+	mu      sync.Mutex
+	running bool
+	domains map[model.Source]model.ScanEvent
+}
+
+// begin marks a scan as started and clears the previous snapshot. It
+// returns false when one is already running, which is what turns a second
+// rescan click into a 409 rather than a queued multi-minute scan.
+func (p *progressTracker) begin() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.running {
+		return false
+	}
+	p.running = true
+	p.domains = map[model.Source]model.ScanEvent{}
+	return true
+}
+
+func (p *progressTracker) update(ev model.ScanEvent) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.domains == nil {
+		p.domains = map[model.Source]model.ScanEvent{}
+	}
+	p.domains[ev.Source] = ev
+}
+
+func (p *progressTracker) finish() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.running = false
+}
+
+// domainProgress is one domain's latest state, shaped for the client.
+type domainProgress struct {
+	Source string `json:"source"`
+	State  string `json:"state"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// snapshot returns whether a scan is running and each seen domain's latest
+// state, in the stable AllSources order so the client's list does not
+// reshuffle between polls.
+func (p *progressTracker) snapshot() (bool, []domainProgress) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := []domainProgress{}
+	for _, src := range model.AllSources() {
+		if ev, ok := p.domains[src]; ok {
+			out = append(out, domainProgress{Source: src.String(), State: ev.State.String(), Reason: ev.Reason})
+		}
+	}
+	return p.running, out
+}

--- a/internal/ui/web/server.go
+++ b/internal/ui/web/server.go
@@ -45,6 +45,13 @@ type Server struct {
 	// token gates every route. See newToken for why loopback alone is not
 	// enough of a boundary here.
 	token string
+	// progress is the per-domain snapshot behind GET /api/rescan/status.
+	progress progressTracker
+	// baseCtx is what a background rescan runs under: it must outlive the
+	// request that started it (a closed tab is not an instruction to stop
+	// scanning) but die with the server (Ctrl-C is). Set by ListenAndServe;
+	// nil means Background, which only happens in tests.
+	baseCtx context.Context
 }
 
 // New builds a web Server bound to addr (e.g. "127.0.0.1:8787"), rendering in
@@ -97,6 +104,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/result", s.handleResult)
 	mux.HandleFunc("GET /api/preview", s.handlePreview)
 	mux.HandleFunc("GET /api/history", s.handleHistory)
+	mux.HandleFunc("GET /api/rescan/status", s.handleRescanStatus)
 	mux.HandleFunc("POST /api/fix", s.handleFix)
 	mux.HandleFunc("POST /api/fix/all", s.handleFixAll)
 	mux.HandleFunc("POST /api/fix/batch", s.handleFixBatch)
@@ -122,6 +130,11 @@ const shutdownGrace = 5 * time.Second
 // Ctrl-C nor `systemctl stop` and died only when systemd escalated to
 // SIGKILL — mid-fix, if that is what it happened to be doing.
 func (s *Server) ListenAndServe(ctx context.Context) error {
+	// Background rescans derive from this context, not from the requests
+	// that start them. Set before the listener opens, so no handler can
+	// observe it half-initialized.
+	s.baseCtx = ctx
+
 	// The startup scan gets the caller's context, so Ctrl-C during the slow
 	// first scan on a Trivy host stops it rather than being ignored until the
 	// listener is up.
@@ -331,9 +344,62 @@ func hostWork(r *http.Request) context.Context {
 	return context.WithoutCancel(r.Context())
 }
 
-func (s *Server) handleRescan(w http.ResponseWriter, r *http.Request) {
-	report := s.engine.Scan(hostWork(r), nil)
-	writeJSON(w, resultPayload{Report: report, Delta: s.engine.LastDelta()})
+// handleRescan starts a scan in the background and returns immediately —
+// a rescan takes minutes on a real host, and a response that blocks for
+// the duration gives the browser nothing to render but a frozen button.
+// The client polls /api/rescan/status and fetches /api/result when the
+// running flag drops.
+//
+// The scan runs under the server's base context rather than the request's:
+// a closed tab must not abort a scan (the hostWork rule), but Ctrl-C on the
+// server should.
+func (s *Server) handleRescan(w http.ResponseWriter, _ *http.Request) {
+	if !s.progress.begin() {
+		http.Error(w, "a scan is already running", http.StatusConflict)
+		return
+	}
+	go s.runTrackedScan()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_, _ = w.Write([]byte("{\"started\":true}\n"))
+}
+
+// scanEventBuffer sizes the progress channel. The engine drops events on a
+// full buffer rather than stall a checker; a generous buffer plus a
+// dedicated drain goroutine makes that a non-event.
+const scanEventBuffer = 64
+
+// runTrackedScan runs one scan, feeding the progress tracker until the
+// engine is done and every event has been drained.
+func (s *Server) runTrackedScan() {
+	events := make(chan model.ScanEvent, scanEventBuffer)
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for ev := range events {
+			s.progress.update(ev)
+		}
+	}()
+
+	ctx := s.baseCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.engine.Scan(ctx, events)
+	close(events)
+	<-drained
+	s.progress.finish()
+}
+
+func (s *Server) handleRescanStatus(w http.ResponseWriter, _ *http.Request) {
+	// Never cache: the whole point of the route is that the answer changes
+	// second to second.
+	w.Header().Set("Cache-Control", "no-store")
+	running, domains := s.progress.snapshot()
+	writeJSON(w, struct {
+		Running bool             `json:"running"`
+		Domains []domainProgress `json:"domains"`
+	}{running, domains})
 }
 
 func (s *Server) handlePreview(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/web/server_test.go
+++ b/internal/ui/web/server_test.go
@@ -332,34 +332,122 @@ func TestResultCarriesDelta(t *testing.T) {
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 
-	for _, path := range []string{"/api/result", "/api/rescan"} {
-		var payload struct {
-			Findings []model.Finding `json:"findings"`
-			Delta    *model.Delta    `json:"delta"`
+	var payload struct {
+		Findings []model.Finding `json:"findings"`
+		Delta    *model.Delta    `json:"delta"`
+	}
+	resp, err := authedClient(t, s, srv).Get(srv.URL + "/api/result")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.NewDecoder(resp.Body).Decode(&payload)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.Delta == nil {
+		t.Error("response carries no delta field")
+	}
+	// Embedding must not have disturbed the existing flat shape.
+	if len(payload.Findings) == 0 {
+		t.Error("findings disappeared from the payload")
+	}
+}
+
+// A rescan takes minutes on a real host, so the route answers 202 and the
+// scan runs in the background; the client follows it on the status route
+// and fetches the result when the running flag drops.
+func TestRescanIsAsynchronous(t *testing.T) {
+	s, _ := testServer(t)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	client := authedClient(t, s, srv)
+
+	resp, err := client.Post(srv.URL+"/api/rescan", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("rescan returned %d, want 202", resp.StatusCode)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var st struct {
+			Running bool `json:"running"`
+			Domains []struct {
+				Source string `json:"source"`
+				State  string `json:"state"`
+			} `json:"domains"`
 		}
-		var resp *http.Response
-		var err error
-		client := authedClient(t, s, srv)
-		if path == "/api/rescan" {
-			resp, err = client.Post(srv.URL+path, "application/json", nil)
-		} else {
-			resp, err = client.Get(srv.URL + path)
-		}
+		resp, err := client.Get(srv.URL + "/api/rescan/status")
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = json.NewDecoder(resp.Body).Decode(&payload)
+		err = json.NewDecoder(resp.Body).Decode(&st)
 		resp.Body.Close()
 		if err != nil {
-			t.Fatalf("%s: %v", path, err)
+			t.Fatal(err)
 		}
-		if payload.Delta == nil {
-			t.Errorf("%s: response carries no delta field", path)
+		if !st.Running {
+			// The finished scan's domains must be visible in the snapshot,
+			// with their final states.
+			if len(st.Domains) == 0 {
+				t.Error("status carries no domain states after a completed scan")
+			}
+			break
 		}
-		// Embedding must not have disturbed the existing flat shape.
-		if len(payload.Findings) == 0 {
-			t.Errorf("%s: findings disappeared from the payload", path)
+		if time.Now().After(deadline) {
+			t.Fatal("the background scan never finished")
 		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The report the scan produced serves as usual.
+	res, err := client.Get(srv.URL + "/api/result")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	var report model.Report
+	if err := json.NewDecoder(res.Body).Decode(&report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Findings) == 0 {
+		t.Error("no findings after the background rescan")
+	}
+}
+
+// A second rescan while one is running queues nothing and answers 409 —
+// the engine serialises scans behind one mutex, so accepting the request
+// would only hold a connection open behind the first.
+func TestConcurrentRescanIsRefused(t *testing.T) {
+	s, _ := testServer(t)
+	if !s.progress.begin() {
+		t.Fatal("tracker should be idle at start")
+	}
+	defer s.progress.finish()
+
+	rec := httptest.NewRecorder()
+	req := authed(s, httptest.NewRequest(http.MethodPost, "/api/rescan", nil))
+	req.Host = "127.0.0.1:8787"
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("concurrent rescan returned %d, want 409", rec.Code)
+	}
+}
+
+// The status route reads scan state gathered as root, so it is gated by
+// the token like everything else.
+func TestRescanStatusRequiresTheToken(t *testing.T) {
+	s, _ := testServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/rescan/status", nil)
+	req.Host = "127.0.0.1:8787"
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("unauthenticated status read returned %d, want 401", rec.Code)
 	}
 }
 


### PR DESCRIPTION
`POST /api/rescan` now answers 202 and runs the scan in the background —
a rescan takes minutes on a real host, and a blocking response gave the
browser nothing to render but a frozen button. The page polls the new
`GET /api/rescan/status` (token-gated like everything else) and narrates
which domains are still working, then fetches `/api/result` when the
running flag drops. A second rescan while one runs is a 409, not a
queued multi-minute request.

The tracker keeps latest-state-per-domain rather than replaying a
stream, because the engine's progress emit is deliberately lossy — a
full buffer drops events rather than stall a checker. Polling over SSE:
it composes with the token/cookie guard, the method-bound router, and
the CSP as they stand, and one request a second for a ten-domain scan
buys nothing from a stream.

Background scans derive from the server's base context, not the
request's: a closed tab must not abort a scan, but Ctrl-C on the server
should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)