### PR TITLE
feat(cmd): show how the score has moved, from snapshots already on disk

### DIFF
--- a/cmd/hostveil/rollback.go
+++ b/cmd/hostveil/rollback.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/seolcu/hostveil/internal/core"
 	"github.com/seolcu/hostveil/internal/history"
+	"github.com/seolcu/hostveil/internal/model"
 )
 
 func cmdRollback(ctx context.Context, args []string) int {
@@ -71,8 +72,12 @@ func cmdRollback(ctx context.Context, args []string) int {
 // documented "no flags" true rather than merely written down.
 func cmdHistory(_ context.Context, args []string) int {
 	fs := flag.NewFlagSet("history", flag.ContinueOnError)
+	scans := fs.Bool("scans", false, "show the score of every past scan instead of the applied-fix log")
 	if code := parseFlags(fs, args); code >= 0 {
 		return code
+	}
+	if *scans {
+		return printScanHistory()
 	}
 	cps, err := newEngine().ListCheckpoints()
 	// An unreadable checkpoint is a warning over a usable list, not a failure:
@@ -119,4 +124,58 @@ func warnAboutStateDirectory() {
 		"\nhostveil: reading %s because this run is not root.\n"+
 			"Fixes applied as root are recorded in /var/lib/hostveil instead — re-run with sudo to see those.\n",
 		history.DefaultDir())
+}
+
+// printScanHistory shows how the host's score has moved.
+//
+// The snapshots have been kept and pruned since the store was written and
+// nothing ever read more than the newest one, so every interface could
+// answer "did that round of fixes help?" and none could answer "is this
+// host getting better?". The data was already on disk.
+func printScanHistory() int {
+	points, err := newEngine().ScoreHistory()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "hostveil:", err)
+		return 1
+	}
+	if len(points) == 0 {
+		fmt.Println("No scans have been saved yet. Run `hostveil scan` first.")
+		warnAboutStateDirectory()
+		return 0
+	}
+
+	fmt.Printf("Saved scans (oldest first, %d kept):\n", len(points))
+	var prev *model.ScorePoint
+	for i := range points {
+		p := points[i]
+		// N/A, not 0. A scan where every domain was skipped or failed has
+		// no score, and printing a number for it would draw a cliff where
+		// the truth is that nobody could look.
+		score := "  N/A"
+		if p.Applicable {
+			score = fmt.Sprintf("%3d/100", p.Overall)
+		}
+		fmt.Printf("  %s  %s %s\n",
+			p.At.Local().Format("2006-01-02 15:04"), score, scoreMove(prev, p))
+		prev = &points[i]
+	}
+	return 0
+}
+
+// scoreMove renders the change from the previous scan.
+//
+// A move is only meaningful between two scans that both produced a score:
+// comparing against an N/A run would report a jump the host never made.
+func scoreMove(prev *model.ScorePoint, cur model.ScorePoint) string {
+	if prev == nil || !prev.Applicable || !cur.Applicable {
+		return ""
+	}
+	switch d := int(cur.Overall) - int(prev.Overall); {
+	case d > 0:
+		return fmt.Sprintf("(+%d)", d)
+	case d < 0:
+		return fmt.Sprintf("(%d)", d)
+	default:
+		return "(=)"
+	}
 }

--- a/cmd/sitegen/content/en/docs/cli.html
+++ b/cmd/sitegen/content/en/docs/cli.html
@@ -57,8 +57,17 @@ hostveil fix --all [flags]</code></pre></div>
 
             <h2 id="history">history</h2>
             <p>List applied fixes and their rollback IDs.</p>
-            <div class="code-block"><pre><code>hostveil history</code></pre></div>
-            <p>Lists checkpoints newest-first with a timestamp, the finding ID, a label, and either the exact <code>hostveil rollback &lt;id&gt;</code> command or <em>not reversible</em>. No flags.</p>
+            <div class="code-block"><pre><code>hostveil history
+hostveil history --scans</code></pre></div>
+            <p>Lists checkpoints newest-first with a timestamp, the finding ID, a label, and either the exact <code>hostveil rollback &lt;id&gt;</code> command or <em>not reversible</em>.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Flag</th><th>What it does</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--scans</code></td><td>Show the score of every retained scan instead of the applied-fix log, oldest first, with the change from the one before it. hostveil keeps the last 30 scans. A scan where no domain could be examined shows <code>N/A</code> rather than a number, and no change is reported against it — a run nobody could score is not a drop to zero.</td></tr>
+                </tbody>
+              </table>
+            </div>
 
             <h2 id="explain">explain</h2>
             <p>Explain a finding in plain language.</p>

