### PR TITLE
build(release): ship .deb and .rpm packages

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,6 +27,56 @@ archives:
       {{ .ProjectName }}-{{ .Os }}-{{ .Arch }}
     formats: ["tar.gz"]
 
+# Native packages, for the audience this tool is actually for. hostveil
+# runs meaningfully only on Linux, and its users administer servers — where
+# `apt install ./hostveil.deb` is the ordinary way software arrives and a
+# tarball extracted into /usr/bin is the exception. Until now the only
+# supported path was piping install.sh to bash, which is exactly the habit
+# a security tool should not be teaching.
+#
+# Linux only: nfpms builds .deb and .rpm, and a macOS build has no business
+# in either. The darwin binaries still ship as archives.
+#
+# The package installs the same single binary to the same path install.sh
+# uses, /usr/bin/hostveil, so the two are interchangeable — an operator can
+# move from one to the other without ending up with two copies on PATH.
+#
+# There is no postinstall script, no service unit, and no config file to
+# ship. hostveil is a command you run, its state lives in /var/lib/hostveil
+# (created on first use as root), and it has no daemon. Packaging it as
+# though it did would invent a lifecycle the tool does not have — and a
+# package that removed /var/lib/hostveil on purge would delete the
+# checkpoints that are the only backup of every file it ever edited, which
+# is precisely why install.sh --uninstall leaves them alone too.
+nfpms:
+  - id: packages
+    package_name: hostveil
+    ids: [hostveil]
+    formats: [deb, rpm]
+    maintainer: seolcu <seolcu@users.noreply.github.com>
+    homepage: https://hostveil.seolcu.com/
+    description: |-
+      Guided security hardening for self-hosted Linux servers.
+      hostveil scans a host for the misconfigurations that get self-hosters
+      breached, merges them into one 0-100 score, explains each in plain
+      language, and applies fixes with preview, backup, and rollback.
+    license: GPL-3.0
+    section: admin
+    bindir: /usr/bin
+    # Every one of these is optional and each unlocks a domain rather than
+    # being required to run: no Docker means the container and CVE domains
+    # report N/A, not that hostveil fails. Recommends, never Depends —
+    # pulling Docker onto a host as a side effect of installing a scanner
+    # would be indefensible.
+    recommends:
+      - docker.io
+      - iproute2
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/hostveil/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/hostveil/README.md
+
 checksum:
   name_template: "{{ .ProjectName }}-checksums.txt"
   algorithm: sha256
@@ -36,6 +86,11 @@ checksum:
 sboms:
   - id: archive-sbom
     artifacts: archive
+  # And one per package, for the same reason. A .deb is the artifact most
+  # likely to be installed without anyone reading a release page, so it is
+  # the one that most needs its dependency set to be auditable afterwards.
+  - id: package-sbom
+    artifacts: package
 
 # The changelog is written by hand into CHANGELOG.md and the release body
 # before this runs, derived from conventional-commit history (see AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ renormalized so you are never handed a misleadingly perfect result.
 curl -fsSL https://hostveil.seolcu.com/install.sh | bash
 ```
 
+Or install a native package from the [latest release](https://github.com/seolcu/hostveil/releases/latest)
+— reasonable if you would rather not pipe a script into a shell, especially
+for a security tool:
+
+```bash
+sudo apt install ./hostveil_<version>_linux_amd64.deb   # or dnf install ./hostveil-<version>.x86_64.rpm
+```
+
+The package installs the same binary to the same path (`/usr/bin/hostveil`),
+so it and the installer are interchangeable. Docker and `iproute2` are
+*recommended*, never required: without them those domains report N/A rather
+than hostveil failing.
+
 Or, if you have Go 1.26+ and would rather build it yourself:
 
 ```bash

--- a/cmd/sitegen/content/en/docs/installation.html
+++ b/cmd/sitegen/content/en/docs/installation.html
@@ -57,6 +57,15 @@
               </table>
             </div>
 
+            <h2 id="packages">Debian and RPM packages</h2>
+            <p>Every release also ships <code>.deb</code> and <code>.rpm</code> packages, for people who would rather not pipe a script into a shell — a reasonable preference, especially for a security tool. Download the one matching your architecture from the <a href="https://github.com/seolcu/hostveil/releases/latest">latest release</a> and install it with your package manager:</p>
+            <div class="code-block"><pre><code>sudo apt install ./hostveil_&lt;version&gt;_linux_amd64.deb
+# or
+sudo dnf install ./hostveil-&lt;version&gt;.x86_64.rpm</code></pre></div>
+            <p>The package installs the same single binary to the same path the installer uses, <code>/usr/bin/hostveil</code>, so the two are interchangeable — you can move from one to the other without ending up with two copies on your PATH. Docker and <code>iproute2</code> are listed as <em>recommended</em>, never required: without them the container, CVE, and exposed-service domains report N/A rather than hostveil failing to run.</p>
+            <p>There is no service to enable and no config file to edit. Removing the package leaves <code>/var/lib/hostveil</code> in place, for the same reason <code>--uninstall</code> does: those checkpoints are the backups of every file hostveil has edited.</p>
+            <p>Packages are Linux-only. hostveil builds and runs on macOS but has nothing to look at there — no systemd, no ufw, no <code>/etc/shadow</code> in the shape it expects.</p>
+
             <h2 id="upgrade">Upgrading and uninstalling</h2>
             <p>To upgrade, re-run the install command. The binary is replaced in place and your saved scans and rollback checkpoints are left alone.</p>
             <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --uninstall</code></pre></div>

