### PR TITLE
feat(check): flag a firewall that runs but accepts everything

### DIFF
--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -127,6 +127,7 @@
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
                   <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>firewall.default-allow</code></td><td>A firewall is running but its default inbound policy accepts everything</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>firewall.docker-bypass</code></td><td>Published container ports are reachable despite an active ufw</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
                 </tbody>
               </table>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -127,6 +127,7 @@
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
                   <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>firewall.default-allow</code></td><td>방화벽이 켜져 있지만 기본 인바운드 정책이 전부 허용</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>firewall.docker-bypass</code></td><td>ufw가 켜져 있는데도 publish된 컨테이너 포트가 외부에서 접근 가능</td><td><span class="sev critical">심각</span></td><td>수동</td></tr>
                 </tbody>
               </table>

--- a/internal/check/firewall/docker_test.go
+++ b/internal/check/firewall/docker_test.go
@@ -18,10 +18,10 @@ func dockerHost(ps, dockerUser string) fakeRunner {
 	return fakeRunner{
 		present: map[string]bool{"ufw": true, "iptables": true, "docker": true},
 		outputs: map[string]string{
-			"ufw status": "Status: active\n",
-			"docker version --format {{.Server.Version}}": "27.3.1\n",
-			"docker ps --format {{.Names}}\t{{.Ports}}":   ps,
-			"iptables -S DOCKER-USER":                     dockerUser,
+			"ufw status":         "Status: active\n",
+			"ufw status verbose": "Status: active\nDefault: deny (incoming), allow (outgoing), disabled (routed)\n", "docker version --format {{.Server.Version}}": "27.3.1\n",
+			"docker ps --format {{.Names}}\t{{.Ports}}": ps,
+			"iptables -S DOCKER-USER":                   dockerUser,
 		},
 	}
 }
