### PR TITLE
test: guard the brand assets, axis gap, and community files against drift

### DIFF
--- a/internal/docs/community_test.go
+++ b/internal/docs/community_test.go
@@ -1,0 +1,203 @@
+// The community-health files are read by GitHub and by people, never by the
+// compiler, so like AGENTS.md they go stale silently — with the extra hazard
+// that GitHub degrades a malformed file instead of rejecting it. An issue
+// form with a YAML error falls back to a blank editor, which quietly reopens
+// the exact hole `blank_issues_enabled: false` exists to close: security
+// reports arriving as public issues. Same policy as agents_test.go — check
+// what is mechanical, never the prose.
+package docs
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestIssueFormsAreWellFormed pins what GitHub actually requires of an issue
+// form: parseable YAML, a name and description, and a non-empty body whose
+// every element declares a type. Anything less renders as a broken template
+// chooser with no error surfaced to anyone.
+func TestIssueFormsAreWellFormed(t *testing.T) {
+	dir := filepath.Join(repoRoot(t), ".github", "ISSUE_TEMPLATE")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	forms := 0
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if name == "config.yml" || name == "config.yaml" {
+			var cfg struct {
+				BlankIssuesEnabled *bool `yaml:"blank_issues_enabled"`
+				ContactLinks       []struct {
+					Name  string `yaml:"name"`
+					URL   string `yaml:"url"`
+					About string `yaml:"about"`
+				} `yaml:"contact_links"`
+			}
+			if err := yaml.Unmarshal(raw, &cfg); err != nil {
+				t.Errorf("%s does not parse: %v", name, err)
+				continue
+			}
+			// The explicit false is the point of the file: blank issues are
+			// how a vulnerability report ends up public.
+			if cfg.BlankIssuesEnabled == nil || *cfg.BlankIssuesEnabled {
+				t.Errorf("%s must set blank_issues_enabled: false", name)
+			}
+			if len(cfg.ContactLinks) == 0 {
+				t.Errorf("%s routes nowhere: no contact_links", name)
+			}
+			for i, l := range cfg.ContactLinks {
+				if l.Name == "" || l.URL == "" || l.About == "" {
+					t.Errorf("%s contact link %d is missing name, url, or about", name, i)
+				}
+			}
+			continue
+		}
+
+		forms++
+		var form struct {
+			Name        string `yaml:"name"`
+			Description string `yaml:"description"`
+			Body        []struct {
+				Type string `yaml:"type"`
+			} `yaml:"body"`
+		}
+		if err := yaml.Unmarshal(raw, &form); err != nil {
+			t.Errorf("%s does not parse: %v", name, err)
+			continue
+		}
+		if form.Name == "" || form.Description == "" {
+			t.Errorf("%s needs both a name and a description to appear in the chooser", name)
+		}
+		if len(form.Body) == 0 {
+			t.Errorf("%s has no body elements", name)
+		}
+		for i, el := range form.Body {
+			if el.Type == "" {
+				t.Errorf("%s body element %d declares no type", name, i)
+			}
+		}
+	}
+	if forms == 0 {
+		t.Fatal("no issue forms found — if they moved on purpose, move this test's directory too")
+	}
+}
+
+// TestCitationFileMatchesTheRepo keeps CITATION.cff honest about the things
+// the repo already states elsewhere: the module path names the repository,
+// and LICENSE names the license. A citation pointing at a renamed repo or
+// claiming the wrong license is worse than none.
+func TestCitationFileMatchesTheRepo(t *testing.T) {
+	var cff struct {
+		CFFVersion     string `yaml:"cff-version"`
+		Title          string `yaml:"title"`
+		RepositoryCode string `yaml:"repository-code"`
+		License        string `yaml:"license"`
+		Authors        []any  `yaml:"authors"`
+	}
+	if err := yaml.Unmarshal([]byte(readRepoFile(t, "CITATION.cff")), &cff); err != nil {
+		t.Fatalf("CITATION.cff does not parse: %v", err)
+	}
+	if cff.CFFVersion == "" {
+		t.Error("CITATION.cff declares no cff-version, so GitHub will not offer the cite button")
+	}
+	if cff.Title == "" || len(cff.Authors) == 0 {
+		t.Error("CITATION.cff needs a title and at least one author to be a citation")
+	}
+
+	m := regexp.MustCompile(`(?m)^module\s+(\S+)`).FindStringSubmatch(readRepoFile(t, "go.mod"))
+	if m == nil {
+		t.Fatal("go.mod has no module line")
+	}
+	if !strings.Contains(cff.RepositoryCode, m[1]) {
+		t.Errorf("CITATION.cff points at %q, but the module is %q", cff.RepositoryCode, m[1])
+	}
+
+	// LICENSE is the GPL text; its title line is enough to anchor the SPDX
+	// family without parsing the whole document.
+	if !strings.Contains(readRepoFile(t, "LICENSE"), "GNU GENERAL PUBLIC LICENSE") ||
+		!strings.HasPrefix(cff.License, "GPL-3.0") {
+		t.Errorf("CITATION.cff says license %q, which does not match LICENSE", cff.License)
+	}
+}
+
+var (
+	mdImage   = regexp.MustCompile(`!\[[^\]]*\]\(([^)\s]+)`)
+	htmlImage = regexp.MustCompile(`<img[^>]+src="([^"]+)"`)
+	mdLink    = regexp.MustCompile(`[^!]\[[^\]]*\]\(([^)\s]+)`)
+)
+
+// TestReadmeLocalReferencesExist does for README.md what
+// TestReferencedPathsExist does for AGENTS.md: every repo-relative image and
+// link must resolve. The hero screenshot is the first thing the project page
+// shows, and a moved PNG turns it into a broken-image icon with no CI signal.
+func TestReadmeLocalReferencesExist(t *testing.T) {
+	root := repoRoot(t)
+	readme := readRepoFile(t, "README.md")
+
+	var refs []string
+	for _, re := range []*regexp.Regexp{mdImage, htmlImage, mdLink} {
+		for _, m := range re.FindAllStringSubmatch(readme, -1) {
+			target := m[1]
+			if strings.Contains(target, "://") || strings.HasPrefix(target, "#") || strings.HasPrefix(target, "mailto:") {
+				continue
+			}
+			target, _, _ = strings.Cut(target, "#")
+			refs = addUnique(refs, target)
+		}
+	}
+	// The same nothing-extracted guard as the AGENTS.md tests: README links
+	// at least its license, module file, and two screenshots today.
+	if len(refs) < 3 {
+		t.Fatalf("only %d local references extracted from README.md (%v) — extraction is broken, not the doc", len(refs), refs)
+	}
+	for _, ref := range refs {
+		if _, err := os.Stat(filepath.Join(root, ref)); err != nil {
+			t.Errorf("README.md references %q, which does not exist", ref)
+		}
+	}
+}
+
+// TestPRTemplateGateMatchesAgentsMd pins the CI-gate commands the pull
+// request template tells a contributor to run to the ones AGENTS.md
+// documents. The template repeats them because a contributor sees it at the
+// exact moment the commands matter; repetition is only safe while this keeps
+// the copies identical — a version bumped in one file and not the other has
+// contributors running a gate CI no longer runs.
+func TestPRTemplateGateMatchesAgentsMd(t *testing.T) {
+	tmpl := readRepoFile(t, filepath.Join(".github", "pull_request_template.md"))
+	agents := agentsMD(t)
+
+	blocks := fencedBlock.FindAllString(tmpl, -1)
+	if len(blocks) == 0 {
+		t.Fatal("the pull request template no longer has a fenced command block")
+	}
+	checked := 0
+	for _, line := range strings.Split(strings.Trim(blocks[0], "`"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		checked++
+		if !strings.Contains(agents, line) {
+			t.Errorf("the pull request template says to run %q, which AGENTS.md does not document", line)
+		}
+	}
+	if checked < 3 {
+		t.Fatalf("only %d gate commands extracted from the template — extraction is broken, not the doc", checked)
+	}
+}

--- a/internal/ui/tui/layout_test.go
+++ b/internal/ui/tui/layout_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -160,6 +161,29 @@ func TestPreviewAndHistoryFitTerminalWidth(t *testing.T) {
 		// end; every mode goes through the same composer and fills the frame.
 		if got := strings.Count(content, "\n") + 1; got != m.height {
 			t.Errorf("%s height=%d: frame is %d lines", name, m.height, got)
+		}
+	}
+}
+
+var ansiSeq = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// The axis id column is one wider than the longest id, so every id keeps at
+// least one space before its meter. It was exactly as wide for a while
+// ("%-9s"), which the width tests above cannot see: "container████────"
+// and "container ███────" are the same number of columns, just the first
+// one is unreadable. The gap is asserted on every axis, N/A and degraded
+// included — each renders its own cell and each regressed the same way.
+func TestAxisIdsKeepAGapBeforeTheMeter(t *testing.T) {
+	m := &appModel{width: 200, report: layoutReport(), selected: map[string]bool{}}
+	strip := ansiSeq.ReplaceAllString(m.axesLine(), "")
+	for _, ax := range m.report.Score.Axes {
+		i := strings.Index(strip, ax.ID)
+		if i < 0 {
+			t.Fatalf("axis %q missing from the strip:\n%s", ax.ID, strip)
+		}
+		rest := strip[i+len(ax.ID):]
+		if rest == "" || rest[0] != ' ' {
+			t.Errorf("axis %q butts straight against its meter: %q", ax.ID, strip[i:min(i+16, len(strip))])
 		}
 	}
 }

