### PR TITLE
fix(check): recognise nologin shells wherever the distribution keeps them

### DIFF
--- a/internal/check/accounts/accounts.go
+++ b/internal/check/accounts/accounts.go
@@ -44,17 +44,6 @@ func (c *Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
 	return true, ""
 }
 
-// nonLoginShells are shells that mean the account cannot interactively log
-// in, so an empty password on such an account is not a login risk.
-var nonLoginShells = map[string]bool{
-	"":                  true,
-	"/usr/sbin/nologin": true,
-	"/sbin/nologin":     true,
-	"/bin/false":        true,
-	"/usr/bin/false":    true,
-	"/bin/true":         true,
-}
-
 // Check parses the user databases and emits account-hygiene findings.
 func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, error) {
 	passwd, err := os.ReadFile(c.PasswdPath) //nolint:gosec // fixed system path
@@ -70,7 +59,12 @@ func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, err
 			continue
 		}
 		name, shell := fields[0], fields[6]
-		loginShell[name] = !nonLoginShells[strings.TrimSpace(shell)]
+		// Asked through platform because the Docker daemon domain asks the
+		// same question of docker-group members, and the two answers used to
+		// differ: this one matched whole paths against a fixed list, so a
+		// nologin at any other path — Arch's /usr/bin/nologin, NixOS's under
+		// /run/current-system — read as an ordinary login shell.
+		loginShell[name] = !platform.IsNonLoginShell(shell)
 		// Compare the UID numerically: the kernel parses "00"/"000" as 0, so
 		// a string compare against "0" would let a leading-zero UID-0
 		// backdoor slip past the very check that exists to catch it.

--- a/internal/check/accounts/accounts_test.go
+++ b/internal/check/accounts/accounts_test.go
@@ -143,3 +143,57 @@ func TestUnavailableWithoutPasswd(t *testing.T) {
 		t.Error("checker should be unavailable when passwd is unreadable")
 	}
 }