@@ -146,7 +146,7 @@ func TestDaemonConfigWithoutIptablesKeyStillFlags(t *testing.T) {
 func TestNoDockerNoBypass(t *testing.T) {
 	r := fakeRunner{
 		present: map[string]bool{"ufw": true},
-		outputs: map[string]string{"ufw status": "Status: active\n"},
+		outputs: map[string]string{"ufw status": "Status: active\n", "ufw status verbose": "Status: active\nDefault: deny (incoming), allow (outgoing), disabled (routed)\n"},
 	}
 	fs, err := checkWith(t, r)
 	if err != nil {
@@ -163,7 +163,8 @@ func TestBypassScopedToUFW(t *testing.T) {
 	r := fakeRunner{
 		present: map[string]bool{"firewall-cmd": true, "iptables": true, "docker": true},
 		outputs: map[string]string{
-			"firewall-cmd --state":                        "running\n",
+			"firewall-cmd --state":            "running\n",
+			"firewall-cmd --get-default-zone": "public\n", "firewall-cmd --zone=public --list-all": "public (active)\n  target: default\n",
 			"docker version --format {{.Server.Version}}": "27.3.1\n",
 			"docker ps --format {{.Names}}\t{{.Ports}}":   "cache\t0.0.0.0:6379->6379/tcp\n",
 			"iptables -S DOCKER-USER":                     emptyDockerUser,

--- a/internal/check/firewall/firewall.go
+++ b/internal/check/firewall/firewall.go
@@ -49,14 +49,41 @@ func (*Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
 func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
 	switch status, which := probe(ctx, env.Runner); status {
 	case StatusActive:
-		// An active firewall is not the end of the question on a Docker
-		// host: published container ports are accepted before ufw's rules
-		// are consulted. Scoring this case clean is what let a host with an
-		// open datastore outscore one running nothing at all.
-		if which == "ufw" {
-			return checkDockerBypass(ctx, env.Runner, c.daemonConfig())
+		// "Running" is not the same as "filtering", and an active firewall
+		// is not the end of the question on a Docker host either. Two
+		// separate ways a host can look protected and not be.
+		var findings []model.Finding
+		var partial *check.PartialError
+
+		switch defaultInbound(ctx, env.Runner, which) {
+		case policyAllow:
+			findings = append(findings, defaultAllowFinding(which))
+		case policyUnknown:
+			// The same rule the probe itself follows: not being able to read
+			// the policy degrades the domain, it does not accuse the host.
+			partial = &check.PartialError{
+				Reason: "cannot read " + which + "'s default inbound policy — re-run with sudo to check whether the firewall actually denies unmatched traffic",
+			}
 		}
-		return nil, nil // the good case: no finding
+
+		// Published container ports are accepted before ufw's rules are
+		// consulted. Scoring this case clean is what let a host with an open
+		// datastore outscore one running nothing at all.
+		if which == "ufw" {
+			fs, err := checkDockerBypass(ctx, env.Runner, c.daemonConfig())
+			findings = append(findings, fs...)
+			// One reason is enough to mark the domain degraded, and the
+			// first is the more fundamental of the two.
+			if pe, ok := err.(*check.PartialError); ok && partial == nil {
+				partial = pe
+			} else if err != nil && !ok {
+				return findings, err
+			}
+		}
+		if partial != nil {
+			return findings, partial
+		}
+		return findings, nil
 	case StatusUnknown:
 		return nil, &check.PartialError{
 			Reason: "cannot read firewall state — re-run with sudo to check the host firewall",

--- a/internal/check/firewall/firewall_test.go
+++ b/internal/check/firewall/firewall_test.go
@@ -42,7 +42,7 @@ func countFindings(t *testing.T, r fakeRunner) int {
 func TestFirewallActiveUFW(t *testing.T) {
 	r := fakeRunner{
 		present: map[string]bool{"ufw": true},
-		outputs: map[string]string{"ufw status": "Status: active\n"},
+		outputs: map[string]string{"ufw status": "Status: active\n", "ufw status verbose": "Status: active\nDefault: deny (incoming), allow (outgoing), disabled (routed)\n"},
 	}
 	if n := countFindings(t, r); n != 0 {
 		t.Errorf("active ufw should yield no finding, got %d", n)
@@ -69,7 +69,7 @@ func TestFirewallNoneInstalled(t *testing.T) {
 func TestFirewallFirewalld(t *testing.T) {
 	r := fakeRunner{
 		present: map[string]bool{"firewall-cmd": true},
-		outputs: map[string]string{"firewall-cmd --state": "running\n"},
+		outputs: map[string]string{"firewall-cmd --state": "running\n", "firewall-cmd --get-default-zone": "public\n", "firewall-cmd --zone=public --list-all": "public (active)\n  target: default\n"},
 	}
 	if n := countFindings(t, r); n != 0 {
 		t.Errorf("running firewalld should yield no finding, got %d", n)
@@ -146,7 +146,7 @@ func TestFirewallUnreadableIsNotReportedAsAbsent(t *testing.T) {
 func TestFirewalldDetectedWhenStateGoesToStderr(t *testing.T) {
 	r := fakeRunner{
 		present: map[string]bool{"firewall-cmd": true},
-		outputs: map[string]string{"firewall-cmd --state": ""}, // exits 0, says nothing on stdout
+		outputs: map[string]string{"firewall-cmd --state": "", "firewall-cmd --get-default-zone": "public\n", "firewall-cmd --zone=public --list-all": "public (active)\n  target: default\n"}, // exits 0, says nothing on stdout
 	}
 	if n := countFindings(t, r); n != 0 {
 		t.Errorf("firewalld running with empty stdout must count as active, got %d findings", n)
@@ -193,7 +193,7 @@ func TestFirewallProbeStatuses(t *testing.T) {
 		{"no tools installed", fakeRunner{}, StatusInactive},
 		{"ufw answers active", fakeRunner{
 			present: map[string]bool{"ufw": true},
-			outputs: map[string]string{"ufw status": "Status: active\n"},
+			outputs: map[string]string{"ufw status": "Status: active\n", "ufw status verbose": "Status: active\nDefault: deny (incoming), allow (outgoing), disabled (routed)\n"},
 		}, StatusActive},
 		{"ufw answers inactive", fakeRunner{
 			present: map[string]bool{"ufw": true},
@@ -204,7 +204,7 @@ func TestFirewallProbeStatuses(t *testing.T) {
 		}, StatusUnknown},
 		{"one tool unreadable, another confirms active", fakeRunner{
 			present: map[string]bool{"ufw": true, "nft": true},
-			outputs: map[string]string{"ufw status": "Status: active\n"},
+			outputs: map[string]string{"ufw status": "Status: active\n", "ufw status verbose": "Status: active\nDefault: deny (incoming), allow (outgoing), disabled (routed)\n"},
 		}, StatusActive},
 		{"firewalld installed but unreadable", fakeRunner{
 			present: map[string]bool{"firewall-cmd": true},

--- a/internal/check/firewall/policy.go
+++ b/internal/check/firewall/policy.go
@@ -1,0 +1,155 @@
+package firewall
+
+import (
+	"context"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// The probe answers "is a firewall running", and for two of the four
+// front-ends that was the whole test. nftables and iptables have to show a
+// base chain whose default policy drops or rejects — hasHostFirewall and
+// hasDropPolicy both insist on it — while ufw was accepted on the strength
+// of "Status: active" and firewalld on `--state` exiting 0.
+//
+// So hostveil held a hand-written ruleset to a stricter standard than the
+// two managed front-ends. `ufw enable` after `ufw default allow incoming`
+// produced a perfect score on the third-heaviest axis while the host
+// accepted everything, which is the same posture that scores 0 through
+// firewall.inactive when nftables is the tool in use. A firewall that is
+// running and permitting is not a firewall; it is a log.
+//
+// This closes that. It asks the same question of the two managed
+// front-ends that the other two already had to answer, and — like every
+// other probe here — reports "cannot tell" rather than guessing when the
+// query fails.
+
+// inboundPolicy is what the active front-end does with a packet no rule
+// matched.
+type inboundPolicy int
+
+const (
+	// policyUnknown means the front-end could not be queried. Almost always
+	// missing root, and never evidence of either answer.
+	policyUnknown inboundPolicy = iota
+	// policyDeny means unmatched inbound traffic is dropped or rejected.
+	policyDeny
+	// policyAllow means it is accepted.
+	policyAllow
+)
+
+// defaultInbound reports the active firewall's default inbound policy.
+//
+// which is the front-end probe() reported active, and it decides how the
+// question is asked. nftables and iptables need no query at all: probe
+// only calls them active when it has already seen a drop or reject policy
+// on the input hook, so asking again could only produce a different answer
+// by reading something else.
+func defaultInbound(ctx context.Context, r platform.CommandRunner, which string) inboundPolicy {
+	switch which {
+	case "ufw":
+		out, err := r.Run(ctx, "ufw", "status", "verbose")
+		if err != nil {
+			return policyUnknown
+		}
+		return parseUFWDefault(string(out))
+	case "firewalld":
+		zone, err := r.Run(ctx, "firewall-cmd", "--get-default-zone")
+		if err != nil {
+			return policyUnknown
+		}
+		name := strings.TrimSpace(string(zone))
+		if name == "" {
+			return policyUnknown
+		}
+		out, err := r.Run(ctx, "firewall-cmd", "--zone="+name, "--list-all")
+		if err != nil {
+			return policyUnknown
+		}
+		return parseFirewalldTarget(string(out))
+	default:
+		return policyDeny
+	}
+}
+
+// parseUFWDefault reads the incoming half of ufw's default line:
+//
+//	Default: deny (incoming), allow (outgoing), disabled (routed)
+//
+// Only the incoming direction is read. Outgoing defaults to allow on
+// essentially every host and denying it is a deliberate, unusual choice —
+// flagging it would accuse the overwhelming majority of correct
+// configurations.
+func parseUFWDefault(out string) inboundPolicy {
+	for _, line := range strings.Split(strings.ToLower(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "default:") {
+			continue
+		}
+		for _, part := range strings.Split(strings.TrimPrefix(line, "default:"), ",") {
+			if !strings.Contains(part, "(incoming)") {
+				continue
+			}
+			switch {
+			case strings.Contains(part, "deny"), strings.Contains(part, "reject"):
+				return policyDeny
+			case strings.Contains(part, "allow"):
+				return policyAllow
+			}
+		}
+	}
+	// The line is there on every ufw version that supports `status verbose`.
+	// Its absence means the output is not what this parser was written for,
+	// which is "cannot tell" — not "allow".
+	return policyUnknown
+}
+
+// parseFirewalldTarget reads the zone target from `firewall-cmd --list-all`:
+//
+//	public (active)
+//	  target: default
+//
+// Only an explicit ACCEPT target permits unmatched inbound traffic.
+// "default" is firewalld's own name for reject, and DROP and %%REJECT%% say
+// so outright.
+func parseFirewalldTarget(out string) inboundPolicy {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "target:") {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(strings.TrimPrefix(line, "target:")), "ACCEPT") {
+			return policyAllow
+		}
+		return policyDeny
+	}
+	return policyUnknown
+}
+
+// defaultAllowFinding reports a firewall that runs and permits.
+//
+// It is High rather than Critical for the same reason firewall.inactive is:
+// the host may well be behind a router or cloud security group, so this is
+// a missing backstop rather than a confirmed exposure. It is the same
+// severity as having no firewall at all, because it is the same posture —
+// the difference is only that this one looks fixed.
+//
+// No fix is registered, for firewall.inactive's reason: changing a default
+// policy to deny on a machine reached over SSH can lock the operator out
+// irrecoverably, and exec fixes leave no checkpoint.
+func defaultAllowFinding(which string) model.Finding {
+	how := "Run `ufw default deny incoming`, then `ufw reload`. Make sure your SSH port is allowed first (`ufw allow OpenSSH`) — the deny policy takes effect immediately and an unallowed session is the one you are using."
+	if which == "firewalld" {
+		how = "Set the default zone's target to something other than ACCEPT (`firewall-cmd --permanent --zone=<zone> --set-target=default`, then `firewall-cmd --reload`). Make sure the ssh service is allowed in that zone first — the new target takes effect immediately."
+	}
+	return model.NewFinding("firewall.default-allow",
+		"Firewall is running but accepts everything by default",
+		model.SeverityHigh, model.SourceFirewall, model.RemediationManual,
+		model.WithDescription("A firewall is active, but its default policy for inbound traffic is to accept. Every port a service binds to a non-loopback address is reachable from any network this host is on, exactly as if no firewall were running — the difference is that `"+which+"` reports it as active, so the host looks protected. A firewall is only a backstop if what it does with traffic no rule matched is refuse it."),
+		model.WithHowToFix(how),
+		model.WithEvidence("firewall", which),
+		model.WithEvidence("default_inbound", "allow"),
+	)
+}

--- a/internal/check/firewall/policy_test.go
+++ b/internal/check/firewall/policy_test.go
@@ -1,0 +1,186 @@
+package firewall
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// denies is the fixture pair for a correctly-configured front-end, so a
+// test about something else does not have to restate it.
+func ufwOutputs(defaultLine string) map[string]string {
+	return map[string]string{
+		"ufw status":         "Status: active\n",
+		"ufw status verbose": "Status: active\n" + defaultLine,
+	}
+}
+
+func firewalldOutputs(target string) map[string]string {
+	return map[string]string{
+		"firewall-cmd --state":                  "running\n",
+		"firewall-cmd --get-default-zone":       "public\n",
+		"firewall-cmd --zone=public --list-all": "public (active)\n  target: " + target + "\n  services: ssh dhcpv6-client\n",
+	}
+}
+
+func checkFindings(t *testing.T, r fakeRunner) ([]model.Finding, error) {
+	t.Helper()
+	return New().Check(context.Background(), platform.Env{Runner: r})
+}
+
+// A firewall that runs and permits is the same posture as no firewall,
+// and it used to score the axis a perfect 100 — the third-heaviest axis in
+// the model. nftables and iptables were always held to the default-policy
+// standard (hasHostFirewall and hasDropPolicy both require a drop or
+// reject on the input hook); ufw and firewalld were not.
+func TestDefaultAllowIsFlagged(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		runner  fakeRunner
+		wantHit bool
+	}{
+		{
+			"ufw denying inbound is clean",
+			fakeRunner{present: map[string]bool{"ufw": true},
+				outputs: ufwOutputs("Default: deny (incoming), allow (outgoing), disabled (routed)\n")},
+			false,
+		},
+		{
+			"ufw rejecting inbound is clean",
+			fakeRunner{present: map[string]bool{"ufw": true},
+				outputs: ufwOutputs("Default: reject (incoming), allow (outgoing), disabled (routed)\n")},
+			false,
+		},
+		{
+			"ufw allowing inbound is flagged",
+			fakeRunner{present: map[string]bool{"ufw": true},
+				outputs: ufwOutputs("Default: allow (incoming), allow (outgoing), disabled (routed)\n")},
+			true,
+		},
+		{
+			// Outgoing is allow on essentially every host and denying it is
+			// a deliberate, unusual choice. Reading the wrong half of the
+			// line would accuse the overwhelming majority of correct
+			// configurations.
+			"denying inbound while allowing outbound is clean",
+			fakeRunner{present: map[string]bool{"ufw": true},
+				outputs: ufwOutputs("Default: deny (incoming), allow (outgoing), allow (routed)\n")},
+			false,
+		},
+		{
+			"firewalld with the default target is clean",
+			fakeRunner{present: map[string]bool{"firewall-cmd": true}, outputs: firewalldOutputs("default")},
+			false,
+		},
+		{
+			"firewalld with an explicit DROP target is clean",
+			fakeRunner{present: map[string]bool{"firewall-cmd": true}, outputs: firewalldOutputs("DROP")},
+			false,
+		},
+		{
+			"firewalld with an ACCEPT target is flagged",
+			fakeRunner{present: map[string]bool{"firewall-cmd": true}, outputs: firewalldOutputs("ACCEPT")},
+			true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs, err := checkFindings(t, tc.runner)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := false
+			for _, f := range fs {
+				if f.ID == "firewall.default-allow" {
+					got = true
+				}
+			}
+			if got != tc.wantHit {
+				t.Errorf("firewall.default-allow fired = %v, want %v (findings: %v)", got, tc.wantHit, fs)
+			}
+		})
+	}
+}
+
+// The same rule the probe itself follows, and the one this whole domain is
+// built on: "I could not look" is not "nothing there". `ufw status
+// verbose` needs root, and a non-root scan must degrade the axis rather
+// than accuse a host whose policy it never read.
+func TestUnreadablePolicyDegradesRatherThanAccuses(t *testing.T) {
+	// Active by `ufw status`, but the verbose query is not stubbed, so it
+	// errors — exactly what happens without root.
+	r := fakeRunner{
+		present: map[string]bool{"ufw": true},
+		outputs: map[string]string{"ufw status": "Status: active\n"},
+	}
+	fs, err := checkFindings(t, r)
+	for _, f := range fs {
+		if f.ID == "firewall.default-allow" {
+			t.Error("an unreadable policy produced the finding; it must only degrade")
+		}
+	}
+	var pe *check.PartialError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want a PartialError so the axis is marked degraded", err)
+	}
+}
+
+// firewalld reached through a zone that cannot be listed is the same case.
+func TestUnreadableFirewalldZoneDegrades(t *testing.T) {
+	r := fakeRunner{
+		present: map[string]bool{"firewall-cmd": true},
+		outputs: map[string]string{
+			"firewall-cmd --state":            "running\n",
+			"firewall-cmd --get-default-zone": "public\n",
+			// --list-all is not stubbed: it errors.
+		},
+	}
+	_, err := checkFindings(t, r)
+	var pe *check.PartialError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want a PartialError", err)
+	}
+}
+
+// nftables and iptables are never queried again: probe only reports them
+// active after seeing a drop or reject policy, so the question is already
+// answered. Asking twice could only produce a different answer by reading
+// something else.
+func TestNftablesNeedsNoSecondQuery(t *testing.T) {
+	r := fakeRunner{
+		present: map[string]bool{"nft": true},
+		outputs: map[string]string{
+			"nft list ruleset": "table inet filter {\n chain input {\n type filter hook input priority 0; policy drop;\n }\n}\n",
+		},
+	}
+	fs, err := checkFindings(t, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fs) != 0 {
+		t.Errorf("a drop-policy nftables ruleset must be clean, got %v", fs)
+	}
+}
+
+// The finding must name the front-end it found, because the remediation
+// differs entirely: `ufw default deny incoming` versus a firewalld zone
+// target. A finding that gave ufw's advice on a firewalld host would be
+// worse than none.
+func TestDefaultAllowFindingNamesItsFrontEnd(t *testing.T) {
+	for which, want := range map[string]string{"ufw": "ufw default deny incoming", "firewalld": "--set-target"} {
+		f := defaultAllowFinding(which)
+		if f.Evidence["firewall"] != which {
+			t.Errorf("%s: evidence names %q", which, f.Evidence["firewall"])
+		}
+		if !strings.Contains(f.HowToFix, want) {
+			t.Errorf("%s: how-to-fix does not carry %q: %s", which, want, f.HowToFix)
+		}
+		if err := f.Validate(); err != nil {
+			t.Errorf("%s: invalid finding: %v", which, err)
+		}
+	}
+}

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -61,6 +61,15 @@ package fix
 //     prompt about modified config files. Nothing about that is reversible
 //     from a checkpoint, and a package upgrade that breaks a service leaves
 //     the operator worse off than the pending patch did.
+//   - firewall.default-allow — the remediation is flipping the default
+//     inbound policy to deny, which is firewall.inactive's remediation
+//     applied to a firewall that happens to already be running, and it is
+//     declined for firewall.inactive's reason. The new policy takes effect
+//     the moment it is set, on every connection no rule already allows —
+//     including the SSH session the operator is issuing it from. Exec fixes
+//     have no checkpoint, so a lockout has no undo. The how-to-fix says to
+//     allow SSH first, which is advice a person can follow in order and a
+//     fix cannot: hostveil does not know which port that session is on.
 //   - firewall.inactive — the only remediation is enabling a firewall, and
 //     the checker records no SSH port, interface, or session data. Enabling
 //     a default-deny policy on a box reached over SSH can lock the user out

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -213,6 +213,7 @@
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
                   <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>firewall.default-allow</code></td><td>A firewall is running but its default inbound policy accepts everything</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>firewall.docker-bypass</code></td><td>Published container ports are reachable despite an active ufw</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
                 </tbody>
               </table>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -213,6 +213,7 @@
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
                   <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>firewall.default-allow</code></td><td>방화벽이 켜져 있지만 기본 인바운드 정책이 전부 허용</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>firewall.docker-bypass</code></td><td>ufw가 켜져 있는데도 publish된 컨테이너 포트가 외부에서 접근 가능</td><td><span class="sev critical">심각</span></td><td>수동</td></tr>
                 </tbody>
               </table>


### PR DESCRIPTION
## What and why

The probe answered *"is a firewall running"*, and for two of the four front-ends that was the whole test:

| Front-end | What it had to show |
| --- | --- |
| nftables | a base chain hooked at input with `policy drop`/`reject` |
| iptables | `-P INPUT DROP`/`REJECT` |
| **ufw** | the text `Status: active` |
| **firewalld** | `firewall-cmd --state` exiting 0 |

So hostveil held a **hand-written ruleset to a stricter standard than the two managed front-ends**. `ufw enable` after `ufw default allow incoming` scored the Host firewall axis a perfect 100 — the third-heaviest axis in the model — while the host accepted every inbound packet. That is the same posture that scores 0 through `firewall.inactive` when nftables happens to be the tool in use.

A firewall that is running and permitting is not a firewall; it is a log. The only thing it reliably does is make the host look protected — which is the same failure mode `firewall.docker-bypass` exists for, and its description already says so: *"The firewall looks correct in `ufw status` while these ports are open."*

## What it does

`firewall.default-allow` asks the two managed front-ends the same question the other two already had to answer:

- **ufw** — the `Default:` line of `status verbose`.
- **firewalld** — the default zone's `target`. Only an explicit `ACCEPT` permits unmatched traffic; `default` is firewalld's own name for reject.

nftables and iptables are **not queried again**, because `probe` only reports them active after seeing the answer. Asking twice could only produce a different one by reading something else.

Only the **incoming** half of ufw's default line is read. Outgoing is allow on essentially every host and denying it is a deliberate, unusual choice; flagging it would accuse the overwhelming majority of correct configurations.

`ufw status verbose` needs root, so the domain's own rule applies: **a policy that cannot be read degrades the axis rather than accusing the host.** The finding fires on an answer, never on the absence of one.

## No fix, and why

Recorded in `fix.Default`'s register. The new policy takes effect the moment it is set, on every connection no rule already allows — **including the SSH session the operator is issuing it from**. Exec fixes have no checkpoint, so a lockout has no undo. The how-to-fix says to allow SSH first, which is advice a person can follow in order and a fix cannot: hostveil does not know which port that session is on. Same reasoning as `firewall.inactive`, which this is a variant of.

## Score impact for users

**Some hosts will drop without their configuration having changed** — specifically, hosts running ufw or firewalld with a default-allow inbound policy. Nothing got worse on those machines; hostveil is looking at more of the firewall. Severity is High, matching `firewall.inactive`, because it is the same posture: a missing backstop rather than a confirmed exposure (the host may still be behind a router or a cloud security group). No axis weight changes.

## Checklist

- [x] Title is conventional with a valid scope (`feat(check):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  `golangci-lint` and `govulncheck` cannot run in this container — they build the module with Go 1.25 and it requires 1.26. Delegated to the `lint` job.
- [x] **Added the case that must not trigger it**, not just the one that must: `deny (incoming)`, `reject (incoming)`, `deny (incoming), allow (outgoing)` (the wrong-half trap), firewalld `target: default`, firewalld `target: DROP`, and a drop-policy nftables ruleset all stay clean.
- [x] For a UI change: n/a.
- [x] **The score stays honest** — an unreadable policy produces a `PartialError`, so the axis is scored on what was seen and flagged Degraded. It never passes "couldn't look" off as "nothing there", and never as "wide open" either.

## Verified by mutation

| Mutation | Result |
| --- | --- |
| Parse the `(outgoing)` half instead of `(incoming)` | `TestDefaultAllowIsFlagged` — every correctly-configured ufw host is flagged |
| Return `policyAllow` where the code returns `policyUnknown` | `TestUnreadablePolicyDegradesRatherThanAccuses` — `an unreadable policy produced the finding; it must only degrade` |

**Two guards from earlier in this cycle fired unprompted**, which is the system working: `TestEveryEmittedFindingIsDocumented` refused the finding until `checks.html` listed it in both languages, and `TestEveryFindingIsEitherFixableOrDeclinedOnPurpose` refused it until the register carried a reason for having no fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_