### PR TITLE
fix(cmd): stop three commands accepting flags they ignore

### DIFF
--- a/cmd/hostveil/clidocs_test.go
+++ b/cmd/hostveil/clidocs_test.go
@@ -31,6 +31,7 @@ var docSection = map[string]string{
 	"cmdExplain":  "explain",
 	"cmdServe":    "serve",
 	"cmdTUI":      "tui",
+	"cmdHistory":  "history",
 }
 
 var docLangs = []string{"en", "ko"}
@@ -83,6 +84,14 @@ func declaredFlags(t *testing.T) map[string][]string {
 			section, documented := docSection[fn.Name.Name]
 			if !documented {
 				continue
+			}
+			// Seed the section even when the command registers nothing, so
+			// "documented as taking no flags" is a checked claim rather
+			// than an absence. `history` is the case: it accepted no flags
+			// and also parsed none, so an unknown one was silently ignored
+			// instead of exiting 2 like every other subcommand.
+			if _, ok := out[section]; !ok {
+				out[section] = []string{}
 			}
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
 				if flag := flagNameOf(n); flag != "" {

--- a/cmd/hostveil/explain.go
+++ b/cmd/hostveil/explain.go
@@ -29,7 +29,7 @@ func cmdExplain(ctx context.Context, args []string) int {
 		return 2
 	}
 
-	engine := buildEngineWithAI(useAI)
+	engine := newEngineWithAI(useAI)
 	report := engine.Scan(ctx, nil)
 	finding, ok := findFinding(report, findingID, service)
 	if !ok {

--- a/cmd/hostveil/fix.go
+++ b/cmd/hostveil/fix.go
@@ -19,6 +19,13 @@ import (
 // could only be exercised by scanning the machine running the tests.
 var newEngine = func() *core.Engine { return buildEngine() }
 
+// newEngineWithAI is the same seam for the three commands that offer the
+// advisory explainer. It exists so `explain` is reachable from a test the
+// way `fix` and `rollback` are; without it, explain built its engine
+// directly and could only be exercised by scanning the machine running the
+// tests.
+var newEngineWithAI = func(useAI bool) *core.Engine { return buildEngineWithAI(useAI) }
+
 func cmdFix(ctx context.Context, args []string) int {
 	fs := flag.NewFlagSet("fix", flag.ContinueOnError)
 	var (
@@ -43,6 +50,20 @@ func cmdFix(ctx context.Context, args []string) int {
 	}
 
 	if all {
+		// --all applies every Auto fix on the host, so there is no one
+		// finding to disambiguate and no alternative to pick — Auto fixes
+		// have exactly one action by definition. Both flags parsed into
+		// this set and were then silently dropped, which is the worst
+		// available answer: `fix --all --action 1` looked like it chose
+		// something. Say so instead.
+		if service != "" || action >= 0 {
+			fmt.Fprintln(os.Stderr, "hostveil: --service and --action apply to a single finding and cannot be combined with --all")
+			return 2
+		}
+		if findingID != "" || fs.NArg() > 0 {
+			fmt.Fprintln(os.Stderr, "hostveil: --all applies every safe fix; do not also name a finding")
+			return 2
+		}
 		return fixAll(ctx, yes)
 	}
 	if findingID == "" {

--- a/cmd/hostveil/flagstrict_test.go
+++ b/cmd/hostveil/flagstrict_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStderr mirrors captureStdout for the stream usage errors go to.
+// A usage error that does not say which flags conflict is only half an
+// answer, so the message is worth asserting, not just the exit code.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	w.Close()
+	os.Stderr = orig
+	return <-done
+}
+
+// Every subcommand exits 2 on a flag it does not accept — that is the
+// documented usage-error contract, and it is what tells a user their
+// invocation did not do what they typed.
+//
+// Three places broke it in different ways. `history` never parsed its
+// arguments at all (`_ = args`), so any flag was accepted and ignored:
+// `hostveil history --json` printed the human table and exited 0, which is
+// the worst possible answer for a flag a scripting user would reasonably
+// try. And `fix --all` parsed --service and --action into the same flag set
+// as --all and then dropped them, so `fix --all --action 1` looked like it
+// had chosen an alternative.
+//
+// Silently accepting a flag is worse than rejecting it: the user believes
+// the flag did something.
+func TestCommandsRejectFlagsTheyDoNotAccept(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"history rejects an unknown flag", []string{"--json"}, ""},
+		{"history rejects a plausible one", []string{"--limit", "5"}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, out := runCmd(t, func() int { return cmdHistory(context.Background(), tc.args) })
+			if code != 2 {
+				t.Errorf("exit %d, want 2 (usage error); output:\n%s", code, out)
+			}
+		})
+	}
+}
+
+// --all applies every Auto fix on the host. There is no single finding to
+// disambiguate with --service, and no alternative to pick with --action:
+// an Auto fix has exactly one action by definition. Combining them is a
+// contradiction, so it is a usage error rather than a silent drop.
+func TestFixAllRejectsSingleFindingFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"with --service", []string{"--all", "--service", "cache"}},
+		{"with --action", []string{"--all", "--action", "1"}},
+		{"with both", []string{"--all", "--service", "cache", "--action", "0"}},
+		{"with a finding id", []string{"compose.ds018", "--all"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var code int
+			msg := captureStderr(t, func() {
+				code = cmdFix(context.Background(), tc.args)
+			})
+			if code != 2 {
+				t.Errorf("exit %d, want 2 (usage error); stderr:\n%s", code, msg)
+			}
+			if !strings.Contains(msg, "--all") {
+				t.Errorf("the error does not mention --all, so it does not say what the conflict is:\n%s", msg)
+			}
+		})
+	}
+}
+
+// The counterpart: --help is not a usage error anywhere. Go's flag package
+// reports it as flag.ErrHelp after printing usage, and treating that like a
+// parse failure is what made `hostveil <cmd> --help` exit 2 once already.
+// history now parses its arguments, so it joins the set that could regress
+// that way.
+func TestHistoryHelpExitsZero(t *testing.T) {
+	for _, arg := range []string{"-h", "--help"} {
+		code, _ := runCmd(t, func() int { return cmdHistory(context.Background(), []string{arg}) })
+		if code != 0 {
+			t.Errorf("hostveil history %s exited %d, want 0", arg, code)
+		}
+	}
+}

