### PR TITLE
feat(check): check who owns a sensitive file, not just its mode

### DIFF
--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -184,6 +184,7 @@
                   <tr><td><code>fileperms.passwd</code></td><td><code>/etc/passwd</code> is writable by non-root users</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>fileperms.group</code></td><td><code>/etc/group</code> is writable by non-root users</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>fileperms.hostkey</code></td><td>An SSH host private key is readable beyond root</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>fileperms.owner</code></td><td>One of the files above is not owned by root — permissions are only half of who can read it</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>fileperms.sshd-config</code></td><td><code>sshd_config</code> is writable by non-root users</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
                 </tbody>
               </table>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -184,6 +184,7 @@
                   <tr><td><code>fileperms.passwd</code></td><td><code>/etc/passwd</code>가 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>fileperms.group</code></td><td><code>/etc/group</code>이 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>fileperms.hostkey</code></td><td>SSH 호스트 개인 키를 root 외 사용자가 읽을 수 있음</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>fileperms.owner</code></td><td>위 파일 중 하나가 root 소유가 아님 — 누가 읽을 수 있는지는 권한 비트만으로 정해지지 않음</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>fileperms.sshd-config</code></td><td><code>sshd_config</code>가 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
                 </tbody>
               </table>

--- a/internal/check/fileperms/fileperms.go
+++ b/internal/check/fileperms/fileperms.go
@@ -1,8 +1,9 @@
-// Package fileperms implements a native checker for over-permissive modes
-// on sensitive host files. A world-writable /etc/passwd or a group-readable
-// SSH host key is a quiet but serious hole; this checker stats a curated set
-// of security-critical files and flags any whose permission bits are looser
-// than they should ever be.
+// Package fileperms implements a native checker for the two things that
+// decide who can read and write a sensitive host file: its permission bits
+// and its owner. A world-writable /etc/passwd or a group-readable SSH host
+// key is a quiet but serious hole, and so is a mode-0600 /etc/shadow that
+// belongs to somebody other than root — 0600 says "only the owner", and the
+// whole question is who that is.
 package fileperms
 
 import (
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/seolcu/hostveil/internal/check"
 	"github.com/seolcu/hostveil/internal/model"
@@ -61,14 +63,42 @@ func (r Rule) paths() ([]string, error) {
 	return nil, nil
 }
 
+// ownerFinding reports sensitive files that are not owned by root.
+//
+// The mode rules above answer "how much access do the bits grant" and
+// stopped there, which is only half the question: mode 0600 grants
+// everything to the owner and nothing to anyone else, so a /etc/shadow at
+// 0600 owned by an ordinary user hands that user every password hash on the
+// host — and the mode check calls it clean, because 0600 is exactly what it
+// wants to see. Ownership is the other half, and every file in this table
+// belongs to root on every distribution.
+//
+// One finding for all of them rather than one per path: the remediation is
+// the same `chown root:root` in every case, and a host where this has gone
+// wrong has usually had it go wrong to several files at once (a restore from
+// a backup taken as the wrong user, an extracted archive).
+const ownerFindingID = "fileperms.owner"
+
+// rootUID is the owner every file in the rule table must have on a real
+// host. These are paths whose ownership is fixed by the system, not by
+// preference — Checker.OwnerUID exists only so a test can assert both
+// directions without caring which account runs the suite.
+const rootUID = 0
+
 // Checker reports sensitive files with over-permissive modes.
 type Checker struct {
 	// Rules is the set of files to check; overridable for tests.
 	Rules []Rule
+	// OwnerUID is the uid every rule's file must belong to. Zero means
+	// root, which is the answer on every real host; it is a field so a test
+	// can assert the wrongly-owned case without having to run as a
+	// particular account, and so the suite behaves the same under root and
+	// under CI's unprivileged user.
+	OwnerUID int
 }
 
 // New returns a fileperms checker with the default sensitive-file rules.
-func New() *Checker { return &Checker{Rules: defaultRules()} }
+func New() *Checker { return &Checker{Rules: defaultRules(), OwnerUID: rootUID} }
 
 func defaultRules() []Rule {
 	return []Rule{
@@ -99,7 +129,8 @@ func (*Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
 	return true, ""
 }
 
-// Check stats each rule's file(s) and flags any over-permissive mode.
+// Check stats each rule's file(s) and flags any over-permissive mode, and any
+// file not owned by root.
 //
 // A rule it could not evaluate is recorded as a coverage gap rather than
 // passed over. "This file is not here" and "I was not allowed to look at it"
@@ -109,6 +140,7 @@ func (*Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
 // wrong people.
 func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, error) {
 	var findings []model.Finding
+	var wrongOwner []string
 	var cov check.Coverage
 	for _, rule := range c.Rules {
 		paths, err := rule.paths()
@@ -133,6 +165,12 @@ func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, err
 				continue
 			case fi.IsDir():
 				continue
+			}
+			// Checked for every rule, and independently of the mode: a file
+			// can have impeccable bits and the wrong owner, which is the
+			// case the mode check reads as clean.
+			if uid, ok := fileUID(fi); ok && uid != c.OwnerUID {
+				wrongOwner = append(wrongOwner, fmt.Sprintf("%s (uid %d)", p, uid))
 			}
 			if fi.Mode().Perm()&^rule.MaxMode != 0 {
 				badPaths = append(badPaths, p)
@@ -163,5 +201,30 @@ func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, err
 			model.WithEvidence("expected", fmt.Sprintf("%#o", rule.MaxMode)),
 		))
 	}
+
+	if len(wrongOwner) > 0 {
+		sort.Strings(wrongOwner)
+		findings = append(findings, model.NewFinding(ownerFindingID,
+			"A sensitive system file is not owned by root",
+			model.SeverityHigh, model.SourceFilePerms, model.RemediationManual,
+			model.WithDescription("These files are owned by an account other than root. Permission bits are only half of who can read and write a file — the other half is who the owner is. A mode-0600 /etc/shadow grants everything to its owner and nothing to anyone else, so if that owner is an ordinary user, they hold every password hash on the host while the permissions look exactly right."),
+			model.WithHowToFix("Restore root ownership, e.g. `chown root:root "+strings.SplitN(wrongOwner[0], " ", 2)[0]+"`. Check the group too — /etc/shadow is usually root:shadow. If this happened to several files at once, something restored them as the wrong user; look at how they got there before assuming a chown is the whole fix."),
+			model.WithEvidence("files", strings.Join(wrongOwner, model.EvidenceSeparator)),
+		))
+	}
 	return findings, cov.Err()
+}
+
+// fileUID reports the owning uid, and whether the platform gave one.
+//
+// ok is false where the stat result carries no Unix owner. That reads as
+// "could not tell", and the caller flags nothing — the same rule the rest of
+// this tool follows, because an unowned-looking file is a gap in what we can
+// see rather than evidence about the host.
+func fileUID(fi os.FileInfo) (int, bool) {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(st.Uid), true
 }

--- a/internal/check/fileperms/fileperms_test.go
+++ b/internal/check/fileperms/fileperms_test.go
@@ -25,9 +25,14 @@ func writeMode(t *testing.T, name string, mode os.FileMode) string {
 	return path
 }
 
+// run drives the mode rules and nothing else. OwnerUID is the account
+// running the suite, so the fixtures in this file — temp files owned by
+// whoever that is — are correctly owned and the ownership check stays
+// silent. Without it these tests pass under root and fail under CI's
+// unprivileged user, which is exactly how this was caught.
 func run(t *testing.T, rules []Rule) []model.Finding {
 	t.Helper()
-	fs, err := (&Checker{Rules: rules}).Check(context.Background(), platform.Env{})
+	fs, err := (&Checker{Rules: rules, OwnerUID: os.Geteuid()}).Check(context.Background(), platform.Env{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/check/fileperms/owner_test.go
+++ b/internal/check/fileperms/owner_test.go
@@ -1,0 +1,141 @@
+package fileperms
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// The mode rules answer "how much access do the bits grant" and stopped
+// there, which is only half the question. Mode 0600 grants everything to
+// the owner and nothing to anyone else — so a /etc/shadow at 0600 owned by
+// an ordinary user hands that user every password hash on the host, and the
+// mode check calls it clean because 0600 is exactly what it wants to see.
+// That is a false clean, the failure class this whole tool is built to
+// refuse.
+
+// ownerFixture builds a checker over one file. wrongOwner decides whether
+// the checker expects an owner the file does not have, so both directions
+// are exercised whoever runs the suite — under root and under CI's
+// unprivileged user alike.
+func ownerFixture(t *testing.T, mode os.FileMode, wrongOwner bool) (*Checker, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "shadow")
+	if err := os.WriteFile(path, []byte("root:!:20000:0:99999:7:::\n"), mode); err != nil {
+		t.Fatal(err)
+	}
+	// Chmod explicitly: WriteFile's perm is masked by umask, and this test
+	// is about exact bits.
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatal(err)
+	}
+	want := os.Geteuid()
+	if wrongOwner {
+		want++ // an account the file certainly does not belong to
+	}
+	return &Checker{OwnerUID: want, Rules: []Rule{{
+		Path: path, MaxMode: 0o640, Sev: model.SeverityHigh, ID: "fileperms.shadow",
+		Title: "t", Desc: "d",
+	}}}, path
+}
+
+func runOwner(t *testing.T, c *Checker) []model.Finding {
+	t.Helper()
+	fs, err := c.Check(context.Background(), platform.Env{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs
+}
+
+func hasFinding(fs []model.Finding, id string) bool {
+	for _, f := range fs {
+		if f.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// The tests run as whatever uid the suite runs as. Under root that is 0 and
+// the fixture is correctly owned; unprivileged, it is not — which is the
+// interesting case and the one CI actually exercises.
+func TestOwnershipIsCheckedIndependentlyOfMode(t *testing.T) {
+	for name, wrong := range map[string]bool{"correctly owned": false, "wrongly owned": true} {
+		t.Run(name, func(t *testing.T) {
+			c, _ := ownerFixture(t, 0o600, wrong)
+			fs := runOwner(t, c)
+
+			// Impeccable bits, so the mode rule stays quiet either way —
+			// which is exactly why the mode check alone called this clean.
+			if hasFinding(fs, "fileperms.shadow") {
+				t.Errorf("a 0600 file was flagged for its mode: %v", fs)
+			}
+			if got := hasFinding(fs, ownerFindingID); got != wrong {
+				t.Errorf("owner finding fired = %v, want %v", got, wrong)
+			}
+		})
+	}
+}
+
+// A file with both problems produces both findings: they are different
+// questions with different remediations, and collapsing them would hide one.
+func TestModeAndOwnerAreSeparateFindings(t *testing.T) {
+	c, _ := ownerFixture(t, 0o666, true)
+	fs := runOwner(t, c)
+
+	for _, id := range []string{"fileperms.shadow", ownerFindingID} {
+		if !hasFinding(fs, id) {
+			t.Errorf("%s did not fire on a file that is both loose and wrongly owned: %v", id, fs)
+		}
+	}
+}
+
+// The finding has to name the files and carry a remediation a person can
+// act on — and say the group is not guessable, because /etc/shadow is
+// root:shadow on Debian and root:root elsewhere.
+func TestOwnerFindingIsActionable(t *testing.T) {
+	c, path := ownerFixture(t, 0o600, true)
+	var owner model.Finding
+	for _, f := range runOwner(t, c) {
+		if f.ID == ownerFindingID {
+			owner = f
+		}
+	}
+	if owner.ID == "" {
+		t.Fatal("no owner finding")
+	}
+	if err := owner.Validate(); err != nil {
+		t.Fatalf("invalid finding: %v", err)
+	}
+	if !strings.Contains(owner.Evidence["files"], path) {
+		t.Errorf("the evidence does not name the file: %q", owner.Evidence["files"])
+	}
+	if !strings.Contains(owner.HowToFix, "chown root:root "+path) {
+		t.Errorf("the how-to-fix does not carry a runnable command: %q", owner.HowToFix)
+	}
+	if !strings.Contains(owner.HowToFix, "group") {
+		t.Errorf("the how-to-fix does not mention the group, which differs by distribution: %q", owner.HowToFix)
+	}
+	// Manual on purpose: chown has no checkpoint. The register says why.
+	if owner.Remediation != model.RemediationManual {
+		t.Errorf("remediation = %v, want Manual", owner.Remediation)
+	}
+}
+
+// A missing file is not a finding, here as everywhere else in this checker:
+// no SSH server means no host keys, not a problem with the host keys.
+func TestAMissingFileHasNoOwner(t *testing.T) {
+	c := &Checker{OwnerUID: os.Geteuid() + 1, Rules: []Rule{{
+		Path: filepath.Join(t.TempDir(), "absent"), MaxMode: 0o600,
+		Sev: model.SeverityHigh, ID: "fileperms.shadow", Title: "t", Desc: "d",
+	}}}
+	if fs := runOwner(t, c); len(fs) != 0 {
+		t.Errorf("a missing file produced %v", fs)
+	}
+}

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -150,6 +150,7 @@ func TestKnownUnregisteredFindings(t *testing.T) {
 		"dockerd.userns-remap":          "same, and it rewrites the ownership of every bind mount on the host",
 		"dockerd.live-restore":          "reload is exec with no checkpoint, and write-then-apply is sequential steps rather than Review's independent alternatives",
 
+		"fileperms.owner":        "chown has no checkpoint — a rollback records contents and mode and has nowhere to put the previous owner; and the right group differs by distribution",
 		"compose.ds012":          "the right healthcheck depends on what the service exposes; a guessed one marks a working container unhealthy and stalls everything waiting on it",
 		"compose.dr004":          "the remediation is about the env_file's permissions and whether it is in git and backups — nothing in the compose file to edit",
 		"ports.exposed":          "the aggregate finding's remediation is firewall.inactive's, and is declined for the same reason",

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -61,6 +61,17 @@ package fix
 //     prompt about modified config files. Nothing about that is reversible
 //     from a checkpoint, and a package upgrade that breaks a service leaves
 //     the operator worse off than the pending patch did.
+//   - fileperms.owner — the remediation is `chown root:root`, and hostveil
+//     cannot undo it. A checkpoint records a file's contents and its mode
+//     and has nowhere to put its previous owner, so this would be the only
+//     fix in the tool that changes something a rollback cannot put back.
+//     The right group is not guessable either: /etc/shadow is root:shadow
+//     on Debian and root:root on others, so a fix would have to pick one
+//     and would be wrong on the other half of hosts. And ownership landing
+//     on the wrong account is usually a symptom — a restore run as the
+//     wrong user, an archive extracted with its own uids — where chowning
+//     the files hostveil happens to know about fixes the visible part and
+//     leaves the rest. Revisit if BackedFile ever records uid/gid.
 //   - firewall.default-allow — the remediation is flipping the default
 //     inbound policy to deny, which is firewall.inactive's remediation
 //     applied to a firewall that happens to already be running, and it is

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -270,6 +270,7 @@
                   <tr><td><code>fileperms.passwd</code></td><td><code>/etc/passwd</code> is writable by non-root users</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>fileperms.group</code></td><td><code>/etc/group</code> is writable by non-root users</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
                   <tr><td><code>fileperms.hostkey</code></td><td>An SSH host private key is readable beyond root</td><td><span class="sev high">High</span></td><td>Auto-fix</td></tr>
+                  <tr><td><code>fileperms.owner</code></td><td>One of the files above is not owned by root — permissions are only half of who can read it</td><td><span class="sev high">High</span></td><td>Manual</td></tr>
                   <tr><td><code>fileperms.sshd-config</code></td><td><code>sshd_config</code> is writable by non-root users</td><td><span class="sev medium">Medium</span></td><td>Auto-fix</td></tr>
                 </tbody>
               </table>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -270,6 +270,7 @@
                   <tr><td><code>fileperms.passwd</code></td><td><code>/etc/passwd</code>가 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>fileperms.group</code></td><td><code>/etc/group</code>이 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
                   <tr><td><code>fileperms.hostkey</code></td><td>SSH 호스트 개인 키를 root 외 사용자가 읽을 수 있음</td><td><span class="sev high">높음</span></td><td>자동 수정</td></tr>
+                  <tr><td><code>fileperms.owner</code></td><td>위 파일 중 하나가 root 소유가 아님 — 누가 읽을 수 있는지는 권한 비트만으로 정해지지 않음</td><td><span class="sev high">높음</span></td><td>수동</td></tr>
                   <tr><td><code>fileperms.sshd-config</code></td><td><code>sshd_config</code>가 root가 아닌 사용자에게 쓰기 가능</td><td><span class="sev medium">보통</span></td><td>자동 수정</td></tr>
                 </tbody>
               </table>


### PR DESCRIPTION
## What and why

The `fileperms` rules answered *"how much access do the bits grant"* and stopped there, which is **half the question**.

Mode `0600` grants everything to the owner and nothing to anyone else — so `/etc/shadow` at `0600` owned by an ordinary user hands that account every password hash on the host, and the mode check calls it **clean**, because 0600 is exactly what it wants to see.

That is a false clean, which is the failure class this tool exists to refuse. It is also not a hypothetical shape: ownership lands on the wrong account through a restore run as the wrong user, or an archive extracted with its own uids — and neither leaves the permission bits looking unusual.

## What it does

`fileperms.owner` covers every path already in the rule table, checked **independently of the mode** so a file with impeccable bits is still examined. That independence is the whole point: gating it behind a loose mode would mean the interesting case is never asked about.

One finding for all of them rather than one per path — the remediation is the same `chown` in every case, and when this goes wrong it has usually gone wrong to several files at once.

A stat result with no Unix owner reports "cannot tell" and flags nothing. Same rule as everywhere else here: an unowned-looking file is a gap in what we can see, not evidence about the host.

## Manual, with the reason recorded

A checkpoint stores a file's contents and its mode and has **nowhere to put its previous owner**, so a `chown` fix would be the only change in the tool a rollback could not put back. The group is not guessable either — `/etc/shadow` is `root:shadow` on Debian and `root:root` elsewhere — so a fix would have to pick one and be wrong on the other half of hosts. The finding says that instead of printing a command that misfires half the time.

## A note on the tests

The first version skipped under root, which is what this container runs as and possibly CI too — a test that silently does nothing on the machine that runs it. `Checker.OwnerUID` is a test seam (matching `Rules` and the other checkers') so both directions are exercised whoever runs the suite.

## Checklist

- [x] Title is conventional with a valid scope (`feat(check):`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  go run ./cmd/sitegen && git diff --exit-code site/
  ```
  Also `GOOS=darwin go build ./...`, since this touches `syscall.Stat_t`. `golangci-lint` and `govulncheck` need Go 1.26 and this container has 1.25 — delegated to the `lint` job.
- [x] **Added the case that must not trigger it**: a correctly-owned file is clean at 0600, a missing file produces nothing, and the mode rule stays quiet on a 0600 file in both directions — which is precisely what made this invisible before.
- [x] For a UI change: n/a.
- [x] **The score stays honest** — a platform that reports no owner flags nothing rather than guessing, and the new finding closes a false *clean* rather than creating a false positive.

## Score impact for users

**Hosts with a wrongly-owned sensitive file will drop.** That is the point — those hosts were being scored clean on a file an ordinary account could read or rewrite. High severity, on the 5-point File permissions axis. No axis weight changes.

## Verified by mutation

| Mutation | Result |
| --- | --- |
| Only check ownership when the mode is already loose | `TestOwnershipIsCheckedIndependentlyOfMode/wrongly_owned` — `owner finding fired = false, want true` |

**Both guards from earlier this cycle fired unprompted again**: `TestEveryEmittedFindingIsDocumented` refused the finding until `checks.html` listed it in both languages, and `TestEveryFindingIsEitherFixableOrDeclinedOnPurpose` refused it until the register carried a reason for having no fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPWUEVTPA6HBTcdqhqEzt)_