### PR TITLE
feat(ui): let the TUI and dashboard reach two engine features they could not

### DIFF
--- a/cmd/sitegen/content/en/docs/interfaces.html
+++ b/cmd/sitegen/content/en/docs/interfaces.html
@@ -5,7 +5,7 @@
             <h2>TUI — the default</h2>
             <p>Running <code>hostveil</code> with no arguments on an interactive terminal opens the keyboard-driven TUI. You can also launch it explicitly:</p>
             <div class="code-block"><pre><code>hostveil        # or: hostveil tui</code></pre></div>
-            <p>It shows the score and findings with severity and domain <strong>filters</strong>, <strong>multi-select</strong> for batch fixing, plain-language detail, and a fix preview before anything is applied.</p>
+            <p>It shows the score and findings with severity and domain <strong>filters</strong>, <strong>multi-select</strong> for batch fixing, plain-language detail, and a fix preview before anything is applied. While a scan runs it names the domains still working, so a slow CVE scan on a host with many images reads as progress rather than as a hang.</p>
             <figure>
               <img src="../assets/tui.png" alt="hostveil terminal UI — findings with severity filters and multi-select" width="1200" height="480" loading="lazy">
               <figcaption><strong>TUI</strong><span>Keyboard-driven findings with severity and domain filters, multi-select, plain-language detail, and fix preview.</span></figcaption>
@@ -30,7 +30,7 @@
                   <tr><td><code>d</code></td><td>Cycle the domain filter through the domains this scan actually found something in.</td></tr>
                   <tr><td><code>x</code></td><td>Show only findings hostveil can fix.</td></tr>
                   <tr><td><code>c</code></td><td>Clear every filter. <code>Esc</code> clears the batch marks.</td></tr>
-                  <tr><td><code>h</code></td><td>Applied-fix history — pick one and press <code>Enter</code> to see what rolling it back would restore, then confirm.</td></tr>
+                  <tr><td><code>h</code></td><td>Applied-fix history — pick one and press <code>Enter</code> to see what rolling it back would restore, then confirm. If the file has changed since the fix wrote it, the rollback is declined and you are asked whether to overwrite anyway; only <code>y</code> does it, and it cannot be undone.</td></tr>
                   <tr><td><code>e</code></td><td>In a finding's detail: add an advisory AI explanation from a local Ollama model. Without one, a one-line note appears instead — <a href="ai">AI explanations</a>.</td></tr>
                   <tr><td><code>t</code></td><td>Theme picker (below).</td></tr>
                   <tr><td><code>r</code></td><td>Rescan.</td></tr>

--- a/cmd/sitegen/content/ko/docs/interfaces.html
+++ b/cmd/sitegen/content/ko/docs/interfaces.html
@@ -5,7 +5,7 @@
             <h2>TUI — 기본값</h2>
             <p>인수 없이 대화형 터미널에서 <code>hostveil</code>을 실행하면 키보드 기반 TUI가 열립니다. 명시적으로 실행할 수도 있습니다.</p>
             <div class="code-block"><pre><code>hostveil        # or: hostveil tui</code></pre></div>
-            <p>점수와 발견 항목을 심각도·영역 <strong>필터</strong>, 일괄 수정을 위한 <strong>다중 선택</strong>, 쉬운 말 상세 설명, 그리고 적용 전 수정 미리보기와 함께 보여 줍니다.</p>
+            <p>점수와 발견 항목을 심각도·영역 <strong>필터</strong>, 일괄 수정을 위한 <strong>다중 선택</strong>, 쉬운 말 상세 설명, 그리고 적용 전 수정 미리보기와 함께 보여 줍니다. 스캔이 도는 동안에는 아직 작업 중인 영역의 이름을 보여 주므로, 이미지가 많은 호스트에서 CVE 스캔이 오래 걸려도 멈춘 것이 아니라 진행 중임을 알 수 있습니다.</p>
             <figure>
               <img src="../../assets/tui.png" alt="hostveil 터미널 UI — 심각도 필터와 다중 선택이 있는 발견 항목" width="1200" height="480" loading="lazy">
               <figcaption><strong>TUI</strong><span>심각도·영역 필터, 다중 선택, 쉬운 말 상세 설명, 수정 미리보기를 갖춘 키보드 기반 발견 항목.</span></figcaption>
@@ -30,7 +30,7 @@
                   <tr><td><code>d</code></td><td>이번 스캔에서 실제로 발견된 영역들만 순환하며 필터링합니다.</td></tr>
                   <tr><td><code>x</code></td><td>hostveil이 고칠 수 있는 항목만 봅니다.</td></tr>
                   <tr><td><code>c</code></td><td>모든 필터를 지웁니다. <code>Esc</code>는 일괄 처리 표시를 지웁니다.</td></tr>