--- a/cmd/sitegen/content/ko/docs/cli.html
+++ b/cmd/sitegen/content/ko/docs/cli.html
@@ -57,8 +57,17 @@ hostveil fix --all [flags]</code></pre></div>
 
             <h2 id="history">history</h2>
             <p>적용된 수정과 그 롤백 ID를 나열합니다.</p>
-            <div class="code-block"><pre><code>hostveil history</code></pre></div>
-            <p>체크포인트를 최신순으로 나열하며, 타임스탬프, 발견 항목 ID, 레이블, 그리고 정확한 <code>hostveil rollback &lt;id&gt;</code> 명령 또는 <em>되돌릴 수 없음</em> 표시가 함께 나옵니다. 플래그는 없습니다.</p>
+            <div class="code-block"><pre><code>hostveil history
+hostveil history --scans</code></pre></div>
+            <p>체크포인트를 최신순으로 나열하며, 타임스탬프, 발견 항목 ID, 레이블, 그리고 정확한 <code>hostveil rollback &lt;id&gt;</code> 명령 또는 <em>되돌릴 수 없음</em> 표시가 함께 나옵니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>플래그</th><th>동작</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--scans</code></td><td>적용된 수정 이력 대신, 보관된 모든 스캔의 점수를 오래된 순으로 보여 주고 직전 스캔 대비 변화를 함께 표시합니다. hostveil은 최근 30개 스캔을 보관합니다. 어떤 영역도 확인하지 못한 스캔은 숫자가 아니라 <code>N/A</code>로 표시되고 변화도 계산하지 않습니다 — 아무도 채점할 수 없었던 실행은 0점으로 떨어진 것이 아니기 때문입니다.</td></tr>
+                </tbody>
+              </table>
+            </div>
 
             <h2 id="explain">explain</h2>
             <p>발견 항목을 쉬운 말로 설명합니다.</p>

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -286,3 +286,35 @@ func validFindings(in []model.Finding) []model.Finding {
 	}
 	return out
 }
+
+// ScoreHistory returns the headline score of every retained scan, oldest
+// first, so a UI can show whether the host is getting better.
+//
+// The data has been on disk since the store was written — thirty snapshots,
+// kept and pruned — and nothing ever read more than the newest one. Every
+// interface showed "since last scan" and nothing longer, which answers
+// "did that round of fixes help?" but not "is this host improving?".
+//
+// A snapshot that will not unmarshal is skipped rather than failing the
+// call, and an unscorable scan keeps Applicable false rather than being
+// flattened to zero: a run where every domain was skipped has no score, and
+// drawing it as 0 would invent a cliff.
+func (e *Engine) ScoreHistory() ([]model.ScorePoint, error) {
+	snaps, err := e.store.ListReports()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.ScorePoint, 0, len(snaps))
+	for _, snap := range snaps {
+		var r model.Report
+		if json.Unmarshal(snap.Data, &r) != nil {
+			continue
+		}
+		out = append(out, model.ScorePoint{
+			At:         snap.At,
+			Overall:    r.Score.Overall,
+			Applicable: r.Score.Applicable,
+		})
+	}
+	return out, nil
+}

