### PR TITLE
feat(core): re-check the finding after applying its fix

### DIFF
--- a/cmd/hostveil/fix.go
+++ b/cmd/hostveil/fix.go
@@ -242,6 +242,12 @@ func printOutcome(o model.FixOutcome) {
 	if o.RestartHint != "" {
 		fmt.Printf("  You may need to restart the '%s' service for the change to take effect.\n", o.RestartHint)
 	}
+	if o.VerifyMessage != "" {
+		fmt.Printf("  %s\n", o.VerifyMessage)
+		if o.VerifyNote != "" {
+			fmt.Printf("    %s\n", o.VerifyNote)
+		}
+	}
 	fmt.Printf("  New security score: %d/100\n", o.NewScore.Overall)
 }
 

--- a/cmd/sitegen/content/en/docs/fixing.html
+++ b/cmd/sitegen/content/en/docs/fixing.html
@@ -23,7 +23,19 @@
               <button class="copy-btn" type="button" data-copy="hostveil fix ssh.rootlogin">Copy</button>
               <pre><code>hostveil fix ssh.rootlogin</code></pre>
             </div>
-            <p>Applying always: <strong>1)</strong> shows the exact diff or command, <strong>2)</strong> backs up the original file to a checkpoint, then <strong>3)</strong> applies the change. You confirm at a <code>[y/N]</code> prompt unless you pass <code>--yes</code>.</p>
+            <p>Applying always: <strong>1)</strong> shows the exact diff or command, <strong>2)</strong> backs up the original file to a checkpoint, <strong>3)</strong> applies the change, then <strong>4)</strong> re-runs that finding's own domain to see whether it is actually gone. You confirm at a <code>[y/N]</code> prompt unless you pass <code>--yes</code>.</p>
+            <p>That last step exists because <em>"hostveil wrote the file"</em> and <em>"the finding is gone"</em> are different claims, and only the first used to be established. The result is reported, never guessed at:</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Result</th><th>What it means</th></tr></thead>
+                <tbody>
+                  <tr><td><strong>Gone</strong></td><td>The domain was re-checked and no longer reports it.</td></tr>
+                  <tr><td><strong>Still reported</strong></td><td>The change landed but the finding persists — usually because it is not yet in force. A sysctl drop-in applies at the next boot; sshd serves from the config it already loaded until it restarts. <strong>Not a failure</strong>, and the fix stays rollbackable.</td></tr>
+                  <tr><td><strong>Unconfirmed</strong></td><td>The re-check could not run or could not cover its ground — no Docker, no root. "Couldn't look" is not "still broken", and it is not "fixed" either.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Verification does <em>not</em> change whether the finding is marked fixed, and <code>fix --all</code> skips it: re-checking after each of twenty fixes would re-run a checker twenty times, and a batch ends with a rescan anyway.</p>
 
             <h3>Choosing a Review alternative</h3>
             <p>Review findings offer independent alternatives. Pass the 0-based index with <code>--action</code>:</p>

--- a/cmd/sitegen/content/ko/docs/fixing.html
+++ b/cmd/sitegen/content/ko/docs/fixing.html
@@ -23,7 +23,19 @@
               <button class="copy-btn" type="button" data-copy="hostveil fix ssh.rootlogin">Copy</button>
               <pre><code>hostveil fix ssh.rootlogin</code></pre>
             </div>