-                  <tr><td><code>h</code></td><td>적용된 수정 이력입니다. 하나를 골라 <code>Enter</code>를 누르면 되돌렸을 때 복원될 내용을 보여 주고, 확인을 받습니다.</td></tr>
+                  <tr><td><code>h</code></td><td>적용된 수정 이력입니다. 하나를 골라 <code>Enter</code>를 누르면 되돌렸을 때 복원될 내용을 보여 주고, 확인을 받습니다. 수정 이후 그 파일이 바뀌었다면 롤백이 거절되고, 그래도 덮어쓸지 묻습니다 — <code>y</code>만 실행하며, 되돌릴 수 없습니다.</td></tr>
                   <tr><td><code>e</code></td><td>발견 항목의 상세 화면에서: 로컬 Ollama 모델의 조언성 AI 설명을 덧붙입니다. 모델이 없으면 한 줄 안내가 대신 나옵니다 — <a href="ai">AI 설명</a> 참고.</td></tr>
                   <tr><td><code>t</code></td><td>테마 선택기(아래 참고).</td></tr>
                   <tr><td><code>r</code></td><td>다시 스캔합니다.</td></tr>

--- a/internal/ui/tui/parity_test.go
+++ b/internal/ui/tui/parity_test.go
@@ -1,0 +1,161 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	// This test file imports internal/history to build the exact error the
+	// engine returns when it declines a rollback. The layering test scans
+	// production files only, and asserting against a stand-in would be
+	// asserting against something core.IsExternalEdit does not actually
+	// recognise — which is the bug this covers.
+	"github.com/seolcu/hostveil/internal/history"
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// The engine has emitted per-domain progress since the CLI display was
+// built for it, and the TUI passed nil and threw every event away. On a
+// host with many images a scan takes minutes, and the screen said
+// "Scanning…" for all of it — a display that cannot distinguish "still
+// working" from "hung" is the one place this is not decoration.
+func TestScanProgressNamesTheDomainsStillWorking(t *testing.T) {
+	m := &appModel{mode: modeScanning, width: 100, height: 24, selected: map[string]bool{}}
+	m.scanRunning = map[model.Source]bool{}
+
+	m.noteScanEvent(model.ScanEvent{Source: model.SourceCVE, State: model.ScanRunning})
+	m.noteScanEvent(model.ScanEvent{Source: model.SourceSSH, State: model.ScanRunning})
+	if !strings.Contains(m.status, model.SourceCVE.Label()) ||
+		!strings.Contains(m.status, model.SourceSSH.Label()) {
+		t.Errorf("status does not name the running domains: %q", m.status)
+	}
+
+	// A finished checker leaves the line and joins the count. Skipped and
+	// Degraded are outcomes, not failures to report, so they finish too.
+	m.noteScanEvent(model.ScanEvent{Source: model.SourceSSH, State: model.ScanDone})
+	if strings.Contains(m.status, model.SourceSSH.Label()) {
+		t.Errorf("a finished domain is still listed as running: %q", m.status)
+	}
+	if !strings.Contains(m.status, "1 done") {
+		t.Errorf("status does not report progress: %q", m.status)
+	}
+
+	m.noteScanEvent(model.ScanEvent{Source: model.SourceCVE, State: model.ScanSkipped})
+	if m.scanDone != 2 {
+		t.Errorf("scanDone = %d, want 2 — a skipped domain still finished", m.scanDone)
+	}
+	if strings.Contains(m.status, ",") {
+		t.Errorf("nothing is running, so nothing should be listed: %q", m.status)
+	}
+}
+
+// The wiring, not just the fold: an event has to reach the model through
+// Update. The TUI's scan already emitted these into a nil channel, so a
+// version of this that only exercised noteScanEvent would pass against the
+// exact bug being fixed.
+func TestScanProgressReachesTheModelThroughUpdate(t *testing.T) {
+	m := &appModel{mode: modeScanning, width: 100, height: 24, selected: map[string]bool{}}
+	m.scanCh = make(chan model.ScanEvent, 1)
+
+	m.Update(scanProgressMsg{event: model.ScanEvent{Source: model.SourceCVE, State: model.ScanRunning}})
+	if !strings.Contains(m.status, model.SourceCVE.Label()) {
+		t.Errorf("an event through Update did not reach the status line: %q", m.status)
+	}
+	if !strings.Contains(m.View().Content, model.SourceCVE.Label()) {
+		t.Errorf("the scanning screen does not show it:\n%s", m.View().Content)
+	}
+
+	// Progress that lands after the report is stale by definition: the scan
+	// is over and the list is drawn. It must not overwrite the screen the
+	// user is now reading.
+	m.mode = modeList
+	before := m.status
+	m.Update(scanProgressMsg{event: model.ScanEvent{Source: model.SourceSSH, State: model.ScanRunning}})
+	if m.status != before {
+		t.Errorf("a late event rewrote the status after the scan finished: %q", m.status)
+	}
+}
+
+// Map iteration order would make the line jitter on every redraw, which
+// reads as the screen malfunctioning rather than as work progressing.
+func TestScanProgressIsStablyOrdered(t *testing.T) {
+	build := func() string {
+		m := &appModel{mode: modeScanning, scanRunning: map[model.Source]bool{}}
+		for _, s := range model.AllSources() {
+			m.noteScanEvent(model.ScanEvent{Source: s, State: model.ScanRunning})
+		}
+		return m.status
+	}
+	first := build()
+	for i := 0; i < 20; i++ {
+		if got := build(); got != first {
+			t.Fatalf("status is not stable across renders:\n %q\n %q", first, got)
+		}
+	}
+}
+
+// A declined rollback is a question, not a failure. The engine refuses when
+// the file changed after hostveil wrote it, the CLI has offered --force
+// since 3.4, and the dashboard's server has accepted it since the token
+// landed — but in the TUI the answer was "Rollback failed" and a dead end.
+func TestDeclinedRollbackOffersToForce(t *testing.T) {
+	m := &appModel{mode: modeHistory, width: 100, height: 24, selected: map[string]bool{},
+		checkpoints: []model.Checkpoint{{ID: "cp1", Label: "Bind redis to loopback",
+			Files: []string{"/opt/stacks/cloud/docker-compose.yml"}, Reversible: true}}}
+
+	m.Update(rolledBackMsg{err: &history.ExternalEditError{CheckpointID: "cp1", Path: "/opt/stacks/cloud/docker-compose.yml"}})
+	if m.mode != modeForceConfirm {
+		t.Fatalf("mode = %v, want modeForceConfirm — a decline must offer the override", m.mode)
+	}
+
+	// The screen has to say the two things the operator cannot recover
+	// from not knowing: the file changed, and forcing cannot be undone.
+	body := m.View().Content
+	for _, want := range []string{"discarding those changes", "cannot be undone"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the declined screen does not say %q:\n%s", want, body)
+		}
+	}
+	if !strings.Contains(body, "/opt/stacks/cloud/docker-compose.yml") {
+		t.Errorf("the declined screen does not name the file it would overwrite:\n%s", body)
+	}
+}
+
+// Forcing is destructive and one-way, so only an explicit yes may do it.
+// Anything else cancels — the same rule keyRollbackConfirm follows, and for
+// a stronger reason.
+func TestForceConfirmTakesOnlyAnExplicitYes(t *testing.T) {
+	for _, key := range []string{"n", "esc", "q", "enter", " "} {
+		m := &appModel{mode: modeForceConfirm, selected: map[string]bool{},
+			checkpoints: []model.Checkpoint{{ID: "cp1", Reversible: true}}}
+		if _, cmd := m.keyForceConfirm(key); cmd != nil {
+			t.Errorf("key %q issued a command; only \"y\" may force", key)
+		}
+		if m.mode != modeList {
+			t.Errorf("key %q left mode = %v, want modeList", key, m.mode)
+		}
+	}
+
+	m := &appModel{mode: modeForceConfirm, selected: map[string]bool{},
+		checkpoints: []model.Checkpoint{{ID: "cp1", Reversible: true}}}
+	if _, cmd := m.keyForceConfirm("y"); cmd == nil {
+		t.Error(`"y" did not issue the force rollback`)
+	}
+}
+
+// An ordinary failure is still an ordinary failure. Only the engine's
+// declined-because-edited answer opens the override.
+func TestOrdinaryRollbackFailureDoesNotOfferToForce(t *testing.T) {
+	m := &appModel{mode: modeHistory, width: 100, height: 24, selected: map[string]bool{},
+		checkpoints: []model.Checkpoint{{ID: "cp1", Reversible: true}}}
+	m.Update(rolledBackMsg{err: plainErr("checkpoint cp1 has no backed-up files to restore")})
+	if m.mode == modeForceConfirm {
+		t.Error("a plain failure offered the destructive override")
+	}
+	if m.mode != modeMessage {
+		t.Errorf("mode = %v, want modeMessage", m.mode)
+	}
+}
+
+type plainErr string
+
+func (e plainErr) Error() string { return string(e) }

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -27,6 +27,10 @@ const (
 	modeMessage
 	modeHistory
 	modeRollbackConfirm
+	// modeForceConfirm is shown when a rollback was declined because the
+	// file changed after the fix wrote it. It is its own mode rather than a
+	// message because the answer is destructive and one-way.
+	modeForceConfirm
 	modeTheme
 )
 
