### PR TITLE
docs: record the post-fix re-check in the 3.7.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,17 @@ to Review, which changes the button they carry, not the number.
   beside the delta line. `model.Sparkline` buckets the scores once and both
   interfaces render what it returns, so the rule cannot drift the way the
   severity palette and the domain table each did before it.
+* **core:** re-check the finding after applying its fix
+  ([#607](https://github.com/seolcu/hostveil/issues/607)). "hostveil wrote
+  the file" and "the finding is gone" are different claims, and only the
+  first was ever established — `markFixed` set the flag the moment an apply
+  returned, and the score moved on that. A fix now re-runs its own domain
+  and says which of the three it got: gone, still reported, or unconfirmed.
+  The result deliberately does not decide whether the finding counts as
+  fixed. A persisted kernel drop-in is correct and complete while the
+  running kernel still reports the old value until the next boot, so a
+  checker that still sees it is not evidence of failure — and a re-check
+  that was skipped or degraded has established nothing in either direction.
 
 ### Bug Fixes
 


### PR DESCRIPTION
## What and why

#607 merged between the last changelog amendment (#608, for #606) and the tag, so the 3.7.0 entry is one bullet short again. Same reason as last time: the entry header's compare link is `v3.6.0...v3.7.0`, so tagging main as it stands publishes release notes that are wrong about their own release.

With this, all fifteen commits since `v3.6.0` are accounted for. **v3.7.0 is tagged immediately after this lands** — the entry has now been amended twice for features that arrived while it was open, and the fix for that is to stop leaving a gap between the changelog and the tag, not to keep amending.

Version is unchanged: `feat` commits were already in the range, so the bump was already minor.

## Checklist

- [x] Title is conventional with a valid scope (`docs:`).
- [x] Ran the CI gate locally and it passes.
- [x] For a new or changed detection rule: n/a — CHANGELOG.md only, no code.
- [x] For a UI change: n/a.
- [x] The score stays honest — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)