--- a/cmd/sitegen/content/ko/docs/installation.html
+++ b/cmd/sitegen/content/ko/docs/installation.html
@@ -57,6 +57,15 @@
               </table>
             </div>
 
+                        <h2 id="packages">Debian·RPM 패키지</h2>
+            <p>모든 릴리스에는 <code>.deb</code>와 <code>.rpm</code> 패키지도 함께 올라갑니다. 스크립트를 셸에 파이프하고 싶지 않은 분들을 위한 것이고, 보안 도구라면 특히 타당한 선호입니다. <a href="https://github.com/seolcu/hostveil/releases/latest">최신 릴리스</a>에서 아키텍처에 맞는 파일을 받아 패키지 관리자로 설치하세요.</p>
+            <div class="code-block"><pre><code>sudo apt install ./hostveil_&lt;version&gt;_linux_amd64.deb
+# 또는
+sudo dnf install ./hostveil-&lt;version&gt;.x86_64.rpm</code></pre></div>
+            <p>패키지는 설치 스크립트와 같은 경로 <code>/usr/bin/hostveil</code>에 같은 바이너리 하나를 설치하므로 둘은 서로 바꿔 쓸 수 있습니다 — PATH에 사본이 두 개 남는 일 없이 옮겨 갈 수 있습니다. Docker와 <code>iproute2</code>는 <em>권장</em>일 뿐 필수가 아닙니다. 없으면 컨테이너·CVE·노출된 서비스 영역이 N/A로 표시될 뿐, hostveil이 실행되지 않는 것은 아닙니다.</p>
+            <p>활성화할 서비스도, 편집할 설정 파일도 없습니다. 패키지를 제거해도 <code>/var/lib/hostveil</code>은 남습니다 — <code>--uninstall</code>과 같은 이유로, 그 체크포인트가 hostveil이 편집한 모든 파일의 백업이기 때문입니다.</p>
+            <p>패키지는 리눅스 전용입니다. hostveil은 macOS에서 빌드되고 실행되지만 거기서는 볼 것이 없습니다 — systemd도, ufw도, 기대하는 형태의 <code>/etc/shadow</code>도 없습니다.</p>
+
             <h2 id="upgrade">업그레이드와 제거</h2>
             <p>업그레이드하려면 설치 명령을 다시 실행하세요. 바이너리만 교체되고, 저장된 스캔 기록과 롤백 체크포인트는 그대로 남습니다.</p>
             <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --uninstall</code></pre></div>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -143,6 +143,15 @@
               </table>
             </div>
 
+            <h2 id="packages">Debian and RPM packages</h2>
+            <p>Every release also ships <code>.deb</code> and <code>.rpm</code> packages, for people who would rather not pipe a script into a shell — a reasonable preference, especially for a security tool. Download the one matching your architecture from the <a href="https://github.com/seolcu/hostveil/releases/latest">latest release</a> and install it with your package manager:</p>
+            <div class="code-block"><pre><code>sudo apt install ./hostveil_&lt;version&gt;_linux_amd64.deb
+# or
+sudo dnf install ./hostveil-&lt;version&gt;.x86_64.rpm</code></pre></div>
+            <p>The package installs the same single binary to the same path the installer uses, <code>/usr/bin/hostveil</code>, so the two are interchangeable — you can move from one to the other without ending up with two copies on your PATH. Docker and <code>iproute2</code> are listed as <em>recommended</em>, never required: without them the container, CVE, and exposed-service domains report N/A rather than hostveil failing to run.</p>
+            <p>There is no service to enable and no config file to edit. Removing the package leaves <code>/var/lib/hostveil</code> in place, for the same reason <code>--uninstall</code> does: those checkpoints are the backups of every file hostveil has edited.</p>
+            <p>Packages are Linux-only. hostveil builds and runs on macOS but has nothing to look at there — no systemd, no ufw, no <code>/etc/shadow</code> in the shape it expects.</p>
+
             <h2 id="upgrade">Upgrading and uninstalling</h2>
             <p>To upgrade, re-run the install command. The binary is replaced in place and your saved scans and rollback checkpoints are left alone.</p>
             <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --uninstall</code></pre></div>

--- a/site/ko/docs/installation.html
+++ b/site/ko/docs/installation.html
@@ -143,6 +143,15 @@
               </table>
             </div>
 