+
+// A service account with an empty password field but no way to log in is
+// not "a login account with an empty password", and reporting it as one is
+// a false Critical that also drags the account-hygiene axis down.
+//
+// This used to depend on where the distribution keeps nologin. The shell
+// was matched against a fixed list of six full paths, so Debian and Fedora
+// were recognised and Arch (/usr/bin/nologin) and NixOS (under
+// /run/current-system/sw/bin) were not — on those hosts every such account
+// was read as an ordinary login.
+func TestEmptyPasswordIgnoresNonLoginShellsAtAnyPath(t *testing.T) {
+	for _, shell := range []string{
+		"/usr/sbin/nologin",                  // Debian, Ubuntu
+		"/sbin/nologin",                      // RHEL, Fedora
+		"/usr/bin/nologin",                   // Arch
+		"/run/current-system/sw/bin/nologin", // NixOS
+		"/usr/local/sbin/nologin",            // hand-built
+		"/bin/false",
+		"/bin/true",
+		"", // no shell recorded at all
+	} {
+		t.Run(shell, func(t *testing.T) {
+			pw := writeFile(t, "passwd", cleanPasswd+"svc:x:998:998::/var/lib/svc:"+shell+"\n")
+			sh := writeFile(t, "shadow", "root:$6$abc:19000:0:99999:7:::\nsvc::19000:0:99999:7:::\n")
+			c := &Checker{PasswdPath: pw, ShadowPath: sh}
+			fs, err := c.Check(context.Background(), platform.Env{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if has(fs, "accounts.emptypassword") {
+				t.Errorf("shell %q cannot log in, but the account was reported as an empty-password login", shell)
+			}
+		})
+	}
+}
+
+// The other direction, which matters just as much: widening what counts as
+// a non-login shell must not stop the finding firing on a real login.
+func TestEmptyPasswordStillFiresOnARealLoginShell(t *testing.T) {
+	for _, shell := range []string{"/bin/bash", "/bin/sh", "/usr/bin/zsh", "/bin/falsehood"} {
+		t.Run(shell, func(t *testing.T) {
+			pw := writeFile(t, "passwd", cleanPasswd+"weak:x:1001:1001::/home/weak:"+shell+"\n")
+			sh := writeFile(t, "shadow", "root:$6$abc:19000:0:99999:7:::\nweak::19000:0:99999:7:::\n")
+			c := &Checker{PasswdPath: pw, ShadowPath: sh}
+			fs, err := c.Check(context.Background(), platform.Env{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !has(fs, "accounts.emptypassword") {
+				t.Errorf("shell %q is a real login shell with an empty password and must be reported", shell)
+			}
+		})
+	}
+}

--- a/internal/check/dockerd/dockerd_test.go
+++ b/internal/check/dockerd/dockerd_test.go
@@ -625,3 +625,46 @@ func TestEvidenceIsStableAcrossScans(t *testing.T) {
 		}
 	}
 }
+
+// The service-account test is shared with the account domain now, so it
+// answers the same way wherever the distribution keeps nologin. This copy
+// already matched on the path suffix and so handled all of these; the test
+// exists because the shared predicate is the thing that could regress, and
+// a regression here silently downgrades the finding from High to Medium.
+func TestServiceAccountShellsAcrossDistributions(t *testing.T) {
+	for _, shell := range []string{
+		"/usr/sbin/nologin",                  // Debian, Ubuntu
+		"/sbin/nologin",                      // RHEL, Fedora
+		"/usr/bin/nologin",                   // Arch
+		"/run/current-system/sw/bin/nologin", // NixOS
+		"/bin/false",
+		"/bin/true", // exits successfully and immediately; still no session
+		"",          // no shell recorded
+	} {
+		t.Run(shell, func(t *testing.T) {
+			h := host(t, "", "root:x:0:\ndocker:x:%GID%:runner\n",
+				cleanPasswd+"runner:x:3000:3000::/srv/runner:"+shell+"\n", 0o660)
+			f := mustFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.group-members")
+			if f.Severity != model.SeverityHigh {
+				t.Errorf("a docker-group member with shell %q has no interactive login, "+
+					"so the finding must be High, got %v", shell, f.Severity)
+			}
+		})
+	}
+}
+
+// And the counterpart: a real login shell above the system range is a human
+// administrator, which is the ordinary shape of a self-hosted server and
+// must stay Medium.
+func TestHumanAdministratorStaysMedium(t *testing.T) {
+	for _, shell := range []string{"/bin/bash", "/usr/bin/zsh", "/bin/falsehood"} {
+		t.Run(shell, func(t *testing.T) {
+			h := host(t, "", "root:x:0:\ndocker:x:%GID%:alice\n",
+				cleanPasswd+"alice:x:3000:3000::/home/alice:"+shell+"\n", 0o660)
+			f := mustFind(t, h.check(t, env(hardenedInfo, "-H fd://")), "dockerd.group-members")
+			if f.Severity != model.SeverityMedium {
+				t.Errorf("shell %q is a real login, so the finding must stay Medium, got %v", shell, f.Severity)
+			}
+		})
+	}
+}

--- a/internal/check/dockerd/socket.go
+++ b/internal/check/dockerd/socket.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/seolcu/hostveil/internal/platform"
 )
 
 // socket is the local unix socket's identity: how open it is, and which
@@ -172,17 +174,14 @@ type account struct {
 // 1000 for services, and an account created above that range with a nologin
 // shell (the shape most CI runners and agents take) is just as much a
 // credential nobody logs into and nobody watches.
+// The shell half is platform.IsNonLoginShell, shared with the account
+// domain, which asks the same question to decide whether an empty password
+// is a login risk. This copy tested the path's suffix and so handled a
+// nologin anywhere; the other matched whole paths against a fixed list and
+// did not. Sharing settles it at the more portable of the two, and picks up
+// /bin/true, which ends a session as firmly as /bin/false.
 func (a account) system() bool {
-	if a.uid < 1000 {
-		return true
-	}
-	switch {
-	case strings.HasSuffix(a.shell, "/nologin"),
-		strings.HasSuffix(a.shell, "/false"),
-		a.shell == "":
-		return true
-	}
-	return false
+	return a.uid < 1000 || platform.IsNonLoginShell(a.shell)
 }
 
 func (c *Checker) accounts() (map[string]account, error) {

--- a/internal/platform/shell.go
+++ b/internal/platform/shell.go
@@ -1,0 +1,47 @@
+package platform
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// nonLoginShellNames are the programs a distribution puts in a passwd shell
+// field to mean "this account does not log in". They are matched by base
+// name, never by full path, because the path is not portable and the name
+// is: nologin lives at /usr/sbin/nologin on Debian and Ubuntu, /sbin/nologin
+// on RHEL and Fedora, /usr/bin/nologin on Arch, and under
+// /run/current-system/sw/bin on NixOS.
+//
+// "true" is here alongside "false" because /bin/true as a login shell exits
+// successfully and immediately, which ends the session just as firmly as
+// failing does.
+var nonLoginShellNames = map[string]bool{
+	"nologin": true,
+	"false":   true,
+	"true":    true,
+}
+
+// IsNonLoginShell reports whether a passwd shell field means the account
+// cannot start an interactive session.
+//
+// An empty field counts. Historically it means /bin/sh, but on a modern
+// distribution it appears on accounts created without a shell at all, and
+// treating it as a login would report a password risk on an account that
+// has no way in.
+//
+// This is one function because it was two, and they disagreed. The account
+// domain matched the whole path against a fixed list of six spellings, so
+// an Arch or NixOS host — where nologin sits at neither of the two paths it
+// knew — had its service accounts read as ordinary logins, and any of them
+// with an empty password field produced a Critical
+// "accounts.emptypassword" for an account nobody can log in to. The Docker
+// daemon domain, asking the same question about docker-group members, had
+// already got this right with a suffix test. A predicate that decides
+// whether to report a Critical is not one to keep two copies of.
+func IsNonLoginShell(shell string) bool {
+	s := strings.TrimSpace(shell)
+	if s == "" {
+		return true
+	}
+	return nonLoginShellNames[filepath.Base(s)]
+}

--- a/internal/platform/shell_test.go
+++ b/internal/platform/shell_test.go
@@ -1,0 +1,42 @@
+package platform
+
+import "testing"
+
+func TestIsNonLoginShell(t *testing.T) {
+	for _, tc := range []struct {
+		shell string
+		want  bool
+		why   string
+	}{
+		// The two paths the old account-domain list knew.
+		{"/usr/sbin/nologin", true, "Debian, Ubuntu"},
+		{"/sbin/nologin", true, "RHEL, Fedora"},
+		// The ones it did not, which is the bug this replaced.
+		{"/usr/bin/nologin", true, "Arch"},
+		{"/run/current-system/sw/bin/nologin", true, "NixOS"},
+		{"/usr/local/sbin/nologin", true, "hand-built"},
+		{"nologin", true, "no path at all"},
+
+		{"/bin/false", true, ""},
+		{"/usr/bin/false", true, ""},
+		{"/bin/true", true, "exits successfully and immediately"},
+		{"", true, "no shell recorded"},
+		{"   ", true, "whitespace only"},
+		{"  /usr/sbin/nologin  ", true, "passwd fields can carry stray space"},
+
+		// Real login shells must stay logins, or the empty-password finding
+		// stops firing on the accounts it exists for.
+		{"/bin/bash", false, ""},
+		{"/bin/sh", false, ""},
+		{"/usr/bin/zsh", false, ""},
+		{"/usr/bin/fish", false, ""},
+		// Names that merely contain a keyword are not it.
+		{"/bin/falsehood", false, "substring, not the program"},
+		{"/usr/bin/nologind", false, "substring, not the program"},
+		{"/opt/truecrypt/bin/truecrypt", false, "substring, not the program"},
+	} {
+		if got := IsNonLoginShell(tc.shell); got != tc.want {
+			t.Errorf("IsNonLoginShell(%q) = %v, want %v (%s)", tc.shell, got, tc.want, tc.why)
+		}
+	}
+}


### PR DESCRIPTION
## The bug

`internal/check/accounts` decided whether an account can log in by matching its shell against a fixed list of **full paths**:

```go
var nonLoginShells = map[string]bool{
	"": true, "/usr/sbin/nologin": true, "/sbin/nologin": true,
	"/bin/false": true, "/usr/bin/false": true, "/bin/true": true,
}
```

That covers Debian and Fedora. It does not cover a distribution that keeps the same program elsewhere:

| Distribution | Path | Recognised before |
| --- | --- | --- |
| Debian, Ubuntu | `/usr/sbin/nologin` | yes |
| RHEL, Fedora | `/sbin/nologin` | yes |
| **Arch** | `/usr/bin/nologin` | **no** |
| **NixOS** | `/run/current-system/sw/bin/nologin` | **no** |
| hand-built | `/usr/local/sbin/nologin` | **no** |

On those hosts every service account read as an ordinary login shell.

The consequence is a **false Critical**. `accounts.emptypassword` fires when the shadow hash is empty *and* the checker believes the account can log in, so a service account with no password produced "Login account with an empty password" — for an account with no way in — and dragged the account-hygiene axis down with it.

## Why it was two answers to one question

`internal/check/dockerd` asks the same thing of docker-group members, to decide whether a membership is a human administrator (Medium) or a credential nobody watches (High). It had already got this right with a suffix test. The copy gating a **Critical** was the wrong one.

Both now call `platform.IsNonLoginShell`, which matches the program's **base name** rather than its path — the path is not portable and the name is.

## Behaviour changes

Both narrow a false report rather than widening a true one:

- `accounts.emptypassword` stops firing on non-login accounts on Arch, NixOS, and hand-built layouts.
- A docker-group member with `/bin/true` is now read as a service identity. The account domain already counted `/bin/true` as non-login and the daemon domain did not; a shell that exits successfully and immediately ends a session as firmly as one that fails.

## Verification

The new accounts test was run against the old allowlist and fails on exactly the three unrecognised paths, while Debian's and Fedora's pass — confirming the bug was distribution-specific rather than general:

```
--- FAIL: TestEmptyPasswordIgnoresNonLoginShellsAtAnyPath//usr/bin/nologin
--- FAIL: TestEmptyPasswordIgnoresNonLoginShellsAtAnyPath//run/current-system/sw/bin/nologin
--- FAIL: TestEmptyPasswordIgnoresNonLoginShellsAtAnyPath//usr/local/sbin/nologin
```

Both directions are covered: the finding must stop firing on non-login shells, and must still fire on `/bin/bash`, `/usr/bin/zsh`, and `/bin/falsehood` — the last checking that a name merely *containing* a keyword is not mistaken for it. The dockerd side has the matching pair for the Medium/High split.

Full gate green: `build`, `vet`, `gofmt`, `mod tidy`, `test -race`, `golangci-lint` (0 issues), `sitegen` with no `site/` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)