### PR TITLE
fix(model): render the batch outcome once instead of four times

### DIFF
--- a/cmd/hostveil/fix.go
+++ b/cmd/hostveil/fix.go
@@ -143,19 +143,14 @@ func fixAll(ctx context.Context, yes bool) int {
 	}
 
 	out := engine.ApplyBatch(ctx, auto)
-	fmt.Printf("\n✓ Applied %d fixes", len(out.Applied))
-	if len(out.Failed) > 0 {
-		fmt.Printf(", %d failed", len(out.Failed))
-	}
-	fmt.Printf(". New security score: %d/100\n", out.NewScore.Overall)
+	// One sentence, rendered by the engine, so this and the other two
+	// interfaces cannot describe the same outcome differently. Only the
+	// per-failure detail and the rollback hint are the CLI's own — it has
+	// the room for the first and is the only place the second is a command
+	// you can type.
+	fmt.Printf("\n✓ %s\n", out.Message)
 	for id, msg := range out.Failed {
 		fmt.Printf("  ✗ %s: %s\n", id, msg)
-	}
-	// Say it before the rollback hint, because the hint is what an
-	// interrupted operator most needs: some fixes did land, and nothing else
-	// on screen would tell them that.
-	if out.Interrupted {
-		fmt.Printf("\nInterrupted — %d of %d fixes were never attempted.\n", len(out.Skipped), len(auto))
 	}
 	fmt.Println("Roll back any change with: hostveil history")
 	if out.Interrupted {

--- a/internal/core/fixflow.go
+++ b/internal/core/fixflow.go
@@ -555,6 +555,9 @@ func (e *Engine) ApplyBatch(ctx context.Context, findings []model.Finding) model
 		out.Applied = append(out.Applied, f.ID)
 	}
 	out.NewScore = e.rescore()
+	// Rendered here, after the score, so every interface reports the same
+	// outcome rather than four descriptions of it.
+	out.Message = out.Summary()
 	return out
 }
 

--- a/internal/core/fixflow_test.go
+++ b/internal/core/fixflow_test.go
@@ -693,6 +693,16 @@ func TestInterruptedBatchReportsWhatItDidNotReach(t *testing.T) {
 	if len(out.Skipped) != len(findings) {
 		t.Errorf("skipped %d, want all %d unreached findings listed", len(out.Skipped), len(findings))
 	}
+	// The flag is only worth setting if it reaches the operator, and every
+	// interface now shows Message and nothing else about the outcome. The
+	// dashboard used to render its own summary and omit the interruption
+	// entirely, so a batch cut short read exactly like a completed one.
+	if !strings.Contains(out.Message, "Interrupted") {
+		t.Errorf("Message = %q, want it to say the batch was interrupted", out.Message)
+	}
+	if !strings.Contains(out.Message, "3 of 3 were never attempted") {
+		t.Errorf("Message = %q, want it to count what was never reached", out.Message)
+	}
 }
 
 // The flag must not fire on the ordinary path, or it means nothing.