+                        <h2 id="packages">Debian·RPM 패키지</h2>
+            <p>모든 릴리스에는 <code>.deb</code>와 <code>.rpm</code> 패키지도 함께 올라갑니다. 스크립트를 셸에 파이프하고 싶지 않은 분들을 위한 것이고, 보안 도구라면 특히 타당한 선호입니다. <a href="https://github.com/seolcu/hostveil/releases/latest">최신 릴리스</a>에서 아키텍처에 맞는 파일을 받아 패키지 관리자로 설치하세요.</p>
+            <div class="code-block"><pre><code>sudo apt install ./hostveil_&lt;version&gt;_linux_amd64.deb
+# 또는
+sudo dnf install ./hostveil-&lt;version&gt;.x86_64.rpm</code></pre></div>
+            <p>패키지는 설치 스크립트와 같은 경로 <code>/usr/bin/hostveil</code>에 같은 바이너리 하나를 설치하므로 둘은 서로 바꿔 쓸 수 있습니다 — PATH에 사본이 두 개 남는 일 없이 옮겨 갈 수 있습니다. Docker와 <code>iproute2</code>는 <em>권장</em>일 뿐 필수가 아닙니다. 없으면 컨테이너·CVE·노출된 서비스 영역이 N/A로 표시될 뿐, hostveil이 실행되지 않는 것은 아닙니다.</p>
+            <p>활성화할 서비스도, 편집할 설정 파일도 없습니다. 패키지를 제거해도 <code>/var/lib/hostveil</code>은 남습니다 — <code>--uninstall</code>과 같은 이유로, 그 체크포인트가 hostveil이 편집한 모든 파일의 백업이기 때문입니다.</p>
+            <p>패키지는 리눅스 전용입니다. hostveil은 macOS에서 빌드되고 실행되지만 거기서는 볼 것이 없습니다 — systemd도, ufw도, 기대하는 형태의 <code>/etc/shadow</code>도 없습니다.</p>
+
             <h2 id="upgrade">업그레이드와 제거</h2>
             <p>업그레이드하려면 설치 명령을 다시 실행하세요. 바이너리만 교체되고, 저장된 스캔 기록과 롤백 체크포인트는 그대로 남습니다.</p>
             <div class="code-block"><pre><code>curl -fsSL https://hostveil.seolcu.com/install.sh | bash -s -- --uninstall</code></pre></div>


### PR DESCRIPTION
## What and why

hostveil runs meaningfully only on Linux, and its users administer servers — where `apt install ./thing.deb` is how software ordinarily arrives and a tarball extracted into `/usr/bin` is the exception.

Until now the only supported path was piping `install.sh` into `bash`. That is exactly the habit a security tool should not be teaching, and the one thing a cautious operator is most likely to refuse.

## Decisions worth stating

**Same path as the installer.** The package puts the same single binary at `/usr/bin/hostveil`, so the two are interchangeable — an operator can move from one to the other without ending up with two copies on PATH.

**Recommends, never Depends.** Every dependency hostveil has is optional by design: no Docker means the container and CVE domains report N/A, not that the tool fails. Pulling Docker onto a host as a side effect of installing a scanner would be indefensible.

**No postinstall, no service unit, no config file.** hostveil is a command you run, its state lives in `/var/lib/hostveil`, and it has no daemon. Packaging it as though it did would invent a lifecycle the tool does not have.

**Purge leaves the state directory alone**, for the same reason `install.sh --uninstall` does: those checkpoints are the backups of every file hostveil has ever edited, and uninstalling is not a decision to give up the ability to undo its fixes.

**Linux only.** The darwin binaries still ship as archives — hostveil builds and runs on macOS but has nothing to look at there.

**An SBOM per package**, alongside the archives'. A `.deb` is the artifact most likely to be installed without anyone reading a release page, so it is the one that most needs its dependency set to be auditable afterwards.

## Checklist

- [x] Title is conventional with a valid scope (`build(release):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  Plus `goreleaser check` against **v2.12.5** — validated clean.
  `golangci-lint` and `govulncheck` cannot run in this container — they build the module with Go 1.25 and it requires 1.26. Delegated to the `lint` job.
- [x] For a new or changed detection rule: n/a — no Go code changes at all. Packaging config and documentation only.
- [x] For a UI change: n/a.
- [x] The score stays honest — untouched.

## A note on `goreleaser check`

`goreleaser check` against **v2.5.1 fails** on this file, and it is not this change's fault: that version does not know `archives.formats` either, which the repo has used since before this PR. A check that fails there is a stale goreleaser, not a bad config. v2.12.5 validates it clean, and `goreleaser-action@v7` resolves to a current release.

## What a maintainer should verify at the next release

This config cannot be exercised end to end from CI on a PR — the packages are only built when a tag starts the release workflow. Worth eyeballing on the next release:

- the `.deb` and `.rpm` appear as release assets for both `amd64` and `arm64`;
- `dpkg -c hostveil_*.deb` shows `/usr/bin/hostveil` and the two files under `/usr/share/doc/hostveil/`;
- `apt install ./hostveil_*.deb` does not pull in Docker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_