@@ -56,6 +60,20 @@ type appModel struct {
 	preview       model.FixPreview
 	previewAction int
 	status        string
+
+	// scanDone counts the domains that have reported a terminal state this
+	// scan, and scanRunning names the ones still working.
+	//
+	// The engine has emitted these events since the progress display was
+	// built for the CLI; the TUI passed nil and threw them away, so a scan
+	// that takes minutes on a host with many images showed a static
+	// "Scanning…" and nothing else. A screen that cannot distinguish "still
+	// working" from "hung" is the one place a spinner is not decoration.
+	scanDone    int
+	scanRunning map[model.Source]bool
+	// scanCh is the live scan's event channel, held so Update can re-arm
+	// the waiter after each event.
+	scanCh chan model.ScanEvent
 
 	// Advisory AI explanation state for the detail view. Cleared whenever
 	// the inspected finding changes, so a slow answer cannot land under the
@@ -150,11 +168,90 @@ type appliedMsg struct {
 	err     error
 }
 
-func scanCmd(ctx context.Context, e *core.Engine) tea.Cmd {
+// scanProgressMsg carries one checker's terminal state as it lands.
+type scanProgressMsg struct{ event model.ScanEvent }
+
+// scanEventBuffer is deep enough that a checker never blocks handing over
+// its result. Ten domains report once each, and the reader is a bubbletea
+// command that may be a frame behind; a buffer this size means the send
+// never has to wait for it.
+const scanEventBuffer = 32
+
+// scanCmd runs a scan and reports it, feeding progress events into ch.
+//
+// The channel is closed here, by the only goroutine that writes to it, so
+// waitForScanEvent's receive ends cleanly when the scan does rather than
+// blocking forever on a channel nobody will write to again.
+func scanCmd(ctx context.Context, e *core.Engine, ch chan model.ScanEvent) tea.Cmd {
 	return func() tea.Msg {
-		report := e.Scan(ctx, nil)
+		report := e.Scan(ctx, ch)
+		close(ch)
 		return scannedMsg{report: report, delta: e.LastDelta()}
 	}
+}
+
+// waitForScanEvent blocks on one event and re-arms itself, which is how a
+// stream reaches a bubbletea model: a Cmd yields exactly one message, so
+// continuous progress is a command that returns the next one and asks for
+// another. A closed channel yields nil, ending the chain.
+func waitForScanEvent(ch chan model.ScanEvent) tea.Cmd {
+	return func() tea.Msg {
+		ev, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return scanProgressMsg{event: ev}
+	}
+}
+
+// startScan wires both halves together.
+func (m *appModel) startScan() tea.Cmd {
+	m.scanDone, m.scanRunning = 0, map[model.Source]bool{}
+	m.scanCh = make(chan model.ScanEvent, scanEventBuffer)
+	return tea.Batch(scanCmd(m.runCtx(), m.engine, m.scanCh), waitForScanEvent(m.scanCh))
+}
+
+// noteScanEvent folds one event into the progress state.
+//
+// Same reading as the CLI renderer: ScanRunning means a checker started,
+// and any other state is that checker finishing — Skipped and Degraded are
+// outcomes, not failures to report. Counting terminal events rather than
+// tracking a total keeps this correct when a scan runs fewer than every
+// domain.
+func (m *appModel) noteScanEvent(ev model.ScanEvent) {
+	if m.scanRunning == nil {
+		m.scanRunning = map[model.Source]bool{}
+	}
+	if ev.State == model.ScanRunning {
+		m.scanRunning[ev.Source] = true
+	} else if m.scanRunning[ev.Source] {
+		delete(m.scanRunning, ev.Source)
+		m.scanDone++
+	}
+	m.status = m.scanStatus()
+}
+
+// scanStatus is the line the scanning screen shows.
+//
+// It names the domains still working rather than the ones finished,
+// because the question the screen has to answer is "is this hung, and on
+// what" — and on a real host the answer is almost always the CVE scan,
+// which can take minutes. Sorted, because map order would make the line
+// jitter on every redraw.
+func (m *appModel) scanStatus() string {
+	verb := "Scanning"
+	if m.scanDone > 0 || len(m.scanRunning) > 0 {
+		verb = fmt.Sprintf("Scanning (%d done)", m.scanDone)
+	}
+	if len(m.scanRunning) == 0 {
+		return verb + "…"
+	}
+	names := make([]string, 0, len(m.scanRunning))
+	for src := range m.scanRunning {
+		names = append(names, src.Label())
+	}
+	sort.Strings(names)
+	return verb + ": " + strings.Join(names, ", ")
 }
 
 func previewCmd(e *core.Engine, f model.Finding) tea.Cmd {
@@ -226,15 +323,39 @@ func rollbackCmd(e *core.Engine, id string) tea.Cmd {
 	}
 }
 
+// forceRollbackCmd restores over the operator's own later edits.
+//
+// It is separate from rollbackCmd, and reached only from the declined
+// screen, because that is the whole safety property: the engine refuses by
+// default, and forcing is a second, informed answer to a question the user
+// has now been asked. Rollback writes no checkpoint of its own, so this is
+// one-way.
+func forceRollbackCmd(e *core.Engine, id string) tea.Cmd {
+	return func() tea.Msg {
+		o, err := e.RollbackForce(id)
+		return rolledBackMsg{outcome: o, err: err}
+	}
+}
+
 // --- tea.Model ---
 
-func (m *appModel) Init() tea.Cmd { return scanCmd(m.runCtx(), m.engine) }
+func (m *appModel) Init() tea.Cmd { return m.startScan() }
 
 func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil
+
+	case scanProgressMsg:
+		// Progress arriving after the report is stale by definition — the
+		// scan is over and the list is already drawn. Drop it rather than
+		// overwrite the screen the user is now reading.
+		if m.mode != modeScanning {
+			return m, nil
+		}
+		m.noteScanEvent(msg.event)
+		return m, waitForScanEvent(m.scanCh)
 
 	case scannedMsg:
 		m.report = msg.report
@@ -309,6 +430,17 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case rolledBackMsg:
 		if msg.err != nil {
+			// A declined rollback is a question, not a failure. The file
+			// changed after hostveil wrote it, so restoring the backup
+			// would discard whatever was done in between — and rollback
+			// keeps no checkpoint of its own, so there is no way back from
+			// that. The CLI has said so and offered --force since 3.4;
+			// here the answer was "Rollback failed" and a dead end.
+			if core.IsExternalEdit(msg.err) {
+				m.status = msg.err.Error()
+				m.mode = modeForceConfirm
+				return m, nil
+			}
 			m.status = "Rollback failed: " + msg.err.Error()
 			m.mode = modeMessage
 			return m, nil
@@ -358,6 +490,8 @@ func (m *appModel) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.keyHistory(key)
 	case modeRollbackConfirm:
 		return m.keyRollbackConfirm(key)
+	case modeForceConfirm:
+		return m.keyForceConfirm(key)
 	case modeTheme:
 		return m.keyTheme(key)
 	case modeMessage:
@@ -402,7 +536,8 @@ func (m *appModel) keyList(key string) (tea.Model, tea.Cmd) {
 	case "r":
 		m.mode = modeScanning
 		m.status = "Rescanning…"
-		return m, scanCmd(m.runCtx(), m.engine)
+		m.status = "Rescanning…"
+		return m, m.startScan()
 	case "h":
 		return m, historyCmd(m.engine)
 	case "t":
@@ -473,6 +608,21 @@ func (m *appModel) keyHistory(key string) (tea.Model, tea.Cmd) {
 		m.mode = modeRollbackConfirm
 	}
 	return m, nil
+}
+
+// keyForceConfirm answers the declined rollback. Anything but an explicit
+// yes cancels, matching keyRollbackConfirm — for a one-way overwrite of the
+// operator's own edits, a stray keypress must never be consent.
+func (m *appModel) keyForceConfirm(key string) (tea.Model, tea.Cmd) {
+	if key != "y" {
+		m.mode = modeList
+		return m, nil
+	}
+	if len(m.checkpoints) == 0 {
+		m.mode = modeList
+		return m, nil
+	}
+	return m, forceRollbackCmd(m.engine, m.checkpoints[m.cpCursor].ID)
 }
 
 func (m *appModel) keyRollbackConfirm(key string) (tea.Model, tea.Cmd) {

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -174,6 +174,11 @@ func (m *appModel) View() tea.View {
 		content = m.compose(compactHeader("ROLL BACK"), title, "y roll back   n cancel",
 			func(n int) []string { return m.clipRows(m.rollbackRows(), n) })
 
+	case modeForceConfirm:
+		content = m.compose(compactHeader("ROLLBACK DECLINED"), nil,
+			"y overwrite anyway   any other key cancel",
+			func(n int) []string { return m.clipRows(m.forceRows(), n) })
+
 	case modeTheme:
 		content = m.compose(compactHeader("THEME"),
 			[]string{s.brand.Render(m.th.Name)}, themeHint,
@@ -680,6 +685,31 @@ func (m *appModel) rollbackRows() []string {
 	if cp.Diff != "" {
 		out = append(out, s.dim.Render("This change will be reverted:"))
 		out = append(out, s.diffRows(cp.Diff)...)
+	}
+	return out
+}
+
+// forceRows explains a declined rollback and what forcing it costs.
+//
+// It says the two things the CLI's --force text says, because they are the
+// two the operator cannot recover from not knowing: the file has changed
+// since hostveil wrote it, and rollback keeps no backup of its own, so
+// whatever is in it now is gone for good.
+func (m *appModel) forceRows() []string {
+	s := m.sty()
+	out := []string{""}
+	out = append(out, styledRows(lipgloss.NewStyle().Foreground(s.cHigh),
+		wrap(m.status, min(m.width-4, 78)))...)
+	out = append(out, "")
+	out = append(out, styledRows(s.bone, wrap(
+		"Forcing the rollback restores hostveil's backup over the current file, discarding those changes. Rollback writes no checkpoint of its own, so this cannot be undone.",
+		min(m.width-4, 78)))...)
+	if len(m.checkpoints) > 0 {
+		cp := m.checkpoints[m.cpCursor]
+		out = append(out, "", s.dim.Render("Would overwrite:"))
+		for _, p := range cp.Files {
+			out = append(out, s.bone.Render("  "+p))
+		}
 	}
 	return out
 }

--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -23,7 +23,17 @@ function fkey(f) { return f.id + "|" + (f.service || ""); }
 
 async function api(path, opts) {
   const res = await fetch(path, opts);
-  if (!res.ok) throw new Error((await res.text()) || res.statusText);
+  if (!res.ok) {
+    // The status matters on one route: a declined rollback answers 409,
+    // and a decline is a question for the operator rather than a failure
+    // to report. Carrying it on the error is what lets the caller tell
+    // them apart — without it the dashboard turned every decline into
+    // "Rollback failed" and offered nothing further, while the server had
+    // supported force all along.
+    const err = new Error((await res.text()) || res.statusText);
+    err.status = res.status;
+    throw err;
+  }
   const ct = res.headers.get("content-type") || "";
   return ct.includes("json") ? res.json() : res.text();
 }
@@ -530,19 +540,31 @@ function checkpointBox(cp) {
     body);
 }
 
-async function rollback(cp) {
-  if (!confirm(`Roll back "${cp.label}"?\n\nThis restores the original file as it was before the fix was applied.`)) return;
+async function rollback(cp, force = false) {
+  if (!force && !confirm(`Roll back "${cp.label}"?\n\nThis restores the original file as it was before the fix was applied.`)) return;
   try {
     const o = await api("/api/rollback", {
       method: "POST", headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ checkpoint_id: cp.id }),
+      body: JSON.stringify({ checkpoint_id: cp.id, force }),
     });
     const n = o.restored_files ? o.restored_files.length : 0;
     flash(`Rolled back. Restored ${n} file${n === 1 ? "" : "s"}. Score ${o.new_score.overall}/100.` +
       (o.restart_service ? `  You may need to restart '${o.restart_service}'.` : ""));
     await refresh();
     await showHistory();
-  } catch (e) { flash("Rollback failed: " + e.message, true); }
+  } catch (e) {
+    // 409 is the engine declining, not failing: the file changed after
+    // hostveil wrote it, so restoring the backup would discard whatever
+    // was done in between. Rollback keeps no checkpoint of its own, so
+    // say that plainly and make the override a second, informed answer.
+    if (e.status === 409) {
+      if (confirm(`${e.message}\n\nOverwrite it anyway?\n\nThis restores hostveil's backup over the current file, discarding those changes. Rollback writes no checkpoint of its own, so this cannot be undone.`)) {
+        await rollback(cp, true);
+      }
+      return;
+    }
+    flash("Rollback failed: " + e.message, true);
+  }
 }
 
 async function refresh() { report = await api("/api/result"); render(); }

--- a/site/docs/interfaces.html
+++ b/site/docs/interfaces.html
@@ -91,7 +91,7 @@
             <h2>TUI — the default</h2>
             <p>Running <code>hostveil</code> with no arguments on an interactive terminal opens the keyboard-driven TUI. You can also launch it explicitly:</p>
             <div class="code-block"><pre><code>hostveil        # or: hostveil tui</code></pre></div>
-            <p>It shows the score and findings with severity and domain <strong>filters</strong>, <strong>multi-select</strong> for batch fixing, plain-language detail, and a fix preview before anything is applied.</p>
+            <p>It shows the score and findings with severity and domain <strong>filters</strong>, <strong>multi-select</strong> for batch fixing, plain-language detail, and a fix preview before anything is applied. While a scan runs it names the domains still working, so a slow CVE scan on a host with many images reads as progress rather than as a hang.</p>
             <figure>
               <img src="../assets/tui.png" alt="hostveil terminal UI — findings with severity filters and multi-select" width="1200" height="480" loading="lazy">
               <figcaption><strong>TUI</strong><span>Keyboard-driven findings with severity and domain filters, multi-select, plain-language detail, and fix preview.</span></figcaption>
@@ -116,7 +116,7 @@
                   <tr><td><code>d</code></td><td>Cycle the domain filter through the domains this scan actually found something in.</td></tr>
                   <tr><td><code>x</code></td><td>Show only findings hostveil can fix.</td></tr>
                   <tr><td><code>c</code></td><td>Clear every filter. <code>Esc</code> clears the batch marks.</td></tr>
-                  <tr><td><code>h</code></td><td>Applied-fix history — pick one and press <code>Enter</code> to see what rolling it back would restore, then confirm.</td></tr>
+                  <tr><td><code>h</code></td><td>Applied-fix history — pick one and press <code>Enter</code> to see what rolling it back would restore, then confirm. If the file has changed since the fix wrote it, the rollback is declined and you are asked whether to overwrite anyway; only <code>y</code> does it, and it cannot be undone.</td></tr>
                   <tr><td><code>e</code></td><td>In a finding's detail: add an advisory AI explanation from a local Ollama model. Without one, a one-line note appears instead — <a href="ai">AI explanations</a>.</td></tr>
                   <tr><td><code>t</code></td><td>Theme picker (below).</td></tr>
                   <tr><td><code>r</code></td><td>Rescan.</td></tr>

--- a/site/ko/docs/interfaces.html
+++ b/site/ko/docs/interfaces.html
@@ -91,7 +91,7 @@
             <h2>TUI — 기본값</h2>
             <p>인수 없이 대화형 터미널에서 <code>hostveil</code>을 실행하면 키보드 기반 TUI가 열립니다. 명시적으로 실행할 수도 있습니다.</p>
             <div class="code-block"><pre><code>hostveil        # or: hostveil tui</code></pre></div>
-            <p>점수와 발견 항목을 심각도·영역 <strong>필터</strong>, 일괄 수정을 위한 <strong>다중 선택</strong>, 쉬운 말 상세 설명, 그리고 적용 전 수정 미리보기와 함께 보여 줍니다.</p>
+            <p>점수와 발견 항목을 심각도·영역 <strong>필터</strong>, 일괄 수정을 위한 <strong>다중 선택</strong>, 쉬운 말 상세 설명, 그리고 적용 전 수정 미리보기와 함께 보여 줍니다. 스캔이 도는 동안에는 아직 작업 중인 영역의 이름을 보여 주므로, 이미지가 많은 호스트에서 CVE 스캔이 오래 걸려도 멈춘 것이 아니라 진행 중임을 알 수 있습니다.</p>
             <figure>
               <img src="../../assets/tui.png" alt="hostveil 터미널 UI — 심각도 필터와 다중 선택이 있는 발견 항목" width="1200" height="480" loading="lazy">
               <figcaption><strong>TUI</strong><span>심각도·영역 필터, 다중 선택, 쉬운 말 상세 설명, 수정 미리보기를 갖춘 키보드 기반 발견 항목.</span></figcaption>
@@ -116,7 +116,7 @@
                   <tr><td><code>d</code></td><td>이번 스캔에서 실제로 발견된 영역들만 순환하며 필터링합니다.</td></tr>
                   <tr><td><code>x</code></td><td>hostveil이 고칠 수 있는 항목만 봅니다.</td></tr>
                   <tr><td><code>c</code></td><td>모든 필터를 지웁니다. <code>Esc</code>는 일괄 처리 표시를 지웁니다.</td></tr>
-                  <tr><td><code>h</code></td><td>적용된 수정 이력입니다. 하나를 골라 <code>Enter</code>를 누르면 되돌렸을 때 복원될 내용을 보여 주고, 확인을 받습니다.</td></tr>
+                  <tr><td><code>h</code></td><td>적용된 수정 이력입니다. 하나를 골라 <code>Enter</code>를 누르면 되돌렸을 때 복원될 내용을 보여 주고, 확인을 받습니다. 수정 이후 그 파일이 바뀌었다면 롤백이 거절되고, 그래도 덮어쓸지 묻습니다 — <code>y</code>만 실행하며, 되돌릴 수 없습니다.</td></tr>
                   <tr><td><code>e</code></td><td>발견 항목의 상세 화면에서: 로컬 Ollama 모델의 조언성 AI 설명을 덧붙입니다. 모델이 없으면 한 줄 안내가 대신 나옵니다 — <a href="ai">AI 설명</a> 참고.</td></tr>
                   <tr><td><code>t</code></td><td>테마 선택기(아래 참고).</td></tr>
                   <tr><td><code>r</code></td><td>다시 스캔합니다.</td></tr>


### PR DESCRIPTION
## What and why

Two engine capabilities existed and were unreachable from the interfaces that needed them. Both are cases where the engine was already right and the UI simply did not ask.

### 1. Scan progress in the TUI

The engine has emitted a `ScanEvent` per domain since the progress display was built for the CLI, and the dashboard grew a polled version in 3.6.0 (#590). The TUI passed `nil` and threw every event away, so a scan that takes minutes on a host with many images showed a static `Scanning…` for all of it.

A screen that cannot distinguish *"still working"* from *"hung"* is the one place this is not decoration. It now names the domains still working — sorted, because map order would make the line jitter on every redraw, which reads as the screen malfunctioning rather than as work progressing.

A stream reaches a bubbletea model as a command that returns the next message and asks for another, so the scan and the waiter are batched and the waiter re-arms per event. The channel is closed by the only goroutine that writes to it, ending the chain rather than leaving a receive blocked forever. **Events arriving after the report are dropped**: the scan is over, the list is drawn, and a late event would overwrite the screen the user is now reading.

### 2. Force rollback, in both UIs

`Engine.RollbackForce` and the dashboard's `{"force": true}` have both existed for releases, and **neither UI could reach them**:

- `app.js` never sent the field and never inspected the status, so the `409` the server returns for a declined rollback rendered as `Rollback failed: …` with nothing further offered.
- The TUI had no path at all — `rollbackCmd` called `e.Rollback` only, and an `ExternalEditError` became `"Rollback failed"` and a dead end.

A declined rollback is a **question, not a failure**: the file changed after hostveil wrote it, so restoring the backup would discard whatever was done in between, and rollback keeps no checkpoint of its own. Both UIs now say exactly that and make the override a second, informed answer.

The TUI gets its own mode rather than a message, because the answer is destructive and one-way, and **only an explicit `y`** takes it — a stray keypress must never be consent to overwriting the operator's own edits. `app.js`'s `api()` now carries the HTTP status on the error, which is what lets one route tell a decline from a failure at all.

## Deliberately not included

**Domain selection in the TUI.** `--only`/`--skip` is also CLI-only, but reaching it needs a new picker screen — that is a feature to design, not a capability the UI is failing to ask for. Left for its own change.

## Checklist

- [x] Title is conventional with a valid scope (`feat(ui):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  `golangci-lint` and `govulncheck` cannot run in this container — they build the module with Go 1.25 and it requires 1.26. Delegated to the `lint` job.
- [x] For a new or changed detection rule: n/a — no checker, finding, fix, or axis changes.
- [x] **For a UI change**: the TUI and web layering tests still pass. No new production imports on either side — `internal/ui/tui` still imports only `core`, `model` and `theme`. The new `modeForceConfirm` goes through the same `compose` path as every other mode, so the existing width/height frame tests cover it.
- [x] The score stays honest — untouched.

## Verified by mutation

| Mutation | Result |
| --- | --- |
| Discard the progress event again (`_ = msg.event`) | `TestScanProgressReachesTheModelThroughUpdate` — `an event through Update did not reach the status line: ""` |
| Treat a decline as a plain failure again | `TestDeclinedRollbackOffersToForce` — `mode = 4, want modeForceConfirm` |

The progress test deliberately drives `Update` rather than calling `noteScanEvent` directly — the first version of it called the helper, passed against the mutation, and would have passed against the original bug too, since the TUI's problem was never the fold but the nil channel.

Also covered: stable ordering across 20 renders, a plain failure *not* opening the destructive override, and `n`/`esc`/`q`/`enter`/space all cancelling the force prompt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_