-            <p>적용은 항상 <strong>1)</strong> 정확한 diff나 명령을 보여 주고, <strong>2)</strong> 원본 파일을 체크포인트로 백업한 뒤, <strong>3)</strong> 변경을 적용합니다. <code>--yes</code>를 넘기지 않는 한 <code>[y/N]</code> 프롬프트에서 확인합니다.</p>
+            <p>적용은 항상 <strong>1)</strong> 정확한 diff나 명령을 보여 주고, <strong>2)</strong> 원본 파일을 체크포인트로 백업하고, <strong>3)</strong> 변경을 적용한 뒤, <strong>4)</strong> 해당 발견 항목의 영역을 다시 돌려 정말 사라졌는지 확인합니다. <code>--yes</code>를 넘기지 않는 한 <code>[y/N]</code> 프롬프트에서 확인합니다.</p>
+            <p>마지막 단계가 있는 이유는 <em>"hostveil이 파일을 썼다"</em>와 <em>"발견 항목이 사라졌다"</em>가 서로 다른 주장이고, 지금까지는 앞의 것만 확인됐기 때문입니다. 결과는 추측하지 않고 그대로 보고합니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>결과</th><th>의미</th></tr></thead>
+                <tbody>
+                  <tr><td><strong>사라짐</strong></td><td>영역을 다시 점검했고 더 이상 보고되지 않습니다.</td></tr>
+                  <tr><td><strong>여전히 보고됨</strong></td><td>변경은 적용됐지만 항목이 남아 있습니다 — 대개 아직 반영되지 않았기 때문입니다. sysctl 드롭인은 다음 부팅에 적용되고, sshd는 재시작 전까지 이미 읽어 둔 설정으로 동작합니다. <strong>실패가 아니며</strong>, 롤백도 그대로 가능합니다.</td></tr>
+                  <tr><td><strong>확인 불가</strong></td><td>재점검이 실행되지 못했거나 범위를 다 못 봤습니다 — Docker 없음, root 아님 등. "들여다보지 못했다"는 "여전히 문제다"도 아니고 "고쳐졌다"도 아닙니다.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>재점검은 수정됨 표시 여부를 바꾸지 않으며, <code>fix --all</code>은 이 단계를 건너뜁니다. 스무 개를 고칠 때마다 재점검하면 체커를 스무 번 돌리게 되고, 일괄 적용은 어차피 재스캔으로 끝나기 때문입니다.</p>
 
             <h3>검토 대안 선택하기</h3>
             <p>검토 발견 항목은 독립적인 대안을 제공합니다. 0부터 시작하는 인덱스를 <code>--action</code>으로 넘깁니다.</p>

--- a/internal/core/fixflow.go
+++ b/internal/core/fixflow.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/seolcu/hostveil/internal/check"
 	"github.com/seolcu/hostveil/internal/diff"
 	"github.com/seolcu/hostveil/internal/fix"
 	"github.com/seolcu/hostveil/internal/history"
