### PR TITLE
feat(tui): add AI explanations to the detail view

### DIFF
--- a/cmd/hostveil/tui.go
+++ b/cmd/hostveil/tui.go
@@ -32,7 +32,10 @@ func cmdTUI(ctx context.Context, args []string) int {
 		Initial: t,
 		Save:    func(id string) error { return theme.Save(dir, id) },
 	}
-	if err := tui.Run(ctx, buildEngine(), opts); err != nil {
+	// The advisory AI provider is wired in for the detail view's `e` key.
+	// Construction does no I/O; with no Ollama reachable the view shows a
+	// one-line note instead.
+	if err := tui.Run(ctx, buildEngineWithAI(true), opts); err != nil {
 		fmt.Fprintln(os.Stderr, "hostveil:", err)
 		return 1
 	}

--- a/cmd/sitegen/content/en/docs/interfaces.html
+++ b/cmd/sitegen/content/en/docs/interfaces.html
@@ -31,6 +31,7 @@
                   <tr><td><code>x</code></td><td>Show only findings hostveil can fix.</td></tr>
                   <tr><td><code>c</code></td><td>Clear every filter. <code>Esc</code> clears the batch marks.</td></tr>
                   <tr><td><code>h</code></td><td>Applied-fix history — pick one and press <code>Enter</code> to see what rolling it back would restore, then confirm.</td></tr>
+                  <tr><td><code>e</code></td><td>In a finding's detail: add an advisory AI explanation from a local Ollama model. Without one, a one-line note appears instead — <a href="ai">AI explanations</a>.</td></tr>
                   <tr><td><code>t</code></td><td>Theme picker (below).</td></tr>
                   <tr><td><code>r</code></td><td>Rescan.</td></tr>
                   <tr><td><code>q</code></td><td>Back, or quit from the list. <code>Ctrl-C</code> always quits.</td></tr>

--- a/cmd/sitegen/content/ko/docs/interfaces.html
+++ b/cmd/sitegen/content/ko/docs/interfaces.html
@@ -31,6 +31,7 @@
                   <tr><td><code>x</code></td><td>hostveil이 고칠 수 있는 항목만 봅니다.</td></tr>
                   <tr><td><code>c</code></td><td>모든 필터를 지웁니다. <code>Esc</code>는 일괄 처리 표시를 지웁니다.</td></tr>
                   <tr><td><code>h</code></td><td>적용된 수정 이력입니다. 하나를 골라 <code>Enter</code>를 누르면 되돌렸을 때 복원될 내용을 보여 주고, 확인을 받습니다.</td></tr>
+                  <tr><td><code>e</code></td><td>발견 항목의 상세 화면에서: 로컬 Ollama 모델의 조언성 AI 설명을 덧붙입니다. 모델이 없으면 한 줄 안내가 대신 나옵니다 — <a href="ai">AI 설명</a> 참고.</td></tr>
                   <tr><td><code>t</code></td><td>테마 선택기(아래 참고).</td></tr>
                   <tr><td><code>r</code></td><td>다시 스캔합니다.</td></tr>
                   <tr><td><code>q</code></td><td>뒤로, 목록 화면에서는 종료. <code>Ctrl-C</code>는 언제나 종료합니다.</td></tr>

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -57,6 +57,14 @@ type appModel struct {
 	previewAction int
 	status        string
 
+	// Advisory AI explanation state for the detail view. Cleared whenever
+	// the inspected finding changes, so a slow answer cannot land under the
+	// wrong finding — explainedMsg also carries the finding's key and is
+	// dropped if the user has moved on.
+	aiBusy bool
+	aiText string
+	aiErr  string
+
 	checkpoints []model.Checkpoint // applied-fix log, newest first
 	cpCursor    int
 	cpOffset    int
@@ -104,6 +112,13 @@ func (m *appModel) runCtx() context.Context {
 		return context.Background()
 	}
 	return m.ctx
+}
+
+// clearAI drops any AI explanation state; called whenever the inspected
+// finding is about to change.
+func (m *appModel) clearAI() {
+	m.aiBusy = false
+	m.aiText, m.aiErr = "", ""
 }
 
 // rebuildActive re-derives the visible list from the current report and
@@ -164,6 +179,20 @@ func batchCmd(ctx context.Context, e *core.Engine, fs []model.Finding) tea.Cmd {
 	}
 }
 
