### PR TITLE
refactor(fix): close the gap between Manual by decision and Manual by omission

### DIFF
--- a/internal/check/checker.go
+++ b/internal/check/checker.go
@@ -64,9 +64,6 @@ func NewRegistry(checkers ...Checker) *Registry {
 	return &Registry{checkers: checkers}
 }
 
-// Register appends a checker.
-func (r *Registry) Register(c Checker) { r.checkers = append(r.checkers, c) }
-
 // Checkers returns the registered checkers.
 func (r *Registry) Checkers() []Checker { return r.checkers }
 

--- a/internal/core/fixflow.go
+++ b/internal/core/fixflow.go
@@ -182,9 +182,9 @@ func (e *Engine) applyFix(ctx context.Context, f model.Finding, actionIdx int) (
 		return model.FixOutcome{Success: false, Error: err.Error()}, err
 	}
 
-	// Mark the finding fixed, cascade to same-service siblings sharing the
-	// fix, and rescore — all inside the engine so no UI reimplements it.
-	outcome.AlsoFixed = e.markFixed(f)
+	// Mark the finding fixed and rescore — both inside the engine so no UI
+	// reimplements either.
+	e.markFixed(f)
 	outcome.Success = true
 	outcome.NewScore = e.rescore()
 	return outcome, nil
@@ -590,11 +590,15 @@ func (e *Engine) buildFix(f model.Finding) (fix.Fix, bool, error) {
 	return e.fixes.Build(f)
 }
 