@@ -169,7 +170,73 @@ func previewMode(a fix.Action) (string, error) {
 func (e *Engine) ApplyFix(ctx context.Context, f model.Finding, actionIdx int) (model.FixOutcome, error) {
 	e.applyMu.Lock()
 	defer e.applyMu.Unlock()
-	return e.applyFix(ctx, f, actionIdx)
+	out, err := e.applyFix(ctx, f, actionIdx)
+	if err != nil {
+		return out, err
+	}
+	// Verify only on the single-fix path. ApplyBatch calls applyFix in a
+	// loop, and re-checking there would re-run a checker once per fix —
+	// twenty compose findings would mean twenty enumerations of every
+	// container on the host. A batch ends with the operator rescanning
+	// anyway; a single fix is the one they are watching.
+	out.Verified, out.VerifyNote = e.verifyFix(ctx, f)
+	out.VerifyMessage = out.Verified.Note(out.RestartHint)
+	return out, nil
+}
+
+// verifyFix re-runs the finding's own domain and reports whether it is
+// still there.
+//
+// It runs the one checker directly rather than going through ScanWith, for
+// two reasons that are each sufficient. ScanWith takes applyMu, which
+// ApplyFix already holds, so calling it here would deadlock. And a scoped
+// scan replaces the current report wholesale with just that domain's
+// findings — verifying an SSH fix would delete every container finding from
+// the report the operator is looking at.
+//
+// The runner is the uncached one, deliberately. e.runner is what fixes use,
+// because a cached answer would report the state of the host before the fix
+// rather than after it — which is the entire question being asked.
+func (e *Engine) verifyFix(ctx context.Context, f model.Finding) (model.FixVerification, string) {
+	if e.registry == nil {
+		return model.VerifyNotRun, ""
+	}
+	var target check.Checker
+	for _, c := range e.registry.Checkers() {
+		if c.Source() == f.Source {
+			target = c
+		}
+	}
+	if target == nil {
+		return model.VerifyUnavailable, "no checker is registered for this domain"
+	}
+
+	env := platform.Detect(ctx, e.runner)
+	results := check.NewRegistry(target).Run(ctx, env, nil)
+	if len(results) != 1 {
+		return model.VerifyUnavailable, "the re-check did not run"
+	}
+	r := results[0]
+
+	// The same rule the scan itself follows. A checker that was skipped,
+	// failed, or covered only part of its ground has not established that
+	// the finding is gone — and "could not look" must never read as either
+	// answer.
+	switch r.State {
+	case model.ScanSkipped, model.ScanError, model.ScanDegraded:
+		reason := r.Reason
+		if reason == "" {
+			reason = "the re-check could not cover this domain"
+		}
+		return model.VerifyUnavailable, reason
+	}
+
+	for _, got := range validFindings(r.Findings) {
+		if got.Key() == f.Key() {
+			return model.VerifyStillPresent, ""
+		}
+	}
+	return model.VerifyGone, ""
 }
 
 // applyFix is ApplyFix's body, with the caller holding applyMu. ApplyBatch

--- a/internal/core/recheck_test.go
+++ b/internal/core/recheck_test.go
@@ -1,0 +1,220 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/fix"
+	"github.com/seolcu/hostveil/internal/history"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// "hostveil wrote the file" and "the finding is gone" are different claims,
+// and only the first was ever established: markFixed set Fixed the moment an
+// apply returned, and the score moved on that. Action.VerifyCmd (see
+// verify_test.go) closes the same gap before a write; this closes the one
+// after it.
+
+// stubChecker reports whatever a test tells it to, so the test can say what
+// the domain looks like once the fix has landed.
+type stubChecker struct {
+	src      model.Source
+	findings []model.Finding
+	state    model.ScanState // zero value runs normally
+	reason   string
+}
+
+func (c *stubChecker) Source() model.Source { return c.src }
+
+func (c *stubChecker) Available(context.Context, platform.Env) (bool, string) {
+	if c.state == model.ScanSkipped {
+		return false, c.reason
+	}
+	return true, ""
+}
+
+func (c *stubChecker) Check(context.Context, platform.Env) ([]model.Finding, error) {
+	switch c.state {
+	case model.ScanError:
+		return nil, errors.New(c.reason)
+	case model.ScanDegraded:
+		return c.findings, &check.PartialError{Reason: c.reason, Covered: 1, Total: 2}
+	}
+	return c.findings, nil
+}
+
+func recheckFinding() model.Finding {
+	return model.NewFinding("fileperms.shadow", "World-readable /etc/shadow",
+		model.SeverityCritical, model.SourceFilePerms, model.RemediationAuto)
+}
+
+// recheckEngine wires one edit fix and one checker that describes the host
+// after it, so the apply path is the ordinary one and only the re-check
+// varies.
+func recheckEngine(t *testing.T, after check.Checker) *Engine {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "target.conf")
+	if err := os.WriteFile(path, []byte("original\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := fix.NewRegistry()
+	r.Register("fileperms.shadow", func(model.Finding) (fix.Fix, error) {
+		return fix.Fix{
+			Label: "tighten it", Kind: model.RemediationAuto,
+			Actions: []fix.Action{{
+				Label: "tighten", Kind: fix.ActionEdit, Path: path,
+				Transform: func([]byte) ([]byte, error) { return []byte("fixed\n"), nil },
+			}},
+		}, nil
+	})
+	e := New(Config{Registry: check.NewRegistry(after), Fixes: r, Store: history.NewStore(t.TempDir())})
+	e.current = model.Report{Findings: []model.Finding{recheckFinding()}}
+	return e
+}
+
+func TestApplyConfirmsTheFindingIsGone(t *testing.T) {
+	e := recheckEngine(t, &stubChecker{src: model.SourceFilePerms})
+
+	out, err := e.ApplyFix(context.Background(), recheckFinding(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Verified != model.VerifyGone {
+		t.Errorf("Verified = %v, want gone", out.Verified)
+	}
+	if out.VerifyMessage == "" {
+		t.Error("nothing was said to the operator")
+	}
+}
+
+// The case that shaped the design. A persisted sysctl drop-in is correct and
+// complete, and the running kernel still reports the old value until the next
+// boot — so a checker that still sees the finding is not evidence the fix
+// failed. Both facts are reported; neither is collapsed into the other.
+func TestAStillPresentFindingIsReportedNotTreatedAsFailure(t *testing.T) {
+	e := recheckEngine(t, &stubChecker{
+		src: model.SourceFilePerms, findings: []model.Finding{recheckFinding()},
+	})
+
+	out, err := e.ApplyFix(context.Background(), recheckFinding(), 0)
+	if err != nil {
+		t.Fatalf("a still-present finding must not fail the apply: %v", err)
+	}
+	if !out.Success {
+		t.Error("the apply reported failure; it succeeded and the finding merely persists")
+	}
+	if out.Verified != model.VerifyStillPresent {
+		t.Errorf("Verified = %v, want still-present", out.Verified)
+	}
+	if out.CheckpointID == "" {
+		t.Error("no checkpoint — the change is real and must stay rollbackable")
+	}
+	// The Fixed decision is unchanged. Collapsing the two facts would call
+	// this fix broken, or call an unverified one confirmed.
+	cur, _ := e.Current()
+	for _, f := range cur.Findings {
+		if f.Key() == recheckFinding().Key() && !f.Fixed {
+			t.Error("the finding was un-marked; verification must not change the Fixed decision")
+		}
+	}
+}
+
+// The rule the whole scan is built on, one level down: a re-check that was
+// skipped, failed, or covered part of its ground has established nothing.
+// "Could not look" is not "still broken", and it is not "fixed" either.
+func TestAnUnrunnableRecheckIsUnavailableNotAnAnswer(t *testing.T) {
+	for name, state := range map[string]model.ScanState{
+		"skipped":  model.ScanSkipped,
+		"failed":   model.ScanError,
+		"degraded": model.ScanDegraded,
+	} {
+		t.Run(name, func(t *testing.T) {
+			e := recheckEngine(t, &stubChecker{
+				src: model.SourceFilePerms, state: state, reason: "docker is unreachable",
+			})
+			out, err := e.ApplyFix(context.Background(), recheckFinding(), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out.Verified != model.VerifyUnavailable {
+				t.Errorf("Verified = %v, want unavailable", out.Verified)
+			}
+			if out.VerifyNote == "" {
+				t.Error("no reason given for the failed re-check")
+			}
+		})
+	}
+}
+
+// countingChecker records how often the domain was re-examined.
+type countingChecker struct {
+	stubChecker
+	calls int
+}
+
+func (c *countingChecker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
+	c.calls++
+	return c.stubChecker.Check(ctx, env)
+}
+
+// A batch re-checks nothing, on purpose. applyFix runs in a loop there, and
+// verifying each would re-run a checker once per fix — twenty compose
+// findings would mean twenty enumerations of every container on the host.
+// A batch ends with the operator rescanning anyway.
+func TestBatchDoesNotVerifyEachFix(t *testing.T) {
+	c := &countingChecker{stubChecker: stubChecker{src: model.SourceFilePerms}}
+	e := recheckEngine(t, c)
+
+	out := e.ApplyBatch(context.Background(), []model.Finding{recheckFinding()})
+	if len(out.Applied) != 1 {
+		t.Fatalf("batch applied %v, failed %v", out.Applied, out.Failed)
+	}
+	if c.calls != 0 {
+		t.Errorf("the batch re-ran the checker %d time(s); it must not verify per fix", c.calls)
+	}
+}
+
+// A domain with no registered checker cannot be re-checked, and that is
+// "unavailable" rather than a claim in either direction.
+func TestVerifyWithNoCheckerForTheDomain(t *testing.T) {
+	e := recheckEngine(t, &stubChecker{src: model.SourceSSH}) // a different domain
+
+	out, err := e.ApplyFix(context.Background(), recheckFinding(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Verified != model.VerifyUnavailable {
+		t.Errorf("Verified = %v, want unavailable", out.Verified)
+	}
+}
+
+// Every result an interface can receive has to say something, and the
+// still-present sentence must not read as a failure — it is most often a
+// change that is correct and not yet in force.
+func TestEveryVerificationResultHasAMessage(t *testing.T) {
+	for _, v := range []model.FixVerification{
+		model.VerifyGone, model.VerifyStillPresent, model.VerifyUnavailable,
+	} {
+		if v.Note("") == "" {
+			t.Errorf("%v has no message", v)
+		}
+	}
+	if got := model.VerifyNotRun.Note(""); got != "" {
+		t.Errorf("not-run rendered %q; it must say nothing", got)
+	}
+	// The restart hint is the difference between a useful sentence and a
+	// vague one, so it has to reach the text.
+	if got := model.VerifyStillPresent.Note("sshd"); !strings.Contains(got, "sshd") {
+		t.Errorf("the still-present message drops the restart hint: %q", got)
+	}
+	// And it must not sound like the fix failed.
+	if got := model.VerifyStillPresent.Note(""); strings.Contains(strings.ToLower(got), "failed") {
+		t.Errorf("the still-present message reads as a failure: %q", got)
+	}
+}

--- a/internal/model/fix.go
+++ b/internal/model/fix.go
@@ -31,6 +31,21 @@ type FixOutcome struct {
 	CheckpointID string         `json:"checkpoint_id,omitempty"` // "" if nothing to roll back
 	RestartHint  string         `json:"restart_hint,omitempty"`  // service the user may need to restart
 	NewScore     ScoreBreakdown `json:"new_score"`
+
+	// Verified is what re-running the finding's own domain found, and
+	// VerifyNote carries the reason when it could not be established.
+	// Applying a fix marks the finding Fixed either way; these say whether
+	// anything actually confirmed it.
+	Verified FixVerification `json:"verified"`
+	// VerifyMessage is the sentence every interface shows, rendered once by
+	// the engine from Verified and RestartHint. The three outcome summaries
+	// already phrase the same fields three different ways; this distinction
+	// is subtle enough that three attempts at it would mean three different
+	// claims.
+	VerifyMessage string `json:"verify_message,omitempty"`
+	// VerifyNote is the checker's own reason when the re-check could not
+	// run — shown under the message, not instead of it.
+	VerifyNote string `json:"verify_note,omitempty"`
 }
 
 // BatchOutcome is the result of applying every eligible Auto fix at once.
@@ -77,4 +92,86 @@ type Checkpoint struct {
 	Diff           string     `json:"diff,omitempty"`
 	RestartService string     `json:"restart_service,omitempty"`
 	Commands       [][]string `json:"commands,omitempty"`
+}
+
+// FixVerification is what a re-check of the finding's own domain found
+// after a fix was applied.
+//
+// It exists because "hostveil wrote the file" and "the finding is gone" are
+// different claims, and until now only the first was ever established —
+// markFixed set Fixed the moment an apply returned, and the score moved on
+// that. That is the same gap Action.VerifyCmd closes before a write: this
+// closes the one after it.
+//
+// It deliberately does not change whether the finding is marked Fixed. A
+// persisted sysctl drop-in is correct and complete and the running kernel
+// still reports the old value until the next boot, so a checker that still
+// sees the finding is not evidence the fix failed. Reporting the two facts
+// separately is honest; collapsing them would either call that fix broken
+// or call an unverified one confirmed.
+type FixVerification int
+
+const (
+	// VerifyNotRun means no re-check was attempted — the batch path, which
+	// would otherwise re-run a checker once per fix.
+	VerifyNotRun FixVerification = iota
+	// VerifyGone means the domain was re-checked and no longer reports it.
+	VerifyGone
+	// VerifyStillPresent means the domain was re-checked and still reports
+	// it. Not necessarily a failure: the change may need a restart or a
+	// reboot to take effect.
+	VerifyStillPresent
+	// VerifyUnavailable means the re-check could not run or could not cover
+	// its ground. "Could not look" is not "still broken", and it is not
+	// "fixed" either.
+	VerifyUnavailable
+)
+
+// String returns the lowercase name used in JSON and in every UI.
+func (v FixVerification) String() string {
+	switch v {
+	case VerifyGone:
+		return "gone"
+	case VerifyStillPresent:
+		return "still-present"
+	case VerifyUnavailable:
+		return "unavailable"
+	default:
+		return "not-run"
+	}
+}
+
+// Note is the one sentence every interface shows for this result.
+//
+// It lives here because the three outcome summaries — the CLI's
+// printOutcome, the TUI's applySummary, and the dashboard's flash — already
+// phrase the same fields three different ways, and this one carries a
+// distinction subtle enough that three attempts at it would produce three
+// different meanings.
+//
+// "Still present" is deliberately not phrased as a failure. The commonest
+// case is a change that is correct and not yet in force: a sysctl drop-in
+// applies at the next boot, and sshd serves from the config it already
+// loaded until it restarts.
+func (v FixVerification) Note(restartHint string) string {
+	switch v {
+	case VerifyGone:
+		return "Re-checked: the finding is gone."
+	case VerifyStillPresent:
+		if restartHint != "" {
+			return "Re-checked: the finding is still reported — the change may not take effect until '" +
+				restartHint + "' restarts."
+		}
+		return "Re-checked: the finding is still reported — the change may not take effect until a restart or reboot."
+	case VerifyUnavailable:
+		return "Could not re-check this domain, so the fix is unconfirmed."
+	default:
+		return ""
+	}
+}
+
+// MarshalJSON emits the name rather than the integer, so a consumer of
+// --json is not left mapping ordinals the way the dashboard once had to.
+func (v FixVerification) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + v.String() + `"`), nil
 }

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -806,6 +806,9 @@ func applySummary(o model.FixOutcome) string {
 	if o.RestartHint != "" {
 		fmt.Fprintf(&b, " You may need to restart '%s'.", o.RestartHint)
 	}
+	if o.VerifyMessage != "" {
+		b.WriteString(" " + o.VerifyMessage)
+	}
 	return b.String()
 }
 

--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -510,8 +510,13 @@ async function applyFix(f, action) {
     // nothing reloads the service, so until the operator restarts it the
     // score has improved for a change that is not yet in effect. The CLI has
     // always said so; the dashboard used to show only the new number.
+    // verify_message is rendered by the engine, not composed here: the
+    // difference between "re-checked and gone" and "applied but not yet in
+    // force" is subtle enough that three interfaces phrasing it themselves
+    // would make three different claims.
     flash(`Fix applied. Score ${o.new_score.overall}/100.` +
       (o.restart_hint ? `  Restart '${o.restart_hint}' for it to take effect.` : "") +
+      (o.verify_message ? `  ${o.verify_message}` : "") +
       (o.checkpoint_id ? `  Rollback: ${o.checkpoint_id}` : ""));
     await refresh();
   } catch (e) { flash("Fix failed: " + e.message, true); }

--- a/site/docs/fixing.html
+++ b/site/docs/fixing.html
@@ -109,7 +109,19 @@
               <button class="copy-btn" type="button" data-copy="hostveil fix ssh.rootlogin">Copy</button>
               <pre><code>hostveil fix ssh.rootlogin</code></pre>
             </div>
-            <p>Applying always: <strong>1)</strong> shows the exact diff or command, <strong>2)</strong> backs up the original file to a checkpoint, then <strong>3)</strong> applies the change. You confirm at a <code>[y/N]</code> prompt unless you pass <code>--yes</code>.</p>
+            <p>Applying always: <strong>1)</strong> shows the exact diff or command, <strong>2)</strong> backs up the original file to a checkpoint, <strong>3)</strong> applies the change, then <strong>4)</strong> re-runs that finding's own domain to see whether it is actually gone. You confirm at a <code>[y/N]</code> prompt unless you pass <code>--yes</code>.</p>
+            <p>That last step exists because <em>"hostveil wrote the file"</em> and <em>"the finding is gone"</em> are different claims, and only the first used to be established. The result is reported, never guessed at:</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>Result</th><th>What it means</th></tr></thead>
+                <tbody>
+                  <tr><td><strong>Gone</strong></td><td>The domain was re-checked and no longer reports it.</td></tr>
+                  <tr><td><strong>Still reported</strong></td><td>The change landed but the finding persists — usually because it is not yet in force. A sysctl drop-in applies at the next boot; sshd serves from the config it already loaded until it restarts. <strong>Not a failure</strong>, and the fix stays rollbackable.</td></tr>
+                  <tr><td><strong>Unconfirmed</strong></td><td>The re-check could not run or could not cover its ground — no Docker, no root. "Couldn't look" is not "still broken", and it is not "fixed" either.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>Verification does <em>not</em> change whether the finding is marked fixed, and <code>fix --all</code> skips it: re-checking after each of twenty fixes would re-run a checker twenty times, and a batch ends with a rescan anyway.</p>
 
             <h3>Choosing a Review alternative</h3>
             <p>Review findings offer independent alternatives. Pass the 0-based index with <code>--action</code>:</p>

