### PR TITLE
feat(fix): make the kernel-hardening domain fixable

### DIFF
--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -186,19 +186,21 @@
 
             <h2 id="sysctl">Kernel hardening <code>sysctl.</code></h2>
             <p>Read directly from <code>/proc/sys</code> — no <code>sysctl</code> binary needed. These are the quiet knobs whose safe value is the same on essentially every server: none of them is the hole an attacker comes in through, each is what stops a foothold from becoming root or a spoofed packet from becoming a route. A parameter this kernel does not have (Yama not built in, say) is simply skipped.</p>
-            <p>Every finding here is Manual for now: making a value stick means creating an <code>/etc/sysctl.d</code> drop-in that does not exist yet, and applying it live takes <code>sysctl --system</code> — so each finding carries the exact line and the exact command instead of a button. <code>net.ipv4.ip_forward</code> is deliberately not audited: Docker, WireGuard, Tailscale exit nodes, and virtualization hosts all legitimately enable it, and hostveil cannot tell those apart from an accident.</p>
+            <p>Every finding here is <strong>Review</strong>, and the two alternatives are a real choice rather than two halves of one procedure. <em>Persist it</em> writes a drop-in under <code>/etc/sysctl.d</code> — one file per finding, named after it — which survives reboots and takes effect at the next one, or immediately if you then run <code>sysctl --system</code>. <em>Apply it now</em> runs <code>sysctl -w</code>, which changes the running kernel this second and is gone at the next boot. Neither dominates: hardening a box you are about to reboot wants the first, and a production host you cannot restart today wants the second now and the first later.</p>
+            <p>They are Review and not Auto-fix because the safe value is not always the only defensible one. <code>rp_filter</code> is 1 on a single-homed server and 2 on a VPN or multi-homed one; <code>sysrq</code> has a restricted-bitmask answer as legitimate as 0. hostveil flags only the unambiguous half of each and writes only what it flagged, but you are the one who knows which host this is. Rolling back a persisted fix deletes the drop-in it created, and declines if you have edited that file since.</p>
+            <p><code>net.ipv4.ip_forward</code> is deliberately not audited: Docker, WireGuard, Tailscale exit nodes, and virtualization hosts all legitimately enable it, and hostveil cannot tell those apart from an accident.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
-                  <tr><td><code>sysctl.ptrace-scope</code></td><td>Any process can debug its siblings and read their memory</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN-flood protection is off</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP redirects can rewrite this host's routing</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.protected-links</code></td><td>Symlink/hardlink race protections are disabled</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.kptr-restrict</code></td><td>Kernel pointer addresses are visible to all users</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>Any user can read the kernel log</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq is fully enabled</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.rp-filter</code></td><td>Source-address spoofing filter is off (strict and loose both pass)</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.ptrace-scope</code></td><td>Any process can debug its siblings and read their memory</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN-flood protection is off</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP redirects can rewrite this host's routing</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.protected-links</code></td><td>Symlink/hardlink race protections are disabled</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.kptr-restrict</code></td><td>Kernel pointer addresses are visible to all users</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>Any user can read the kernel log</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq is fully enabled</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.rp-filter</code></td><td>Source-address spoofing filter is off (strict and loose both pass)</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
                 </tbody>
               </table>
             </div>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -186,19 +186,21 @@
 
             <h2 id="sysctl">커널 하드닝 <code>sysctl.</code></h2>
             <p><code>/proc/sys</code>에서 직접 읽습니다 — <code>sysctl</code> 바이너리가 필요 없습니다. 이 항목들은 사실상 모든 서버에서 안전한 값이 같은 조용한 손잡이들입니다. 공격자가 들어오는 구멍은 아니지만, 각각은 발판이 root가 되는 것과 위조된 패킷이 경로가 되는 것을 막아 줍니다. 이 커널에 없는 파라미터(예: Yama가 빌드되지 않은 경우)는 그냥 건너뜁니다.</p>
-            <p>여기의 모든 발견 항목은 지금은 수동입니다. 값을 유지하려면 아직 존재하지 않는 <code>/etc/sysctl.d</code> 드롭인 파일을 만들어야 하고, 즉시 적용하려면 <code>sysctl --system</code>이 필요합니다 — 그래서 버튼 대신 정확한 설정 줄과 명령을 발견 항목이 직접 알려줍니다. <code>net.ipv4.ip_forward</code>는 의도적으로 점검하지 않습니다. Docker, WireGuard, Tailscale 종료 노드, 가상화 호스트가 모두 정당하게 켜는 값이고, hostveil은 그것을 실수와 구별할 수 없습니다.</p>
+            <p>여기의 모든 발견 항목은 <strong>검토</strong>이고, 두 대안은 한 절차의 앞뒤가 아니라 진짜 선택지입니다. <em>영구 적용</em>은 <code>/etc/sysctl.d</code> 아래에 발견 항목 이름을 딴 드롭인 파일을 하나 씁니다 — 재부팅해도 남고, 다음 부팅 때(또는 바로 <code>sysctl --system</code>을 실행하면 그 즉시) 적용됩니다. <em>지금 적용</em>은 <code>sysctl -w</code>로 실행 중인 커널을 이 순간 바꾸지만 다음 부팅에 사라집니다. 어느 쪽도 항상 낫지 않습니다. 곧 재부팅할 서버를 강화하는 중이라면 앞쪽을, 오늘 재시작할 수 없는 운영 호스트라면 지금은 뒤쪽을 그리고 나중에 앞쪽을 원하게 됩니다.</p>
+            <p>자동 수정이 아니라 검토인 이유는, 안전한 값이 언제나 유일하게 타당한 값은 아니기 때문입니다. <code>rp_filter</code>는 단일 회선 서버에서는 1이지만 VPN이나 다중 회선 호스트에서는 2이고, <code>sysrq</code>도 0만큼이나 정당한 제한 비트마스크 형태가 있습니다. hostveil은 각 항목에서 모호하지 않은 부분만 표시하고 표시한 것만 씁니다만, 이 호스트가 어느 쪽인지 아는 사람은 당신입니다. 영구 적용한 수정을 롤백하면 만들어진 드롭인 파일이 삭제되고, 그 파일을 그 뒤에 직접 고쳤다면 롤백은 거절됩니다.</p>
+            <p><code>net.ipv4.ip_forward</code>는 의도적으로 점검하지 않습니다. Docker, WireGuard, Tailscale 종료 노드, 가상화 호스트가 모두 정당하게 켜는 값이고, hostveil은 그것을 실수와 구별할 수 없습니다.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
-                  <tr><td><code>sysctl.ptrace-scope</code></td><td>아무 프로세스나 형제 프로세스를 디버깅해 메모리를 읽을 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN 플러드 보호가 꺼져 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP 리다이렉트가 이 호스트의 라우팅을 바꿀 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.protected-links</code></td><td>심볼릭/하드 링크 경쟁 보호가 비활성화됨</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.kptr-restrict</code></td><td>커널 포인터 주소가 모든 사용자에게 보임</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>아무 사용자나 커널 로그를 읽을 수 있음</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq가 전부 활성화됨</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.rp-filter</code></td><td>출발지 주소 위조 필터가 꺼져 있음 (strict와 loose 모두 통과)</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.ptrace-scope</code></td><td>아무 프로세스나 형제 프로세스를 디버깅해 메모리를 읽을 수 있음</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN 플러드 보호가 꺼져 있음</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP 리다이렉트가 이 호스트의 라우팅을 바꿀 수 있음</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.protected-links</code></td><td>심볼릭/하드 링크 경쟁 보호가 비활성화됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.kptr-restrict</code></td><td>커널 포인터 주소가 모든 사용자에게 보임</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>아무 사용자나 커널 로그를 읽을 수 있음</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq가 전부 활성화됨</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.rp-filter</code></td><td>출발지 주소 위조 필터가 꺼져 있음 (strict와 loose 모두 통과)</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
                 </tbody>
               </table>
             </div>