--- a/cmd/hostveil/rollback.go
+++ b/cmd/hostveil/rollback.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -21,11 +20,8 @@ func cmdRollback(ctx context.Context, args []string) int {
 	if len(args) > 0 && args[0] != "" && args[0][0] != '-' {
 		id, args = args[0], args[1:]
 	}
-	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
-			return 0
-		}
-		return 2
+	if code := parseFlags(fs, args); code >= 0 {
+		return code
 	}
 	if id == "" {
 		id = fs.Arg(0)
@@ -67,8 +63,17 @@ func cmdRollback(ctx context.Context, args []string) int {
 	return 0
 }
 
+// cmdHistory takes no flags, which is not the same as ignoring them. It
+// used to discard args entirely, so `hostveil history --json` — a flag a
+// user has every reason to expect, and which the CLI reference says does
+// not exist — printed the human table and exited 0. Every other subcommand
+// exits 2 on an unknown flag. Parsing an empty flag set is what makes the
+// documented "no flags" true rather than merely written down.
 func cmdHistory(_ context.Context, args []string) int {
-	_ = args
+	fs := flag.NewFlagSet("history", flag.ContinueOnError)
+	if code := parseFlags(fs, args); code >= 0 {
+		return code
+	}
 	cps, err := newEngine().ListCheckpoints()
 	// An unreadable checkpoint is a warning over a usable list, not a failure:
 	// the entries that survived still name fixes the operator can roll back,

--- a/cmd/hostveil/scan.go
+++ b/cmd/hostveil/scan.go
@@ -44,7 +44,7 @@ func cmdScan(ctx context.Context, args []string) int {
 		return 2
 	}
 
-	engine := buildEngine()
+	engine := newEngine()
 	report := scanWithProgress(ctx, engine, scanOpts)
 
 	var rendered string


### PR DESCRIPTION
## What and why

Every subcommand exits 2 on a flag it does not accept. That is the documented usage-error contract, and it is what tells a user their invocation did not do what they typed. Three places broke it, each differently, and all three failed in the same direction — **silently accepting**, which is worse than rejecting, because the user believes the flag did something.

### `history` never parsed its arguments

The body opened with `_ = args`. So `hostveil history --json` printed the human table and exited 0 — the worst available answer for a flag a scripting user would reasonably reach for.

It was also the one subcommand `clidocs_test.go` did not cover, and for a structural reason: `declaredFlags` only recorded a section when the command registered at least one flag, so "documented as taking no flags" was an *absence* rather than a checked claim. Seeding the section makes it checked, and `history` joins the guard — a flag added there without documentation now fails the build.

### `fix --all` parsed two flags and dropped them

`--service` and `--action` registered into the same flag set as `--all` and were discarded when `all` was true, so `fix --all --action 1` looked like it had chosen an alternative. It cannot have: `--all` applies every Auto fix on the host, so there is no single finding to disambiguate, and an Auto fix has exactly one action by definition. Naming a finding alongside `--all` is the same contradiction. Both are usage errors now, and the message names the conflicting flags rather than only reporting that something is wrong.

### `rollback` hand-rolled `flag.ErrHelp`

The same logic `parseFlags` exists to own, written twice — one copy of which could drift back into treating `--help` as exit 2, which is a bug this repo has already shipped once (#520, and again one level down).

## Also here

`scan` and `explain` now build their engine through the `newEngine` seam like `fix` and `rollback` do, instead of calling `buildEngine` directly. That seam exists so a command can be driven against a fixture host; bypassing it meant those two could only be exercised by scanning the machine running the tests. `explain` needs the AI-capable variant, so it gets `newEngineWithAI`.

## Checklist

- [x] Title is conventional with a valid scope (`fix(cmd):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  `golangci-lint` and `govulncheck` cannot run in this container — they build the module with Go 1.25 and it requires 1.26. Delegated to the `lint` job.
- [x] For a new or changed detection rule: n/a — no checker, finding, fix or axis is touched.
- [x] For a UI change: n/a — CLI argument handling only. No output format changes on any successful path.
- [x] The score stays honest — untouched.

## Verified by mutation

| Mutation | Result |
| --- | --- |
| Restore `_ = args` in `cmdHistory` | `TestCommandsRejectFlagsTheyDoNotAccept` — `exit 0, want 2` for both cases |
| Remove the `--all` conflict check | `TestFixAllRejectsSingleFindingFlags` — `exit 0, want 2` for `--service`, `--action`, and both |

`TestHistoryHelpExitsZero` covers the counterpart that makes this safe: `-h`/`--help` is not a usage error, which is exactly the regression that adding flag parsing could otherwise introduce.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_