@@ -709,6 +719,9 @@ func TestCompletedBatchIsNotMarkedInterrupted(t *testing.T) {
 	out := engine.ApplyBatch(context.Background(), []model.Finding{f})
 	if out.Interrupted {
 		t.Error("a batch that ran to completion must not report Interrupted")
+	}
+	if strings.Contains(out.Message, "Interrupted") {
+		t.Errorf("Message = %q must not mention an interruption on the ordinary path", out.Message)
 	}
 	if len(out.Applied) != 1 {
 		t.Errorf("applied = %v, want the one auto fix", out.Applied)

--- a/internal/model/batchsummary_test.go
+++ b/internal/model/batchsummary_test.go
@@ -1,0 +1,93 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+// The sentence is the whole reason this type carries a Message: four
+// surfaces phrased it themselves and each dropped a different field.
+func TestBatchOutcomeSummary(t *testing.T) {
+	score := ScoreBreakdown{Overall: 64, Applicable: true}
+
+	for name, tc := range map[string]struct {
+		out     BatchOutcome
+		want    []string
+		wantNot []string
+	}{
+		"all applied": {
+			out:     BatchOutcome{Applied: []string{"a", "b"}, NewScore: score},
+			want:    []string{"Applied 2", "New score: 64/100."},
+			wantNot: []string{"skipped", "failed", "Interrupted"},
+		},
+		"skipped and failed are both named": {
+			out: BatchOutcome{
+				Applied: []string{"a"}, Skipped: []string{"b", "c"},
+				Failed: map[string]string{"d": "boom"}, NewScore: score,
+			},
+			want: []string{"Applied 1", "skipped 2", "failed 1"},
+		},
+		// The bug this replaced: the dashboard's batch path counted these
+		// three and never mentioned the interruption, so a batch cut short
+		// read exactly like one that completed.
+		"interrupted says how many were never reached": {
+			out: BatchOutcome{
+				Applied: []string{"a", "b"}, Skipped: []string{"c", "d", "e"},
+				Interrupted: true, NewScore: score,
+			},
+			want: []string{"Applied 2", "skipped 3", "Interrupted — 3 of 5 were never attempted."},
+		},
+		// The other half: a failure must never be silent, which is what the
+		// fix-all path did by reporting only the applied count.
+		"a failure is never silent": {
+			out: BatchOutcome{
+				Applied: []string{"a"}, Failed: map[string]string{"b": "boom"}, NewScore: score,
+			},
+			want: []string{"failed 1"},
+		},
+		"nothing applied at all": {
+			out:  BatchOutcome{Skipped: []string{"a"}, NewScore: score},
+			want: []string{"Applied 0", "skipped 1"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := tc.out.Summary()
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("Summary() = %q, want it to contain %q", got, w)
+				}
+			}
+			for _, w := range tc.wantNot {
+				if strings.Contains(got, w) {
+					t.Errorf("Summary() = %q, must not mention %q", got, w)
+				}
+			}
+		})
+	}
+}
+
+// The total in "3 of 5" is derived rather than passed in, which only works
+// because every finding handed to a batch lands in exactly one bucket.
+func TestBatchSummaryTotalCoversEveryBucket(t *testing.T) {
+	out := BatchOutcome{
+		Applied:     []string{"a", "b"},
+		Skipped:     []string{"c"},
+		Failed:      map[string]string{"d": "boom", "e": "boom"},
+		Interrupted: true,
+	}
+	if got := out.Summary(); !strings.Contains(got, "1 of 5 were never attempted") {
+		t.Errorf("Summary() = %q; the total must count applied + skipped + failed", got)
+	}
+}
+
+// Summary states what happened and stops. "press h" and "hostveil history"
+// are directions to a place only one interface has.
+func TestBatchSummaryCarriesNoInterfaceDirections(t *testing.T) {
+	out := BatchOutcome{Applied: []string{"a"}, Interrupted: true}
+	got := out.Summary()
+	for _, leak := range []string{"press", "hostveil", "history", "click", "button"} {
+		if strings.Contains(strings.ToLower(got), leak) {
+			t.Errorf("Summary() = %q leaks the interface-specific direction %q", got, leak)
+		}
+	}
+}

--- a/internal/model/fix.go
+++ b/internal/model/fix.go
@@ -1,6 +1,10 @@
 package model
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 // FixPreview is the side-effect-free preview of a finding's fix: what each
 // available action would change, computed without touching any live file
@@ -60,6 +64,42 @@ type BatchOutcome struct {
 	// has no reason to go looking for them.
 	Interrupted bool           `json:"interrupted,omitempty"`
 	NewScore    ScoreBreakdown `json:"new_score"`
+	// Message is the sentence every interface shows, rendered once by the
+	// engine from the fields above. It exists for the reason
+	// FixOutcome.VerifyMessage does, and the reason turned out to apply
+	// here with more force: four surfaces phrased this outcome themselves
+	// and each dropped something different. The dashboard's batch path
+	// never mentioned Interrupted at all, so a batch cut short read exactly
+	// like one that completed — the outcome the flag was added to prevent —
+	// and its fix-all path reported neither skipped nor failed, so a fix
+	// that errored was invisible.
+	Message string `json:"message"`
+}
+
+// Summary renders the outcome as one sentence.
+//
+// It deliberately stops before saying where to look. "press h" and
+// "hostveil history" are directions to a place only one interface has, and
+// an interface appends its own; what may not vary is the claim about what
+// happened.
+func (o BatchOutcome) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Applied %d", len(o.Applied))
+	if n := len(o.Skipped); n > 0 {
+		fmt.Fprintf(&b, " · skipped %d", n)
+	}
+	if n := len(o.Failed); n > 0 {
+		fmt.Fprintf(&b, " · failed %d", n)
+	}
+	fmt.Fprintf(&b, ". New score: %d/100.", o.NewScore.Overall)
+	// Every finding handed to a batch lands in exactly one of the three, so
+	// their sum is what was asked for — which is what makes "8 of 11" sayable
+	// without the caller passing the total back in.
+	if o.Interrupted {
+		fmt.Fprintf(&b, " Interrupted — %d of %d were never attempted.",
+			len(o.Skipped), len(o.Applied)+len(o.Skipped)+len(o.Failed))
+	}
+	return b.String()
 }
 
 // RollbackOutcome is the result of rolling back a checkpoint. Unfixed and

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -826,21 +826,14 @@ func rollbackSummary(o model.RollbackOutcome) string {
 }
 
 func batchSummary(o model.BatchOutcome) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "✓ Applied %d", len(o.Applied))