--- a/internal/check/sysctl/sysctl.go
+++ b/internal/check/sysctl/sysctl.go
@@ -35,6 +35,18 @@ type Rule struct {
 	Keys    []string // dotted sysctl names, e.g. "kernel.kptr_restrict"
 	Want    string   // the sysctl.d line(s) the how-to-fix recommends
 	Flagged func(vals map[string]int64) bool
+
+	// Set is the same recommendation as Want in machine-readable form: the
+	// exact key=value pairs a fix writes into a drop-in or passes to
+	// `sysctl -w`. Want stays prose because it also carries the caveats
+	// ("or 2 on VPN/multi-homed hosts") that a person needs and a fix must
+	// not act on.
+	//
+	// It names only keys this rule actually audits. Writing a value the
+	// checker never reads would produce a fix whose effect the next scan
+	// cannot confirm, and on a host with IPv6 disabled `sysctl -w` on an
+	// absent key fails outright — taking the rest of the fix with it.
+	Set []string
 }
 
 // Checker reports weak kernel-parameter values.
@@ -56,6 +68,7 @@ func defaultRules() []Rule {
 			Desc: "kernel.yama.ptrace_scope is 0, so every process can attach a debugger to any other process of the same user and read its memory — including the session tokens inside a running agent, browser, or password manager. Setting it to 1 limits attaching to direct children.",
 			Keys: []string{"kernel.yama.ptrace_scope"},
 			Want: "kernel.yama.ptrace_scope = 1",
+			Set:  []string{"kernel.yama.ptrace_scope=1"},
 			Flagged: func(v map[string]int64) bool {
 				val, ok := v["kernel.yama.ptrace_scope"]
 				return ok && val == 0
@@ -67,6 +80,7 @@ func defaultRules() []Rule {
 			Desc: "net.ipv4.tcp_syncookies lets listening services survive a SYN-flood denial of service. It costs nothing in normal operation and only activates under attack, which is why every mainstream distribution ships it on.",
 			Keys: []string{"net.ipv4.tcp_syncookies"},
 			Want: "net.ipv4.tcp_syncookies = 1",
+			Set:  []string{"net.ipv4.tcp_syncookies=1"},
 			Flagged: func(v map[string]int64) bool {
 				val, ok := v["net.ipv4.tcp_syncookies"]
 				return ok && val != 1
@@ -77,7 +91,8 @@ func defaultRules() []Rule {
 			Sev:  model.SeverityMedium,
 			Desc: "Accepting ICMP redirect messages lets a machine on the same network rewrite this host's routing decisions — a classic man-in-the-middle primitive. A server has no use for them.",
 			Keys: []string{"net.ipv4.conf.all.accept_redirects"},
-			Want: "net.ipv4.conf.all.accept_redirects = 0 (and net.ipv6.conf.all.accept_redirects = 0)",
+			Want: "net.ipv4.conf.all.accept_redirects = 0",
+			Set:  []string{"net.ipv4.conf.all.accept_redirects=0"},
 			Flagged: func(v map[string]int64) bool {
 				val, ok := v["net.ipv4.conf.all.accept_redirects"]
 				return ok && val != 0
@@ -89,6 +104,7 @@ func defaultRules() []Rule {
 			Desc: "fs.protected_symlinks and fs.protected_hardlinks close a family of /tmp link races that local attackers use to trick privileged processes into overwriting files of the attacker's choosing. Every mainstream distribution ships both enabled.",
 			Keys: []string{"fs.protected_symlinks", "fs.protected_hardlinks"},
 			Want: "fs.protected_symlinks = 1 and fs.protected_hardlinks = 1",
+			Set:  []string{"fs.protected_symlinks=1", "fs.protected_hardlinks=1"},
 			Flagged: func(v map[string]int64) bool {
 				for _, k := range []string{"fs.protected_symlinks", "fs.protected_hardlinks"} {
 					if val, ok := v[k]; ok && val == 0 {
@@ -104,6 +120,7 @@ func defaultRules() []Rule {
 			Desc: "With kernel.kptr_restrict at 0, /proc exposes raw kernel pointers to any local user. Those addresses defeat kernel address-space randomization, handing a local exploit the memory layout it needs.",
 			Keys: []string{"kernel.kptr_restrict"},
 			Want: "kernel.kptr_restrict = 1",
+			Set:  []string{"kernel.kptr_restrict=1"},
 			Flagged: func(v map[string]int64) bool {
 				val, ok := v["kernel.kptr_restrict"]
 				return ok && val < 1
@@ -115,6 +132,7 @@ func defaultRules() []Rule {
 			Desc: "The kernel log leaks addresses, hardware details, and stack traces that make local privilege-escalation exploits easier to build. With kernel.dmesg_restrict at 0, every account can read it.",
 			Keys: []string{"kernel.dmesg_restrict"},
 			Want: "kernel.dmesg_restrict = 1",
+			Set:  []string{"kernel.dmesg_restrict=1"},
 			Flagged: func(v map[string]int64) bool {
 				val, ok := v["kernel.dmesg_restrict"]
 				return ok && val != 1
@@ -126,6 +144,7 @@ func defaultRules() []Rule {
 			Desc: "kernel.sysrq = 1 enables every SysRq function, letting anyone with console, serial, or IPMI access kill processes, remount filesystems, or crash the machine with a keystroke. Distributions default to 0 or a restricted bitmask for a reason.",
 			Keys: []string{"kernel.sysrq"},
 			Want: "kernel.sysrq = 0 (or a restricted bitmask such as 176)",
+			Set:  []string{"kernel.sysrq=0"},
 			// Only the fully-enabled value is flagged: anything else is
 			// either off or a deliberate restricted mask.
 			Flagged: func(v map[string]int64) bool {
@@ -139,6 +158,7 @@ func defaultRules() []Rule {
 			Desc: "Reverse-path filtering drops packets whose source address could not be reached back through the interface they arrived on — cheap protection against spoofed traffic. Strict (1) and loose (2) both count; loose is the right setting for VPN and multi-homed hosts.",
 			Keys: []string{"net.ipv4.conf.all.rp_filter"},
 			Want: "net.ipv4.conf.all.rp_filter = 1 (or 2 on VPN/multi-homed hosts)",
+			Set:  []string{"net.ipv4.conf.all.rp_filter=1"},
 			Flagged: func(v map[string]int64) bool {
 				val, ok := v["net.ipv4.conf.all.rp_filter"]
 				return ok && val == 0
@@ -193,10 +213,14 @@ func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, err
 			continue
 		}
 		findings = append(findings, model.NewFinding(r.ID, r.Title, r.Sev,
-			model.SourceSysctl, model.RemediationManual,
+			model.SourceSysctl, model.RemediationReview,
 			model.WithDescription(r.Desc),
 			model.WithHowToFix(fmt.Sprintf("Add `%s` to a file under /etc/sysctl.d (e.g. 99-hardening.conf), then run `sysctl --system` to apply it without a reboot.", r.Want)),
 			model.WithEvidence("value", evidenceFor(r.Keys, vals)),
+			// The machine-readable form of the same recommendation, so the
+			// fix registry can build an action from the finding alone — a
+			// fix never sees the Rule it came from.
+			model.WithEvidence("set", strings.Join(r.Set, ",")),
 		))
 	}
 	if len(unreadable) > 0 {

--- a/internal/check/sysctl/sysctl_test.go
+++ b/internal/check/sysctl/sysctl_test.go
@@ -75,8 +75,24 @@ func TestWeakValuesAreFlagged(t *testing.T) {
 		if err := f.Validate(); err != nil {
 			t.Errorf("%s: invalid finding: %v", f.ID, err)
 		}
-		if f.Remediation != model.RemediationManual {
-			t.Errorf("%s: remediation = %v, want Manual", f.ID, f.Remediation)
+		// Review, not Manual: the fix registry now offers a drop-in and a
+		// `sysctl -w`, and the checker asks for a human eye because the
+		// unambiguous value is not the only defensible one on every host
+		// (rp_filter is 2 on a multi-homed box, sysrq has a bitmask form).
+		if f.Remediation != model.RemediationReview {
+			t.Errorf("%s: remediation = %v, want Review", f.ID, f.Remediation)
+		}
+		// Every finding must carry the machine-readable recommendation the
+		// fix is built from. Without it the fix errors out at build time
+		// and the UI shows a fix button that leads nowhere.
+		if f.Evidence["set"] == "" {
+			t.Errorf("%s: no 'set' evidence, so no fix can be built from it", f.ID)
+		}
+		for _, kv := range strings.Split(f.Evidence["set"], ",") {
+			k, _, ok := strings.Cut(kv, "=")
+			if !ok || k == "" {
+				t.Errorf("%s: malformed 'set' evidence %q", f.ID, f.Evidence["set"])
+			}
 		}
 		if !strings.Contains(f.HowToFix, "/etc/sysctl.d") || !strings.Contains(f.HowToFix, "sysctl --system") {
 			t.Errorf("%s: how-to-fix must carry the drop-in path and apply command: %q", f.ID, f.HowToFix)

--- a/internal/core/createfix_test.go
+++ b/internal/core/createfix_test.go
@@ -1,0 +1,180 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/fix"
+	"github.com/seolcu/hostveil/internal/history"
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// An edit action could only ever modify a file already on disk, which left
+// the whole kernel-hardening domain unfixable: persisting a sysctl value
+// means writing a drop-in that by definition is not there — if it were, the
+// value would be set and the finding would not have fired.
+//
+// CreateIfMissing closes that, and the delicate half is not the write but
+// the undo. Restoring "this file did not exist" means deleting it, and
+// deletion is the one restore operation that cannot be taken back. These
+// tests cover the round trip and the two ways it must refuse.
+
+func createFinding() model.Finding {
+	return model.NewFinding("sysctl.kptr-restrict", "Kernel pointers are visible",
+		model.SeverityLow, model.SourceSysctl, model.RemediationReview,
+		model.WithEvidence("set", "kernel.kptr_restrict=1"))
+}
+
+// createEngine wires an engine whose one fix creates path.
+func createEngine(t *testing.T, path string) *Engine {
+	t.Helper()
+	r := fix.NewRegistry()
+	r.Register("sysctl.kptr-restrict", func(model.Finding) (fix.Fix, error) {
+		return fix.Fix{
+			Label: "create it",
+			Kind:  model.RemediationReview,
+			Actions: []fix.Action{
+				{
+					Label: "write the drop-in", Kind: fix.ActionEdit,
+					Path: path, CreateIfMissing: true,
+					Transform: func(in []byte) ([]byte, error) {
+						return append(in, []byte("kernel.kptr_restrict = 1\n")...), nil
+					},
+				},
+				{Label: "apply now", Kind: fix.ActionExec, Commands: [][]string{{"true"}}},
+			},
+		}, nil
+	})
+	return New(Config{Fixes: r, Store: history.NewStore(t.TempDir())})
+}
+
+// The whole point: a fix creates a file that was not there, and rolling it
+// back leaves the host as it found it — no file, not an empty one. An empty
+// drop-in would look configured while configuring nothing.
+func TestCreateThenRollbackRemovesTheFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "60-hostveil-kptr.conf")
+	e := createEngine(t, path)
+	e.current = model.Report{Findings: []model.Finding{createFinding()}}
+
+	out, err := e.ApplyFix(context.Background(), createFinding(), 0)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !out.Success || out.CheckpointID == "" {
+		t.Fatalf("apply produced no checkpoint: %+v", out)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the fix did not create the file: %v", err)
+	}
+	if !strings.Contains(string(body), "kernel.kptr_restrict = 1") {
+		t.Errorf("created file has the wrong contents:\n%s", body)
+	}
+
+	if _, err := e.Rollback(out.CheckpointID); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		rest, _ := os.ReadFile(path)
+		t.Errorf("rollback left the file behind (%v):\n%s", err, rest)
+	}
+}
+
+// The diff an operator approves must show the whole file as an addition.
+// A preview that rendered nothing — or that failed because the target is
+// absent — would ask them to approve a change they cannot see.
+func TestPreviewOfACreatedFileShowsTheWholeBody(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "60-hostveil-kptr.conf")
+	e := createEngine(t, path)
+
+	p, err := e.PreviewFix(createFinding())
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if len(p.Actions) == 0 {
+		t.Fatal("preview has no actions")
+	}
+	if !strings.Contains(p.Actions[0].Diff, "+kernel.kptr_restrict = 1") {
+		t.Errorf("the diff does not show the created line:\n%s", p.Actions[0].Diff)
+	}
+	// Preview is pure. It must not have brought the file into existence.
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("preview created the file; it must only ever compute a diff")
+	}
+}
+
+// Rollback deletes, and deletion cannot be undone — so the external-edit
+// guard matters more here than anywhere else. An operator who tuned the
+// drop-in hostveil created must not have it removed out from under them by
+// a rollback that thinks it is restoring an absence.
+func TestRollbackDeclinesToDeleteAnEditedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "60-hostveil-kptr.conf")
+	e := createEngine(t, path)
+	e.current = model.Report{Findings: []model.Finding{createFinding()}}
+
+	out, err := e.ApplyFix(context.Background(), createFinding(), 0)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("kernel.kptr_restrict = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = e.Rollback(out.CheckpointID)
+	if !IsExternalEdit(err) {
+		t.Fatalf("rollback err = %v, want an external-edit refusal", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("the declined rollback deleted the file anyway: %v", err)
+	}
+}
+
+// Deleting a file that is already gone is the desired end state, not a
+// failure. An operator who removed the drop-in by hand and then rolled back
+// should get success, not an error describing what they already did.
+func TestRollbackOfAnAlreadyDeletedFileSucceeds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "60-hostveil-kptr.conf")
+	e := createEngine(t, path)
+	e.current = model.Report{Findings: []model.Finding{createFinding()}}
+
+	out, err := e.ApplyFix(context.Background(), createFinding(), 0)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.Rollback(out.CheckpointID); err != nil {
+		t.Errorf("rollback of an already-absent file failed: %v", err)
+	}
+}
+
+// CreateIfMissing is opt-in per action for a reason: for every other fix a
+// missing target is a real error. An sshd_config that is not there means
+// the finding was stale or the path was wrong, and quietly creating one
+// would be worse than failing.
+func TestEditWithoutCreateStillFailsOnAMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.conf")
+	r := fix.NewRegistry()
+	r.Register("sysctl.kptr-restrict", func(model.Finding) (fix.Fix, error) {
+		return fix.Fix{
+			Label: "edit it", Kind: model.RemediationAuto,
+			Actions: []fix.Action{{
+				Label: "edit", Kind: fix.ActionEdit, Path: path,
+				Transform: func(in []byte) ([]byte, error) { return in, nil },
+			}},
+		}, nil
+	})
+	e := New(Config{Fixes: r, Store: history.NewStore(t.TempDir())})
+	e.current = model.Report{Findings: []model.Finding{createFinding()}}
+
+	if _, err := e.ApplyFix(context.Background(), createFinding(), 0); err == nil {
+		t.Error("applying an edit to a missing file succeeded; only CreateIfMissing may do that")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("the failed edit created the file")
+	}
+}

--- a/internal/core/fixflow.go
+++ b/internal/core/fixflow.go
@@ -67,7 +67,7 @@ func (e *Engine) PreviewFix(f model.Finding) (model.FixPreview, error) {
 // previewEdit computes an edit action's diff purely: read the file, run the
 // pure Transform on a copy, diff the two. The live file is never written.
 func previewEdit(a fix.Action) (string, error) {
-	orig, err := os.ReadFile(a.Path) //nolint:gosec // path from a discovered finding
+	orig, _, err := readEditTarget(a)
 	if err != nil {
 		return "", err
 	}
@@ -76,6 +76,27 @@ func previewEdit(a fix.Action) (string, error) {
 		return "", err
 	}
 	return diff.Unified(a.Path, string(orig), string(next)), nil
+}
+
+// readEditTarget reads an edit action's file, reporting whether the action
+// is about to create it.
+//
+// A CreateIfMissing action treats an absent file as empty input, so
+// Transform composes the whole contents and the diff renders as a pure
+// addition — which is exactly what the operator is being asked to approve.
+// Any other read error is still an error, including for such an action: a
+// permission denial or an EISDIR must not be mistaken for "not there yet"
+// and answered by creating something.
+func readEditTarget(a fix.Action) (data []byte, creating bool, err error) {
+	data, err = os.ReadFile(a.Path) //nolint:gosec // path from a discovered finding
+	switch {
+	case err == nil:
+		return data, false, nil
+	case a.CreateIfMissing && errors.Is(err, fs.ErrNotExist):
+		return nil, true, nil
+	default:
+		return nil, false, err
+	}
 }
 
 // modeChange is one file whose permission bits a mode action would alter.
@@ -191,7 +212,7 @@ func (e *Engine) applyFix(ctx context.Context, f model.Finding, actionIdx int) (
 }
 
 func (e *Engine) applyEdit(ctx context.Context, f model.Finding, fx fix.Fix, a fix.Action) (model.FixOutcome, error) {
-	orig, err := os.ReadFile(a.Path) //nolint:gosec // path from a discovered finding
+	orig, creating, err := readEditTarget(a)
 	if err != nil {
 		return model.FixOutcome{}, err
 	}
@@ -223,7 +244,17 @@ func (e *Engine) applyEdit(ctx context.Context, f model.Finding, fx fix.Fix, a f
 		// before anything on the host changes.
 		AppliedSHA256: map[string]string{a.Path: history.SHA256Hex(next)},
 	}
-	saved, err := e.store.Save(cp, map[string][]byte{a.Path: orig})
+	// A file that did not exist has nothing to back up, and the checkpoint
+	// has to say so rather than record an empty backup: restoring an empty
+	// file is not the same as restoring its absence, and a host left with a
+	// zero-byte drop-in would look configured while configuring nothing.
+	save := func() (history.Checkpoint, error) {
+		if creating {
+			return e.store.SaveCreations(cp, []string{a.Path})
+		}
+		return e.store.Save(cp, map[string][]byte{a.Path: orig})
+	}
+	saved, err := save()
 	if err != nil {
 		return model.FixOutcome{}, fmt.Errorf("backup failed, not applying: %w", err)
 	}

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -25,6 +25,7 @@ func representative(id string) model.Finding {
 		model.WithEvidence("reference", "tag"),
 		model.WithEvidence("paths", "/etc/shadow"),
 		model.WithEvidence("expected", "0640"),
+		model.WithEvidence("set", "kernel.kptr_restrict=1"),
 	)
 	return f
 }
@@ -135,14 +136,6 @@ func TestKnownUnregisteredFindings(t *testing.T) {
 		// applying the live value is exec (never Auto); and a
 		// write-then-apply pair is sequential steps, not the independent
 		// alternatives Review requires.
-		"sysctl.kptr-restrict":    "edit actions cannot create the missing sysctl.d drop-in, and sysctl --system is exec",
-		"sysctl.dmesg-restrict":   "same drop-in problem",
-		"sysctl.sysrq":            "same drop-in problem",
-		"sysctl.ptrace-scope":     "same drop-in problem",
-		"sysctl.syncookies":       "same drop-in problem",
-		"sysctl.accept-redirects": "same drop-in problem",
-		"sysctl.rp-filter":        "same drop-in problem",
-		"sysctl.protected-links":  "same drop-in problem",
 
 		"compose.ds012":          "the right healthcheck depends on what the service exposes; a guessed one marks a working container unhealthy and stalls everything waiting on it",
 		"compose.dr004":          "the remediation is about the env_file's permissions and whether it is in git and backups — nothing in the compose file to edit",

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -186,16 +186,8 @@ package fix
 //     SSH in as, and /etc/shadow does not say which this is. Setting a
 //     password instead cannot be done unattended by definition — hostveil
 //     would have to invent one, and then it would know it.
-//   - sysctl.* (every kernel-hardening finding) — one shared reason.
-//     Persisting a value means writing an /etc/sysctl.d drop-in that does
-//     not exist, and edit actions cannot create files: previewEdit and
-//     applyEdit both read the target before doing anything. Making it live
-//     needs `sysctl --system`, which is exec and so never Auto; and
-//     "write the drop-in, then apply it" is sequential steps, exactly what
-//     Review's independent-alternatives shape forbids. Each finding's
-//     how-to-fix carries the exact line and command instead. Revisit if
-//     Action ever grows a create-if-missing mode, at which point these
-//     become natural Review fixes.
+//
+// (sysctl.* was in this list and is not any more; see below.)
 //
 // # Auto fixes that touch a user's home
 //
@@ -225,6 +217,38 @@ package fix
 // otherwise turn `fix --all` into root tightening the password database off
 // the host. Any future Auto fix whose target another account can influence
 // owes the same discipline.
+//
+// # The kernel-hardening fixes, and why they stopped being declined
+//
+// Every sysctl.* finding was on the list above, for one shared reason:
+// persisting a value means writing an /etc/sysctl.d drop-in that does not
+// exist — and if it did exist the value would already be set, so the
+// finding would not have fired — while edit actions could only modify a
+// file already on disk. That left one remediation, `sysctl --system`, with
+// no partner, and "write the drop-in, then apply it" is sequential steps,
+// exactly what Review's independent-alternatives shape forbids.
+//
+// Action.CreateIfMissing removes the blocker, and what it reveals is that
+// there were two independent alternatives all along:
+//
+//   - write the drop-in — persistent, effective at the next boot;
+//   - `sysctl -w` — effective now, gone at the next boot.
+//
+// Neither dominates. An operator hardening a box they are about to reboot
+// wants the first; one who cannot restart a production host today wants
+// the second now and the first later. That is a choice, not a sequence.
+//
+// They are Review and not Auto, and the reason is not the shape. Writing
+// the drop-in is one mechanical, reversible file edit and would otherwise
+// qualify — but it is not unambiguous. rp_filter is 1 on a single-homed
+// server and 2 on a VPN or multi-homed one; sysrq has a restricted-bitmask
+// answer as legitimate as 0. hostveil audits only the unambiguous half of
+// each and writes only what it audited, but the operator is the one who
+// knows which host this is, so they see it first.
+//
+// One file per finding, never a shared 99-hostveil.conf. Independence is
+// the whole point: applying the second fix must not have to read what the
+// first wrote, and rolling one back must not take another's line with it.
 //
 // # The one CVE finding that does have a fix
 //
@@ -259,5 +283,6 @@ func Default() *Registry {
 	registerSSH(r)
 	registerUpdates(r)
 	registerAgent(r)
+	registerSysctl(r)
 	return r
 }

--- a/internal/fix/registry.go
+++ b/internal/fix/registry.go
@@ -33,6 +33,22 @@ type Action struct {
 	Path      string
 	Transform func(in []byte) (out []byte, err error)
 
+	// CreateIfMissing lets an edit action target a file that does not exist
+	// yet: Transform is handed nil rather than the read failing, and the
+	// checkpoint records that undoing the fix means deleting the file.
+	//
+	// Without it an edit action could only ever modify something already on
+	// disk, which left an entire detection domain unfixable. Persisting a
+	// kernel parameter means writing a drop-in under /etc/sysctl.d that by
+	// definition is not there — if it were, the value would already be set
+	// and the finding would not have fired.
+	//
+	// It is opt-in per action, not the default, because for every other fix
+	// a missing target is a real error worth reporting: an sshd_config that
+	// is not there means the finding was stale or the path was wrong, and
+	// silently creating one would be worse than failing.
+	CreateIfMissing bool
+
 	// VerifyCmd is an optional argv that validates an edit action's *result*
 	// before it is written. Exactly one element must be VerifyPathToken; the
 	// engine substitutes a temporary file holding the bytes Transform

--- a/internal/fix/sysctl.go
+++ b/internal/fix/sysctl.go
@@ -1,0 +1,158 @@
+package fix
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// dropInDir is where a persistent kernel parameter belongs on any systemd
+// distribution. hostveil writes one file per finding rather than appending
+// to a shared one, which is what keeps the fixes independent: applying the
+// second never has to read what the first wrote, and rolling one back
+// cannot take another's line with it.
+const dropInDir = "/etc/sysctl.d/"
+
+// registerSysctl wires the kernel-hardening fixes into the registry.
+//
+// Every sysctl finding is Review, and the two alternatives are genuinely
+// independent rather than two halves of one procedure:
+//
+//   - write a drop-in — persistent, and takes effect at the next boot or
+//     the next `sysctl --system`;
+//   - `sysctl -w` — takes effect immediately, and is lost at the next boot.
+//
+// Neither is strictly better, which is what makes this a choice rather
+// than a sequence. An operator hardening a box they are about to reboot
+// wants the first; one who cannot reboot a production host today wants the
+// second now and the first later. Offering only "do both, in order" would
+// be the sequential shape Review exists to refuse.
+//
+// This is the arrangement fix.Default's register anticipated: the blocker
+// was that an edit action could not create a file, so the drop-in
+// alternative could not exist and the remaining one had no partner.
+func registerSysctl(r *Registry) {
+	for _, id := range []string{
+		"sysctl.ptrace-scope",
+		"sysctl.syncookies",
+		"sysctl.accept-redirects",
+		"sysctl.protected-links",
+		"sysctl.kptr-restrict",
+		"sysctl.dmesg-restrict",
+		"sysctl.sysrq",
+		"sysctl.rp-filter",
+	} {
+		r.Register(id, buildSysctl)
+	}
+}
+
+// buildSysctl assembles both alternatives from the finding's "set"
+// evidence, which carries the exact key=value pairs the checker audited.
+func buildSysctl(f model.Finding) (Fix, error) {
+	pairs, err := sysctlPairs(f)
+	if err != nil {
+		return Fix{}, err
+	}
+
+	path := dropInDir + "60-hostveil-" + strings.TrimPrefix(f.ID, "sysctl.") + ".conf"
+	body := sysctlDropIn(f, pairs)
+
+	var commands [][]string
+	for _, kv := range pairs {
+		commands = append(commands, []string{"sysctl", "-w", kv})
+	}
+
+	return Fix{
+		Label: "Harden " + strings.Join(keysOf(pairs), ", "),
+		Kind:  model.RemediationReview,
+		Actions: []Action{
+			{
+				Label:           "Persist it: write " + path,
+				Warning:         "Takes effect at the next boot, or immediately if you then run `sysctl --system`. The running kernel keeps its current value until one of those happens.",
+				Kind:            ActionEdit,
+				Path:            path,
+				CreateIfMissing: true,
+				Transform: func(in []byte) ([]byte, error) {
+					// Idempotent: a drop-in this fix already wrote is
+					// returned unchanged rather than doubled. Applying a
+					// fix twice is not an error the user should have to
+					// avoid, and a file with the line twice is not wrong
+					// so much as it is evidence of a tool that does not
+					// know what it has done.
+					if bytes.Contains(in, []byte(body)) {
+						return in, nil
+					}
+					if len(in) > 0 && !bytes.HasSuffix(in, []byte("\n")) {
+						in = append(in, '\n')
+					}
+					return append(in, []byte(body)...), nil
+				},
+			},
+			{
+				Label: "Apply it now: " + strings.Join(keysOf(pairs), ", "),
+				// Exec actions have no checkpoint, and this one genuinely
+				// has nothing to undo from: the previous value is in the
+				// finding's evidence, not on disk, and a reboot reverts it
+				// anyway. Say so rather than implying a rollback exists.
+				Warning:  "Changes the running kernel immediately and is lost at the next boot. There is no rollback checkpoint: exec fixes are not file-backed.",
+				Kind:     ActionExec,
+				Commands: commands,
+			},
+		},
+	}, nil
+}
+
+// sysctlPairs reads the key=value list the checker recorded.
+//
+// A finding without it is an error rather than a fix built from a guess:
+// the alternative would be deriving the values from the finding ID, which
+// is exactly the kind of invented mapping the CVE fixes are declined for.
+func sysctlPairs(f model.Finding) ([]string, error) {
+	raw := f.Evidence["set"]
+	if raw == "" {
+		return nil, fmt.Errorf("finding %s carries no 'set' evidence, so there is no value to write", f.ID)
+	}
+	var out []string
+	for _, kv := range strings.Split(raw, ",") {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue
+		}
+		if k, _, ok := strings.Cut(kv, "="); !ok || k == "" {
+			return nil, fmt.Errorf("finding %s has malformed 'set' evidence %q", f.ID, raw)
+		}
+		out = append(out, kv)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("finding %s has empty 'set' evidence", f.ID)
+	}
+	return out, nil
+}
+
+// sysctlDropIn renders the file body: a comment naming what wrote it and
+// why, then one `key = value` line per parameter.
+//
+// The comment matters more than it looks. This file appears in /etc on a
+// host the operator administers, and an unattributed one-line config is
+// indistinguishable from something a compromise left behind.
+func sysctlDropIn(f model.Finding, pairs []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Written by hostveil for %s (%s).\n", f.ID, f.Title)
+	b.WriteString("# Remove this file to revert, or run: hostveil rollback <id>\n")
+	for _, kv := range pairs {
+		k, v, _ := strings.Cut(kv, "=")
+		fmt.Fprintf(&b, "%s = %s\n", k, v)
+	}
+	return b.String()
+}
+
+func keysOf(pairs []string) []string {
+	out := make([]string, 0, len(pairs))
+	for _, kv := range pairs {
+		k, _, _ := strings.Cut(kv, "=")
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -48,6 +49,17 @@ type BackedFile struct {
 	// missing hash means "cannot tell", which must not read as either answer —
 	// see verifyBlob.
 	BlobSHA256 string `json:"blob_sha256,omitempty"`
+
+	// Created records that the fix brought this file into existence, so
+	// restoring it means deleting it rather than writing something back.
+	//
+	// It is an explicit flag rather than an inference from an empty Blob,
+	// because an empty Blob already means something else — SaveModes writes
+	// mode-only entries with no blob, and those must be left alone. Guessing
+	// between "no contents were touched" and "there were no contents" would
+	// make rollback delete a file whose permissions were the only thing a
+	// fix ever changed.
+	Created bool `json:"created,omitempty"`
 }
 
 // Checkpoint is a restore point created when a fix is applied.
@@ -230,6 +242,39 @@ func (s *Store) SaveModes(cp Checkpoint, modes map[string]os.FileMode) (Checkpoi
 	cp.Files = cp.Files[:0]
 	for path, mode := range modes {
 		cp.Files = append(cp.Files, BackedFile{Path: path, Mode: mode})
+	}
+	sort.Slice(cp.Files, func(i, j int) bool { return cp.Files[i].Path < cp.Files[j].Path })
+
+	if err := s.writeMeta(dir, cp); err != nil {
+		return Checkpoint{}, err
+	}
+	s.pruneCheckpoints()
+	return cp, nil
+}
+
+// SaveCreations writes a checkpoint for a fix that created files which did
+// not exist before. paths names them; restoring the checkpoint deletes them.
+//
+// It is the third sibling of Save and SaveModes, and it exists for the same
+// reason SaveModes does: the checkpoint has to describe what undoing this
+// fix means, and "write these bytes back" cannot describe a file that had
+// no bytes. There is nothing to back up — that is the whole point — so the
+// checkpoint stores no blobs and is Reversible on the strength of naming
+// the paths.
+//
+// A fix that both creates one file and edits another would need Save and
+// this at once, and cannot express it. No such fix exists: an Action
+// carries a single Path. If one is ever written, this is where it breaks,
+// loudly, rather than silently checkpointing half of it.
+func (s *Store) SaveCreations(cp Checkpoint, paths []string) (Checkpoint, error) {
+	dir := filepath.Join(s.checkpointsDir(), cp.ID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return Checkpoint{}, err
+	}
+
+	cp.Files = cp.Files[:0]
+	for _, path := range paths {
+		cp.Files = append(cp.Files, BackedFile{Path: path, Created: true})
 	}
 	sort.Slice(cp.Files, func(i, j int) bool { return cp.Files[i].Path < cp.Files[j].Path })
 
@@ -492,6 +537,21 @@ func (s *Store) rollback(id string, force bool) (Checkpoint, error) {
 	}
 
 	for _, bf := range cp.Files {
+		// The file did not exist before the fix, so restoring it means
+		// removing it. An already-absent file is the desired end state, not
+		// an error — an operator who deleted the drop-in by hand and then
+		// rolled back should get success, not a failure describing the thing
+		// they already did.
+		//
+		// This runs after the same external-edit check every other entry
+		// gets, so a drop-in the operator has since edited declines here
+		// rather than being deleted out from under them.
+		if bf.Created {
+			if err := os.Remove(bf.Path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return cp, err
+			}
+			continue
+		}
 		// A mode-only entry carries no blob: the fix changed permissions and
 		// never touched the contents, so there is nothing to write back.
 		if data, ok := blobs[bf.Path]; ok {

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -272,19 +272,21 @@
 
             <h2 id="sysctl">Kernel hardening <code>sysctl.</code></h2>
             <p>Read directly from <code>/proc/sys</code> — no <code>sysctl</code> binary needed. These are the quiet knobs whose safe value is the same on essentially every server: none of them is the hole an attacker comes in through, each is what stops a foothold from becoming root or a spoofed packet from becoming a route. A parameter this kernel does not have (Yama not built in, say) is simply skipped.</p>
-            <p>Every finding here is Manual for now: making a value stick means creating an <code>/etc/sysctl.d</code> drop-in that does not exist yet, and applying it live takes <code>sysctl --system</code> — so each finding carries the exact line and the exact command instead of a button. <code>net.ipv4.ip_forward</code> is deliberately not audited: Docker, WireGuard, Tailscale exit nodes, and virtualization hosts all legitimately enable it, and hostveil cannot tell those apart from an accident.</p>
+            <p>Every finding here is <strong>Review</strong>, and the two alternatives are a real choice rather than two halves of one procedure. <em>Persist it</em> writes a drop-in under <code>/etc/sysctl.d</code> — one file per finding, named after it — which survives reboots and takes effect at the next one, or immediately if you then run <code>sysctl --system</code>. <em>Apply it now</em> runs <code>sysctl -w</code>, which changes the running kernel this second and is gone at the next boot. Neither dominates: hardening a box you are about to reboot wants the first, and a production host you cannot restart today wants the second now and the first later.</p>
+            <p>They are Review and not Auto-fix because the safe value is not always the only defensible one. <code>rp_filter</code> is 1 on a single-homed server and 2 on a VPN or multi-homed one; <code>sysrq</code> has a restricted-bitmask answer as legitimate as 0. hostveil flags only the unambiguous half of each and writes only what it flagged, but you are the one who knows which host this is. Rolling back a persisted fix deletes the drop-in it created, and declines if you have edited that file since.</p>
+            <p><code>net.ipv4.ip_forward</code> is deliberately not audited: Docker, WireGuard, Tailscale exit nodes, and virtualization hosts all legitimately enable it, and hostveil cannot tell those apart from an accident.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
-                  <tr><td><code>sysctl.ptrace-scope</code></td><td>Any process can debug its siblings and read their memory</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN-flood protection is off</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP redirects can rewrite this host's routing</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.protected-links</code></td><td>Symlink/hardlink race protections are disabled</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.kptr-restrict</code></td><td>Kernel pointer addresses are visible to all users</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>Any user can read the kernel log</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq is fully enabled</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
-                  <tr><td><code>sysctl.rp-filter</code></td><td>Source-address spoofing filter is off (strict and loose both pass)</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>sysctl.ptrace-scope</code></td><td>Any process can debug its siblings and read their memory</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN-flood protection is off</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP redirects can rewrite this host's routing</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.protected-links</code></td><td>Symlink/hardlink race protections are disabled</td><td><span class="sev medium">Medium</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.kptr-restrict</code></td><td>Kernel pointer addresses are visible to all users</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>Any user can read the kernel log</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq is fully enabled</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
+                  <tr><td><code>sysctl.rp-filter</code></td><td>Source-address spoofing filter is off (strict and loose both pass)</td><td><span class="sev low">Low</span></td><td>Review</td></tr>
                 </tbody>
               </table>
             </div>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -272,19 +272,21 @@
 
             <h2 id="sysctl">커널 하드닝 <code>sysctl.</code></h2>
             <p><code>/proc/sys</code>에서 직접 읽습니다 — <code>sysctl</code> 바이너리가 필요 없습니다. 이 항목들은 사실상 모든 서버에서 안전한 값이 같은 조용한 손잡이들입니다. 공격자가 들어오는 구멍은 아니지만, 각각은 발판이 root가 되는 것과 위조된 패킷이 경로가 되는 것을 막아 줍니다. 이 커널에 없는 파라미터(예: Yama가 빌드되지 않은 경우)는 그냥 건너뜁니다.</p>
-            <p>여기의 모든 발견 항목은 지금은 수동입니다. 값을 유지하려면 아직 존재하지 않는 <code>/etc/sysctl.d</code> 드롭인 파일을 만들어야 하고, 즉시 적용하려면 <code>sysctl --system</code>이 필요합니다 — 그래서 버튼 대신 정확한 설정 줄과 명령을 발견 항목이 직접 알려줍니다. <code>net.ipv4.ip_forward</code>는 의도적으로 점검하지 않습니다. Docker, WireGuard, Tailscale 종료 노드, 가상화 호스트가 모두 정당하게 켜는 값이고, hostveil은 그것을 실수와 구별할 수 없습니다.</p>
+            <p>여기의 모든 발견 항목은 <strong>검토</strong>이고, 두 대안은 한 절차의 앞뒤가 아니라 진짜 선택지입니다. <em>영구 적용</em>은 <code>/etc/sysctl.d</code> 아래에 발견 항목 이름을 딴 드롭인 파일을 하나 씁니다 — 재부팅해도 남고, 다음 부팅 때(또는 바로 <code>sysctl --system</code>을 실행하면 그 즉시) 적용됩니다. <em>지금 적용</em>은 <code>sysctl -w</code>로 실행 중인 커널을 이 순간 바꾸지만 다음 부팅에 사라집니다. 어느 쪽도 항상 낫지 않습니다. 곧 재부팅할 서버를 강화하는 중이라면 앞쪽을, 오늘 재시작할 수 없는 운영 호스트라면 지금은 뒤쪽을 그리고 나중에 앞쪽을 원하게 됩니다.</p>
+            <p>자동 수정이 아니라 검토인 이유는, 안전한 값이 언제나 유일하게 타당한 값은 아니기 때문입니다. <code>rp_filter</code>는 단일 회선 서버에서는 1이지만 VPN이나 다중 회선 호스트에서는 2이고, <code>sysrq</code>도 0만큼이나 정당한 제한 비트마스크 형태가 있습니다. hostveil은 각 항목에서 모호하지 않은 부분만 표시하고 표시한 것만 씁니다만, 이 호스트가 어느 쪽인지 아는 사람은 당신입니다. 영구 적용한 수정을 롤백하면 만들어진 드롭인 파일이 삭제되고, 그 파일을 그 뒤에 직접 고쳤다면 롤백은 거절됩니다.</p>
+            <p><code>net.ipv4.ip_forward</code>는 의도적으로 점검하지 않습니다. Docker, WireGuard, Tailscale 종료 노드, 가상화 호스트가 모두 정당하게 켜는 값이고, hostveil은 그것을 실수와 구별할 수 없습니다.</p>
             <div class="docs-table-wrap">
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
-                  <tr><td><code>sysctl.ptrace-scope</code></td><td>아무 프로세스나 형제 프로세스를 디버깅해 메모리를 읽을 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN 플러드 보호가 꺼져 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP 리다이렉트가 이 호스트의 라우팅을 바꿀 수 있음</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.protected-links</code></td><td>심볼릭/하드 링크 경쟁 보호가 비활성화됨</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.kptr-restrict</code></td><td>커널 포인터 주소가 모든 사용자에게 보임</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>아무 사용자나 커널 로그를 읽을 수 있음</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq가 전부 활성화됨</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
-                  <tr><td><code>sysctl.rp-filter</code></td><td>출발지 주소 위조 필터가 꺼져 있음 (strict와 loose 모두 통과)</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>sysctl.ptrace-scope</code></td><td>아무 프로세스나 형제 프로세스를 디버깅해 메모리를 읽을 수 있음</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.syncookies</code></td><td>TCP SYN 플러드 보호가 꺼져 있음</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.accept-redirects</code></td><td>ICMP 리다이렉트가 이 호스트의 라우팅을 바꿀 수 있음</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.protected-links</code></td><td>심볼릭/하드 링크 경쟁 보호가 비활성화됨</td><td><span class="sev medium">보통</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.kptr-restrict</code></td><td>커널 포인터 주소가 모든 사용자에게 보임</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.dmesg-restrict</code></td><td>아무 사용자나 커널 로그를 읽을 수 있음</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.sysrq</code></td><td>Magic SysRq가 전부 활성화됨</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
+                  <tr><td><code>sysctl.rp-filter</code></td><td>출발지 주소 위조 필터가 꺼져 있음 (strict와 loose 모두 통과)</td><td><span class="sev low">낮음</span></td><td>검토</td></tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
## What and why

`sysctl` was the only domain with **no registered fix at all**: eight findings, every one Manual, a 5-point axis a user could see and not act on.

The blocker was already written down in `fix.Default`'s register. Persisting a kernel parameter means writing a drop-in under `/etc/sysctl.d` that does not exist — and if it did, the value would be set and the finding would not have fired — while an edit action could only ever modify a file already on disk (`previewEdit` and `applyEdit` both began by reading the target). That left one remediation, `sysctl --system`, with no partner, and *"write the drop-in, then apply it"* is sequential steps — exactly the shape Review refuses.

`Action.CreateIfMissing` removes the blocker, and what it reveals is that there were **two independent alternatives all along**:

- **Persist it** — write the drop-in. Survives reboots, effective at the next one (or immediately after `sysctl --system`).
- **Apply it now** — `sysctl -w`. Effective this second, gone at the next boot.

Neither dominates. Someone hardening a box they are about to reboot wants the first; someone who cannot restart a production host today wants the second now and the first later. That is a choice, not a sequence.

**Review, not Auto** — and not because of the shape. Writing the drop-in is one mechanical, reversible edit and would otherwise qualify. It is because the safe value is not always the only defensible one: `rp_filter` is 1 on a single-homed server and 2 on a VPN or multi-homed one, and `sysrq` has a restricted-bitmask answer as legitimate as 0. hostveil audits only the unambiguous half of each and writes only what it audited, but the operator knows which host this is.

**One drop-in per finding**, never a shared `99-hostveil.conf`. Independence is the point: applying the second fix never has to read what the first wrote, and rolling one back cannot take another's line with it.

## The delicate half is the undo

Restoring *"this file did not exist"* means deleting it, and deletion is the one restore operation that cannot be taken back. So:

- `BackedFile.Created` is an **explicit flag**, not an inference from an empty `Blob`. An empty `Blob` already means something else — `SaveModes` writes mode-only entries with no blob — and guessing between "no contents were touched" and "there were no contents" would make rollback delete a file whose permissions were all a fix ever changed.
- The deletion runs **after** the same external-edit check every other entry gets, so a drop-in the operator has since tuned declines rather than vanishing.
- An **already-absent** file is success, not an error describing what the operator already did by hand.
- `CreateIfMissing` is **opt-in per action**. For every other fix a missing target is a real error: an `sshd_config` that is not there means the finding was stale or the path was wrong, and silently creating one would be worse than failing. Only `fs.ErrNotExist` is treated as "not there yet" — a permission denial or EISDIR still fails.

## Checker changes

`Rule` grows `Set`, the machine-readable form of the prose already in `Want`, passed to the fix through the finding's evidence — a fix never sees the `Rule` it came from. It names only keys the rule actually audits, which also drops the IPv6 twin that `accept-redirects`' how-to-fix promised and the checker never read.

## Checklist

- [x] Title is conventional with a valid scope (`feat(fix):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  `golangci-lint` and `govulncheck` cannot run in this container — they build the module with Go 1.25 and it requires 1.26. Delegated to the `lint` job.
- [x] For a new or changed detection rule: the sysctl tests assert the *negative* case too — `Set` must be present and well-formed on every emitted finding, so a rule that grows without it fails rather than shipping a fix button that errors at build time.
- [x] For a UI change: n/a — no UI code changes. The findings move Manual → Review, so all three UIs now offer the fix through the existing preview/apply path.
- [x] The score stays honest — no axis, weight, or coverage state changes. The findings' severities are unchanged; only their remediation kind moves, which affects the fix button, not the score.

## Score impact for users

**No score movement.** `RemediationReview` and `RemediationManual` are weighted identically — only `RemediationUnavailable` is discounted. Existing hosts see the same number with eight findings that now have a fix button.

## Verified by mutation

| Mutation | Result |
| --- | --- |
| Make rollback ignore `bf.Created` | `TestCreateThenRollbackRemovesTheFile` — `rollback left the file behind` |
| Disable the external-edit guard | `TestRollbackDeclinesToDeleteAnEditedFile` — `rollback err = <nil>, want an external-edit refusal` |

Five round-trip tests cover create → verify contents → rollback → verify absence, the pure-preview property (preview must not create the file), the declined-rollback case, the already-deleted case, and that a plain edit action *still* fails on a missing file.

**The docs guard fired unprompted**, which is the system working: flipping the registry turned `TestDocumentedFixKindsMatchTheRegistry` red in both languages until `checks.html` said Review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_