### PR TITLE
feat(check): audit the Docker daemon itself

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ The central rule: **one engine, three thin UIs.** `internal/core.Engine` owns al
 
 This is enforced structurally: `internal/ui/tui/layering_test.go` and `internal/ui/web/layering_test.go` parse imports and fail if production UI code imports `internal/fix`, `internal/history`, `internal/check`, or `internal/compose`. UIs may import only `core` and `model`. (v2's duplicated-fix-logic failure is what these tests exist to prevent.)
 
-Flow: `cmd/hostveil/app.go` builds the one engine (all ten checkers + `fix.Default()`) → `Engine.Scan` detects `platform.Env`, runs the checker registry concurrently, validates and classifies findings, scores, diffs against the last saved scan, persists.
+Flow: `cmd/hostveil/app.go` builds the one engine (all eleven checkers + `fix.Default()`) → `Engine.Scan` detects `platform.Env`, runs the checker registry concurrently, validates and classifies findings, scores, diffs against the last saved scan, persists.
 
 ### Key seams
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ second column is what you type into `hostveil fix` and `hostveil explain`.
 | **File permissions** | `fileperms.*` | Over-permissive modes on `/etc/shadow`, `/etc/passwd`, `/etc/group`, `sshd_config`, and SSH host private keys | — |
 | **AI agent runtimes** | `agent.*` | Self-hosted agent runtimes — OpenClaw and Hermes Agent: a gateway reachable off-host, authentication turned off on one that is, unrestricted shell and elevated tools, the sandbox disabled, and loose permissions on the config and the API keys beside it | — |
 | **Kernel hardening** | `sysctl.*` | Eight kernel parameters read straight from `/proc/sys` — the quiet knobs that stop a local foothold from becoming root and a spoofed packet from becoming a route. No `sysctl` binary needed | — |
+| **Docker daemon** | `dockerd.*` | The daemon underneath your containers: an API served over TCP without TLS client verification (unauthenticated root for anyone who can reach the port), a world-writable socket, who holds the socket's group, and the defaults — no-new-privileges, userns-remap, live-restore | Docker |
 | **Image CVEs** *(optional)* | `cve.*` | Known vulnerabilities in the images your Compose services run | Trivy |
 
 Missing Docker or Trivy? Those domains are skipped cleanly and the score is

--- a/cmd/hostveil/app.go
+++ b/cmd/hostveil/app.go
@@ -9,6 +9,7 @@ import (
 	agentcheck "github.com/seolcu/hostveil/internal/check/agent"
 	composecheck "github.com/seolcu/hostveil/internal/check/compose"
 	cvecheck "github.com/seolcu/hostveil/internal/check/cve"
+	dockerdcheck "github.com/seolcu/hostveil/internal/check/dockerd"
 	filepermscheck "github.com/seolcu/hostveil/internal/check/fileperms"
 	firewallcheck "github.com/seolcu/hostveil/internal/check/firewall"
 	portscheck "github.com/seolcu/hostveil/internal/check/ports"
@@ -40,6 +41,7 @@ func buildEngineWithAI(useAI bool) *core.Engine {
 			filepermscheck.New(),
 			agentcheck.New(),
 			sysctlcheck.New(),
+			dockerdcheck.New(),
 		),
 		Fixes:  fix.Default(),
 		Runner: debugRunner(),

--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -16,6 +16,7 @@
                   <tr><td>File permissions</td><td><code>fileperms.</code></td><td>—</td></tr>
                   <tr><td>AI agent runtimes</td><td><code>agent.</code></td><td>OpenClaw or Hermes installed</td></tr>
                   <tr><td>Kernel hardening</td><td><code>sysctl.</code></td><td>—</td></tr>
+                  <tr><td>Docker daemon</td><td><code>dockerd.</code></td><td>Docker</td></tr>
                   <tr><td>Image CVEs <em>(optional)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -44,14 +45,15 @@
               <table>
                 <thead><tr><th>Axis</th><th>Weight</th></tr></thead>
                 <tbody>
-                  <tr><td>Container exposure</td><td>17</td></tr>
-                  <tr><td>SSH hardening</td><td>16</td></tr>
-                  <tr><td>Vulnerabilities</td><td>12</td></tr>
-                  <tr><td>Host firewall</td><td>11</td></tr>
-                  <tr><td>Exposed services</td><td>10</td></tr>
-                  <tr><td>AI agent runtimes</td><td>10</td></tr>
+                  <tr><td>Container exposure</td><td>15</td></tr>
+                  <tr><td>SSH hardening</td><td>15</td></tr>
+                  <tr><td>Vulnerabilities</td><td>11</td></tr>
+                  <tr><td>Host firewall</td><td>10</td></tr>
+                  <tr><td>Exposed services</td><td>9</td></tr>
+                  <tr><td>AI agent runtimes</td><td>9</td></tr>
                   <tr><td>Account hygiene</td><td>7</td></tr>
                   <tr><td>Auto-updates</td><td>7</td></tr>
+                  <tr><td>Docker daemon</td><td>7</td></tr>
                   <tr><td>File permissions</td><td>5</td></tr>
                   <tr><td>Kernel hardening</td><td>5</td></tr>
                 </tbody>
@@ -205,6 +207,28 @@
                 </tbody>
               </table>
             </div>
+
+            <h2 id="dockerd">Docker daemon <code>dockerd.</code></h2>
+            <p>The Compose audit judges what your services declare and the CVE scan judges the images they run. This domain judges the daemon underneath both — the part of the stack that actually holds root.</p>
+            <p>It is worth being blunt about the worst finding here, because it is the worst finding hostveil has. A daemon listening on a TCP port without TLS client verification is root on the host for anyone who can reach that port: no password, no vulnerability, one HTTP request that starts a container with your filesystem mounted inside it. Membership in the socket's group is the same authority from a local account, and unlike <code>sudo</code> it asks for nothing and logs nothing.</p>
+            <p><strong>Three sources, and they disagree.</strong> Docker's settings live in <code>/etc/docker/daemon.json</code>, in flags on the service unit, and in the running daemon — and after an edit without a restart those are different answers. So the daemon defaults are read from <code>docker info</code>, which is what the daemon actually loaded rather than what someone wrote down; the socket and TLS settings are read from the file and the unit together, because <code>docker info</code> does not report them at all; and <code>ss</code> supplies the endpoint you can go and verify, without ever deciding whether a finding exists.</p>
+            <p><strong>Every finding here is Manual, on purpose.</strong> The checker reads the running daemon, but a fix would edit a file the daemon does not read again until it restarts — and restarting Docker stops every container on the host. A fix that marked the finding resolved and raised your score while changing nothing an attacker can see would be worse than no fix, so the how-to-fix text carries the exact change and you choose the moment.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it means</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>dockerd.api-unauthenticated</code></td><td>The Docker API is served over TCP with no TLS client verification — unauthenticated root for anyone who can reach the port</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.socket-world-writable</code></td><td>Every local account can connect to the Docker socket, and so become root</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.api-tls-unverified</code></td><td>The API is encrypted but accepts any client — TLS without <code>tlsverify</code> authenticates the server, not the caller</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.group-members</code></td><td>Accounts other than root hold the socket's group, which is root-equivalent with no password prompt and no audit record</td><td><span class="sev medium">Medium</span> / <span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.no-new-privileges</code></td><td>Containers can still gain privileges through setuid binaries</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.userns-remap</code></td><td>User namespaces are not remapped, so container root is host root</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.live-restore</code></td><td>Restarting the daemon stops every container, which is why daemon updates get deferred</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><code>dockerd.group-members</code> is <span class="sev medium">Medium</span> when the accounts holding the group are people, and <span class="sev high">High</span> when any of them is a service account — one with a system UID or no interactive login. Nobody deliberately grants a CI runner or a monitoring agent the ability to become root, and a credential that never logs in is one nobody is watching.</p>
+            <p>A loopback-only TCP socket is not flagged: it reaches nothing the unix socket did not, and it is the documented way to put a proxy in front of the daemon. A daemon running <strong>rootless</strong> has <code>userns-remap</code> and <code>group-members</code> suppressed and its API finding lowered to <span class="sev high">High</span>, because the blast radius is that user's containers rather than the host. <code>live-restore</code> is suppressed on a swarm node, where Docker does not support it.</p>
 
             <h2 id="agent">AI agent runtimes <code>agent.</code></h2>
             <p>Self-hosted AI agents — <a href="https://docs.openclaw.ai/">OpenClaw</a> and <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a> — run a network gateway and keep API keys on disk in your home directory. Misconfigured, the worst case is someone reaching that gateway and driving an agent that can read your files and run commands as you.</p>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -16,6 +16,7 @@
                   <tr><td>파일 권한</td><td><code>fileperms.</code></td><td>—</td></tr>
                   <tr><td>AI 에이전트 런타임</td><td><code>agent.</code></td><td>OpenClaw 또는 Hermes 설치</td></tr>
                   <tr><td>커널 하드닝</td><td><code>sysctl.</code></td><td>—</td></tr>
+                  <tr><td>Docker 데몬</td><td><code>dockerd.</code></td><td>Docker</td></tr>
                   <tr><td>이미지 CVE <em>(선택)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -44,14 +45,15 @@
               <table>
                 <thead><tr><th>축</th><th>가중치</th></tr></thead>
                 <tbody>
-                  <tr><td>컨테이너 노출</td><td>17</td></tr>
-                  <tr><td>SSH 하드닝</td><td>16</td></tr>
-                  <tr><td>취약점</td><td>12</td></tr>
-                  <tr><td>호스트 방화벽</td><td>11</td></tr>
-                  <tr><td>노출된 서비스</td><td>10</td></tr>
-                  <tr><td>AI 에이전트 런타임</td><td>10</td></tr>
+                  <tr><td>컨테이너 노출</td><td>15</td></tr>
+                  <tr><td>SSH 하드닝</td><td>15</td></tr>
+                  <tr><td>취약점</td><td>11</td></tr>
+                  <tr><td>호스트 방화벽</td><td>10</td></tr>
+                  <tr><td>노출된 서비스</td><td>9</td></tr>
+                  <tr><td>AI 에이전트 런타임</td><td>9</td></tr>
                   <tr><td>계정 위생</td><td>7</td></tr>
                   <tr><td>자동 업데이트</td><td>7</td></tr>
+                  <tr><td>Docker 데몬</td><td>7</td></tr>
                   <tr><td>파일 권한</td><td>5</td></tr>
                   <tr><td>커널 하드닝</td><td>5</td></tr>
                 </tbody>
@@ -205,6 +207,28 @@
                 </tbody>
               </table>
             </div>
+
+            <h2 id="dockerd">Docker 데몬 <code>dockerd.</code></h2>
+            <p>Compose 점검은 서비스가 무엇을 선언했는지를 보고, CVE 점검은 그 서비스가 돌리는 이미지를 봅니다. 이 영역은 그 둘 밑에 있는 데몬 자체 — 실제로 root를 쥐고 있는 부분 — 을 봅니다.</p>
+            <p>여기서 가장 심각한 항목은 hostveil 전체에서 가장 심각한 항목이므로 분명히 말해 둘 필요가 있습니다. TLS 클라이언트 검증 없이 TCP 포트로 듣고 있는 데몬은 그 포트에 닿을 수 있는 누구에게나 호스트의 root입니다. 비밀번호도, 취약점도 필요 없고, 당신의 파일시스템을 안에 마운트한 컨테이너를 시작하는 HTTP 요청 하나면 됩니다. 소켓 그룹의 멤버십은 로컬 계정에서 얻는 같은 권한이고, <code>sudo</code>와 달리 아무것도 묻지 않고 아무것도 기록하지 않습니다.</p>
+            <p><strong>출처가 셋이고, 서로 어긋납니다.</strong> Docker 설정은 <code>/etc/docker/daemon.json</code>, 서비스 유닛의 플래그, 그리고 실행 중인 데몬 안에 각각 있습니다 — 재시작 없이 파일만 고쳤다면 이 셋은 서로 다른 답입니다. 그래서 데몬 기본값은 <code>docker info</code>에서 읽습니다. 누가 적어 둔 내용이 아니라 데몬이 실제로 적재한 내용이기 때문입니다. 소켓과 TLS 설정은 파일과 유닛을 함께 읽습니다. <code>docker info</code>가 아예 보고하지 않기 때문입니다. <code>ss</code>는 직접 확인해 볼 수 있는 엔드포인트를 증거로 덧붙이되, 발견 항목의 존재 여부를 결정하지는 않습니다.</p>
+            <p><strong>여기의 모든 항목은 의도적으로 수동입니다.</strong> 점검기는 실행 중인 데몬을 읽지만, 수정은 데몬이 재시작 전까지 다시 읽지 않는 파일을 고치게 됩니다 — 그리고 Docker를 재시작하면 호스트의 모든 컨테이너가 멈춥니다. 공격자에게 보이는 것은 아무것도 바꾸지 않은 채 항목을 해결됨으로 표시하고 점수만 올리는 수정은 수정이 없는 편만 못합니다. 그래서 조치 안내에 정확한 변경 내용을 담고, 시점은 당신이 고릅니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>의미</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>dockerd.api-unauthenticated</code></td><td>Docker API가 TLS 클라이언트 검증 없이 TCP로 제공됩니다 — 포트에 닿는 누구에게나 인증 없는 root</td><td><span class="sev critical">심각</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.socket-world-writable</code></td><td>모든 로컬 계정이 Docker 소켓에 접속할 수 있고, 따라서 root가 될 수 있습니다</td><td><span class="sev critical">심각</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.api-tls-unverified</code></td><td>API가 암호화되어 있지만 아무 클라이언트나 받습니다 — <code>tlsverify</code> 없는 TLS는 서버를 인증할 뿐 호출자를 인증하지 않습니다</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.group-members</code></td><td>root 외의 계정이 소켓 그룹을 갖고 있습니다. 비밀번호 확인도 감사 기록도 없는 root 동등 권한입니다</td><td><span class="sev medium">보통</span> / <span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.no-new-privileges</code></td><td>컨테이너가 여전히 setuid 바이너리로 권한을 얻을 수 있습니다</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.userns-remap</code></td><td>사용자 네임스페이스가 재매핑되지 않아 컨테이너 root가 곧 호스트 root입니다</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.live-restore</code></td><td>데몬을 재시작하면 모든 컨테이너가 멈춥니다. 그래서 데몬 업데이트가 미뤄집니다</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><code>dockerd.group-members</code>는 그룹을 가진 계정이 사람일 때 <span class="sev medium">보통</span>, 그중 하나라도 서비스 계정 — 시스템 UID이거나 대화형 로그인이 없는 계정 — 이면 <span class="sev high">높음</span>입니다. CI 러너나 모니터링 에이전트에게 root가 될 능력을 일부러 주는 사람은 없고, 한 번도 로그인하지 않는 자격 증명은 아무도 지켜보지 않는 자격 증명입니다.</p>
+            <p>루프백 전용 TCP 소켓은 표시하지 않습니다. 유닉스 소켓이 닿지 않던 곳에 닿지 않고, 데몬 앞에 프록시를 두는 문서화된 방법이기 때문입니다. <strong>rootless</strong>로 실행 중인 데몬은 <code>userns-remap</code>과 <code>group-members</code>가 억제되고 API 항목이 <span class="sev high">높음</span>으로 내려갑니다. 피해 범위가 호스트가 아니라 그 사용자의 컨테이너이기 때문입니다. <code>live-restore</code>는 Docker가 지원하지 않는 swarm 노드에서 억제됩니다.</p>
 
             <h2 id="agent">AI 에이전트 런타임 <code>agent.</code></h2>
             <p>셀프호스트 AI 에이전트인 <a href="https://docs.openclaw.ai/">OpenClaw</a>와 <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a>는 네트워크 게이트웨이를 띄우고 API 키를 홈 디렉터리에 저장합니다. 설정이 잘못되면 최악의 경우 외부에서 그 게이트웨이에 접근해, 내 파일을 읽고 내 권한으로 명령을 실행하는 에이전트를 그대로 조종할 수 있습니다.</p>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -48,7 +48,7 @@ cmd/sitegen/         static-site generator for site/ (templates + content + page
 internal/
   core/              the shared engine — the only thing the UIs call
   check/             detection domains (compose, ssh, firewall, updates, cve,
-                     ports, accounts, fileperms, agent, sysctl)
+                     ports, accounts, fileperms, agent, sysctl, dockerd)
   fix/ compose/ history/   fix registry, YAML editing, backup/rollback
   model/ platform/   pure value types; the OS/command seam
   clirender/         the CLI's report rendering

--- a/internal/check/dockerd/config.go
+++ b/internal/check/dockerd/config.go
@@ -1,0 +1,263 @@
+package dockerd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// maxConfigBytes bounds the daemon.json read. The real file is a handful of
+// lines; anything approaching this is not a configuration file, and reading
+// it unbounded during a scan is how one strange path stalls a domain.
+const maxConfigBytes = 1 << 20
+
+// config is the daemon's socket and TLS configuration, merged from
+// daemon.json and the service unit's ExecStart.
+//
+// Only the settings `docker info` cannot report are collected here. Anything
+// the running daemon can be asked about directly is read from there instead,
+// because this file records what the operator asked for and `docker info`
+// records what the daemon is doing — and after an edit-without-restart those
+// are different answers to different questions.
+type config struct {
+	hosts     []string
+	tls       bool
+	tlsVerify bool
+
+	inFile bool // daemon.json contributed
+	inUnit bool // the unit's ExecStart contributed
+}
+
+// origin names where the operator will find the settings this finding is
+// about, which is not always where they expect: a packaged unit carrying
+// `-H` on its ExecStart is invisible to anyone reading daemon.json.
+func (c config) origin() string {
+	switch {
+	case c.inFile && c.inUnit:
+		return "daemon.json and the service unit"
+	case c.inUnit:
+		return "the service unit's ExecStart"
+	default:
+		return "daemon.json"
+	}
+}
+
+// exposedEndpoints lists the configured TCP endpoints reachable from off this
+// host, in sorted order so a repeat scan produces no delta nobody caused.
+//
+// Unix and fd sockets are not endpoints in this sense — they are the local
+// socket, judged by its permissions instead. A loopback TCP socket is
+// deliberately clean: it is the documented way to put a proxy in front of the
+// daemon, and it is reachable by nothing the unix socket was not.
+func (c config) exposedEndpoints() []string {
+	var out []string
+	for _, h := range c.hosts {
+		host, _, ok := splitEndpoint(h)
+		if !ok {
+			continue
+		}
+		// A bare wildcard, an empty host, or a name we cannot resolve to a
+		// loopback literal all mean "reachable from somewhere else".
+		if (platform.Listener{Addr: host}).Loopback() {
+			continue
+		}
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// splitEndpoint parses a Docker host string such as "tcp://0.0.0.0:2375".
+// Anything that is not TCP is not an endpoint this domain judges, and is
+// rejected rather than guessed at.
+func splitEndpoint(h string) (host string, port int, ok bool) {
+	rest, found := strings.CutPrefix(strings.TrimSpace(h), "tcp://")
+	if !found {
+		return "", 0, false
+	}
+	hostPart, portPart, err := net.SplitHostPort(rest)
+	if err != nil {
+		// "tcp://0.0.0.0" with no port is legal and means the default.
+		return strings.Trim(rest, "[]"), 2375, true
+	}
+	p, err := strconv.Atoi(portPart)
+	if err != nil {
+		return "", 0, false
+	}
+	return hostPart, p, true
+}
+
+// readConfig merges daemon.json with the unit's ExecStart flags.
+//
+// Both are read because either alone is a partial view: the packaged unit
+// ships `-H fd://` on ExecStart while an operator adding a TCP socket may
+// edit either, and Docker refuses to start when `hosts` is set in both at
+// once — so in a reachable daemon at most one of them is carrying the
+// setting, and the checker cannot know in advance which.
+//
+// It reports not-known only when neither source could be consulted. An absent
+// daemon.json is a complete answer, not a failed read: it means no options
+// are set there, which is the default state of most hosts.
+func (c *Checker) readConfig(ctx context.Context, env platform.Env) (config, bool, string) {
+	var cfg config
+	var failed []string
+
+	fileCfg, err := readDaemonJSON(c.DaemonConfig)
+	switch {
+	case err == nil:
+		cfg = fileCfg
+		cfg.inFile = fileCfg.inFile
+	case os.IsNotExist(err):
+		// No file, no options. A complete answer.
+	default:
+		failed = append(failed, fmt.Sprintf("cannot read %s", c.DaemonConfig))
+	}
+
+	unitHosts, unitTLS, unitVerify, unitOK := c.readUnit(ctx, env)
+	if unitOK {
+		cfg.inUnit = true
+		cfg.hosts = append(cfg.hosts, unitHosts...)
+		cfg.tls = cfg.tls || unitTLS
+		cfg.tlsVerify = cfg.tlsVerify || unitVerify
+	}
+
+	// The unit carries both the socket flags and the TLS flags, so having
+	// parsed it makes up for an unreadable daemon.json entirely. Only losing
+	// both leaves these rules unanswered.
+	if len(failed) > 0 && !unitOK {
+		return config{}, false, failed[0] + " and the daemon's unit file could not be inspected — the API socket and TLS settings were not audited"
+	}
+	return cfg, true, ""
+}
+
+// daemonJSON is the narrow view of daemon.json this domain needs. Docker
+// accepts dozens of keys; decoding into a struct rather than a map means an
+// unrelated key added by a future Docker release cannot change what is read.
+type daemonJSON struct {
+	Hosts     []string `json:"hosts"`
+	TLS       *bool    `json:"tls"`
+	TLSVerify *bool    `json:"tlsverify"`
+	TLSCert   string   `json:"tlscert"`
+}
+
+func readDaemonJSON(path string) (config, error) {
+	b, err := platform.ReadFileNoFollow(path, maxConfigBytes)
+	if err != nil {
+		return config{}, err
+	}
+	// An empty file is valid to dockerd and means no options set.
+	if len(strings.TrimSpace(string(b))) == 0 {
+		return config{inFile: true}, nil
+	}
+	var d daemonJSON
+	if err := json.Unmarshal(b, &d); err != nil {
+		return config{}, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	cfg := config{hosts: d.Hosts, inFile: true}
+	// A certificate without the `tls` switch still means the operator set up
+	// TLS: dockerd turns it on implicitly. Reading only the boolean would
+	// grade a TLS-serving daemon as if it were plaintext.
+	cfg.tls = (d.TLS != nil && *d.TLS) || d.TLSCert != ""
+	cfg.tlsVerify = d.TLSVerify != nil && *d.TLSVerify
+	// tlsverify implies tls, in dockerd and here.
+	cfg.tls = cfg.tls || cfg.tlsVerify
+	return cfg, nil
+}
+
+// readUnit pulls daemon flags off the service unit's ExecStart.
+//
+// This is not redundant with daemon.json. Every mainstream package ships the
+// daemon's listening socket as a flag on the unit, so a checker that read
+// only the file would conclude that a host with a TCP socket on its ExecStart
+// had no sockets configured at all.
+func (c *Checker) readUnit(ctx context.Context, env platform.Env) (hosts []string, tls, verify, ok bool) {
+	if env.ServiceManager != platform.SMSystemd {
+		return nil, false, false, false
+	}
+	out, err := env.Runner.Run(ctx, "systemctl", "show", c.Unit, "--property=ExecStart", "--no-pager")
+	if err != nil {
+		return nil, false, false, false
+	}
+	for _, argv := range execStartArgv(string(out)) {
+		h, t, v := parseDaemonFlags(argv)
+		hosts = append(hosts, h...)
+		tls = tls || t
+		verify = verify || v
+	}
+	return hosts, tls, verify, true
+}
+
+// execStartArgv extracts each argv list from `systemctl show --property=
+// ExecStart` output, which renders as:
+//
+//	ExecStart={ path=/usr/bin/dockerd ; argv[]=/usr/bin/dockerd -H fd:// ; ... }
+//
+// A unit may have several ExecStart entries — a drop-in that clears the
+// packaged one with a bare `ExecStart=` and adds its own is the standard way
+// to change the daemon's flags — so every argv list is returned.
+func execStartArgv(out string) []string {
+	var argvs []string
+	rest := out
+	for {
+		i := strings.Index(rest, "argv[]=")
+		if i < 0 {
+			return argvs
+		}
+		rest = rest[i+len("argv[]="):]
+		end := strings.Index(rest, " ; ")
+		if end < 0 {
+			// Last field before the closing brace.
+			if j := strings.Index(rest, " }"); j >= 0 {
+				end = j
+			} else {
+				argvs = append(argvs, rest)
+				return argvs
+			}
+		}
+		argvs = append(argvs, rest[:end])
+		rest = rest[end:]
+	}
+}
+
+// parseDaemonFlags reads the socket and TLS flags out of one dockerd argv.
+func parseDaemonFlags(argv string) (hosts []string, tls, verify bool) {
+	fields := strings.Fields(argv)
+	for i := 0; i < len(fields); i++ {
+		arg := fields[i]
+		// A flag's value may be attached with "=" or be the next field.
+		name, val, attached := strings.Cut(arg, "=")
+		next := func() (string, bool) {
+			if attached {
+				return val, true
+			}
+			if i+1 < len(fields) {
+				i++
+				return fields[i], true
+			}
+			return "", false
+		}
+		switch name {
+		case "-H", "--host":
+			if v, ok := next(); ok {
+				hosts = append(hosts, v)
+			}
+		case "--tlsverify":
+			// `--tlsverify=false` is an explicit opt-out; a bare flag is on.
+			verify = !attached || val != "false"
+		case "--tls":
+			tls = !attached || val != "false"
+		case "--tlscert", "--tlscacert", "--tlskey":
+			if _, ok := next(); ok {
+				tls = true
+			}
+		}
+	}
+	return hosts, tls, verify || false
+}

--- a/internal/check/dockerd/dockerd.go
+++ b/internal/check/dockerd/dockerd.go
@@ -1,0 +1,467 @@
+// Package dockerd audits the Docker daemon itself — the process that runs
+// every container the compose and CVE domains have opinions about, and the
+// one part of that stack hostveil could not see.
+//
+// The worst finding here is the worst finding hostveil has. A daemon
+// listening on a TCP socket without TLS client verification is root on the
+// host for anyone who can reach the port: no credentials, no exploit, one
+// HTTP request that creates a container with / bind-mounted into it.
+// Membership in the socket's group is the same authority from a local
+// account, and unlike sudo it prompts for nothing and records nothing.
+//
+// # Three sources that disagree
+//
+// The hardest part of this domain is not the rules, it is deciding what to
+// believe. Docker's configuration lives in three places that routinely
+// contradict each other, so each rule names one of them and the package doc
+// is where that reasoning lives.
+//
+//   - `docker info` is the truth for effective daemon state. It reports what
+//     the daemon actually loaded, after the file and the flags were merged.
+//     The three default-hardening rules (no-new-privileges, userns-remap,
+//     live-restore) read only from here. Reading daemon.json for them would
+//     report the operator's intention as though it were the machine's
+//     behaviour — the file may have been edited since the last restart, and a
+//     flag on the unit may be overriding it outright.
+//
+//   - daemon.json and the service unit's ExecStart are the truth for what
+//     `docker info` does not report at all, and for where a human goes to
+//     change it. `docker info` carries no listening addresses and no TLS
+//     settings whatsoever, so the socket rules have nowhere else to read
+//     from. Both are consulted and unioned: the packaged unit puts `-H fd://`
+//     on ExecStart while an operator adding a TCP socket may reach for
+//     either, and a checker that read only one would miss the other
+//     configuration style completely.
+//
+//   - `ss` is the truth for what is actually listening. It turns a socket
+//     finding from a reading of intent into an observed fact and supplies the
+//     endpoint an operator can go and verify. It does not gate any finding:
+//     it can see the door but not the lock, so it can neither confirm nor
+//     deny the TLS half, and its absence is not lost ground.
+//
+// # What is deliberately not audited
+//
+// The logging driver and its rotation options. It is the one candidate rule
+// that is availability rather than security — a full disk, not a way in — and
+// more decisively it cannot be answered honestly from here: `docker info`
+// reports the driver but never its log-opts, so `json-file` with a max-size
+// is indistinguishable from `json-file` without one, and a per-service
+// `logging:` block in a compose file overrides both. A rule blind to two of
+// the three places the answer lives would fire on correctly configured hosts,
+// which is the same objection the sysctl domain records for ip_forward.
+package dockerd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// Checker reports weak Docker daemon configuration.
+type Checker struct {
+	// DaemonConfig is the daemon's JSON configuration file.
+	DaemonConfig string
+	// SocketPath is the unix socket the daemon listens on locally. Its mode
+	// and owning group are both findings in their own right.
+	SocketPath string
+	// GroupPath and PasswdPath resolve the socket's owning group to the
+	// accounts that hold it.
+	GroupPath  string
+	PasswdPath string
+	// Unit is the systemd service whose ExecStart may carry daemon flags
+	// that daemon.json never mentions.
+	Unit string
+}
+
+// New returns a dockerd checker pointed at the real host paths.
+func New() *Checker {
+	return &Checker{
+		DaemonConfig: "/etc/docker/daemon.json",
+		SocketPath:   "/var/run/docker.sock",
+		GroupPath:    "/etc/group",
+		PasswdPath:   "/etc/passwd",
+		Unit:         "docker.service",
+	}
+}
+
+// Source identifies the dockerd domain.
+func (*Checker) Source() model.Source { return model.SourceDockerd }
+
+// Available requires a daemon that actually answers, not merely a `docker`
+// binary on PATH. The distinction is the whole point: a client that cannot
+// reach the socket reports no daemon configuration at all, and a domain that
+// accepted that would score a perfect Docker-daemon axis on precisely the
+// host whose daemon nobody could examine.
+func (*Checker) Available(ctx context.Context, env platform.Env) (bool, string) {
+	if ok, reason := platform.DockerReachable(ctx, env.Runner); !ok {
+		return false, reason + " — the daemon's configuration cannot be read"
+	}
+	return true, ""
+}
+
+// Check gathers the daemon's configuration from every source that has part
+// of it, then runs the rules that source supports.
+//
+// Coverage is counted in rules, not in sources, because that is the unit a
+// user loses when something cannot be read: losing `docker info` costs the
+// three default-hardening rules and leaves the four socket and group rules —
+// including two of the three Criticals — genuinely answered. Reporting that
+// as an outright error would exclude the axis *and discard those findings*,
+// which is strictly worse than reporting it degraded.
+func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
+	f := c.gather(ctx, env)
+
+	var findings []model.Finding
+	findings = append(findings, f.apiFindings()...)
+	findings = append(findings, f.socketFindings()...)
+	findings = append(findings, f.groupFindings()...)
+	findings = append(findings, f.defaultsFindings()...)
+
+	covered, total, reasons := f.coverage()
+	if len(reasons) > 0 {
+		return findings, &check.PartialError{
+			Reason:  strings.Join(reasons, "; "),
+			Covered: covered,
+			Total:   total,
+		}
+	}
+	return findings, nil
+}
+
+// facts is everything the checker managed to learn, plus what it could not.
+// Each "known" flag is what separates "the answer is no" from "there was no
+// answer" — the distinction this whole domain turns on.
+type facts struct {
+	cfg      config
+	cfgKnown bool
+	// cfgReason explains a config that could not be determined from either
+	// daemon.json or the unit.
+	cfgReason string
+
+	info       info
+	infoKnown  bool
+	infoReason string
+
+	sock       socket
+	sockKnown  bool
+	sockAbsent bool // reachable daemon, no local socket: DOCKER_HOST elsewhere
+	sockReason string
+
+	members       []member
+	membersKnown  bool
+	membersReason string
+
+	// listeners corroborates the config. Never gates a finding.
+	listeners []platform.Listener
+}
+
+// gather reads every source. Nothing here fails the scan: each source
+// records what it learned or why it could not, and the rules decide what
+// that costs.
+func (c *Checker) gather(ctx context.Context, env platform.Env) *facts {
+	f := &facts{}
+
+	f.cfg, f.cfgKnown, f.cfgReason = c.readConfig(ctx, env)
+	f.info, f.infoKnown, f.infoReason = readInfo(ctx, env.Runner)
+	f.sock, f.sockKnown, f.sockAbsent, f.sockReason = c.readSocket()
+
+	// The group is only resolvable once the socket has named it: the owning
+	// group is whatever daemon.json's "group" key or the socket unit set, so
+	// it is not necessarily called "docker" at all.
+	if f.sockKnown {
+		f.members, f.membersKnown, f.membersReason = c.readMembers(f.sock.gid)
+	}
+
+	// A missing or failing `ss` is not partial coverage. The configuration is
+	// the authoritative statement of what the daemon was asked to do; the
+	// listener only corroborates it and supplies an endpoint a human can go
+	// and check. Losing a confidence booster is not losing ground.
+	f.listeners, _ = platform.Listeners(ctx, env.Runner)
+
+	return f
+}
+
+// rootless reports whether this is a rootless daemon, which changes what two
+// rules mean rather than merely how bad they are.
+func (f *facts) rootless() bool { return f.infoKnown && f.info.rootless }
+
+// coverage translates what could not be read into the rule count it cost.
+func (f *facts) coverage() (covered, total int, reasons []string) {
+	// The two socket-configuration rules.
+	total += 2
+	if f.cfgKnown {
+		covered += 2
+	} else {
+		reasons = append(reasons, f.cfgReason)
+	}
+
+	// The three daemon-default rules.
+	total += 3
+	if f.infoKnown {
+		covered += 3
+	} else {
+		reasons = append(reasons, f.infoReason)
+	}
+
+	// The socket mode rule. A daemon reached over DOCKER_HOST with no local
+	// socket has nothing to judge — that is not applicable, not uncovered,
+	// so it leaves the denominator rather than lowering the fraction.
+	if !f.sockAbsent {
+		total++
+		if f.sockKnown {
+			covered++
+		} else {
+			reasons = append(reasons, f.sockReason)
+		}
+	}
+
+	// The group-membership rule. A rootless daemon's socket confers only that
+	// user's own containers, so there is no root-equivalent group to audit.
+	if !f.sockAbsent && !f.rootless() {
+		total++
+		switch {
+		case f.membersKnown:
+			covered++
+		case f.sockKnown:
+			reasons = append(reasons, f.membersReason)
+		default:
+			// Already reported by the socket rule; the group could not be
+			// resolved because the socket could not be, and saying so twice
+			// tells the operator nothing new.
+		}
+	}
+	return covered, total, reasons
+}
+
+// apiFindings judges the daemon's network-facing sockets.
+//
+// The ordering is the argument: TLS with client verification is a correctly
+// secured remote daemon and produces nothing at all. Anything less is graded
+// by what an attacker who reaches the port can do, which is why the absence
+// of TLS is Critical while its presence without verification is one rung
+// below — the operator has demonstrably thought about the socket, and the
+// remaining work is incremental rather than a rethink.
+func (f *facts) apiFindings() []model.Finding {
+	if !f.cfgKnown {
+		return nil
+	}
+	exposed := f.cfg.exposedEndpoints()
+	if len(exposed) == 0 {
+		return nil
+	}
+	// Mutual TLS: reaching the port is not enough, a client certificate the
+	// daemon's CA signed is required. This is the supported way to run a
+	// remote daemon and it is not a finding.
+	if f.cfg.tlsVerify {
+		return nil
+	}
+
+	ev := []model.FindingOption{
+		model.WithEvidence("endpoints", strings.Join(exposed, model.EvidenceSeparator)),
+		model.WithEvidence("configured in", f.cfg.origin()),
+	}
+	if obs := f.observed(exposed); obs != "" {
+		ev = append(ev, model.WithEvidence("listening", obs))
+	}
+
+	if f.cfg.tls {
+		return []model.Finding{model.NewFinding(
+			"dockerd.api-tls-unverified",
+			"Docker API is encrypted but does not verify clients",
+			model.SeverityHigh, model.SourceDockerd, model.RemediationManual,
+			append(ev,
+				model.WithDescription("The daemon serves its API over TLS but does not require a client certificate, so the traffic is confidential and the authorization is nonexistent. TLS without client verification authenticates the server to the client and nothing in the other direction: anyone who can reach the port still gets full control of the daemon, and full control of the daemon is root on this host."),
+				model.WithHowToFix("Set `\"tlsverify\": true` alongside a `\"tlscacert\"` naming the CA that signed your client certificates, then restart the daemon. Docker treats `tlsverify` as the switch that turns encryption into authentication; without it the `tls` setting is only encryption."),
+			)...,
+		)}
+	}
+
+	// Rootless is still severe and still remote code execution, but the
+	// blast radius is that user's own containers rather than the host, and
+	// a severity that cannot tell those apart is not measuring anything.
+	sev := model.SeverityCritical
+	desc := "The Docker daemon accepts API requests over TCP with no TLS client verification. The API has no authentication of its own, so anyone who can reach this port is root on this host: a single request can create a container with the host filesystem mounted inside it. This is not an escalation path that needs a vulnerability — it is the daemon working as documented, exposed to the network."
+	if f.rootless() {
+		sev = model.SeverityHigh
+		desc = "The rootless Docker daemon accepts API requests over TCP with no TLS client verification. The API has no authentication of its own, so anyone who can reach this port gets full control of this user's containers and any file the user can read. Rootless keeps it from being immediate root on the host, which is the only reason this is not Critical."
+	}
+	return []model.Finding{model.NewFinding(
+		"dockerd.api-unauthenticated",
+		"Docker API is exposed over TCP without authentication",
+		sev, model.SourceDockerd, model.RemediationManual,
+		append(ev,
+			model.WithDescription(desc),
+			model.WithHowToFix("Remove the `tcp://` endpoint and administer the daemon over SSH instead (`DOCKER_HOST=ssh://user@host`), which is the supported remote path and needs no new listening port. If the socket must stay, put it behind mutual TLS: `\"tlsverify\": true` with `\"tlscacert\"`, `\"tlscert\"`, and `\"tlskey\"`, and restrict the port at the firewall as well."),
+		)...,
+	)}
+}
+
+// observed renders the endpoints `ss` confirms are actually listening. It is
+// evidence only — a daemon that was configured for a socket it failed to
+// open is still misconfigured, so this never decides whether a finding
+// exists.
+func (f *facts) observed(exposed []string) string {
+	want := map[int]bool{}
+	for _, e := range exposed {
+		if _, port, ok := splitEndpoint(e); ok {
+			want[port] = true
+		}
+	}
+	var seen []string
+	for _, l := range f.listeners {
+		if want[l.Port] && !l.Loopback() {
+			seen = append(seen, fmt.Sprintf("%s:%d", l.Addr, l.Port))
+		}
+	}
+	sort.Strings(seen)
+	return strings.Join(seen, model.EvidenceSeparator)
+}
+
+// socketFindings judges the local unix socket's permissions.
+//
+// The trigger is the world-*write* bit and nothing else. Connecting to a unix
+// socket requires write permission on it, so a world-readable socket grants
+// nobody anything and flagging it would be noise on a host that is fine.
+func (f *facts) socketFindings() []model.Finding {
+	if !f.sockKnown || f.sock.perm&0o002 == 0 {
+		return nil
+	}
+	return []model.Finding{model.NewFinding(
+		"dockerd.socket-world-writable",
+		"Docker socket is writable by every account on this host",
+		model.SeverityCritical, model.SourceDockerd, model.RemediationManual,
+		model.WithDescription("Every local account can connect to the Docker socket, and the Docker API grants whoever reaches it the ability to start a container with the host filesystem mounted inside. Any unprivileged user, and any process running as one — a web application, a compromised service account — can therefore become root on this host without a password and without an exploit."),
+		model.WithHowToFix("Restore the socket to group-only access. The mode is set by systemd, not by the daemon, so a `chmod` is undone at the next restart: put `[Socket]` / `SocketMode=0660` in a drop-in under /etc/systemd/system/docker.socket.d/, then `systemctl daemon-reload && systemctl restart docker.socket`. Grant access by adding accounts to the socket's group rather than by widening the mode."),
+		model.WithEvidence("path", f.sock.path),
+		model.WithEvidence("mode", fmt.Sprintf("%04o", f.sock.perm)),
+	)}
+}
+
+// groupFindings reports the accounts that hold the socket's group, which is
+// root-equivalent authority on this host.
+//
+// This finding lives in the dockerd domain rather than in account hygiene for
+// three reasons, in ascending order of weight. The account checker gates on a
+// readable /etc/passwd and has no way to ask whether Docker is even here, so
+// it would report root-equivalence on a host where the group is a leftover of
+// a package that has been removed. Behind a reachable daemon the claim is
+// exactly true, and a host with no Docker gets the axis excluded rather than
+// scored. And the group is not necessarily named "docker" at all — it is
+// whichever group owns the socket, which daemon.json's "group" key can set to
+// anything — so answering correctly needs a daemon fact that account hygiene
+// has no business knowing.
+func (f *facts) groupFindings() []model.Finding {
+	if !f.membersKnown || len(f.members) == 0 || f.rootless() {
+		return nil
+	}
+
+	var names, service []string
+	for _, m := range f.members {
+		names = append(names, m.name)
+		if m.system {
+			service = append(service, m.name)
+		}
+	}
+
+	// A human administrator in the docker group is the ordinary shape of a
+	// self-hosted server, and a High that fires on almost every correctly-run
+	// host teaches people to ignore the domain. It stays a finding because
+	// most operators genuinely do not know the membership is equivalent to
+	// passwordless sudo that leaves no audit record — but the severity says
+	// "know this", not "you are breached".
+	//
+	// A service account is a different claim. Nobody deliberately grants a CI
+	// runner or a monitoring agent the ability to become root, and a
+	// credential that never logs in is one nobody is watching.
+	sev, extra := model.SeverityMedium, ""
+	if len(service) > 0 {
+		sev = model.SeverityHigh
+		extra = fmt.Sprintf(" Among them %s %s no interactive login, so %s a credential that can become root and that nobody is watching.",
+			plural(len(service), "is", "are"), joinNames(service),
+			plural(len(service), "it is", "they are"))
+	}
+
+	return []model.Finding{model.NewFinding(
+		"dockerd.group-members",
+		fmt.Sprintf("%s can control the Docker daemon", plural(len(names), "One account", fmt.Sprintf("%d accounts", len(names)))),
+		sev, model.SourceDockerd, model.RemediationManual,
+		model.WithDescription(fmt.Sprintf("Membership in the %q group is root on this host. Anyone in it can start a container that mounts / and read or write any file, with no password prompt, no sudoers entry, and no entry in the sudo log. It is a privilege grant that looks like a convenience setting.%s", f.sock.group, extra)),
+		model.WithHowToFix(fmt.Sprintf("Remove any account that does not need to administer containers: `gpasswd -d <user> %s`. For accounts that do, consider rootless Docker, which gives them a daemon of their own with no path to host root. Do not remove the account you are currently administering this host with until you have confirmed another route in.", f.sock.group)),
+		model.WithEvidence("group", f.sock.group),
+		model.WithEvidence("members", strings.Join(names, model.EvidenceSeparator)),
+	)}
+}
+
+// defaultsFindings covers the daemon-wide defaults that harden every
+// container ever started on this host. All three are read from `docker info`
+// because all three are questions about the running daemon.
+func (f *facts) defaultsFindings() []model.Finding {
+	if !f.infoKnown {
+		return nil
+	}
+	var out []model.Finding
+
+	if !f.info.noNewPrivileges {
+		out = append(out, model.NewFinding(
+			"dockerd.no-new-privileges",
+			"Containers can gain privileges through setuid binaries",
+			model.SeverityMedium, model.SourceDockerd, model.RemediationManual,
+			model.WithDescription("The daemon does not apply no-new-privileges by default, so a process inside a container can still gain privileges by executing a setuid binary. That is the step that turns a foothold in an application container into root inside that container, and root inside a container is the starting point for every escape technique that follows."),
+			model.WithHowToFix("Add `\"no-new-privileges\": true` to /etc/docker/daemon.json and restart the daemon. It becomes the default for every container; a service that genuinely needs setuid escalation can still opt out with `security_opt: [\"no-new-privileges:false\"]`."),
+			model.WithEvidence("security options", f.info.securityOptions()),
+		))
+	}
+
+	if !f.info.usernsRemap && !f.info.rootless {
+		out = append(out, model.NewFinding(
+			"dockerd.userns-remap",
+			"Container root is host root",
+			model.SeverityLow, model.SourceDockerd, model.RemediationManual,
+			model.WithDescription("User-namespace remapping is not enabled, so uid 0 inside a container is uid 0 on the host. Any container escape, any bind mount the operator did not think through, and any misconfigured volume therefore lands with real root privileges rather than with an unprivileged subordinate uid."),
+			model.WithHowToFix("Set `\"userns-remap\": \"default\"` in /etc/docker/daemon.json and restart the daemon. Weigh it first: remapping changes the ownership of every bind mount, and containers using `--privileged`, host networking, or host PID cannot use it — which is why this is a Low and not an instruction."),
+			model.WithEvidence("security options", f.info.securityOptions()),
+		))
+	}
+
+	// Swarm mode does not support live restore, so on a swarm node this is
+	// not a setting the operator declined — it is one Docker refuses. Flagging
+	// it there would be a guaranteed false positive.
+	if !f.info.liveRestore && !f.info.swarmActive {
+		out = append(out, model.NewFinding(
+			"dockerd.live-restore",
+			"Restarting the daemon stops every container",
+			model.SeverityLow, model.SourceDockerd, model.RemediationManual,
+			model.WithDescription("Without live-restore, containers do not survive a daemon restart. The security cost is indirect and worth stating as such: it makes upgrading Docker an outage, so daemon updates get deferred, and a deferred daemon update is an unpatched daemon holding root on this host."),
+			model.WithHowToFix("Add `\"live-restore\": true` to /etc/docker/daemon.json. Unlike the other daemon defaults this one is picked up by `systemctl reload docker`, so enabling it does not itself require an outage. It is unsupported in swarm mode."),
+			model.WithEvidence("live restore", "disabled"),
+		))
+	}
+	return out
+}
+
+// plural picks between a singular and a plural form. The findings here count
+// accounts, and "1 accounts can control the Docker daemon" is the kind of
+// detail that makes a reader trust the rest of the report less.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+// joinNames renders a list of accounts as English prose.
+func joinNames(names []string) string {
+	switch len(names) {
+	case 1:
+		return names[0]
+	case 2:
+		return names[0] + " and " + names[1]
+	default:
+		return strings.Join(names[:len(names)-1], ", ") + ", and " + names[len(names)-1]
+	}
+}

--- a/internal/check/dockerd/dockerd_test.go
+++ b/internal/check/dockerd/dockerd_test.go
@@ -1,0 +1,627 @@
+package dockerd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+type fakeRunner struct {
+	present map[string]bool
+	outputs map[string]string // key: "name arg1 arg2..."
+}
+
+func (f fakeRunner) LookPath(name string) (string, error) {
+	if f.present[name] {
+		return "/usr/bin/" + name, nil
+	}
+	return "", errors.New("not found")
+}
+
+func (f fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	if out, ok := f.outputs[key]; ok {
+		return []byte(out), nil
+	}
+	return nil, errors.New("no output for: " + key)
+}
+
+const infoCmd = "docker info --format {{json .}}"
+
+// hardenedInfo is a daemon with every default this domain checks turned on,
+// so a test that means to isolate one rule does not accidentally assert the
+// other two as well.
+const hardenedInfo = `{"SecurityOptions":["name=seccomp,profile=builtin","name=no-new-privileges","name=userns"],"LiveRestoreEnabled":true}`
+
+// bareInfo is a stock daemon: none of the three defaults set.
+const bareInfo = `{"SecurityOptions":["name=seccomp,profile=builtin"],"LiveRestoreEnabled":false}`
+
+// execStart renders `systemctl show` output the way systemd really does,
+// so the parser is exercised against the real shape rather than a
+// convenient one.
+func execStart(args string) string {
+	return "ExecStart={ path=/usr/bin/dockerd ; argv[]=/usr/bin/dockerd " + args +
+		" ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }\n"
+}
+
+// env builds a scan environment whose daemon answers with the given info
+// document and whose unit carries the given dockerd flags.
+func env(info, unitArgs string) platform.Env {
+	out := map[string]string{
+		infoCmd: info,
+		"docker version --format {{.Server.Version}}": "27.0.0\n",
+	}
+	if unitArgs != "" {
+		out["systemctl show docker.service --property=ExecStart --no-pager"] = execStart(unitArgs)
+	}
+	return platform.Env{
+		ServiceManager: platform.SMSystemd,
+		Runner:         fakeRunner{present: map[string]bool{"docker": true}, outputs: out},
+	}
+}
+
+// host writes a fixture host: a daemon.json (skipped when empty), a group
+// file, a passwd file, and a real unix socket at the requested mode.
+//
+// The socket lives in os.MkdirTemp rather than t.TempDir because a unix
+// socket path is bounded by sun_path (~104 bytes) and darwin's per-test
+// temp directories are long enough to overflow it.
+type fixture struct {
+	c *Checker
+}
+
+func host(t *testing.T, daemonJSON, group, passwd string, mode os.FileMode) fixture {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "hvdockerd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	c := &Checker{
+		DaemonConfig: filepath.Join(dir, "daemon.json"),
+		SocketPath:   filepath.Join(dir, "docker.sock"),
+		GroupPath:    filepath.Join(dir, "group"),
+		PasswdPath:   filepath.Join(dir, "passwd"),
+		Unit:         "docker.service",
+	}
+	if daemonJSON != "" {
+		write(t, c.DaemonConfig, daemonJSON)
+	}
+	if mode != 0 {
+		l, err := net.Listen("unix", c.SocketPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = l.Close() })
+		if err := os.Chmod(c.SocketPath, mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The fixture socket is owned by whichever group created it, which is
+	// the test user's and differs between a developer's machine and CI's
+	// root container. Chowning it would need privileges the tests must not
+	// require, so the passwd and group fixtures name the socket's real gid
+	// instead: %GID% is substituted here, and a test asserting membership
+	// writes %GID% wherever it means "the group that owns the socket".
+	gid := "999"
+	if mode != 0 {
+		s, _, _, _ := c.readSocket()
+		gid = strconv.FormatUint(uint64(s.gid), 10)
+	}
+	write(t, c.GroupPath, strings.ReplaceAll(group, "%GID%", gid))
+	write(t, c.PasswdPath, strings.ReplaceAll(passwd, "%GID%", gid))
+	return fixture{c: c}
+}
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// cleanGroup is a docker group nobody but root holds, so group-membership
+// findings stay out of tests about something else. %GID% is the gid that
+// actually owns the fixture socket; see host.
+const cleanGroup = "root:x:0:\ndocker:x:%GID%:\n"
+const cleanPasswd = "root:x:0:0:root:/root:/bin/bash\n"
+
+func (f fixture) check(t *testing.T, e platform.Env) []model.Finding {
+	t.Helper()
+	fs, err := f.c.Check(context.Background(), e)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return fs
+}
+
+// find returns the finding with the given ID, or nil.
+func find(fs []model.Finding, id string) *model.Finding {
+	for i := range fs {
+		if fs[i].ID == id {
+			return &fs[i]
+		}
+	}
+	return nil
+}
+
+func mustFind(t *testing.T, fs []model.Finding, id string) model.Finding {
+	t.Helper()
+	f := find(fs, id)
+	if f == nil {
+		t.Fatalf("expected %s; got %v", id, ids(fs))
+	}
+	return *f
+}
+
+func mustNotFind(t *testing.T, fs []model.Finding, id string) {
+	t.Helper()
+	if f := find(fs, id); f != nil {
+		t.Fatalf("did not expect %s; got %v", id, ids(fs))
+	}
+}
+
+func ids(fs []model.Finding) []string {
+	out := make([]string, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, f.ID)
+	}
+	return out
+}
+
+// --- the API socket -------------------------------------------------------
+
+func TestUnauthenticatedTCPFromDaemonJSON(t *testing.T) {
+	h := host(t, `{"hosts":["unix:///var/run/docker.sock","tcp://0.0.0.0:2375"]}`,
+		cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H fd://"))
+
+	f := mustFind(t, fs, "dockerd.api-unauthenticated")
+	if f.Severity != model.SeverityCritical {
+		t.Errorf("severity = %v, want Critical", f.Severity)
+	}
+	if got := f.Evidence["endpoints"]; got != "tcp://0.0.0.0:2375" {
+		t.Errorf("endpoints evidence = %q", got)
+	}
+	if !strings.Contains(f.Evidence["configured in"], "daemon.json") {
+		t.Errorf("configured-in evidence = %q, should name daemon.json", f.Evidence["configured in"])
+	}
+}
+
+// The packaged unit is where every mainstream distribution puts the daemon's
+// listening socket, so a checker that read only daemon.json would report a
+// host with an exposed API as having no sockets configured at all.
+func TestUnauthenticatedTCPFromExecStart(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H fd:// -H tcp://0.0.0.0:2375"))
+
+	f := mustFind(t, fs, "dockerd.api-unauthenticated")
+	if !strings.Contains(f.Evidence["configured in"], "unit") {
+		t.Errorf("configured-in evidence = %q, should name the unit", f.Evidence["configured in"])
+	}
+}
+
+func TestUnauthenticatedTCPFromAttachedHostFlag(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "--host=tcp://0.0.0.0:2375"))
+	mustFind(t, fs, "dockerd.api-unauthenticated")
+}
+
+// The regression that matters most in this domain: an operator who set up
+// mutual TLS did the work correctly and must see nothing at all.
+func TestTLSVerifiedTCPIsClean(t *testing.T) {
+	h := host(t, `{"hosts":["tcp://0.0.0.0:2376"],"tlsverify":true,"tlscacert":"/etc/docker/ca.pem","tlscert":"/etc/docker/cert.pem"}`,
+		cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H fd://"))
+
+	mustNotFind(t, fs, "dockerd.api-unauthenticated")
+	mustNotFind(t, fs, "dockerd.api-tls-unverified")
+}
+
+func TestTLSVerifiedFromExecStartIsClean(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H tcp://0.0.0.0:2376 --tlsverify"))
+	mustNotFind(t, fs, "dockerd.api-unauthenticated")
+	mustNotFind(t, fs, "dockerd.api-tls-unverified")
+}
+
+// TLS without client verification is encryption without authorization: a
+// rung below Critical, but never clean and never the unauthenticated finding.
+func TestTLSWithoutVerifyIsHighNotCritical(t *testing.T) {
+	h := host(t, `{"hosts":["tcp://0.0.0.0:2376"],"tls":true,"tlscert":"/etc/docker/cert.pem"}`,
+		cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H fd://"))
+
+	f := mustFind(t, fs, "dockerd.api-tls-unverified")
+	if f.Severity != model.SeverityHigh {
+		t.Errorf("severity = %v, want High", f.Severity)
+	}
+	mustNotFind(t, fs, "dockerd.api-unauthenticated")
+}
+
+// A certificate with no explicit "tls": true still means TLS is in force —
+// dockerd enables it implicitly — so reading only the boolean would grade a
+// TLS-serving daemon as plaintext.
+func TestCertificateWithoutTLSFlagStillCountsAsTLS(t *testing.T) {
+	h := host(t, `{"hosts":["tcp://0.0.0.0:2376"],"tlscert":"/etc/docker/cert.pem"}`,
+		cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H fd://"))
+	mustFind(t, fs, "dockerd.api-tls-unverified")
+	mustNotFind(t, fs, "dockerd.api-unauthenticated")
+}
+
+// An explicit --tlsverify=false is an opt-out, not a setting.
+func TestExplicitTLSVerifyFalseIsNotVerified(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H tcp://0.0.0.0:2375 --tlsverify=false"))
+	mustFind(t, fs, "dockerd.api-unauthenticated")
+}
+
+// Binding the API to loopback is the documented way to put a proxy in front
+// of the daemon and reaches nothing the unix socket did not.
+func TestLoopbackTCPIsNotAFinding(t *testing.T) {
+	h := host(t, `{"hosts":["tcp://127.0.0.1:2375"]}`, cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H fd://"))
+	mustNotFind(t, fs, "dockerd.api-unauthenticated")
+	mustNotFind(t, fs, "dockerd.api-tls-unverified")
+}
+
+func TestUnixAndFdSocketsAreNotEndpoints(t *testing.T) {
+	h := host(t, `{"hosts":["unix:///var/run/docker.sock","fd://"]}`, cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H fd://"))
+	mustNotFind(t, fs, "dockerd.api-unauthenticated")
+}
+
+// ss sharpens the evidence but must never decide whether the finding exists.
+func TestListenerCorroboratesEvidence(t *testing.T) {
+	h := host(t, `{"hosts":["tcp://0.0.0.0:2375"]}`, cleanGroup, cleanPasswd, 0o660)
+	e := env(hardenedInfo, "-H fd://")
+	r := e.Runner.(fakeRunner)
+	r.present["ss"] = true
+	r.outputs["ss -tlnp"] = "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process\n" +
+		`LISTEN 0      4096   0.0.0.0:2375        0.0.0.0:*         users:(("dockerd",pid=1,fd=3))` + "\n"
+	e.Runner = r
+
+	f := mustFind(t, h.check(t, e), "dockerd.api-unauthenticated")
+	if got := f.Evidence["listening"]; got != "0.0.0.0:2375" {
+		t.Errorf("listening evidence = %q, want the observed socket", got)
+	}
+}
+
+func TestMissingSsIsNotPartial(t *testing.T) {
+	h := host(t, `{"hosts":["tcp://0.0.0.0:2375"]}`, cleanGroup, cleanPasswd, 0o660)
+	// env() never registers ss, so Listeners fails.
+	fs, err := h.c.Check(context.Background(), env(hardenedInfo, "-H fd://"))
+	if err != nil {
+		t.Fatalf("a missing ss must not degrade the domain: %v", err)
+	}
+	f := mustFind(t, fs, "dockerd.api-unauthenticated")
+	if _, ok := f.Evidence["listening"]; ok {
+		t.Error("no listener evidence should be attached when ss is unavailable")
+	}
+}
+
+// --- the socket -----------------------------------------------------------
+
+func TestWorldWritableSocket(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o666)
+	f := mustFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.socket-world-writable")
+	if f.Severity != model.SeverityCritical {
+		t.Errorf("severity = %v, want Critical", f.Severity)
+	}
+	if f.Evidence["mode"] != "0666" {
+		t.Errorf("mode evidence = %q, want 0666", f.Evidence["mode"])
+	}
+}
+
+func TestDefaultSocketModeIsClean(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	mustNotFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.socket-world-writable")
+}
+
+// Connecting to a unix socket requires write permission, so a world-readable
+// socket grants nobody anything and flagging it would be noise.
+func TestWorldReadableSocketIsNotAFinding(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o664)
+	mustNotFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.socket-world-writable")
+}
+
+// A reachable daemon with no local socket is being reached over DOCKER_HOST.
+// There is nothing to judge, which is not the same as failing to judge it.
+func TestAbsentSocketIsNotPartial(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0) // no socket created
+	fs, err := h.c.Check(context.Background(), env(hardenedInfo, "-H fd://"))
+	if err != nil {
+		t.Fatalf("an absent socket must not degrade the domain: %v", err)
+	}
+	mustNotFind(t, fs, "dockerd.socket-world-writable")
+	mustNotFind(t, fs, "dockerd.group-members")
+}
+
+// --- the group ------------------------------------------------------------
+
+func TestGroupMembersAreMediumForHumans(t *testing.T) {
+	h := host(t, "", "root:x:0:\ndocker:x:%GID%:alice\n",
+		cleanPasswd+"alice:x:1000:2000::/home/alice:/bin/bash\n", 0o660)
+	f := mustFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.group-members")
+	if f.Severity != model.SeverityMedium {
+		t.Errorf("severity = %v, want Medium for a human administrator", f.Severity)
+	}
+	if f.Evidence["members"] != "alice" {
+		t.Errorf("members evidence = %q", f.Evidence["members"])
+	}
+}
+
+// Nobody deliberately grants a CI runner the ability to become root, and a
+// credential that never logs in is one nobody is watching.
+func TestGroupMembersEscalateForServiceAccounts(t *testing.T) {
+	h := host(t, "", "root:x:0:\ndocker:x:%GID%:alice,ci_runner\n",
+		cleanPasswd+"alice:x:1000:2000::/home/alice:/bin/bash\nci_runner:x:997:997::/nonexistent:/usr/sbin/nologin\n", 0o660)
+	f := mustFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.group-members")
+	if f.Severity != model.SeverityHigh {
+		t.Errorf("severity = %v, want High when a service account holds the group", f.Severity)
+	}
+	if !strings.Contains(f.Description, "ci_runner") {
+		t.Errorf("description should name the service account: %q", f.Description)
+	}
+}
+
+// A nologin shell above the system uid range is still a service identity.
+func TestHighUIDNologinAccountIsAServiceAccount(t *testing.T) {
+	h := host(t, "", "root:x:0:\ndocker:x:%GID%:runner\n",
+		cleanPasswd+"runner:x:3000:3000::/srv/runner:/bin/false\n", 0o660)
+	f := mustFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.group-members")
+	if f.Severity != model.SeverityHigh {
+		t.Errorf("severity = %v, want High", f.Severity)
+	}
+}
+
+// An account added with `useradd -g docker` appears nowhere in the group's
+// member list, only as a primary gid in passwd.
+func TestPrimaryGIDCountsAsMembership(t *testing.T) {
+	h := host(t, "", "root:x:0:\ndocker:x:%GID%:\n",
+		cleanPasswd+"bob:x:1001:%GID%::/home/bob:/bin/bash\n", 0o660)
+	f := mustFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.group-members")
+	if f.Evidence["members"] != "bob" {
+		t.Errorf("members evidence = %q, want the primary-group member", f.Evidence["members"])
+	}
+}
+
+// The socket's group is whatever owns it, which daemon.json's "group" key can
+// set to anything. Looking up "docker" by name would report a clean host in
+// exactly the case worth catching.
+func TestSocketGroupIsResolvedByGidNotByName(t *testing.T) {
+	h := host(t, "", cleanGroup+"wheel:x:4242:carol\n",
+		cleanPasswd+"carol:x:1000:2000::/home/carol:/bin/bash\n", 0o660)
+	// Point the checker at a socket owned by gid 998 by rewriting what it
+	// resolves: the fixture socket is owned by the test user's gid, so assert
+	// the resolution path directly instead.
+	if got := h.c.groupName(4242); got != "wheel" {
+		t.Fatalf("groupName(4242) = %q, want wheel", got)
+	}
+	members, ok, _ := h.c.readMembers(4242)
+	if !ok || len(members) != 1 || members[0].name != "carol" {
+		t.Fatalf("readMembers(4242) = %v (ok=%v), want carol", members, ok)
+	}
+}
+
+// root already holds this authority by every other route, so naming it here
+// would be noise in a finding that is about everyone else.
+func TestRootIsNotReportedAsAGroupMember(t *testing.T) {
+	h := host(t, "", "root:x:0:\ndocker:x:%GID%:root\n", cleanPasswd, 0o660)
+	mustNotFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.group-members")
+}
+
+// --- the daemon defaults --------------------------------------------------
+
+func TestDaemonDefaultsFromDockerInfo(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(bareInfo, "-H fd://"))
+	for _, id := range []string{"dockerd.no-new-privileges", "dockerd.userns-remap", "dockerd.live-restore"} {
+		mustFind(t, fs, id)
+	}
+}
+
+func TestHardenedDaemonIsClean(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	fs := h.check(t, env(hardenedInfo, "-H fd://"))
+	if len(fs) != 0 {
+		t.Errorf("a correctly configured daemon should produce nothing; got %v", ids(fs))
+	}
+}
+
+// live-restore is unsupported in swarm mode, so flagging it on a swarm node
+// would be a guaranteed false positive.
+func TestSwarmSuppressesLiveRestore(t *testing.T) {
+	const swarm = `{"SecurityOptions":["name=no-new-privileges","name=userns"],"LiveRestoreEnabled":false,"Swarm":{"LocalNodeState":"active"}}`
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	mustNotFind(t, h.check(t, env(swarm, "-H fd://")), "dockerd.live-restore")
+}
+
+// Rootless already gives every container a remapped uid, and its socket
+// confers only that user's own containers rather than host root.
+func TestRootlessSuppressesUsernsAndGroup(t *testing.T) {
+	const rootless = `{"SecurityOptions":["name=rootless","name=no-new-privileges"],"LiveRestoreEnabled":true}`
+	h := host(t, "", "root:x:0:\ndocker:x:%GID%:alice\n",
+		cleanPasswd+"alice:x:1000:2000::/home/alice:/bin/bash\n", 0o660)
+	fs := h.check(t, env(rootless, "-H fd://"))
+	mustNotFind(t, fs, "dockerd.userns-remap")
+	mustNotFind(t, fs, "dockerd.group-members")
+}
+
+func TestRootlessDowngradesTheAPIFinding(t *testing.T) {
+	const rootless = `{"SecurityOptions":["name=rootless","name=no-new-privileges","name=userns"],"LiveRestoreEnabled":true}`
+	h := host(t, `{"hosts":["tcp://0.0.0.0:2375"]}`, cleanGroup, cleanPasswd, 0o660)
+	f := mustFind(t, h.check(t, env(rootless, "-H fd://")), "dockerd.api-unauthenticated")
+	if f.Severity != model.SeverityHigh {
+		t.Errorf("severity = %v, want High on a rootless daemon", f.Severity)
+	}
+}
+
+// --- coverage -------------------------------------------------------------
+
+// Losing `docker info` costs the three default-hardening rules and leaves the
+// four socket and group rules genuinely answered — including two of the three
+// Criticals. Reporting that as an outright error would discard them.
+func TestDockerInfoFailureIsPartialNotFatal(t *testing.T) {
+	h := host(t, `{"hosts":["tcp://0.0.0.0:2375"]}`, cleanGroup, cleanPasswd, 0o666)
+	e := env(hardenedInfo, "-H fd://")
+	r := e.Runner.(fakeRunner)
+	delete(r.outputs, infoCmd)
+	e.Runner = r
+
+	fs, err := h.c.Check(context.Background(), e)
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("err = %v, want a PartialError", err)
+	}
+	if partial.Covered != 4 || partial.Total != 7 {
+		t.Errorf("coverage = %d/%d, want 4/7", partial.Covered, partial.Total)
+	}
+	// The findings that did run must survive the degradation.
+	mustFind(t, fs, "dockerd.api-unauthenticated")
+	mustFind(t, fs, "dockerd.socket-world-writable")
+}
+
+// An absent daemon.json is a complete answer — it means no options are set
+// there, which is the default state of most hosts — not a failed read.
+func TestAbsentDaemonJSONIsNotPartial(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	if _, err := h.c.Check(context.Background(), env(hardenedInfo, "-H fd://")); err != nil {
+		t.Fatalf("an absent daemon.json must not degrade the domain: %v", err)
+	}
+}
+
+// An unreadable daemon.json still leaves the unit, which carries both the
+// socket flags and the TLS flags, so the two rules are answered.
+func TestUnreadableDaemonJSONWithAUnitIsNotPartial(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	// A directory in the file's place fails with EISDIR regardless of uid.
+	// CI runs some jobs as root, where a chmod 000 fixture would read fine
+	// and the test would pass without exercising anything.
+	if err := os.Mkdir(h.c.DaemonConfig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.c.Check(context.Background(), env(hardenedInfo, "-H fd://")); err != nil {
+		t.Fatalf("the unit covers what daemon.json would have: %v", err)
+	}
+}
+
+func TestUnreadableDaemonJSONAndNoUnitIsPartial(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	if err := os.Mkdir(h.c.DaemonConfig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	e := env(hardenedInfo, "") // no systemctl output registered
+	_, err := h.c.Check(context.Background(), e)
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("err = %v, want a PartialError", err)
+	}
+	if partial.Covered != 5 || partial.Total != 7 {
+		t.Errorf("coverage = %d/%d, want 5/7", partial.Covered, partial.Total)
+	}
+}
+
+func TestUnreadableGroupIsPartial(t *testing.T) {
+	h := host(t, "", cleanGroup, cleanPasswd, 0o660)
+	if err := os.Remove(h.c.GroupPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(h.c.GroupPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := h.c.Check(context.Background(), env(hardenedInfo, "-H fd://"))
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("err = %v, want a PartialError", err)
+	}
+	if partial.Covered != 6 || partial.Total != 7 {
+		t.Errorf("coverage = %d/%d, want 6/7", partial.Covered, partial.Total)
+	}
+}
+
+// --- contract -------------------------------------------------------------
+
+// A `docker` binary on PATH says nothing about whether this user may talk to
+// the socket, and a domain that accepted that would score a perfect axis on
+// exactly the host whose daemon nobody could examine.
+func TestAvailableRequiresAReachableDaemon(t *testing.T) {
+	r := fakeRunner{present: map[string]bool{"docker": true}} // no version output
+	ok, reason := New().Available(context.Background(), platform.Env{Runner: r})
+	if ok {
+		t.Fatal("Available should be false when the daemon does not answer")
+	}
+	if !strings.Contains(reason, "docker group") && !strings.Contains(reason, "sudo") {
+		t.Errorf("reason = %q, should tell the operator what to do", reason)
+	}
+}
+
+func TestAvailableWhenDockerIsAbsent(t *testing.T) {
+	ok, reason := New().Available(context.Background(), platform.Env{Runner: fakeRunner{}})
+	if ok {
+		t.Fatal("Available should be false with no Docker at all")
+	}
+	if reason == "" {
+		t.Error("a skipped domain must say why")
+	}
+}
+
+// Every finding must survive the engine's post-scan validation, carry this
+// domain's source, and be namespaced by it — the Valid() upper bound in
+// model.Source is a range check, and getting it wrong drops the whole domain
+// silently.
+func TestEveryFindingValidates(t *testing.T) {
+	h := host(t, `{"hosts":["tcp://0.0.0.0:2375"]}`,
+		"root:x:0:\ndocker:x:%GID%:alice\n",
+		cleanPasswd+"alice:x:1000:2000::/home/alice:/bin/bash\n", 0o666)
+	fs := h.check(t, env(bareInfo, "-H fd://"))
+	if len(fs) == 0 {
+		t.Fatal("expected findings from a thoroughly misconfigured daemon")
+	}
+	for _, f := range fs {
+		if err := f.Validate(); err != nil {
+			t.Errorf("%s: %v", f.ID, err)
+		}
+		if f.Source != model.SourceDockerd {
+			t.Errorf("%s: source = %v, want SourceDockerd", f.ID, f.Source)
+		}
+		if !strings.HasPrefix(f.ID, "dockerd.") {
+			t.Errorf("%s is not namespaced by its domain", f.ID)
+		}
+		if f.Remediation != model.RemediationManual {
+			t.Errorf("%s: remediation = %v; every dockerd finding is Manual by decision", f.ID, f.Remediation)
+		}
+		if f.Description == "" || f.HowToFix == "" {
+			t.Errorf("%s: a Manual finding is only as good as its prose", f.ID)
+		}
+	}
+}
+
+// Evidence assembled from a map iterates in a random order unless it is
+// sorted, and unstable evidence makes every repeat scan report a delta
+// nobody caused.
+func TestEvidenceIsStableAcrossScans(t *testing.T) {
+	h := host(t, `{"hosts":["tcp://0.0.0.0:2375","tcp://10.0.0.5:2376"]}`,
+		"root:x:0:\ndocker:x:%GID%:zoe,alice,mallory\n",
+		cleanPasswd+"alice:x:1000:2000::/home/alice:/bin/bash\nzoe:x:1002:2000::/home/zoe:/bin/bash\nmallory:x:1003:2000::/home/mallory:/bin/bash\n",
+		0o660)
+	first := fmt.Sprint(h.check(t, env(bareInfo, "-H fd://")))
+	for i := range 5 {
+		if got := fmt.Sprint(h.check(t, env(bareInfo, "-H fd://"))); got != first {
+			t.Fatalf("scan %d differs from the first:\n%s\n%s", i+2, first, got)
+		}
+	}
+}

--- a/internal/check/dockerd/info.go
+++ b/internal/check/dockerd/info.go
@@ -1,0 +1,89 @@
+package dockerd
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// info is the effective daemon state, as the daemon itself reports it.
+//
+// This is the only trustworthy source for the three default-hardening rules.
+// daemon.json says what the operator wrote down, which after an edit without
+// a restart is a statement about the future; `docker info` says what the
+// process running right now is doing, which is what an attacker meets.
+type info struct {
+	noNewPrivileges bool
+	usernsRemap     bool
+	rootless        bool
+	liveRestore     bool
+	swarmActive     bool
+
+	// opts is the raw SecurityOptions list, kept for evidence so an operator
+	// can see the same string the daemon reports.
+	opts []string
+}
+
+// securityOptions renders the daemon's security options for evidence, sorted
+// so a repeat scan produces no delta nobody caused.
+func (i info) securityOptions() string {
+	if len(i.opts) == 0 {
+		return "none reported"
+	}
+	out := append([]string(nil), i.opts...)
+	sort.Strings(out)
+	return strings.Join(out, model.EvidenceSeparator)
+}
+
+// infoJSON is the narrow view of `docker info` this domain needs. The full
+// document is several kilobytes — the runtime table alone carries every OCI
+// feature the installed runc supports — and decoding it into a map would
+// mean carrying all of that through a scan for five fields.
+type infoJSON struct {
+	SecurityOptions    []string `json:"SecurityOptions"`
+	LiveRestoreEnabled bool     `json:"LiveRestoreEnabled"`
+	Swarm              struct {
+		LocalNodeState string `json:"LocalNodeState"`
+	} `json:"Swarm"`
+}
+
+// readInfo asks the daemon what it is actually doing.
+//
+// The format is `{{json .}}` rather than the shorter `--format json`, which
+// only exists in Docker CLI 23 and later. A checker that fails on an older
+// CLI reports a degraded domain on a host that is merely not new, and the
+// difference costs nothing to avoid.
+func readInfo(ctx context.Context, r platform.CommandRunner) (info, bool, string) {
+	out, err := r.Run(ctx, "docker", "info", "--format", "{{json .}}")
+	if err != nil {
+		return info{}, false, "cannot read the daemon's effective configuration with `docker info` — its default hardening settings were not audited"
+	}
+	var d infoJSON
+	if err := json.Unmarshal(out, &d); err != nil {
+		return info{}, false, "the daemon's `docker info` output could not be parsed — its default hardening settings were not audited"
+	}
+
+	i := info{
+		opts:        d.SecurityOptions,
+		liveRestore: d.LiveRestoreEnabled,
+		swarmActive: d.Swarm.LocalNodeState == "active",
+	}
+	// SecurityOptions is a list of "name=value" entries where the presence of
+	// the name is the signal: the daemon lists a feature only when it is in
+	// force, so absence means off rather than unknown.
+	for _, o := range d.SecurityOptions {
+		switch name, _, _ := strings.Cut(o, ","); name {
+		case "name=no-new-privileges":
+			i.noNewPrivileges = true
+		case "name=userns":
+			i.usernsRemap = true
+		case "name=rootless":
+			i.rootless = true
+		}
+	}
+	return i, true, ""
+}

--- a/internal/check/dockerd/socket.go
+++ b/internal/check/dockerd/socket.go
@@ -1,0 +1,218 @@
+package dockerd
+
+import (
+	"bufio"
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// socket is the local unix socket's identity: how open it is, and which
+// group holds it.
+type socket struct {
+	path  string
+	perm  fs.FileMode
+	gid   uint32
+	group string // resolved name, or the numeric gid if it has none
+}
+
+// member is one account that holds the socket's group.
+type member struct {
+	name string
+	// system marks an account that does not log in interactively — a service
+	// identity rather than a person. It is what separates an administrator who
+	// chose this from a credential nobody is watching.
+	system bool
+}
+
+// readSocket stats the daemon's unix socket.
+//
+// A missing socket is not a failure. A daemon answered `docker version` or
+// this checker would not be running at all, so if there is nothing at this
+// path the client is reaching it another way — DOCKER_HOST pointing at a
+// remote daemon, or a socket somewhere non-standard. There is no local
+// socket to judge, which is a different thing from failing to judge one.
+func (c *Checker) readSocket() (s socket, known, absent bool, reason string) {
+	fi, err := os.Stat(c.SocketPath)
+	switch {
+	case err == nil:
+	case os.IsNotExist(err):
+		return socket{}, false, true, ""
+	default:
+		return socket{}, false, false,
+			fmt.Sprintf("cannot inspect %s — its permissions and owning group were not audited", c.SocketPath)
+	}
+
+	s = socket{path: c.SocketPath, perm: fi.Mode().Perm()}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		// No unix ownership information available. The mode is still a real
+		// answer, so the rule that needs it stands; the group rule reports
+		// separately that it could not be resolved.
+		return s, true, false, ""
+	}
+	s.gid = st.Gid
+	s.group = c.groupName(st.Gid)
+	return s, true, false, ""
+}
+
+// groupName resolves a gid to its name via /etc/group, falling back to the
+// numeric id.
+//
+// The socket's group is resolved by gid rather than by looking up the name
+// "docker", because the name is not fixed: daemon.json's "group" key and the
+// socket unit's SocketGroup both set it, so `"group": "wheel"` is legal and
+// means every member of wheel is root on this host. Asking for "docker" by
+// name would report a clean host in exactly the case worth catching.
+func (c *Checker) groupName(gid uint32) string {
+	f, err := os.Open(c.GroupPath)
+	if err != nil {
+		return strconv.FormatUint(uint64(gid), 10)
+	}
+	defer func() { _ = f.Close() }()
+
+	want := strconv.FormatUint(uint64(gid), 10)
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Split(sc.Text(), ":")
+		if len(fields) >= 3 && fields[2] == want {
+			return fields[0]
+		}
+	}
+	return want
+}
+
+// readMembers lists the accounts that hold the socket's group, excluding
+// root — which already has this authority by every other route, so naming it
+// here would be noise in a finding that is about everyone else.
+//
+// Membership comes from two places and both count: the group's own member
+// list in /etc/group, and any account in /etc/passwd whose *primary* group is
+// this gid. An account added with `useradd -g docker` appears only in the
+// second, and a checker that read only the first would miss it entirely.
+func (c *Checker) readMembers(gid uint32) ([]member, bool, string) {
+	secondary, err := c.secondaryMembers(gid)
+	if err != nil {
+		return nil, false, fmt.Sprintf("cannot read %s — the accounts holding the Docker socket's group were not audited", c.GroupPath)
+	}
+	accounts, err := c.accounts()
+	if err != nil {
+		return nil, false, fmt.Sprintf("cannot read %s — the accounts holding the Docker socket's group were not audited", c.PasswdPath)
+	}
+
+	held := map[string]bool{}
+	for _, n := range secondary {
+		held[n] = true
+	}
+	for _, a := range accounts {
+		if a.gid == gid {
+			held[a.name] = true
+		}
+	}
+	delete(held, "root")
+
+	var out []member
+	for name := range held {
+		m := member{name: name}
+		if a, ok := accounts[name]; ok {
+			m.system = a.system()
+		} else {
+			// Named in /etc/group but absent from /etc/passwd: the account was
+			// removed and the membership outlived it. Not a login, so it is
+			// treated as the service-account case.
+			m.system = true
+		}
+		out = append(out, m)
+	}
+	// Sorted so evidence is stable across scans; map iteration is not.
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+	return out, true, ""
+}
+
+// secondaryMembers reads the group's explicit member list from /etc/group.
+func (c *Checker) secondaryMembers(gid uint32) ([]string, error) {
+	f, err := os.Open(c.GroupPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	want := strconv.FormatUint(uint64(gid), 10)
+	var names []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Split(sc.Text(), ":")
+		if len(fields) < 4 || fields[2] != want {
+			continue
+		}
+		for _, n := range strings.Split(fields[3], ",") {
+			if n = strings.TrimSpace(n); n != "" {
+				names = append(names, n)
+			}
+		}
+	}
+	return names, sc.Err()
+}
+
+// account is one /etc/passwd entry, reduced to what decides whether its
+// holder is a person.
+type account struct {
+	name  string
+	uid   uint32
+	gid   uint32
+	shell string
+}
+
+// system reports whether this account is a service identity rather than a
+// human login. Both signals are needed: a distribution reserves uids below
+// 1000 for services, and an account created above that range with a nologin
+// shell (the shape most CI runners and agents take) is just as much a
+// credential nobody logs into and nobody watches.
+func (a account) system() bool {
+	if a.uid < 1000 {
+		return true
+	}
+	switch {
+	case strings.HasSuffix(a.shell, "/nologin"),
+		strings.HasSuffix(a.shell, "/false"),
+		a.shell == "":
+		return true
+	}
+	return false
+}
+
+func (c *Checker) accounts() (map[string]account, error) {
+	f, err := os.Open(c.PasswdPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	out := map[string]account{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Split(sc.Text(), ":")
+		if len(fields) < 7 {
+			continue
+		}
+		uid, err := strconv.ParseUint(fields[2], 10, 32)
+		if err != nil {
+			continue
+		}
+		gid, err := strconv.ParseUint(fields[3], 10, 32)
+		if err != nil {
+			continue
+		}
+		out[fields[0]] = account{
+			name:  fields[0],
+			uid:   uint32(uid),
+			gid:   uint32(gid),
+			shell: fields[6],
+		}
+	}
+	return out, sc.Err()
+}

--- a/internal/docs/findings_test.go
+++ b/internal/docs/findings_test.go
@@ -30,7 +30,7 @@ import (
 // findingID matches a namespaced finding ID. The namespace must be one of
 // the real sources, so incidental dotted strings in the check packages
 // (config filenames, config keys like net.bindIp) do not masquerade as IDs.
-var findingID = regexp.MustCompile(`^(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent|sysctl)\.[a-z0-9][a-z0-9.\-]*$`)
+var findingID = regexp.MustCompile(`^(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent|sysctl|dockerd)\.[a-z0-9][a-z0-9.\-]*$`)
 
 // composeRuleID matches compose's bare rule IDs, which reach NewFinding
 // through a helper that prefixes them: f("ds016", …) → "compose.ds016".

--- a/internal/docs/fixregister_test.go
+++ b/internal/docs/fixregister_test.go
@@ -52,7 +52,7 @@ func TestEveryFindingIsEitherFixableOrDeclinedOnPurpose(t *testing.T) {
 
 // registerID matches an ID as the register writes it, including the
 // source-wide glob form.
-var registerID = regexp.MustCompile(`\b(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent|sysctl)\.(\*|[a-z0-9][a-z0-9.\-]*)`)
+var registerID = regexp.MustCompile(`\b(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent|sysctl|dockerd)\.(\*|[a-z0-9][a-z0-9.\-]*)`)
 
 // declinedInRegister reads the doc comment on fix.Default and returns every
 // finding ID it names.

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -137,6 +137,19 @@ func TestKnownUnregisteredFindings(t *testing.T) {
 		// write-then-apply pair is sequential steps, not the independent
 		// alternatives Review requires.
 
+		// Every dockerd.* finding, one shared reason: the checker reads the
+		// running daemon's state while a fix would edit a file the daemon
+		// does not re-read until a restart that stops every container — so
+		// the fix would mark the finding Fixed and change nothing the next
+		// scan can see.
+		"dockerd.api-unauthenticated":   "removing the TCP endpoint severs the channel a remote operator may be administering the host through",
+		"dockerd.api-tls-unverified":    "same as dockerd.api-unauthenticated",
+		"dockerd.socket-world-writable": "the socket's mode is recreated from the systemd unit at every restart, so a chmod does not persist",
+		"dockerd.group-members":         "gpasswd -d is exec, and the member it removes may be the operator's own account",
+		"dockerd.no-new-privileges":     "a daemon default that takes effect only for containers started after a restart",
+		"dockerd.userns-remap":          "same, and it rewrites the ownership of every bind mount on the host",
+		"dockerd.live-restore":          "reload is exec with no checkpoint, and write-then-apply is sequential steps rather than Review's independent alternatives",
+
 		"compose.ds012":          "the right healthcheck depends on what the service exposes; a guessed one marks a working container unhealthy and stalls everything waiting on it",
 		"compose.dr004":          "the remediation is about the env_file's permissions and whether it is in git and backups — nothing in the compose file to edit",
 		"ports.exposed":          "the aggregate finding's remediation is firewall.inactive's, and is declined for the same reason",

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -259,6 +259,66 @@ package fix
 // the whole point: applying the second fix must not have to read what the
 // first wrote, and rolling one back must not take another's line with it.
 //
+// # The Docker daemon domain, declined whole
+//
+// dockerd.* has no registered fix at all — not one finding, and not because
+// nobody has looked. The two blockers that would ordinarily explain it are
+// both gone, which is why the real reason has to be written down.
+//
+// Action.CreateIfMissing handles the absent /etc/docker/daemon.json, exactly
+// as it does for the sysctl drop-in. And `dockerd --validate --config-file`
+// is a genuine `sshd -t` analogue: it rejects malformed JSON and unknown
+// directives, accepts an empty file — so verifyEdit's control run on the
+// original passes for a create-if-missing action — and needs no running
+// daemon. A VerifyCmd here would work.
+//
+// The reason is structural, and it is the one thing this domain does that
+// no other does: the checker reads the daemon's *running* state, while a fix
+// would edit a file the running daemon will not read again until it
+// restarts. `systemctl restart docker` stops every container on the host.
+//
+// So an applied fix would write the file, take a checkpoint, mark the
+// finding Fixed, and raise the score — while changing nothing an attacker
+// can see. The next scan asks `docker info`, gets the same answer as before,
+// and reports the finding again. A fix that improves the score without
+// improving the host is the objection already recorded for compose.ds016,
+// arriving by a different route.
+//
+// The asymmetry with SSH is what makes this consistent rather than
+// arbitrary. The ssh checker reads sshd_config, which is the same artifact
+// the ssh fix edits, so the Fixed mark is honest and the restart is a hint.
+// Here the artifact and the oracle are two different objects, and only one
+// of them is what the domain reports on.
+//
+// Each finding also has its own reason on top of that shared one:
+//
+//   - dockerd.api-unauthenticated and dockerd.api-tls-unverified — removing
+//     the TCP endpoint severs the exact channel a remote operator may be
+//     administering the host through: DOCKER_HOST, a Portainer agent, a CI
+//     runner. That is firewall.inactive's recoverability criterion.
+//   - dockerd.group-members — `gpasswd -d` is exec, so never Auto, and the
+//     member it removes may be the operator's own account and the access
+//     they administer the daemon with. That is accounts.emptypassword's
+//     objection.
+//   - dockerd.socket-world-writable — the socket's mode is not durable
+//     state. dockerd recreates the socket from the systemd docker.socket
+//     unit on every start, so a chmod is undone at the next restart and the
+//     honest remediation is a unit drop-in — which needs a restart to apply.
+//   - dockerd.live-restore — the one setting `systemctl reload docker` picks
+//     up without bouncing containers, which is what makes it look fixable.
+//     The reload is exec and has no checkpoint, and pairing it with the
+//     daemon.json edit is "write it, then apply it" — sequential steps, the
+//     shape Review forbids. Docker has no `sysctl -w` equivalent, no way to
+//     change a running daemon's setting in place, so there is no second
+//     independent alternative to pair with. That leaves one action, which
+//     would have to be Auto: `fix --all`, unattended, re-encoding the
+//     operator's daemon.json through encoding/json and reordering every key
+//     for a one-line change.
+//   - dockerd.no-new-privileges and dockerd.userns-remap — the shared reason
+//     alone. Both are daemon defaults that take effect only for containers
+//     started after a restart, and userns-remap additionally rewrites the
+//     ownership of every bind mount on the host.
+//
 // # The one CVE finding that does have a fix
 //
 // cve.outdated-image, the per-image rollup, IS registered, because its

--- a/internal/model/score.go
+++ b/internal/model/score.go
@@ -68,17 +68,37 @@ type axisDef struct {
 // "sysctl" ties with "fileperms" deliberately too: both are quiet local-
 // hardening backstops — neither is the hole an attacker comes in through,
 // each is what stops a foothold from becoming root.
+//
+// "dockerd" ties with "accounts" and "updates", and the tie is the argument:
+// like account hygiene it is a small rule set where one member is
+// catastrophic and the rest are hygiene, and like both it is excluded
+// entirely on a host it does not apply to. Six axes gave up a point to fund
+// it. "container" gave two because it was the only place any Docker risk
+// landed and was implicitly priced to cover the daemon as well; it no longer
+// has to, and compose findings are now strictly about what a service
+// declares. "ssh" gave one because on a host running Docker the daemon socket
+// is a second remote-administration channel with SSH's blast radius and none
+// of its hardening. "cve" gave one because both are Docker-conditional and an
+// open API hands over every container today, while an image's patch level is
+// a slower problem. "firewall" gave one because firewall.docker-bypass
+// already says the daemon walks through the host firewall. "ports" gave one
+// because this axis takes custody of the most dangerous port a Docker host
+// can publish — one the port table could never have judged, since the number
+// alone does not say whether TLS verification is in force. "agent" gave one
+// because its generous cap was argued from being N/A on most hosts, and that
+// argument now has a second claimant.
 var axisDefs = []axisDef{
-	{"container", "Container exposure", SourceCompose, 17},
-	{"ssh", "SSH hardening", SourceSSH, 16},
-	{"firewall", "Host firewall", SourceFirewall, 11},
+	{"container", "Container exposure", SourceCompose, 15},
+	{"ssh", "SSH hardening", SourceSSH, 15},
+	{"firewall", "Host firewall", SourceFirewall, 10},
 	{"updates", "Auto-updates", SourceUpdates, 7},
-	{"cve", "Vulnerabilities", SourceCVE, 12},
-	{"ports", "Exposed services", SourcePorts, 10},
+	{"cve", "Vulnerabilities", SourceCVE, 11},
+	{"ports", "Exposed services", SourcePorts, 9},
 	{"accounts", "Account hygiene", SourceAccounts, 7},
 	{"fileperms", "File permissions", SourceFilePerms, 5},
-	{"agent", "AI agent runtimes", SourceAgent, 10},
+	{"agent", "AI agent runtimes", SourceAgent, 9},
 	{"sysctl", "Kernel hardening", SourceSysctl, 5},
+	{"dockerd", "Docker daemon", SourceDockerd, 7},
 }
 
 // criticalHalves is the anchor of the whole penalty model: one Critical

--- a/internal/model/source.go
+++ b/internal/model/source.go
@@ -22,6 +22,7 @@ const (
 	SourceFilePerms
 	SourceAgent
 	SourceSysctl
+	SourceDockerd
 )
 
 // String returns the stable lowercase domain name, also used as the
@@ -48,6 +49,8 @@ func (s Source) String() string {
 		return "agent"
 	case SourceSysctl:
 		return "sysctl"
+	case SourceDockerd:
+		return "dockerd"
 	default:
 		return "unset"
 	}
@@ -92,6 +95,8 @@ func (s Source) Label() string {
 		return "AI agents"
 	case SourceSysctl:
 		return "Kernel"
+	case SourceDockerd:
+		return "Dockerd"
 	default:
 		return ""
 	}
@@ -104,7 +109,7 @@ func (s Source) Label() string {
 // finding from the new domain fails Validate() and is dropped after the
 // scan, so the domain reports clean rather than reporting nothing.
 func (s Source) Valid() bool {
-	return s >= SourceCompose && s <= SourceSysctl
+	return s >= SourceCompose && s <= SourceDockerd
 }
 
 // AllSources lists every real detection domain in scan/report order.
@@ -112,5 +117,6 @@ func AllSources() []Source {
 	return []Source{
 		SourceCompose, SourceSSH, SourceFirewall, SourceUpdates, SourceCVE,
 		SourcePorts, SourceAccounts, SourceFilePerms, SourceAgent, SourceSysctl,
+		SourceDockerd,
 	}
 }

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -102,6 +102,7 @@
                   <tr><td>File permissions</td><td><code>fileperms.</code></td><td>—</td></tr>
                   <tr><td>AI agent runtimes</td><td><code>agent.</code></td><td>OpenClaw or Hermes installed</td></tr>
                   <tr><td>Kernel hardening</td><td><code>sysctl.</code></td><td>—</td></tr>
+                  <tr><td>Docker daemon</td><td><code>dockerd.</code></td><td>Docker</td></tr>
                   <tr><td>Image CVEs <em>(optional)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -130,14 +131,15 @@
               <table>
                 <thead><tr><th>Axis</th><th>Weight</th></tr></thead>
                 <tbody>
-                  <tr><td>Container exposure</td><td>17</td></tr>
-                  <tr><td>SSH hardening</td><td>16</td></tr>
-                  <tr><td>Vulnerabilities</td><td>12</td></tr>
-                  <tr><td>Host firewall</td><td>11</td></tr>
-                  <tr><td>Exposed services</td><td>10</td></tr>
-                  <tr><td>AI agent runtimes</td><td>10</td></tr>
+                  <tr><td>Container exposure</td><td>15</td></tr>
+                  <tr><td>SSH hardening</td><td>15</td></tr>
+                  <tr><td>Vulnerabilities</td><td>11</td></tr>
+                  <tr><td>Host firewall</td><td>10</td></tr>
+                  <tr><td>Exposed services</td><td>9</td></tr>
+                  <tr><td>AI agent runtimes</td><td>9</td></tr>
                   <tr><td>Account hygiene</td><td>7</td></tr>
                   <tr><td>Auto-updates</td><td>7</td></tr>
+                  <tr><td>Docker daemon</td><td>7</td></tr>
                   <tr><td>File permissions</td><td>5</td></tr>
                   <tr><td>Kernel hardening</td><td>5</td></tr>
                 </tbody>
@@ -291,6 +293,28 @@
                 </tbody>
               </table>
             </div>
+
+            <h2 id="dockerd">Docker daemon <code>dockerd.</code></h2>
+            <p>The Compose audit judges what your services declare and the CVE scan judges the images they run. This domain judges the daemon underneath both — the part of the stack that actually holds root.</p>
+            <p>It is worth being blunt about the worst finding here, because it is the worst finding hostveil has. A daemon listening on a TCP port without TLS client verification is root on the host for anyone who can reach that port: no password, no vulnerability, one HTTP request that starts a container with your filesystem mounted inside it. Membership in the socket's group is the same authority from a local account, and unlike <code>sudo</code> it asks for nothing and logs nothing.</p>
+            <p><strong>Three sources, and they disagree.</strong> Docker's settings live in <code>/etc/docker/daemon.json</code>, in flags on the service unit, and in the running daemon — and after an edit without a restart those are different answers. So the daemon defaults are read from <code>docker info</code>, which is what the daemon actually loaded rather than what someone wrote down; the socket and TLS settings are read from the file and the unit together, because <code>docker info</code> does not report them at all; and <code>ss</code> supplies the endpoint you can go and verify, without ever deciding whether a finding exists.</p>
+            <p><strong>Every finding here is Manual, on purpose.</strong> The checker reads the running daemon, but a fix would edit a file the daemon does not read again until it restarts — and restarting Docker stops every container on the host. A fix that marked the finding resolved and raised your score while changing nothing an attacker can see would be worse than no fix, so the how-to-fix text carries the exact change and you choose the moment.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it means</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>dockerd.api-unauthenticated</code></td><td>The Docker API is served over TCP with no TLS client verification — unauthenticated root for anyone who can reach the port</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.socket-world-writable</code></td><td>Every local account can connect to the Docker socket, and so become root</td><td><span class="sev critical">Critical</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.api-tls-unverified</code></td><td>The API is encrypted but accepts any client — TLS without <code>tlsverify</code> authenticates the server, not the caller</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.group-members</code></td><td>Accounts other than root hold the socket's group, which is root-equivalent with no password prompt and no audit record</td><td><span class="sev medium">Medium</span> / <span class="sev high">High</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.no-new-privileges</code></td><td>Containers can still gain privileges through setuid binaries</td><td><span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.userns-remap</code></td><td>User namespaces are not remapped, so container root is host root</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>dockerd.live-restore</code></td><td>Restarting the daemon stops every container, which is why daemon updates get deferred</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><code>dockerd.group-members</code> is <span class="sev medium">Medium</span> when the accounts holding the group are people, and <span class="sev high">High</span> when any of them is a service account — one with a system UID or no interactive login. Nobody deliberately grants a CI runner or a monitoring agent the ability to become root, and a credential that never logs in is one nobody is watching.</p>
+            <p>A loopback-only TCP socket is not flagged: it reaches nothing the unix socket did not, and it is the documented way to put a proxy in front of the daemon. A daemon running <strong>rootless</strong> has <code>userns-remap</code> and <code>group-members</code> suppressed and its API finding lowered to <span class="sev high">High</span>, because the blast radius is that user's containers rather than the host. <code>live-restore</code> is suppressed on a swarm node, where Docker does not support it.</p>
 
             <h2 id="agent">AI agent runtimes <code>agent.</code></h2>
             <p>Self-hosted AI agents — <a href="https://docs.openclaw.ai/">OpenClaw</a> and <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a> — run a network gateway and keep API keys on disk in your home directory. Misconfigured, the worst case is someone reaching that gateway and driving an agent that can read your files and run commands as you.</p>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -102,6 +102,7 @@
                   <tr><td>파일 권한</td><td><code>fileperms.</code></td><td>—</td></tr>
                   <tr><td>AI 에이전트 런타임</td><td><code>agent.</code></td><td>OpenClaw 또는 Hermes 설치</td></tr>
                   <tr><td>커널 하드닝</td><td><code>sysctl.</code></td><td>—</td></tr>
+                  <tr><td>Docker 데몬</td><td><code>dockerd.</code></td><td>Docker</td></tr>
                   <tr><td>이미지 CVE <em>(선택)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -130,14 +131,15 @@
               <table>
                 <thead><tr><th>축</th><th>가중치</th></tr></thead>
                 <tbody>
-                  <tr><td>컨테이너 노출</td><td>17</td></tr>
-                  <tr><td>SSH 하드닝</td><td>16</td></tr>
-                  <tr><td>취약점</td><td>12</td></tr>
-                  <tr><td>호스트 방화벽</td><td>11</td></tr>
-                  <tr><td>노출된 서비스</td><td>10</td></tr>
-                  <tr><td>AI 에이전트 런타임</td><td>10</td></tr>
+                  <tr><td>컨테이너 노출</td><td>15</td></tr>
+                  <tr><td>SSH 하드닝</td><td>15</td></tr>
+                  <tr><td>취약점</td><td>11</td></tr>
+                  <tr><td>호스트 방화벽</td><td>10</td></tr>
+                  <tr><td>노출된 서비스</td><td>9</td></tr>
+                  <tr><td>AI 에이전트 런타임</td><td>9</td></tr>
                   <tr><td>계정 위생</td><td>7</td></tr>
                   <tr><td>자동 업데이트</td><td>7</td></tr>
+                  <tr><td>Docker 데몬</td><td>7</td></tr>
                   <tr><td>파일 권한</td><td>5</td></tr>
                   <tr><td>커널 하드닝</td><td>5</td></tr>
                 </tbody>
@@ -291,6 +293,28 @@
                 </tbody>
               </table>
             </div>
+
+            <h2 id="dockerd">Docker 데몬 <code>dockerd.</code></h2>
+            <p>Compose 점검은 서비스가 무엇을 선언했는지를 보고, CVE 점검은 그 서비스가 돌리는 이미지를 봅니다. 이 영역은 그 둘 밑에 있는 데몬 자체 — 실제로 root를 쥐고 있는 부분 — 을 봅니다.</p>
+            <p>여기서 가장 심각한 항목은 hostveil 전체에서 가장 심각한 항목이므로 분명히 말해 둘 필요가 있습니다. TLS 클라이언트 검증 없이 TCP 포트로 듣고 있는 데몬은 그 포트에 닿을 수 있는 누구에게나 호스트의 root입니다. 비밀번호도, 취약점도 필요 없고, 당신의 파일시스템을 안에 마운트한 컨테이너를 시작하는 HTTP 요청 하나면 됩니다. 소켓 그룹의 멤버십은 로컬 계정에서 얻는 같은 권한이고, <code>sudo</code>와 달리 아무것도 묻지 않고 아무것도 기록하지 않습니다.</p>
+            <p><strong>출처가 셋이고, 서로 어긋납니다.</strong> Docker 설정은 <code>/etc/docker/daemon.json</code>, 서비스 유닛의 플래그, 그리고 실행 중인 데몬 안에 각각 있습니다 — 재시작 없이 파일만 고쳤다면 이 셋은 서로 다른 답입니다. 그래서 데몬 기본값은 <code>docker info</code>에서 읽습니다. 누가 적어 둔 내용이 아니라 데몬이 실제로 적재한 내용이기 때문입니다. 소켓과 TLS 설정은 파일과 유닛을 함께 읽습니다. <code>docker info</code>가 아예 보고하지 않기 때문입니다. <code>ss</code>는 직접 확인해 볼 수 있는 엔드포인트를 증거로 덧붙이되, 발견 항목의 존재 여부를 결정하지는 않습니다.</p>
+            <p><strong>여기의 모든 항목은 의도적으로 수동입니다.</strong> 점검기는 실행 중인 데몬을 읽지만, 수정은 데몬이 재시작 전까지 다시 읽지 않는 파일을 고치게 됩니다 — 그리고 Docker를 재시작하면 호스트의 모든 컨테이너가 멈춥니다. 공격자에게 보이는 것은 아무것도 바꾸지 않은 채 항목을 해결됨으로 표시하고 점수만 올리는 수정은 수정이 없는 편만 못합니다. 그래서 조치 안내에 정확한 변경 내용을 담고, 시점은 당신이 고릅니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>의미</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>dockerd.api-unauthenticated</code></td><td>Docker API가 TLS 클라이언트 검증 없이 TCP로 제공됩니다 — 포트에 닿는 누구에게나 인증 없는 root</td><td><span class="sev critical">심각</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.socket-world-writable</code></td><td>모든 로컬 계정이 Docker 소켓에 접속할 수 있고, 따라서 root가 될 수 있습니다</td><td><span class="sev critical">심각</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.api-tls-unverified</code></td><td>API가 암호화되어 있지만 아무 클라이언트나 받습니다 — <code>tlsverify</code> 없는 TLS는 서버를 인증할 뿐 호출자를 인증하지 않습니다</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.group-members</code></td><td>root 외의 계정이 소켓 그룹을 갖고 있습니다. 비밀번호 확인도 감사 기록도 없는 root 동등 권한입니다</td><td><span class="sev medium">보통</span> / <span class="sev high">높음</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.no-new-privileges</code></td><td>컨테이너가 여전히 setuid 바이너리로 권한을 얻을 수 있습니다</td><td><span class="sev medium">보통</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.userns-remap</code></td><td>사용자 네임스페이스가 재매핑되지 않아 컨테이너 root가 곧 호스트 root입니다</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                  <tr><td><code>dockerd.live-restore</code></td><td>데몬을 재시작하면 모든 컨테이너가 멈춥니다. 그래서 데몬 업데이트가 미뤄집니다</td><td><span class="sev low">낮음</span></td><td>수동</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><code>dockerd.group-members</code>는 그룹을 가진 계정이 사람일 때 <span class="sev medium">보통</span>, 그중 하나라도 서비스 계정 — 시스템 UID이거나 대화형 로그인이 없는 계정 — 이면 <span class="sev high">높음</span>입니다. CI 러너나 모니터링 에이전트에게 root가 될 능력을 일부러 주는 사람은 없고, 한 번도 로그인하지 않는 자격 증명은 아무도 지켜보지 않는 자격 증명입니다.</p>
+            <p>루프백 전용 TCP 소켓은 표시하지 않습니다. 유닉스 소켓이 닿지 않던 곳에 닿지 않고, 데몬 앞에 프록시를 두는 문서화된 방법이기 때문입니다. <strong>rootless</strong>로 실행 중인 데몬은 <code>userns-remap</code>과 <code>group-members</code>가 억제되고 API 항목이 <span class="sev high">높음</span>으로 내려갑니다. 피해 범위가 호스트가 아니라 그 사용자의 컨테이너이기 때문입니다. <code>live-restore</code>는 Docker가 지원하지 않는 swarm 노드에서 억제됩니다.</p>
 
             <h2 id="agent">AI 에이전트 런타임 <code>agent.</code></h2>
             <p>셀프호스트 AI 에이전트인 <a href="https://docs.openclaw.ai/">OpenClaw</a>와 <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a>는 네트워크 게이트웨이를 띄우고 API 키를 홈 디렉터리에 저장합니다. 설정이 잘못되면 최악의 경우 외부에서 그 게이트웨이에 접근해, 내 파일을 읽고 내 권한으로 명령을 실행하는 에이전트를 그대로 조종할 수 있습니다.</p>


### PR DESCRIPTION
## What and why

The compose domain judges what a service declares and the CVE domain judges the images it runs. Neither looks at the daemon underneath — the part of that stack that actually holds root. So the single worst misconfiguration a self-hosted Docker server can have was invisible to hostveil.

A daemon listening on TCP without TLS client verification is **unauthenticated root** for anyone who can reach the port: no password, no vulnerability, one HTTP request that creates a container with `/` mounted inside it.

No existing domain could have caught it, and not by oversight:

- `internal/check/ports` has neither 2375 nor 2376 in `datastorePorts`/`adminPorts`, and adding them would not help — the port number alone does not say whether TLS verification is in force, and its generic exposure finding is suppressed whenever a firewall is active.
- `internal/check/accounts` cannot own the group finding: it gates on a readable `/etc/passwd` and has no way to ask whether Docker is here, so it would report root-equivalence for a group left behind by a removed package. It also could not resolve the group correctly — the socket's group is whatever owns it, and `"group": "wheel"` in daemon.json is legal.
- `internal/check/fileperms` cannot own the socket mode: `core.planModes` refuses any path that is not a regular file or directory, and `registerFilePerms` registers an **Auto** mode-fix for every fileperms finding, so the button would always error at apply.

## Three sources that disagree

The hard part was deciding what to believe. Docker's configuration lives in `daemon.json`, in flags on the unit, and in the running daemon — and after an edit without a restart those are different answers. Each rule names one source, and the package doc carries the reasoning:

- **`docker info` for effective daemon state** (no-new-privileges, userns-remap, live-restore). Reading the file for these would report the operator's *intention* as though it were the machine's behaviour.
- **daemon.json ∪ the unit's ExecStart for the socket and TLS settings** — `docker info` reports no listening addresses and no TLS settings whatsoever. Both are unioned because the packaged unit ships `-H fd://` while an operator adding TCP may edit either.
- **`ss` for what is actually listening** — evidence only. It can see the door but not the lock, so its absence is not lost ground.

## Every finding is Manual, and not for want of machinery

Both blockers you would expect are gone. `Action.CreateIfMissing` (#600) handles an absent daemon.json, and `dockerd --validate --config-file` is a genuine `sshd -t` analogue — **verified on a real daemon**: it rejects malformed JSON, and accepts an empty file, so `verifyEdit`'s control run on the original passes for a create-if-missing action.

The blocker is structural: **the checker reads the running daemon, while a fix would edit a file the daemon does not re-read until a restart that stops every container.** An applied fix would write, checkpoint, mark the finding Fixed and raise the score — while changing nothing an attacker can see; the next scan asks `docker info`, gets the same answer, and reports it again. That is `compose.ds016`'s recorded objection arriving by another route. SSH is different, and the difference is the point: its checker reads the same artifact its fix edits.

All seven are named in `fix.Default()`'s register with their own reasons on top of the shared one.

## The score moves on every Docker host

Six caps give up a point (container gives two) to fund a cap of 7, so **an existing host's overall score changes with identical findings**. Per-finding deltas are unaffected; `history --scans` will show one step at this release. Reasoning for each of the six is in the `axisDefs` doc comment. The release changelog will lead with this.

| | container | ssh | cve | firewall | ports | agent | **dockerd** |
| --- | --- | --- | --- | --- | --- | --- | --- |
| before | 17 | 16 | 12 | 11 | 10 | 10 | — |
| after | 15 | 15 | 11 | 10 | 9 | 9 | **7** |

## Verification

Beyond the unit tests, the checker was run against a real daemon and cross-checked against ground truth:

```
$ hostveil scan --only dockerd
  Docker daemon           67/100  2 medium, 2 low
$ # evidence: {group: docker, members: seolcu}, severity Medium
$ getent group $(stat -c %g /var/run/docker.sock)   ->  docker:x:969:seolcu
$ stat -c '%a %G' /var/run/docker.sock              ->  660 docker
```

The group was resolved by gid (969), not by the name "docker"; mode 660 correctly produced no socket finding.

Two empirical claims in the code comments were measured rather than assumed: `docker info --format '{{json .}}'` really does report `SecurityOptions` as `name=`-prefixed entries with no addresses or TLS fields anywhere, and `dockerd --validate` behaves as described above.

## Checklist

- [x] Title is conventional with a valid scope (`check`).
- [x] Ran the CI gate locally and it passes — build, vet, gofmt, `go mod tidy`, `go test -race ./...`, `golangci-lint` (0 issues), `govulncheck` (no vulnerabilities), `sitegen` with no `site/` drift.
- [x] For a new or changed detection rule: documented in both languages, both `site/` outputs regenerated, README row added, register entry written, AGENTS.md checker count updated. Every one of those was demanded by a failing test in `internal/docs` before it was written.
- [x] For a UI change: n/a — nothing in `internal/ui` needed touching. Since #595 the dashboard's domain table, the TUI's labels, the progress display and the `--only`/`--skip` vocabulary all derive from `model.AllSources()`.
- [x] The score stays honest — a host with no reachable daemon reports the domain **Skipped** with a reason and the axis N/A, never a clean 100. Losing `docker info` after `Available()` passed is **Degraded at 4/7**, keeping the four rules that genuinely ran including two of the three Criticals; losing `ss` is not degradation at all.

## Not done here

Demo seeding, which follows in its own PR: it makes a VM genuinely more dangerous (a real unauthenticated daemon and a world-writable socket) and deserves its own review thread rather than a paragraph at the end of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)