--- a/site/ko/docs/fixing.html
+++ b/site/ko/docs/fixing.html
@@ -109,7 +109,19 @@
               <button class="copy-btn" type="button" data-copy="hostveil fix ssh.rootlogin">Copy</button>
               <pre><code>hostveil fix ssh.rootlogin</code></pre>
             </div>
-            <p>적용은 항상 <strong>1)</strong> 정확한 diff나 명령을 보여 주고, <strong>2)</strong> 원본 파일을 체크포인트로 백업한 뒤, <strong>3)</strong> 변경을 적용합니다. <code>--yes</code>를 넘기지 않는 한 <code>[y/N]</code> 프롬프트에서 확인합니다.</p>
+            <p>적용은 항상 <strong>1)</strong> 정확한 diff나 명령을 보여 주고, <strong>2)</strong> 원본 파일을 체크포인트로 백업하고, <strong>3)</strong> 변경을 적용한 뒤, <strong>4)</strong> 해당 발견 항목의 영역을 다시 돌려 정말 사라졌는지 확인합니다. <code>--yes</code>를 넘기지 않는 한 <code>[y/N]</code> 프롬프트에서 확인합니다.</p>
+            <p>마지막 단계가 있는 이유는 <em>"hostveil이 파일을 썼다"</em>와 <em>"발견 항목이 사라졌다"</em>가 서로 다른 주장이고, 지금까지는 앞의 것만 확인됐기 때문입니다. 결과는 추측하지 않고 그대로 보고합니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>결과</th><th>의미</th></tr></thead>
+                <tbody>
+                  <tr><td><strong>사라짐</strong></td><td>영역을 다시 점검했고 더 이상 보고되지 않습니다.</td></tr>
+                  <tr><td><strong>여전히 보고됨</strong></td><td>변경은 적용됐지만 항목이 남아 있습니다 — 대개 아직 반영되지 않았기 때문입니다. sysctl 드롭인은 다음 부팅에 적용되고, sshd는 재시작 전까지 이미 읽어 둔 설정으로 동작합니다. <strong>실패가 아니며</strong>, 롤백도 그대로 가능합니다.</td></tr>
+                  <tr><td><strong>확인 불가</strong></td><td>재점검이 실행되지 못했거나 범위를 다 못 봤습니다 — Docker 없음, root 아님 등. "들여다보지 못했다"는 "여전히 문제다"도 아니고 "고쳐졌다"도 아닙니다.</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>재점검은 수정됨 표시 여부를 바꾸지 않으며, <code>fix --all</code>은 이 단계를 건너뜁니다. 스무 개를 고칠 때마다 재점검하면 체커를 스무 번 돌리게 되고, 일괄 적용은 어차피 재스캔으로 끝나기 때문입니다.</p>
 
             <h3>검토 대안 선택하기</h3>
             <p>검토 발견 항목은 독립적인 대안을 제공합니다. 0부터 시작하는 인덱스를 <code>--action</code>으로 넘깁니다.</p>


