### PR TITLE
fix(core): check a fix's shape before offering it, not while applying it

### DIFF
--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -245,7 +245,10 @@ func (e *Engine) Current() (model.Report, bool) {
 func (e *Engine) classify(findings []model.Finding) {
 	for i := range findings {
 		if e.fixes != nil {
-			if fx, ok, err := e.fixes.Build(findings[i]); ok && err == nil && fx.Kind.IsFixable() {
+			// Through buildFix, so a fix whose shape contradicts its kind is
+			// treated exactly like one that failed to build: demoted here
+			// rather than offered and discovered at apply.
+			if fx, ok, err := e.buildFix(findings[i]); ok && err == nil && fx.Kind.IsFixable() {
 				findings[i].Remediation = classifiedKind(findings[i].Remediation, fx.Kind)
 				continue
 			}

--- a/internal/core/fixflow.go
+++ b/internal/core/fixflow.go
@@ -687,11 +687,36 @@ func toModelCheckpoint(cp history.Checkpoint) model.Checkpoint {
 	return out
 }
 
+// buildFix resolves the registered fix for a finding and checks that its
+// shape matches the kind it claims.
+//
+// fix.Validate is the contract — Auto is exactly one action, Review is two
+// or more alternatives, an edit carries a Transform, an exec carries a
+// command — and until now nothing but a test ever ran it. That left the
+// registry's shape guaranteed only for the representative findings
+// internal/fix/fix_test.go happens to build. A registration that came out
+// malformed for some other finding got no complaint at all: classify saw a
+// fixable Kind and left the finding Auto, so a UI drew a fix button, and
+// the first thing to notice was applyEdit calling a nil Transform. There is
+// no recover on that path.
+//
+// A registered fix whose shape contradicts its kind is therefore an error
+// rather than a fix. Reporting it as "registered, but broken" is what lets
+// classify demote the finding to Manual, which is the same answer it
+// already gives when no fix is registered and the same promise the rest of
+// the engine makes: a UI never offers a button that leads nowhere.
 func (e *Engine) buildFix(f model.Finding) (fix.Fix, bool, error) {
 	if e.fixes == nil {
 		return fix.Fix{}, false, nil
 	}
-	return e.fixes.Build(f)
+	fx, ok, err := e.fixes.Build(f)
+	if !ok || err != nil {
+		return fx, ok, err
+	}
+	if err := fix.Validate(fx); err != nil {
+		return fix.Fix{}, true, err
+	}
+	return fx, true, nil
 }
 
 // markFixed marks the target finding fixed in the current report.

--- a/internal/core/fixshape_test.go
+++ b/internal/core/fixshape_test.go
@@ -1,0 +1,145 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check"
+	"github.com/seolcu/hostveil/internal/fix"
+	"github.com/seolcu/hostveil/internal/history"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// fix.Validate is the shape contract, and for most of this project's life it
+// ran only in internal/fix/fix_test.go — against the representative findings
+// that file happens to construct. A registration that came out malformed for
+// any other finding was reported by nothing.
+//
+// It was not a quiet failure either. classify saw a fixable Kind, left the
+// finding Auto, and a UI drew a fix button; the first thing to notice was
+// applyEdit calling a nil Transform, and there is no recover on that path.
+//
+// These tests build fixes that are broken in each of the ways Validate
+// knows about and require the engine to demote rather than offer.
+
+type shapeChecker struct{ findings []model.Finding }
+
+func (c *shapeChecker) Source() model.Source { return model.SourceSysctl }
+
+func (c *shapeChecker) Available(context.Context, platform.Env) (bool, string) { return true, "" }
+
+func (c *shapeChecker) Check(context.Context, platform.Env) ([]model.Finding, error) {
+	return c.findings, nil
+}
+
+func shapeFinding() model.Finding {
+	return model.NewFinding("sysctl.aslr", "ASLR disabled", model.SeverityHigh,
+		model.SourceSysctl, model.RemediationAuto)
+}
+
+// shapeEngine wires one checker emitting one Auto finding, and one fix
+// registration returning fx.
+func shapeEngine(t *testing.T, fx fix.Fix) *Engine {
+	t.Helper()
+	r := fix.NewRegistry()
+	r.Register("sysctl.aslr", func(model.Finding) (fix.Fix, error) { return fx, nil })
+	return New(Config{
+		Registry: check.NewRegistry(&shapeChecker{findings: []model.Finding{shapeFinding()}}),
+		Fixes:    r,
+		Store:    history.NewStore(t.TempDir()),
+	})
+}
+
+func TestMalformedFixIsDemotedNotOffered(t *testing.T) {
+	for name, broken := range map[string]fix.Fix{
+		// The one that panics: applyEdit and previewEdit both call
+		// a.Transform with no nil check.
+		"edit with no Transform": {
+			Label: "x", Kind: model.RemediationAuto,
+			Actions: []fix.Action{{Label: "x", Kind: fix.ActionEdit, Path: "/tmp/x"}},
+		},
+		"exec with no command": {
+			Label: "x", Kind: model.RemediationAuto,
+			Actions: []fix.Action{{Label: "x", Kind: fix.ActionExec}},
+		},
+		// Auto is a claim about shape — one mechanical action. Two of them
+		// is a Review wearing Auto's label, and ApplyBatch silently skips it
+		// while every interface counts it as one that will be applied.
+		"auto with two actions": {
+			Label: "x", Kind: model.RemediationAuto,
+			Actions: []fix.Action{
+				{Label: "a", Kind: fix.ActionEdit, Path: "/tmp/a", Transform: func(b []byte) ([]byte, error) { return b, nil }},
+				{Label: "b", Kind: fix.ActionEdit, Path: "/tmp/b", Transform: func(b []byte) ([]byte, error) { return b, nil }},
+			},
+		},
+		"review with one action": {
+			Label: "x", Kind: model.RemediationReview,
+			Actions: []fix.Action{
+				{Label: "a", Kind: fix.ActionEdit, Path: "/tmp/a", Transform: func(b []byte) ([]byte, error) { return b, nil }},
+			},
+		},
+		"mode change with no Mode function": {
+			Label: "x", Kind: model.RemediationAuto,
+			Actions: []fix.Action{{Label: "x", Kind: fix.ActionMode, Paths: []string{"/tmp/x"}}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			e := shapeEngine(t, broken)
+			r := e.Scan(context.Background(), nil)
+			if len(r.Findings) != 1 {
+				t.Fatalf("expected the one finding, got %d", len(r.Findings))
+			}
+
+			// Demoted, which is the same answer an unregistered fix gets.
+			if got := r.Findings[0].Remediation; got != model.RemediationManual {
+				t.Errorf("remediation = %v, want Manual — a fix whose shape contradicts its kind "+
+					"must not reach a UI as a button", got)
+			}
+			if r.Findings[0].IsFixable() {
+				t.Error("a malformed fix must not present the finding as fixable")
+			}
+
+			// And the direct route refuses in words rather than panicking.
+			if _, err := e.PreviewFix(shapeFinding()); err == nil {
+				t.Error("PreviewFix accepted a malformed fix")
+			}
+		})
+	}
+}
+
+// The counterpart: a well-formed fix must still be offered, or the guard
+// above would "pass" by rejecting everything.
+func TestWellFormedFixIsStillOffered(t *testing.T) {
+	e := shapeEngine(t, fix.Fix{
+		Label: "tighten it", Kind: model.RemediationAuto,
+		Actions: []fix.Action{{
+			Label: "tighten", Kind: fix.ActionEdit, Path: "/tmp/ok",
+			Transform: func(b []byte) ([]byte, error) { return b, nil },
+		}},
+	})
+	r := e.Scan(context.Background(), nil)
+	if len(r.Findings) != 1 {
+		t.Fatalf("expected the one finding, got %d", len(r.Findings))
+	}
+	if got := r.Findings[0].Remediation; got != model.RemediationAuto {
+		t.Errorf("remediation = %v, want Auto", got)
+	}
+}
+
+// The message has to name the fix that is broken. A registry bug that says
+// only "invalid" leaves a maintainer diffing registrations.
+func TestMalformedFixErrorNamesTheFinding(t *testing.T) {
+	e := shapeEngine(t, fix.Fix{
+		Label: "x", Kind: model.RemediationAuto,
+		Actions: []fix.Action{{Label: "x", Kind: fix.ActionEdit, Path: "/tmp/x"}},
+	})
+	_, err := e.PreviewFix(shapeFinding())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "sysctl.aslr") {
+		t.Errorf("error %q does not name the finding whose fix is malformed", err)
+	}
+}

--- a/internal/fix/registry.go
+++ b/internal/fix/registry.go
@@ -167,7 +167,14 @@ func matchPattern(pattern, id string) bool {
 
 // Validate checks a Fix's shape against its kind: Auto has exactly one
 // action, Review has two or more independent alternatives, and every edit
-// action has a Transform. It is used by tests and can gate registration.
+// action has a Transform.
+//
+// core.Engine.buildFix runs it on every fix it resolves, so a registration
+// whose shape contradicts its kind demotes the finding to Manual instead of
+// reaching a UI as a button. It used to run only in this package's tests,
+// against the representative findings those tests happen to construct,
+// which left the contract unenforced for every other finding — and the
+// first thing to notice a missing Transform was applyEdit calling it.
 func Validate(fx Fix) error {
 	switch fx.Kind {
 	case model.RemediationAuto:


### PR DESCRIPTION
## A contract that enforced nothing

`fix.Validate` is the `Fix` shape contract — Auto is exactly one action, Review is two or more alternatives, an edit carries a `Transform`, an exec carries a command, a mode change carries both paths and a `Mode` function.

Its own doc comment said it *"is used by tests and can gate registration."* It gated nothing. The only callers were in `internal/fix/fix_test.go`.

So the contract held only for the representative findings that file happens to construct. A registration that came out malformed for some *other* finding got no complaint anywhere: `Engine.classify` calls `Build`, sees a `Kind` that `IsFixable()`, and leaves the finding Auto — so every interface draws a fix button.

## What that costs

The first thing to notice a missing `Transform` is `applyEdit` calling it. There is no `recover` anywhere on the fix path, and `previewEdit` calls it too — so clicking **either** button is a nil pointer dereference. Reproduced against a real file:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0]
```

`hostveil serve` auto-elevates, so that is a root process. The other shapes fail more quietly but still wrongly: an Auto fix with two actions is counted by every UI as one that will be applied and then **silently skipped** by `ApplyBatch`, which requires `len(fx.Actions) == 1`.

## The change

`Engine.buildFix` now validates. Every fix path already went through it — preview, apply, batch — and `classify` now does too rather than calling the registry directly.

A fix whose shape contradicts its kind is therefore treated exactly like one that failed to build: the finding **demotes to Manual**. That is the answer the engine already gives when no fix is registered, and it keeps the promise the rest of it makes — *a UI never offers a button that leads nowhere.*

This also closes the predicate gap I went looking for originally. `ApplyBatch` tests `len(fx.Actions) == 1` while every UI tests only `Remediation == Auto`; with the shape now guaranteed at classification time, the simpler UI predicate becomes correct rather than merely usually-correct, and `ApplyBatch`'s check becomes genuinely defensive.

## Verification

`TestMalformedFixIsDemotedNotOffered` covers all five shapes Validate knows about, asserting the finding demotes **and** that `PreviewFix` refuses in words. Reverting `buildFix` makes it fail:

```
remediation = auto, want Manual — a fix whose shape contradicts its kind
must not reach a UI as a button
```

`TestWellFormedFixIsStillOffered` is the counterpart, so the guard cannot "pass" by rejecting everything. `TestMalformedFixErrorNamesTheFinding` pins that the error names the culprit, since a registry bug reported as "invalid" leaves a maintainer diffing registrations.

**Nothing currently registered is affected** — the whole suite passes unchanged, which is expected given `fix_test.go` already asserted the same shapes from the other side. What changes is that the assertion now holds for every finding rather than the sampled ones.

Full gate green: `build`, `vet`, `gofmt`, `mod tidy`, `test -race`, `golangci-lint` (0 issues), `sitegen` with no `site/` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)