-	if len(o.Skipped) > 0 {
-		fmt.Fprintf(&b, " · skipped %d", len(o.Skipped))
-	}
-	if len(o.Failed) > 0 {
-		fmt.Fprintf(&b, " · failed %d", len(o.Failed))
-	}
-	fmt.Fprintf(&b, ". New score: %d/100.", o.NewScore.Overall)
-	// An interrupted batch and a completed one differ only in this sentence,
-	// and the difference matters: the skipped findings were never judged
-	// ineligible, they were never reached, and the fixes that did land are
-	// already on the host with checkpoints waiting in the history view.
+	// The claim comes from the engine; this adds only the tick and the one
+	// thing that is genuinely local — which key reaches the history view.
+	// The fixes that did land are already on the host with checkpoints
+	// waiting there, and an operator who thinks the batch completed has no
+	// reason to go looking.
+	s := "✓ " + o.Message
 	if o.Interrupted {
-		b.WriteString(" Interrupted before the rest were attempted; press h to see what was applied.")
+		s += " Press h to see what was applied."
 	}
-	return b.String()
+	return s
 }

--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -189,10 +189,11 @@ async function applyBatch() {
       method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ findings }),
     });
-    const parts = [`Applied ${o.applied ? o.applied.length : 0}`];
-    if (o.skipped && o.skipped.length) parts.push(`skipped ${o.skipped.length}`);
-    if (o.failed && Object.keys(o.failed).length) parts.push(`failed ${Object.keys(o.failed).length}`);
-    flash(parts.join(" · ") + `. Score ${o.new_score.overall}/100.`);
+    // The engine's own sentence. Written here by hand it counted applied,
+    // skipped and failed but never mentioned o.interrupted, so a batch cut
+    // short read exactly like one that ran to completion — which is the one
+    // thing that flag exists to prevent.
+    flash(o.message);
     marked.clear();
     await refresh();
   } catch (e) { flash("Batch fix failed: " + e.message, true); }
@@ -767,8 +768,11 @@ fixallBtn.onclick = () => {
   if (!confirm("Apply every safe (Auto) fix now?")) return;
   whileBusy(fixallBtn, "Applying…", async () => {
     const o = await api("/api/fix/all", { method: "POST", headers: { "Content-Type": "application/json" } });
-    flash(`Applied ${o.applied ? o.applied.length : 0} fixes. Score ${o.new_score.overall}/100.`
-      + (o.interrupted ? "  Interrupted — the rest were never attempted." : ""));
+    // Same route's outcome as the batch button above, so the same sentence.
+    // This one used to report only the applied count and the interruption,
+    // so a fix that errored was invisible: the score moved, nothing said
+    // why, and the failure was in the response all along.
+    flash(o.message);
     marked.clear();
     await refresh();
   });

--- a/internal/ui/web/server_test.go
+++ b/internal/ui/web/server_test.go
@@ -828,3 +828,53 @@ func TestHostWorkOutlivesTheRequest(t *testing.T) {
 		t.Errorf("host work was cancelled with the request: %v", err)
 	}
 }