### PR DESCRIPTION
## What and why

*"hostveil wrote the file"* and *"the finding is gone"* are different claims, and only the first was ever established. `markFixed` set `Fixed` the moment an apply returned, and the score moved on that — nothing ever looked again. `Action.VerifyCmd` closes the same gap **before** a write; this closes the one **after** it.

A single fix now re-runs its own domain and reports one of three answers, said out loud in the CLI, the TUI and the dashboard:

| Result | Meaning |
| --- | --- |
| **Gone** | Re-checked; the domain no longer reports it. |
| **Still reported** | The change landed but the finding persists — usually because it is not yet in force. **Not a failure.** |
| **Unconfirmed** | The re-check could not run or could not cover its ground. |

## The decision the design turns on

**Verification does not change whether the finding is marked Fixed.**

A persisted sysctl drop-in is correct and complete, and the running kernel still reports the old value until the next boot — so a checker that still sees the finding is *not* evidence the fix failed. Collapsing the two facts would either call that fix broken or call an unverified one confirmed. Reporting them separately is the only honest option, and it turns the sysctl case into exactly the right sentence: *applied, and not in force until the next boot.*

"Unconfirmed" follows the rule the whole scan is built on: a re-check that was skipped, failed, or **degraded** has established nothing. "Could not look" is not "still broken", and it is not "fixed" either.