+type explainedMsg struct {
+	key string // Finding.Key() of the finding this answers for
+	exp model.Explanation
+}
+
+// explainCmd asks the engine for an explanation with the advisory AI
+// enabled. The engine degrades on its own: no reachable provider comes
+// back as AIError, never as a failure.
+func explainCmd(ctx context.Context, e *core.Engine, f model.Finding) tea.Cmd {
+	return func() tea.Msg {
+		return explainedMsg{key: f.Key(), exp: e.Explain(ctx, f, true)}
+	}
+}
+
 type historyMsg struct {
 	checkpoints []model.Checkpoint
 	// warning is set when some checkpoints could not be read. The list is
@@ -211,9 +240,19 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.report = msg.report
 		m.delta = msg.delta
 		m.selected = map[string]bool{} // a fresh scan invalidates old picks
+		m.clearAI()
 		m.rebuildActive()
 		m.offset = 0
 		m.mode = modeList
+		return m, nil
+
+	case explainedMsg:
+		m.aiBusy = false
+		// A slow answer for a finding the user has already left is dropped
+		// rather than rendered under whatever is on screen now.
+		if m.mode == modeDetail && len(m.active) > 0 && m.active[m.cursor].Key() == msg.key {
+			m.aiText, m.aiErr = msg.exp.AI, msg.exp.AIError
+		}
 		return m, nil
 
 	case previewMsg:
@@ -302,9 +341,16 @@ func (m *appModel) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case modeDetail:
 		switch key {
 		case "esc", "q", "backspace":
+			m.clearAI()
 			m.mode = modeList
 		case "f":
 			return m, m.startPreview()
+		case "e":
+			if len(m.active) > 0 && !m.aiBusy {
+				m.aiBusy = true
+				m.aiText, m.aiErr = "", ""
+				return m, explainCmd(m.runCtx(), m.engine, m.active[m.cursor])
+			}
 		}
 	case modePreview:
 		return m.keyPreview(key)
@@ -330,6 +376,7 @@ func (m *appModel) keyList(key string) (tea.Model, tea.Cmd) {
 		m.cursor = clamp(m.cursor+1, 0, len(m.active)-1)
 	case "enter":
 		if len(m.active) > 0 {
+			m.clearAI()
 			m.mode = modeDetail
 		}
 	case "f":

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -115,6 +115,48 @@ func TestSnapshotDump(t *testing.T) {
 	}
 }
 
+// The detail view's `e` key asks for an advisory AI explanation. With no
+// provider the engine answers through AIError, which must render as a note
+// in the detail pane — and a slow answer for a finding the user already
+// left must be dropped, not drawn under the wrong finding.
+func TestDetailAIExplanation(t *testing.T) {
+	m := tea.Model(&appModel{mode: modeList, selected: map[string]bool{},
+		engine: core.New(core.Config{Registry: check.NewRegistry()})})
+	m = send(m, tea.WindowSizeMsg{Width: 96, Height: 34})
+	m = send(m, scannedMsg{report: sampleReport()})
+	m = send(m, tea.KeyPressMsg(tea.Key{Text: "enter", Code: tea.KeyEnter}))
+
+	am := m.(*appModel)
+	if am.mode != modeDetail {
+		t.Fatalf("mode = %v, want detail", am.mode)
+	}
+	next, cmd := am.handleKey(tea.KeyPressMsg(tea.Key{Text: "e"}))
+	am = next.(*appModel)
+	if !am.aiBusy || cmd == nil {
+		t.Fatal("e should mark the pane busy and start the explain command")
+	}
+	if !strings.Contains(am.View().Content, "AI EXPLANATION") {
+		t.Error("busy state should already show the AI section")
+	}
+
+	key := am.active[am.cursor].Key()
+	m = send(tea.Model(am), explainedMsg{key: key, exp: model.Explanation{AIError: "no AI provider is reachable"}})
+	am = m.(*appModel)
+	if am.aiBusy || am.aiErr == "" {
+		t.Errorf("the answer should land as a note: busy=%v err=%q", am.aiBusy, am.aiErr)
+	}
+	if !strings.Contains(am.View().Content, "no AI provider is reachable") {
+		t.Error("the AI note is not rendered in the detail pane")
+	}
+
+	// Leave the detail view; a late answer must be dropped.
+	m = send(m, tea.KeyPressMsg(tea.Key{Text: "esc", Code: tea.KeyEscape}))
+	m = send(m, explainedMsg{key: key, exp: model.Explanation{AI: "late answer"}})
+	if am := m.(*appModel); am.aiText != "" {
+		t.Error("an answer that arrives after leaving the detail view must be dropped")
+	}
+}
+
 // TestListScrolls verifies the list viewport follows the cursor when there
 // are more findings than fit on screen.
 func TestListScrolls(t *testing.T) {

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -145,7 +145,7 @@ func (m *appModel) View() tea.View {
 		content = m.compose(fullHeader(), nil, hint, m.listRows)
 
 	case modeDetail:
-		hint := "esc back   q list"
+		hint := "e explain (AI)   esc back   q list"
 		if len(m.active) > 0 && m.active[m.cursor].IsFixable() {
 			hint = "f apply fix   " + hint
 		}
@@ -487,6 +487,17 @@ func (m *appModel) detailRows() []string {
 	if f.HowToFix != "" {
 		out = append(out, "", s.dim.Render("HOW TO FIX"))
 		out = append(out, styledRows(s.bone, wrap(f.HowToFix, min(m.width-4, 78)))...)
+	}
+	if m.aiBusy || m.aiText != "" || m.aiErr != "" {
+		out = append(out, "", s.dim.Render("AI EXPLANATION (ADVISORY)"))
+		switch {
+		case m.aiBusy:
+			out = append(out, s.dim.Render("  asking the local AI model…"))
+		case m.aiText != "":
+			out = append(out, styledRows(s.bone, wrap(m.aiText, min(m.width-4, 78)))...)
+		default:
+			out = append(out, styledRows(s.dim, wrap(m.aiErr, min(m.width-4, 78)))...)
+		}
 	}
 	return out
 }

--- a/site/docs/interfaces.html
+++ b/site/docs/interfaces.html
@@ -117,6 +117,7 @@
                   <tr><td><code>x</code></td><td>Show only findings hostveil can fix.</td></tr>
                   <tr><td><code>c</code></td><td>Clear every filter. <code>Esc</code> clears the batch marks.</td></tr>
                   <tr><td><code>h</code></td><td>Applied-fix history — pick one and press <code>Enter</code> to see what rolling it back would restore, then confirm.</td></tr>
+                  <tr><td><code>e</code></td><td>In a finding's detail: add an advisory AI explanation from a local Ollama model. Without one, a one-line note appears instead — <a href="ai">AI explanations</a>.</td></tr>
                   <tr><td><code>t</code></td><td>Theme picker (below).</td></tr>
                   <tr><td><code>r</code></td><td>Rescan.</td></tr>
                   <tr><td><code>q</code></td><td>Back, or quit from the list. <code>Ctrl-C</code> always quits.</td></tr>

--- a/site/ko/docs/interfaces.html
+++ b/site/ko/docs/interfaces.html
@@ -117,6 +117,7 @@
                   <tr><td><code>x</code></td><td>hostveil이 고칠 수 있는 항목만 봅니다.</td></tr>
                   <tr><td><code>c</code></td><td>모든 필터를 지웁니다. <code>Esc</code>는 일괄 처리 표시를 지웁니다.</td></tr>
                   <tr><td><code>h</code></td><td>적용된 수정 이력입니다. 하나를 골라 <code>Enter</code>를 누르면 되돌렸을 때 복원될 내용을 보여 주고, 확인을 받습니다.</td></tr>
+                  <tr><td><code>e</code></td><td>발견 항목의 상세 화면에서: 로컬 Ollama 모델의 조언성 AI 설명을 덧붙입니다. 모델이 없으면 한 줄 안내가 대신 나옵니다 — <a href="ai">AI 설명</a> 참고.</td></tr>
                   <tr><td><code>t</code></td><td>테마 선택기(아래 참고).</td></tr>
                   <tr><td><code>r</code></td><td>다시 스캔합니다.</td></tr>
                   <tr><td><code>q</code></td><td>뒤로, 목록 화면에서는 종료. <code>Ctrl-C</code>는 언제나 종료합니다.</td></tr>


### PR DESCRIPTION
The detail view answers `e` with an advisory AI explanation, fetched
asynchronously through a `tea.Cmd` so the interface never blocks on a
model; the pane shows "asking the local AI model…" meanwhile. The
answer carries the finding's key and is dropped if the user has moved
on — a slow response must not land under the wrong finding. With no
Ollama reachable the engine's `AIError` renders as a one-line note,
never an error state.

The TUI now constructs its engine with the AI provider wired in;
construction does no I/O and the explainer is only consulted on the
explicit keypress, so the advisory invariant holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)