+
+// Both batch routes must carry the outcome sentence, because the dashboard
+// now shows nothing else about what happened.
+//
+// It shows nothing else because writing it in JavaScript produced two
+// summaries of one response that each dropped a different field: the batch
+// button never mentioned an interruption, so a batch cut short read exactly
+// like a completed one, and the fix-all button reported neither skipped nor
+// failed, so a fix that errored moved the score and said nothing. The
+// message is rendered once in the engine; these assert it arrives.
+func TestBatchRoutesCarryTheOutcomeMessage(t *testing.T) {
+	for _, tc := range []struct{ name, route, body string }{
+		{"batch", "/api/fix/batch", `{"findings":[{"id":"compose.ds018","service":"cache"}]}`},
+		{"fix all", "/api/fix/all", `{}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := testServer(t)
+			srv := httptest.NewServer(s.Handler())
+			defer srv.Close()
+
+			req, _ := http.NewRequest(http.MethodPost, srv.URL+tc.route, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Origin", srv.URL)
+			resp, err := authedClient(t, s, srv).Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("%s returned %d", tc.route, resp.StatusCode)
+			}
+
+			// Decoded as a bare map as well, so this fails if the field is
+			// renamed or dropped from the wire rather than only from Go.
+			var raw map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+				t.Fatal(err)
+			}
+			msg, _ := raw["message"].(string)
+			if msg == "" {
+				t.Fatalf("%s carried no message; the dashboard would flash an empty toast: %v", tc.route, raw)
+			}
+			for _, want := range []string{"Applied ", "New score: "} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("%s message = %q, want it to contain %q", tc.route, msg, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Two silent outcomes in the dashboard

`model.BatchOutcome` carries four facts — applied, skipped, failed, and whether the run was cut short — and four surfaces described them in their own words:

| | applied | skipped | failed | interrupted |
| --- | :-: | :-: | :-: | :-: |
| CLI `fix --all` | ✓ | only inside the interrupted line | ✓ | ✓ |
| TUI `batchSummary` | ✓ | ✓ | ✓ | ✓ |
| dashboard — batch button | ✓ | ✓ | ✓ | **✗** |
| dashboard — fix-all button | ✓ | **✗** | **✗** | ✓ |

Both dashboard gaps are real, and they are gaps in the *same* engine response — both buttons call `ApplyBatch` and both get the identical struct.

**The batch button never mentioned `Interrupted`.** That is exactly the outcome the flag was added to prevent. From `ApplyBatch` itself:

> Everything after the interruption lands in Skipped, and Interrupted says those were never reached rather than judged ineligible — otherwise a batch cut short reads exactly like one that ran to completion.

In the dashboard it read exactly like one that ran to completion. The fixes that *did* land were on the host with checkpoints waiting in History, and nothing on screen said to go looking.

**The fix-all button reported neither skipped nor failed**, so a fix that errored was invisible: the score moved, no reason was given, and the error was in the response the whole time.

## The precedent this follows

`FixOutcome` solved this one struct up, and its comment says why:

> VerifyMessage is the sentence every interface shows, rendered once by the engine from Verified and RestartHint. The three outcome summaries already phrase the same fields three different ways; this distinction is subtle enough that three attempts at it would mean three different claims.

`BatchOutcome` had the same problem and no such field. Now `BatchOutcome.Summary()` renders the sentence, `ApplyBatch` assigns it to `Message`, and all three interfaces print that.

`Summary()` deliberately stops before saying *where to look*. "press h" and "hostveil history" are directions to a place only one interface has, and each appends its own — `TestBatchSummaryCarriesNoInterfaceDirections` pins that. What may not vary is the claim about what happened.

## Behaviour notes

- The CLI keeps its per-failure detail lines and its **exit code 1** on interruption.
- Its summary line now also names the skipped count, which it only ever showed inside the interrupted sentence.
- `"New security score"` → `"New score"`, matching the other two.

## Verification

- `Summary()` is covered across all four field combinations, including "a failure is never silent" and the derived total in "3 of 5 were never attempted" (derived rather than passed in, which works only because every finding lands in exactly one bucket — asserted separately).
- The engine's existing interrupted/completed batch tests now also assert the message says so, and does not on the ordinary path.
- `TestBatchRoutesCarryTheOutcomeMessage` decodes both routes as a bare map, so renaming or dropping the field on the wire fails even if Go still compiles — the dashboard would otherwise flash an empty toast.

Full gate green: `build`, `vet`, `gofmt`, `mod tidy`, `test -race`, `golangci-lint` (0 issues), `sitegen` with no `site/` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)