## Two traps, both avoided

The re-check runs the one checker **directly** rather than through `ScanWith`:

1. `ScanWith` takes `applyMu`, which `ApplyFix` already holds — calling it would **deadlock**.
2. A scoped scan replaces the current report wholesale with just that domain's findings, so verifying an SSH fix would **delete every container finding** from the report the operator is reading.

And it uses the **uncached** runner (`e.runner`, the one fixes use), because a cached answer describes the host *before* the fix rather than after it — which is the entire question being asked.

## Not in the batch path

`ApplyBatch` verifies nothing, on purpose. `applyFix` runs in a loop there, and re-checking each would re-run a checker once per fix — twenty compose findings would mean twenty enumerations of every container on the host. A batch ends with the operator rescanning anyway; a single fix is the one they are watching.

## One sentence, three interfaces

The message is rendered once, by the engine, and all three UIs print it. The three outcome summaries already phrase the same fields three different ways, and this distinction is subtle enough that three attempts at it would make three different claims. A test asserts the still-present message never reads as a failure and always carries the restart hint when there is one.

## Checklist

- [x] Title is conventional with a valid scope (`feat(core):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  `golangci-lint` and `govulncheck` cannot run in this container — they build the module with Go 1.25 and it requires 1.26. Delegated to the `lint` job.
- [x] For a new or changed detection rule: n/a — no checker, finding, fix or axis changes. Checkers are still read-only; this re-runs one, it does not add one.
- [x] For a UI change: both layering tests pass; no new production imports in either UI.
- [x] **The score stays honest** — a skipped, failed *or degraded* re-check reports "unconfirmed" rather than either answer, and verification never moves the score: the Fixed decision is untouched.

## Verified by mutation

| Mutation | Result |
| --- | --- |
| Treat a skipped/failed/degraded re-check as "gone" | `TestAnUnrunnableRecheckIsUnavailableNotAnAnswer` — `Verified = gone, want unavailable` on failed and degraded |
| Verify inside the batch loop | `TestBatchDoesNotVerifyEachFix` — `the batch re-ran the checker 1 time(s)` |

Also covered: a still-present finding keeps `Success`, keeps its checkpoint, and stays marked Fixed; a domain with no registered checker reports unconfirmed rather than guessing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_