### PR TITLE
docs: record the score-trend UI change in the 3.7.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ to Review, which changes the button they carry, not the number.
   along. A scan where no domain could be examined shows N/A rather than a
   number, and no change is reported against it — a run nobody could score is
   not a drop to zero.
+* **ui:** draw the score trend in the TUI and the dashboard
+  ([#606](https://github.com/seolcu/hostveil/issues/606)). The other half of
+  the change above, and the same omission this release is otherwise about:
+  the engine gained the series and neither interface asked for it. The TUI
+  draws it on the history screen, where the checkpoint list already says what
+  was changed and the trend says whether it helped; the dashboard draws it
+  beside the delta line. `model.Sparkline` buckets the scores once and both
+  interfaces render what it returns, so the rule cannot drift the way the
+  severity palette and the domain table each did before it.
 
 ### Bug Fixes
 


### PR DESCRIPTION
## What and why

#606 merged **after** #605 (the 3.7.0 changelog) and **before** the tag was created, so the entry on main describes ten of the eleven changes v3.7.0 would contain. The compare link in the entry header is `v3.6.0...v3.7.0`, so tagging main as it stands publishes a range containing a feature the notes never mention.

**It belongs in 3.7.0, not 3.8.0.** It is the follow-up half of #603 — which the entry already lists — and #603 shipped `ScoreHistory` on the engine while saying plainly that neither interface drew the series yet. Holding it back would split one change across two releases, and the next release is about an unrelated subject.

It is also squarely the theme this entry is already written around: the engine knew something and the interfaces never asked. That is the same sentence the entry writes about `RollbackForce` and per-domain scan progress, so the bullet needed no new argument, only a place in the list.

## Checklist

- [x] Title is conventional with a valid scope (`docs:`).
- [x] Ran the CI gate locally and it passes — build, vet, gofmt, `go mod tidy`, `go test -race ./...`, `golangci-lint` (0 issues), `govulncheck` (no vulnerabilities), and `sitegen` with no `site/` drift.
- [x] For a new or changed detection rule: n/a — CHANGELOG.md only, no code.
- [x] For a UI change: n/a.
- [x] The score stays honest — untouched.

## Next

`gh release create v3.7.0 --target "$(git rev-parse origin/main)"` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)