--- a/internal/core/trend_test.go
+++ b/internal/core/trend_test.go
@@ -1,0 +1,159 @@
+package core
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/history"
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// hostveil has kept and pruned the last 30 scan snapshots since the store
+// was written, and nothing ever read more than the newest one: LastReport
+// takes the last element, and every interface shows "since last scan" and
+// nothing longer. That answers "did that round of fixes help?" and cannot
+// answer "is this host getting better?" — with the data for it already on
+// disk the whole time.
+
+// saveScan writes a snapshot with a chosen score. The id carries the time,
+// so the fixtures control ordering by naming their own.
+func saveScan(t *testing.T, s *history.Store, id string, overall uint8, applicable bool) {
+	t.Helper()
+	data, err := json.Marshal(model.Report{
+		Score: model.ScoreBreakdown{Overall: overall, Applicable: applicable},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveReport(id, data); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScoreHistoryReturnsEveryScanOldestFirst(t *testing.T) {
+	dir := t.TempDir()
+	store := history.NewStore(dir)
+	e := New(Config{Store: store})
+
+	// Deliberately saved out of order: the ids are timestamp-prefixed and
+	// the listing sorts by them, so a store that returned directory order
+	// would produce a chart running backwards.
+	saveScan(t, store, "20260101-120000.000-c", 71, true)
+	saveScan(t, store, "20260101-100000.000-a", 42, true)
+	saveScan(t, store, "20260101-110000.000-b", 58, true)
+
+	points, err := e.ScoreHistory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) != 3 {
+		t.Fatalf("got %d points, want 3", len(points))
+	}
+	for i, want := range []uint8{42, 58, 71} {
+		if points[i].Overall != want {
+			t.Errorf("point %d = %d, want %d — the series is not oldest-first", i, points[i].Overall, want)
+		}
+	}
+	if !points[0].At.Before(points[2].At) {
+		t.Errorf("timestamps are not increasing: %v then %v", points[0].At, points[2].At)
+	}
+}
+
+// A scan where every domain was skipped or failed has no score at all —
+// ScoreBreakdown.Applicable is false and all three UIs render N/A. A trend
+// that flattened that to 0 would draw a cliff where the truth is that
+// nobody could look, which is the same lie the aggregate score already
+// refuses to tell.
+func TestScoreHistoryCarriesTheNotApplicableFlag(t *testing.T) {
+	store := history.NewStore(t.TempDir())
+	e := New(Config{Store: store})
+
+	saveScan(t, store, "20260101-100000.000-a", 80, true)
+	saveScan(t, store, "20260101-110000.000-b", 0, false)
+
+	points, err := e.ScoreHistory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("got %d points, want 2", len(points))
+	}
+	if !points[0].Applicable {
+		t.Error("a scored scan came back as not applicable")
+	}
+	if points[1].Applicable {
+		t.Error("an unscorable scan came back as applicable — it would be charted as a drop to 0")
+	}
+}
+
+// One damaged snapshot costs that snapshot, not the series. This is a
+// history view, and the same reasoning Store.List follows when it returns
+// what it could read: a file that will not parse is one missing point, not
+// a reason to refuse the other twenty-nine.
+func TestScoreHistorySkipsUnreadableSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	store := history.NewStore(dir)
+	e := New(Config{Store: store})
+
+	saveScan(t, store, "20260101-100000.000-a", 42, true)
+	saveScan(t, store, "20260101-120000.000-c", 71, true)
+	// A truncated snapshot, of the kind a crash mid-write used to leave.
+	if err := os.WriteFile(filepath.Join(dir, "scans", "20260101-110000.000-b.json"),
+		[]byte(`{"score":{"over`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// And one whose name carries no timestamp at all.
+	if err := os.WriteFile(filepath.Join(dir, "scans", "not-a-scan.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	points, err := e.ScoreHistory()
+	if err != nil {
+		t.Fatalf("one bad snapshot failed the whole call: %v", err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("got %d points, want the 2 readable ones", len(points))
+	}
+	if points[0].Overall != 42 || points[1].Overall != 71 {
+		t.Errorf("wrong points survived: %+v", points)
+	}
+}
+
+// Nothing saved is not an error — it is a host that has not been scanned.
+func TestScoreHistoryOnAFreshStateDirectory(t *testing.T) {
+	e := New(Config{Store: history.NewStore(t.TempDir())})
+	points, err := e.ScoreHistory()
+	if err != nil {
+		t.Fatalf("an empty store errored: %v", err)
+	}
+	if len(points) != 0 {
+		t.Errorf("got %d points from an empty store", len(points))
+	}
+}
+
+// The retention cap already applied to snapshots applies to the trend, by
+// construction rather than by a second limit: the series is exactly what
+// the store kept.
+func TestScoreHistoryIsBoundedByRetention(t *testing.T) {
+	store := history.NewStore(t.TempDir())
+	e := New(Config{Store: store})
+	for i := range 40 {
+		saveScan(t, store, "202601"+twoDigit(i/24+1)+"-"+twoDigit(i%24)+"0000.000-x", uint8(i), true)
+	}
+	points, err := e.ScoreHistory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) > 30 {
+		t.Errorf("got %d points; the store keeps 30", len(points))
+	}
+}
+
+func twoDigit(n int) string {
+	if n < 10 {
+		return "0" + string(rune('0'+n))
+	}
+	return string(rune('0'+n/10)) + string(rune('0'+n%10))
+}

--- a/internal/history/scans.go
+++ b/internal/history/scans.go
@@ -1,9 +1,12 @@
 package history
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/seolcu/hostveil/internal/platform"
 )
@@ -83,4 +86,59 @@ func scanFiles(dir string) ([]string, error) {
 	}
 	sort.Strings(names)
 	return names, nil
+}
+
+// ScanSnapshot is one saved scan: when it ran, and the opaque bytes it was
+// saved as. The store deliberately does not parse them — it holds
+// snapshots, it does not know what a report is — so the caller unmarshals.
+type ScanSnapshot struct {
+	ID   string
+	At   time.Time
+	Data []byte
+}
+
+// scanIDTime is the timestamp layout NewScanID writes. The ids are
+// timestamp-prefixed so a lexical sort is chronological, which pruning and
+// LastReport both already rely on; this reads the same prefix back.
+const scanIDTime = "20060102-150405.000"
+
+// ListReports returns every retained scan snapshot, oldest first.
+//
+// Thirty of these have been kept and pruned since the store was written,
+// and nothing ever read more than the newest one — LastReport takes the
+// last element and every interface shows only "since last scan". The data
+// for a trend was on disk the whole time with no way to ask for it.
+//
+// A snapshot whose id does not carry a parseable timestamp, or that cannot
+// be read, is skipped rather than failing the call. This is a history
+// view: one unreadable entry should cost that entry, not the whole series
+// — the same reasoning as Store.List returning what it could read
+// alongside its error.
+func (s *Store) ListReports() ([]ScanSnapshot, error) {
+	names, err := scanFiles(s.scansDir())
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ScanSnapshot, 0, len(names))
+	for _, name := range names {
+		id := strings.TrimSuffix(name, ".json")
+		at, err := scanIDAt(id)
+		if err != nil {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.scansDir(), name))
+		if err != nil {
+			continue
+		}
+		out = append(out, ScanSnapshot{ID: id, At: at, Data: data})
+	}
+	return out, nil
+}
+
+// scanIDAt recovers the scan time from its id.
+func scanIDAt(id string) (time.Time, error) {
+	if len(id) < len(scanIDTime) {
+		return time.Time{}, fmt.Errorf("scan id %q is too short to carry a timestamp", id)
+	}
+	return time.Parse(scanIDTime, id[:len(scanIDTime)])
 }