--- a/internal/ui/web/brand_test.go
+++ b/internal/ui/web/brand_test.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"io"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/ui/theme"
+)
+
+// The brand mark ships as two files on purpose: favicon.svg keeps an opaque
+// tile because a browser tab has no known background, and mark.svg drops it
+// so the status-bar figure dissolves into whatever palette the page runs in.
+// index.html asks for one and app.css paints the other, so a missing or
+// misnamed asset is a broken tab icon or an empty 20px gap before the brand
+// text — neither of which any Go test noticed when the files landed.
+func TestBrandAssetsAreServed(t *testing.T) {
+	s, _ := testServer(t)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	for _, path := range []string{"/favicon.svg", "/mark.svg"} {
+		resp, err := authedClient(t, s, srv).Get(srv.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Errorf("%s returned %d", path, resp.StatusCode)
+		}
+		// The browser refuses to rasterize an SVG served under another type,
+		// so the icon silently disappears rather than erroring.
+		if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "image/svg+xml") {
+			t.Errorf("%s Content-Type = %q, want image/svg+xml", path, ct)
+		}
+		if !strings.Contains(string(body), "<svg") {
+			t.Errorf("%s does not look like an SVG:\n%s", path, body)
+		}
+	}
+}
+
+// The page has to actually reference both variants, each in its own place:
+// the tab icon from index.html, the status-bar mark from app.css. Renaming
+// an asset without updating its reference degrades silently — the dashboard
+// still loads, just without its mark.
+func TestBrandAssetsAreReferenced(t *testing.T) {
+	index, err := assets.ReadFile("assets/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(index), `rel="icon"`) || !strings.Contains(string(index), `href="/favicon.svg"`) {
+		t.Error(`index.html does not link the favicon (rel="icon" href="/favicon.svg")`)
+	}
+
+	css, err := assets.ReadFile("assets/app.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(css), "url(/mark.svg)") {
+		t.Error("app.css no longer paints the brand from /mark.svg")
+	}
+	// The mark replaced a ▚ glyph that rendered as tofu in fonts without the
+	// quadrant block; the character must not creep back into either file.
+	for name, b := range map[string][]byte{"index.html": index, "app.css": css} {
+		if strings.Contains(string(b), "▚") {
+			t.Errorf("%s still contains the ▚ placeholder glyph the mark replaced", name)
+		}
+	}
+}
+
+var svgFill = regexp.MustCompile(`fill="(#[0-9a-fA-F]{6})"`)
+
+// internal/ui/theme is the only place a color is written down; the two brand
+// SVGs are the one static exception, because a favicon is fetched before any
+// theme is known. That exception is tolerable only while their hexes stay
+// the Instrument roles they were drawn from — the Ink2 tile, Bone slats, and
+// the Safe teal core. If the palette moves, this fails instead of the mark
+// quietly drifting off-brand.
+func TestBrandMarkColorsAreTheInstrumentPalette(t *testing.T) {
+	instrument, ok := theme.Lookup("instrument")
+	if !ok {
+		t.Fatal("the instrument theme is gone")
+	}
+	p := instrument.Palette
+	role := map[string]string{p.Ink2: "Ink2", p.Bone: "Bone", p.Safe: "Safe"}
+
+	for _, name := range []string{"assets/favicon.svg", "assets/mark.svg"} {
+		b, err := assets.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fills := svgFill.FindAllStringSubmatch(string(b), -1)
+		if len(fills) == 0 {
+			t.Fatalf("%s declares no fills — the extraction is broken, not the mark", name)
+		}
+		seen := map[string]bool{}
+		for _, m := range fills {
+			hex := strings.ToLower(m[1])
+			r, ok := role[hex]
+			if !ok {
+				t.Errorf("%s fills with %s, which is no Instrument Ink2/Bone/Safe", name, hex)
+				continue
+			}
+			seen[r] = true
+		}
+		// Both variants are the same figure: bone veil slats over a safe-teal
+		// core. Losing either color is losing half the mark's meaning.
+		for _, want := range []string{"Bone", "Safe"} {
+			if !seen[want] {
+				t.Errorf("%s no longer uses the %s role", name, want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What and why

The last two changes (#565, #566) landed with no tests of their own. This adds the missing guards, in the same spirit as `agents_test.go`: pin the mechanical claims, never the prose. Test-only — no production code changes.

**`internal/ui/web/brand_test.go`**
- `/favicon.svg` and `/mark.svg` are served with the `image/svg+xml` type (a browser refuses to rasterize an SVG served as anything else — the icon disappears silently).
- `index.html` links the favicon and `app.css` paints the status-bar mark from `/mark.svg`; the `▚` placeholder glyph must not creep back.
- Both SVGs fill only with the Instrument palette's Ink2/Bone/Safe roles. The brand marks are the one static exception to "`internal/ui/theme` is the only place a color is written down", and that exception is tolerable only while this test holds.

**`internal/ui/tui/layout_test.go`**
- Every axis id keeps a space before its meter. The id column was exactly as wide as `container` for a while (`%-9s`), which the existing width tests cannot see: the butted and gapped strips are the same number of columns, only one of them is readable.

**`internal/docs/community_test.go`**
- Issue forms parse and declare name/description/body types — GitHub degrades a malformed form to a blank editor rather than erroring, silently reopening the door `blank_issues_enabled: false` closes on public vulnerability reports.
- `config.yml` keeps blank issues off and its contact links complete.
- `CITATION.cff` parses, points at the module path from `go.mod`, and claims the license `LICENSE` actually contains.
- README's repo-relative images and links resolve (the hero screenshot is the first thing the project page shows; a moved PNG is a broken-image icon with no CI signal).
- The PR template's gate commands stay character-identical to AGENTS.md's, so a version bump in one file can't strand the other.

Each extraction-based test carries the same nothing-extracted guard as `agents_test.go`, so a broken regexp fails loudly instead of passing vacuously.

## Checklist

- [x] Title is conventional with a valid scope (`type(scope): ...`) — `test:`, scope-free as allowed by `requireScope: false`; the change spans web, tui, and docs.
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
  go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  build/vet/gofmt/tidy/`test -race` (27 packages) and sitegen drift pass locally. golangci-lint and govulncheck cannot run in this container (their binaries are built with go1.25, the module targets go1.26) — CI covers both, and the change is test-only.
- [x] For a new or changed detection rule: n/a (no detection changes).
- [x] For a UI change: n/a (tests only); the TUI/web layering tests still pass.
- [x] The score stays honest — no scoring paths touched.

Verified by mutation: reverting the axis pad to `%-9s` fails `TestAxisIdsKeepAGapBeforeTheMeter`, and an off-palette fill in `mark.svg` fails `TestBrandMarkColorsAreTheInstrumentPalette`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_