### PR TITLE
fix(history): write scan snapshots atomically

### DIFF
--- a/internal/history/atomicity_test.go
+++ b/internal/history/atomicity_test.go
@@ -1,0 +1,109 @@
+package history
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This package is the recovery layer: the checkpoints it holds are the only
+// copy of what a fix overwrote, and the scan snapshots it holds are the
+// baseline every delta is computed against. Both are files that something
+// else depends on being whole, and os.WriteFile truncates the target before
+// it writes a byte — so a crash, an OOM kill, or delayed allocation on XFS
+// or btrfs leaves a valid-looking file that is a prefix of the real one.
+//
+// AGENTS.md states the rule as "every write in internal/history goes
+// through platform.WriteFileAtomic". It was not quite true: SaveReport
+// still used os.WriteFile, which is how the newest scan snapshot — the one
+// LastReport reads and the next scan diffs against — could be torn.
+//
+// A test that provokes a torn write would have to crash the process at a
+// chosen instant, which is not something a unit test can do reliably. So
+// this asserts the property the invariant is actually about: no production
+// file here calls os.WriteFile at all. It is the same shape as the UI
+// layering tests — read the source, fail on the call that must not exist.
+func TestNoProductionWriteBypassesAtomicWrite(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checked := 0
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		checked++
+		file, err := parser.ParseFile(token.NewFileSet(), name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "os" {
+				return true
+			}
+			// os.Remove and os.ReadFile are fine — the rule is about
+			// creating or replacing a file's contents, which is the only
+			// operation that can leave a truncated one behind.
+			if sel.Sel.Name == "WriteFile" || sel.Sel.Name == "Create" {
+				t.Errorf("%s calls os.%s; every write in this package must go through platform.WriteFileAtomic",
+					name, sel.Sel.Name)
+			}
+			return true
+		})
+	}
+	// Nothing-extracted guard: a glob that matched no production file would
+	// pass this test while checking nothing.
+	if checked < 2 {
+		t.Fatalf("only %d production files scanned — the package layout moved and this test did not", checked)
+	}
+}
+
+// A scan snapshot has to survive the round trip byte for byte: the delta is
+// computed by unmarshalling it, so a write that changed the content at all
+// would be a wrong delta rather than a missing one.
+func TestSaveReportRoundTrips(t *testing.T) {
+	s := NewStore(t.TempDir())
+	want := []byte(`{"findings":[],"score":{"overall":42}}`)
+	if err := s.SaveReport(NewScanID(), want); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := s.LastReport()
+	if err != nil || !ok {
+		t.Fatalf("LastReport() = ok %v, err %v", ok, err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("round-tripped %q, want %q", got, want)
+	}
+
+	// The atomic write stages beside the target and renames. If a temp file
+	// were left behind, scanFiles would sort it in as though it were a
+	// snapshot and LastReport could return it.
+	entries, err := os.ReadDir(filepath.Join(s.dir, "scans"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("scans dir holds %v, want exactly one snapshot", names)
+	}
+}

--- a/internal/history/scans.go
+++ b/internal/history/scans.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/seolcu/hostveil/internal/platform"
 )
 
 // maxScans caps how many past scan snapshots are retained.
@@ -13,12 +15,23 @@ func (s *Store) scansDir() string { return filepath.Join(s.dir, "scans") }
 
 // SaveReport persists a scan snapshot (opaque JSON) under a sortable id,
 // pruning old snapshots beyond maxScans.
+//
+// The write is atomic for the same reason every other write in this package
+// is, even though a scan snapshot is not a backup. The newest snapshot is
+// the baseline: LastReport reads it and nothing else, and the next scan
+// diffs against it to decide what is newly appeared, resolved, or changed.
+// A snapshot torn by a crash — or by delayed allocation on XFS or btrfs —
+// therefore does not degrade the delta, it destroys it: the file fails to
+// unmarshal, and the run that follows either reports no delta at all or
+// announces the whole host as new. os.WriteFile truncates before it writes,
+// so the window where that file is a half-written prefix of valid JSON is
+// real, and it lands on exactly the file the next scan depends on.
 func (s *Store) SaveReport(id string, data []byte) error {
 	dir := s.scansDir()
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(dir, id+".json"), data, 0o600); err != nil {
+	if err := platform.WriteFileAtomic(filepath.Join(dir, id+".json"), data, 0o600); err != nil {
 		return err
 	}
 	s.pruneScans()


### PR DESCRIPTION
## What and why

AGENTS.md states the recovery layer's rule as *"every write in `internal/history` goes through `platform.WriteFileAtomic`"*. One did not. `SaveReport` (`internal/history/scans.go`) still used `os.WriteFile`, and it was the only one left in the package.

It is also the write that matters most after the checkpoint blobs themselves. The newest snapshot **is** the baseline: `LastReport` reads it and nothing else, and the next scan diffs against it to decide what is newly appeared, resolved, or changed.

`os.WriteFile` truncates the target before writing a byte. So a crash, an OOM kill, or delayed allocation on XFS or btrfs leaves that file a valid-looking prefix of the real one — and the next run either reports no delta at all or announces the whole host as newly appeared. Both failures are silent; nothing warns, and the run just looks like a first scan.

## The test is the interesting part

Provoking a torn write needs the process to die at a chosen instant, which a unit test cannot do reliably. So `TestNoProductionWriteBypassesAtomicWrite` asserts the property the invariant is actually about: **no production file in this package calls `os.WriteFile` or `os.Create` at all**, read out of the package's own AST. Same shape as the UI layering tests — read the source, fail on the call that must not exist.

`os.Remove` and `os.ReadFile` are deliberately allowed. The rule is about replacing a file's contents, which is the only operation that can leave a truncated one behind.

`TestSaveReportRoundTrips` covers the other half: the snapshot survives byte for byte (a delta is computed by unmarshalling it, so a write that altered content would be a *wrong* delta rather than a missing one), and the staging file does not survive the rename — a leftover temp file would be sorted in by `scanFiles` as though it were a snapshot, and `LastReport` could return it.

## Checklist

- [x] Title is conventional with a valid scope (`fix(history):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  `golangci-lint` and `govulncheck` cannot run in this container — they build the module with Go 1.25 and it requires 1.26. Delegated to the `lint` job.
- [x] For a new or changed detection rule: n/a — no checker, finding or fix is touched.
- [x] For a UI change: n/a.
- [x] The score stays honest — the change protects the delta, which is downstream of the score and never feeds it.

## Verified by mutation

| Mutation | Result |
| --- | --- |
| Put `os.WriteFile` back in `SaveReport` | `TestNoProductionWriteBypassesAtomicWrite` — `scans.go calls os.WriteFile; every write in this package must go through platform.WriteFileAtomic` |

The test also carries a nothing-extracted guard, so a package layout change that made the file glob match nothing fails loudly instead of passing vacuously.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_