-// markFixed marks the target finding fixed in the current report. Richer
-// cross-finding cascade and re-scan verification arrive in a later phase;
-// here the applied finding alone is marked, and its return value is the
-// list of additional findings marked (currently none).
-func (e *Engine) markFixed(target model.Finding) []string {
+// markFixed marks the target finding fixed in the current report.
+//
+// It used to return "the list of additional findings marked (currently
+// none)" against a planned cross-finding cascade, and FixOutcome carried
+// that list to the UIs as `also_fixed`. Nothing ever populated it and no
+// interface ever read it, so the field promised a behaviour the engine did
+// not have; both are gone. If a cascade is ever built, it should be built
+// with the thing that reports it, not ahead of it.
+func (e *Engine) markFixed(target model.Finding) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	for i := range e.current.Findings {
@@ -603,7 +607,6 @@ func (e *Engine) markFixed(target model.Finding) []string {
 			f.Fixed = true
 		}
 	}
-	return nil
 }
 
 func (e *Engine) rescore() model.ScoreBreakdown {

--- a/internal/docs/fixregister_test.go
+++ b/internal/docs/fixregister_test.go
@@ -1,0 +1,96 @@
+package docs
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/fix"
+)
+
+// fix.Default()'s doc comment is the register of findings deliberately left
+// without a fix: each one named, each with the reason it is Manual on
+// purpose. TestKnownUnregisteredFindings pins that register from one side —
+// it asserts nothing in the list has acquired a fix.
+//
+// Nothing pinned the other side, and five findings fell through it:
+// compose.ds012, compose.dr004, ports.exposed, accounts.uid0 and
+// accounts.emptypassword had no registered fix and no entry in the
+// register either. That is the state the register exists to make
+// impossible. Manual is a decision — "there is no action hostveil can
+// safely take" — and a finding that is Manual because nobody has looked at
+// it is indistinguishable, in the interface, from one that is Manual
+// because a maintainer weighed the remediation and refused it.
+//
+// So: every finding a checker can emit must either have a fix, or be named
+// in the register with a reason. There is no third state.
+func TestEveryFindingIsEitherFixableOrDeclinedOnPurpose(t *testing.T) {
+	registry := fix.Default()
+	declined := declinedInRegister(t)
+
+	for _, id := range emittedFindingIDs(t) {
+		if registry.Has(id) {
+			continue
+		}
+		if declined[id] {
+			continue
+		}
+		// A source-wide entry (sysctl.*) covers its whole domain; the
+		// register uses one where the reason is genuinely shared.
+		if src, _, ok := strings.Cut(id, "."); ok && declined[src+".*"] {
+			continue
+		}
+		t.Errorf("%s has no registered fix and no entry in fix.Default()'s register of "+
+			"deliberately-unfixed findings — it is Manual by omission, which a user cannot "+
+			"tell from Manual by decision", id)
+	}
+}
+
+// registerID matches an ID as the register writes it, including the
+// source-wide glob form.
+var registerID = regexp.MustCompile(`\b(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent|sysctl)\.(\*|[a-z0-9][a-z0-9.\-]*)`)
+
+// declinedInRegister reads the doc comment on fix.Default and returns every
+// finding ID it names.
+//
+// It reads the comment rather than a list kept here on purpose: the comment
+// is the normative statement — it carries the reasons, and it is what a
+// maintainer edits when they change their mind. A copy in a test would be
+// one more thing to drift.
+func declinedInRegister(t *testing.T) map[string]bool {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "internal", "fix", "register.go")
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var doc string
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "Default" && fn.Doc != nil {
+			doc = fn.Doc.Text()
+		}
+	}
+	if doc == "" {
+		t.Fatal("fix.Default has no doc comment — the register of deliberately-unfixed findings is gone")
+	}
+
+	out := map[string]bool{}
+	for _, m := range registerID.FindAllString(doc, -1) {
+		out[m] = true
+	}
+	// Nothing-extracted guard. The register names well over a dozen
+	// findings; a regexp that stopped matching would otherwise make this
+	// test demand a fix for every Manual finding in the tree, which reads
+	// as a code failure rather than as the test failure it is.
+	if len(out) < 10 {
+		t.Fatalf("only %d finding IDs extracted from the register (%v) — extraction is broken, not the register",
+			len(out), out)
+	}
+	return out
+}

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -143,6 +143,12 @@ func TestKnownUnregisteredFindings(t *testing.T) {
 		"sysctl.accept-redirects": "same drop-in problem",
 		"sysctl.rp-filter":        "same drop-in problem",
 		"sysctl.protected-links":  "same drop-in problem",
+
+		"compose.ds012":          "the right healthcheck depends on what the service exposes; a guessed one marks a working container unhealthy and stalls everything waiting on it",
+		"compose.dr004":          "the remediation is about the env_file's permissions and whether it is in git and backups — nothing in the compose file to edit",
+		"ports.exposed":          "the aggregate finding's remediation is firewall.inactive's, and is declined for the same reason",
+		"accounts.uid0":          "userdel is exec, irreversible, and takes the home directory with it; hostveil cannot tell a backdoor from a deliberate second root",
+		"accounts.emptypassword": "passwd -l is exec, and the account it locks may be the only way the operator reaches the machine",
 	}
 	r := Default()
 	for id, why := range declined {

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -150,6 +150,42 @@ package fix
 //     requires. agent.gateway-exposed fails the recoverability test on top
 //     of all that: rebinding a gateway to loopback can cut an operator off
 //     from the agent they administer remotely.
+//   - compose.ds012 — the remediation is a healthcheck, and the right one
+//     depends entirely on what the service exposes: an HTTP path, a CLI
+//     probe, a port to open. A static audit cannot learn any of them, and a
+//     guessed healthcheck is worse than none — a probe that does not match
+//     the app marks a working container unhealthy, and anything waiting on
+//     `condition: service_healthy` then never starts. The finding's own
+//     how-to-fix says this cannot be filled in automatically; this is the
+//     registry agreeing with it.
+//   - compose.dr004 — the finding is not that a value is wrong but that
+//     credentials live in an env_file, and the remediation is to check that
+//     file's permissions and that it is out of version control and backups.
+//     One of those is a fact about a path the finding does not carry, and
+//     the other two are about systems hostveil cannot see. There is nothing
+//     in the compose file to edit.
+//   - ports.exposed — the aggregate finding, which fires only when no
+//     firewall is active at all. Its remediation is firewall.inactive's,
+//     and it is declined for firewall.inactive's reason: enabling
+//     default-deny on a box reached over SSH can lock the operator out
+//     irrecoverably, and exec fixes have no checkpoint. Fixing the firewall
+//     resolves this finding as a side effect, which is the right order.
+//   - accounts.uid0 — the remediation is deleting an account or changing
+//     its UID, and hostveil cannot tell a backdoor from a deliberate
+//     second root that a recovery procedure depends on. `userdel` is not
+//     reversible from a checkpoint at all: it takes the home directory,
+//     the mail spool, and the account's file ownership with it. Changing
+//     the UID instead orphans every file the account owns, which the
+//     finding does not enumerate and could not restore.
+//   - accounts.emptypassword — `passwd -l` is a real, mechanical
+//     remediation and it is deliberately not registered. It is exec, so
+//     never Auto; and it fails the recoverability test in the way that
+//     matters most, because the account it locks may be the only one the
+//     operator can reach the machine with. An empty password on a console-
+//     only account is a different situation from one on the account you
+//     SSH in as, and /etc/shadow does not say which this is. Setting a
+//     password instead cannot be done unattended by definition — hostveil
+//     would have to invent one, and then it would know it.
 //   - sysctl.* (every kernel-hardening finding) — one shared reason.
 //     Persisting a value means writing an /etc/sysctl.d drop-in that does
 //     not exist, and edit actions cannot create files: previewEdit and

--- a/internal/model/fix.go
+++ b/internal/model/fix.go
@@ -29,7 +29,6 @@ type FixOutcome struct {
 	Error        string         `json:"error,omitempty"`
 	Diff         string         `json:"diff,omitempty"`
 	CheckpointID string         `json:"checkpoint_id,omitempty"` // "" if nothing to roll back
-	AlsoFixed    []string       `json:"also_fixed,omitempty"`    // cascaded finding IDs
 	RestartHint  string         `json:"restart_hint,omitempty"`  // service the user may need to restart
 	NewScore     ScoreBreakdown `json:"new_score"`
 }
@@ -49,9 +48,8 @@ type BatchOutcome struct {
 }
 
 // RollbackOutcome is the result of rolling back a checkpoint. Unfixed and
-// NewScore mirror FixOutcome's AlsoFixed/NewScore so a long-lived UI can
-// refresh its list and gauge straight from the response, exactly as it
-// does after an apply.
+// NewScore let a long-lived UI refresh its list and gauge straight from the
+// response, exactly as NewScore does after an apply.
 type RollbackOutcome struct {
 	CheckpointID   string         `json:"checkpoint_id"`
 	RestoredFiles  []string       `json:"restored_files"`

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -806,10 +806,3 @@ func wrap(s string, width int) string {
 	}
 	return b.String()
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
## What and why

`fix.Default()`'s doc comment is the register of findings deliberately left without a fix — each one named, each with the reason it is Manual on purpose. `TestKnownUnregisteredFindings` pins that register from one side: nothing in the list may quietly acquire a fix.

Nothing pinned the other side. **Five findings fell through it** — `compose.ds012`, `compose.dr004`, `ports.exposed`, `accounts.uid0` and `accounts.emptypassword` had no registered fix *and* no entry in the register.

That is exactly the state the register exists to make impossible. Manual means "there is no action hostveil can safely take" — it is a decision. A finding that is Manual because nobody has looked at it renders identically, in all three interfaces, to one a maintainer weighed and refused. The user cannot tell them apart, and neither could a contributor deciding whether a fix would be welcome.

## The guard

`TestEveryFindingIsEitherFixableOrDeclinedOnPurpose` asserts there is no third state: every finding a checker can emit either has a registered fix or is named in the register. It reuses `emittedFindingIDs` (the existing AST harvest over `internal/check`) and reads the register **out of `fix.Default`'s doc comment**, not from a list kept beside it — the comment is the normative statement, it carries the reasons, and it is what a maintainer edits when they change their mind. A copy in a test would be one more thing to drift. It handles the source-wide form (`sysctl.*`) the register uses where the reason is genuinely shared, and carries the nothing-extracted guard this package's tests use.

## The two that were closest to fixable

Worth stating explicitly, since they are the ones a future contributor will reach for:

- **`accounts.emptypassword`** has an exact mechanical remediation that the finding already prints — `passwd -l <user>`. It is declined because it is exec (so never Auto), and because it fails recoverability in the way that matters most: the account it locks may be the only one the operator can reach the machine with, and `/etc/shadow` does not say whether this is a console-only account or the one you SSH in as.
- **`accounts.uid0`**'s remediation is `userdel` or a UID change. `userdel` is not reversible from a checkpoint at all — it takes the home directory, the mail spool, and the account's file ownership with it. Changing the UID instead orphans every file the account owns, which the finding does not enumerate and could not restore.

## Dead code removed in the same neighbourhood

- `check.(*Registry).Register` — no caller anywhere, not even a test. Every registry is built through `NewRegistry(...)`.
- `FixOutcome.AlsoFixed` — in the JSON contract as `also_fixed`, populated by `markFixed`, which always returned `nil`. No UI read it. The field promised a cross-finding cascade the engine does not have; if one is ever built it should arrive with the thing that reports it. `omitempty` means the emitted JSON is unchanged.
- A local `min()` in `internal/ui/tui/view.go` shadowing the Go 1.21 builtin, in a package whose `frame.go` already uses the builtin `max`.

## Checklist

- [x] Title is conventional with a valid scope (`refactor(fix):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  `golangci-lint` and `govulncheck` cannot run in this container — they build the module with Go 1.25 and it requires 1.26. Delegated to the `lint` job.
- [x] For a new or changed detection rule: n/a — no checker or finding changes. No fix is added or removed, so no finding's remediation kind moves.
- [x] For a UI change: n/a. The removed `min` is a pure helper; the TUI layout tests still pass.
- [x] The score stays honest — untouched. All five findings were already Manual and are still Manual; only the reason is now written down.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_