--- a/internal/model/report.go
+++ b/internal/model/report.go
@@ -1,6 +1,9 @@
 package model
 
-import "sort"
+import (
+	"sort"
+	"time"
+)
 
 // ScanState is the lifecycle state of one domain's checker during a scan.
 type ScanState int
@@ -111,4 +114,17 @@ func SortFindings(findings []Finding) {
 		}
 		return a.ID < b.ID
 	})
+}
+
+// ScorePoint is one past scan's headline score, for a trend.
+//
+// Applicable mirrors ScoreBreakdown.Applicable and must be carried, not
+// flattened to a number: a scan where every domain was skipped or failed
+// has no score at all, and rendering it as 0 would draw a cliff where the
+// truth is "nobody could look". The same lie the aggregate score already
+// refuses to tell, told again by a chart.
+type ScorePoint struct {
+	At         time.Time `json:"at"`
+	Overall    uint8     `json:"overall"`
+	Applicable bool      `json:"applicable"`
 }

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -143,8 +143,17 @@ hostveil fix --all [flags]</code></pre></div>
 
             <h2 id="history">history</h2>
             <p>List applied fixes and their rollback IDs.</p>
-            <div class="code-block"><pre><code>hostveil history</code></pre></div>
-            <p>Lists checkpoints newest-first with a timestamp, the finding ID, a label, and either the exact <code>hostveil rollback &lt;id&gt;</code> command or <em>not reversible</em>. No flags.</p>
+            <div class="code-block"><pre><code>hostveil history
+hostveil history --scans</code></pre></div>
+            <p>Lists checkpoints newest-first with a timestamp, the finding ID, a label, and either the exact <code>hostveil rollback &lt;id&gt;</code> command or <em>not reversible</em>.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Flag</th><th>What it does</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--scans</code></td><td>Show the score of every retained scan instead of the applied-fix log, oldest first, with the change from the one before it. hostveil keeps the last 30 scans. A scan where no domain could be examined shows <code>N/A</code> rather than a number, and no change is reported against it — a run nobody could score is not a drop to zero.</td></tr>
+                </tbody>
+              </table>
+            </div>
 
             <h2 id="explain">explain</h2>
             <p>Explain a finding in plain language.</p>

--- a/site/ko/docs/cli.html
+++ b/site/ko/docs/cli.html
@@ -143,8 +143,17 @@ hostveil fix --all [flags]</code></pre></div>
 
             <h2 id="history">history</h2>
             <p>적용된 수정과 그 롤백 ID를 나열합니다.</p>
-            <div class="code-block"><pre><code>hostveil history</code></pre></div>
-            <p>체크포인트를 최신순으로 나열하며, 타임스탬프, 발견 항목 ID, 레이블, 그리고 정확한 <code>hostveil rollback &lt;id&gt;</code> 명령 또는 <em>되돌릴 수 없음</em> 표시가 함께 나옵니다. 플래그는 없습니다.</p>
+            <div class="code-block"><pre><code>hostveil history
+hostveil history --scans</code></pre></div>
+            <p>체크포인트를 최신순으로 나열하며, 타임스탬프, 발견 항목 ID, 레이블, 그리고 정확한 <code>hostveil rollback &lt;id&gt;</code> 명령 또는 <em>되돌릴 수 없음</em> 표시가 함께 나옵니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>플래그</th><th>동작</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--scans</code></td><td>적용된 수정 이력 대신, 보관된 모든 스캔의 점수를 오래된 순으로 보여 주고 직전 스캔 대비 변화를 함께 표시합니다. hostveil은 최근 30개 스캔을 보관합니다. 어떤 영역도 확인하지 못한 스캔은 숫자가 아니라 <code>N/A</code>로 표시되고 변화도 계산하지 않습니다 — 아무도 채점할 수 없었던 실행은 0점으로 떨어진 것이 아니기 때문입니다.</td></tr>
+                </tbody>
+              </table>
+            </div>
 
             <h2 id="explain">explain</h2>
             <p>발견 항목을 쉬운 말로 설명합니다.</p>


### PR DESCRIPTION
## What and why

hostveil has kept and pruned the last **30 scan snapshots** since the store was written, and nothing ever read more than the newest one. `LastReport` takes the last element; every interface shows *"since last scan"* and nothing longer.

So the tool could answer *"did that round of fixes help?"* and could not answer *"is this host getting better?"* — with the data for it sitting in the state directory the whole time, being pruned on a schedule nobody benefited from.

`Store.ListReports` returns the retained snapshots oldest first, `Engine.ScoreHistory` turns them into score points, and `hostveil history --scans` prints them with the change from the scan before:

```
Saved scans (oldest first, 4 kept):
  2026-07-26 09:14   42/100
  2026-07-26 21:02   58/100 (+16)
  2026-07-27 08:30     N/A
  2026-07-28 07:15   71/100
```

## Three refusals, all the same refusal

**A scan with no score is not a zero.** A run where every domain was skipped or failed has `ScoreBreakdown.Applicable == false`, and all three UIs already render N/A. The point carries that flag rather than a number — flattening it would draw a cliff where the truth is that nobody could look, which is exactly the lie the aggregate score was changed to stop telling in #577. The change column is blank against such a scan too: a move is only meaningful between two runs that both produced a score.

**A damaged snapshot costs itself, not the series.** One that will not parse, or whose name carries no timestamp, is skipped rather than failing the call. Same reasoning as `Store.List` returning what it could read alongside its error: one bad entry should not cost the other twenty-nine.

**The store stays ignorant of what a report is.** `SaveReport` takes opaque bytes and `ListReports` returns them; the engine unmarshals. The recovery layer holds snapshots — it does not know what is in them.

The retention bound needs no second limit: the series is exactly what the store kept, so `maxScans` governs both.

## Why the engine, not the CLI

`Engine.ScoreHistory` lives on the engine so the TUI and dashboard can draw the same series without reimplementing it. **Neither does yet** — a sparkline is UI design rather than a capability those UIs cannot reach, and is better as its own change than tacked onto this one. Flagging it explicitly since #602 was about exactly the opposite problem.

## Checklist

- [x] Title is conventional with a valid scope (`feat(cmd):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  `golangci-lint` and `govulncheck` cannot run in this container — they build the module with Go 1.25 and it requires 1.26. Delegated to the `lint` job.
- [x] For a new or changed detection rule: n/a — no checker, finding, fix or axis changes. Nothing is scanned differently; this only reads what was already saved.
- [x] For a UI change: n/a — CLI output only.
- [x] **The score stays honest** — an unscorable scan stays N/A in the series and produces no change figure, rather than being charted as a drop to zero.

## Verified by mutation

| Mutation | Result |
| --- | --- |
| Force `Applicable: true` on every point | `TestScoreHistoryCarriesTheNotApplicableFlag` — `an unscorable scan came back as applicable — it would be charted as a drop to 0` |
| Sort the series newest-first | `TestScoreHistoryReturnsEveryScanOldestFirst` — `point 0 = 71, want 42 — the series is not oldest-first` |

Also covered: a truncated snapshot and a badly-named one are both skipped while the readable points survive, an empty state directory is not an error, and the series never exceeds the store's retention.

**The CLI-docs guard fired unprompted** — `TestCLIReferenceMatchesTheFlagSets` refused `--scans` until the reference documented it in both languages. That guard only reaches `history` because #598 seeded the section for commands that register no flags.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_