### PR TITLE
fix(ui): measure text in display columns, not bytes or runes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.3
 require (
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
+	github.com/mattn/go-runewidth v0.0.24
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -18,7 +19,6 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
-	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/clirender/text.go
+++ b/internal/clirender/text.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/textwidth"
 )
 
 // Options controls text rendering.
@@ -316,23 +317,15 @@ func scoreColor(c colors, score uint8) string {
 }
 
 // wrap reflows text to width columns, indenting continuation lines.
+// wrap reflows text to width display columns, indenting continuation lines.
+//
+// The count is columns rather than bytes. Counting bytes wrapped Hangul at
+// roughly two-thirds of the width it was given, and the TUI's copy of this
+// function had the same flaw — which is why there is now one of it.
 func wrap(s string, width int, indent string) string {
-	words := strings.Fields(s)
-	if len(words) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	lineLen := 0
-	for i, w := range words {
-		if i > 0 && lineLen+1+len(w) > width {
-			b.WriteString("\n" + indent)
-			lineLen = 0
-		} else if i > 0 {
-			b.WriteString(" ")
-			lineLen++
-		}
-		b.WriteString(w)
-		lineLen += len(w)
-	}
-	return b.String()
+	return textwidth.Wrap(s, width, minWrapWidth, indent)
 }
+
+// minWrapWidth is the floor for a computed width; one word per line is
+// unreadable in a way an overrun is not.
+const minWrapWidth = 8

--- a/internal/textwidth/textwidth.go
+++ b/internal/textwidth/textwidth.go
@@ -1,0 +1,120 @@
+// Package textwidth fits text to a terminal measured in the unit a
+// terminal actually uses: display columns.
+//
+// It exists because three notions of "how wide is this" were in use at
+// once, and only one of them was right. The TUI's padRight measured
+// display columns; its truncate measured runes; its wrap and the CLI
+// renderer's wrap both measured bytes. For ASCII all three agree, which is
+// why the disagreement went unnoticed, and for anything else they diverge
+// in opposite directions.
+//
+// Measured against a line of Hangul, where one character is three bytes,
+// one rune, and two columns:
+//
+//	wrap(s, 40)     produced lines 24 columns wide — 40% of the terminal
+//	                thrown away, because bytes overcount
+//	truncate(s, 20) produced 34 columns — a 70% overflow of the budget it
+//	                was handed, because runes undercount
+//
+// The second is the damaging one: truncate exists to make a cell fit the
+// space computed for it, and returning something wider than that pushes
+// the row past the edge of the terminal.
+//
+// Non-ASCII reaches these on ordinary hosts. Compose service names and file
+// paths come from the operator, and `explain --ai` renders whatever the
+// local model wrote — which for a non-English operator is not English.
+package textwidth
+
+import (
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// narrow measures with East Asian Ambiguous characters counted as one
+// column, and it is deliberately not runewidth's package default.
+//
+// That default is chosen from the environment: runewidth reads LANG and
+// LC_ALL at init and sets EastAsianWidth when the locale is an East Asian
+// one. Under ko_KR.UTF-8 it then reports two columns for "…", "→", "±" and
+// "·" — all four of which hostveil draws, in the ellipsis truncate appends,
+// the domain-status bullets, and the score arrows. The same binary would
+// lay its screens out differently for an operator in Seoul and an operator
+// in Berlin, from the same terminal width and the same findings.
+//
+// It also has to agree with lipgloss, which the TUI already uses for
+// padRight and for measuring its own rows, and lipgloss counts those four
+// as one column each. Two measurements that disagree are worse than either
+// being wrong: truncate would cut to one budget while padRight padded to
+// another, and the row would be over-full or ragged depending on the glyph.
+// This condition matches lipgloss on every character the UI uses, and
+// TestAgreesWithLipgloss in internal/ui/tui pins that.
+var narrow = func() *runewidth.Condition {
+	c := runewidth.NewCondition()
+	c.EastAsianWidth = false
+	return c
+}()
+
+// Of returns the number of terminal columns s occupies.
+//
+// Not len(), which counts bytes, and not len([]rune()), which counts code
+// points: a Hangul syllable or a CJK ideograph occupies two columns and a
+// combining mark occupies none.
+func Of(s string) int { return narrow.StringWidth(s) }
+
+// Truncate shortens s to at most max columns, ending with an ellipsis when
+// anything was removed.
+//
+// The ellipsis costs a column of its own, so it is only used when there is
+// room for it to be worth one; below that the text is simply cut. A max of
+// zero or less yields the empty string rather than a bare ellipsis, since
+// a caller with no room has nothing to say.
+func Truncate(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	if Of(s) <= max {
+		return s
+	}
+	if max < 4 {
+		return narrow.Truncate(s, max, "")
+	}
+	return narrow.Truncate(s, max, "…")
+}
+
+// Wrap reflows s to lines of at most width columns, prefixing every line
+// after the first with indent.
+//
+// Words are never split: a single word wider than the budget takes a line
+// of its own and overruns it, which is the lesser of the two failures — a
+// path or an identifier broken across lines cannot be copied.
+//
+// The indent is not counted against the width. Callers pass a width they
+// have already reduced by the indent they want, which is how both callers
+// used it before this moved here.
+func Wrap(s string, width, minWidth int, indent string) string {
+	if width < minWidth {
+		width = minWidth
+	}
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	line := 0
+	for i, w := range words {
+		ww := Of(w)
+		switch {
+		case i == 0:
+		case line+1+ww > width:
+			b.WriteString("\n" + indent)
+			line = 0
+		default:
+			b.WriteString(" ")
+			line++
+		}
+		b.WriteString(w)
+		line += ww
+	}
+	return b.String()
+}

--- a/internal/textwidth/textwidth_test.go
+++ b/internal/textwidth/textwidth_test.go
@@ -1,0 +1,171 @@
+package textwidth
+
+import (
+	"strings"
+	"testing"
+)
+
+// One Hangul syllable is three bytes, one rune, and two columns. Every
+// assertion below is a case where at least two of those disagree, which is
+// the whole reason this package exists.
+const ko = "한글은 한 글자가 두 칸을 차지하고 세 바이트입니다"
+
+func TestOfCountsColumns(t *testing.T) {
+	for _, tc := range []struct {
+		s    string
+		want int
+	}{
+		{"", 0},
+		{"abc", 3},
+		{"한", 2},
+		{"한글", 4},
+		{"a한b", 4},
+		{"…", 1},
+	} {
+		if got := Of(tc.s); got != tc.want {
+			t.Errorf("Of(%q) = %d, want %d", tc.s, got, tc.want)
+		}
+	}
+	if got, bytes := Of(ko), len(ko); got == bytes {
+		t.Errorf("Of and len agree at %d on Hangul; the fixture is not exercising the bug", got)
+	}
+	if got, runes := Of(ko), len([]rune(ko)); got == runes {
+		t.Errorf("Of and rune count agree at %d on Hangul; the fixture is not exercising the bug", got)
+	}
+}
+
+// The damaging half of the old behaviour: truncate measured runes, so a
+// cell budgeted 20 columns came back 34 wide and pushed the row past the
+// edge of the terminal.
+func TestTruncateNeverExceedsItsBudget(t *testing.T) {
+	for _, s := range []string{ko, "plain ascii text that is quite long indeed", "混合 mixed 텍스트 content", "…"} {
+		for _, max := range []int{0, 1, 2, 3, 4, 5, 10, 20, 40, 200} {
+			got := Truncate(s, max)
+			if w := Of(got); w > max {
+				t.Errorf("Truncate(%q, %d) = %q, %d columns — over budget", s, max, got, w)
+			}
+		}
+	}
+}
+
+func TestTruncateKeepsWhatFits(t *testing.T) {
+	if got := Truncate("abc", 10); got != "abc" {
+		t.Errorf("Truncate = %q, want the string unchanged when it fits", got)
+	}
+	if got := Truncate(ko, 200); got != ko {
+		t.Errorf("Truncate shortened a string that already fits")
+	}
+	if got := Truncate("abc", 0); got != "" {
+		t.Errorf("Truncate(_, 0) = %q, want empty — no room means nothing to say", got)
+	}
+	// An ellipsis is only worth a column when there is room for it.
+	if got := Truncate("abcdefgh", 10); got != "abcdefgh" {
+		t.Errorf("Truncate = %q, want no ellipsis when nothing was cut", got)
+	}
+	if got := Truncate("abcdefgh", 5); !strings.HasSuffix(got, "…") {
+		t.Errorf("Truncate = %q, want an ellipsis to mark what was cut", got)
+	}
+}
+
+// The wasteful half: wrap measured bytes, so Hangul wrapped at roughly
+// two-thirds of the width it was given.
+func TestWrapFillsTheWidthItIsGiven(t *testing.T) {
+	const width = 40
+	lines := strings.Split(Wrap(ko, width, 8, ""), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("fixture did not wrap at width %d: %q", width, lines)
+	}
+	for i, l := range lines {
+		if w := Of(l); w > width {
+			t.Errorf("line %d is %d columns, over the %d budget: %q", i, w, width, l)
+		}
+	}
+	// Every line but the last must be within one word of full, or the
+	// wrapping is leaving the terminal empty — which is what counting bytes
+	// did.
+	for i, l := range lines[:len(lines)-1] {
+		next := strings.Fields(lines[i+1])[0]
+		if Of(l)+1+Of(next) <= width {
+			t.Errorf("line %d is only %d of %d columns and the next word would have fit: %q",
+				i, Of(l), width, l)
+		}
+	}
+}
+
+func TestWrapASCIIIsUnchangedInSpirit(t *testing.T) {
+	const width = 40
+	for _, l := range strings.Split(Wrap("the quick brown fox jumps over the lazy dog and keeps going", width, 8, ""), "\n") {
+		if w := Of(l); w > width {
+			t.Errorf("line is %d columns, over %d: %q", w, width, l)
+		}
+	}
+}
+
+func TestWrapIndentsContinuationLines(t *testing.T) {
+	out := Wrap("alpha beta gamma delta epsilon zeta eta theta", 20, 8, "  ")
+	lines := strings.Split(out, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected a wrap: %q", out)
+	}
+	if strings.HasPrefix(lines[0], "  ") {
+		t.Error("the first line must not be indented")
+	}
+	for _, l := range lines[1:] {
+		if !strings.HasPrefix(l, "  ") {
+			t.Errorf("continuation line not indented: %q", l)
+		}
+	}
+}
+
+// A word wider than the whole budget takes a line of its own and overruns
+// it. Splitting it would be worse: a path or an identifier broken across
+// lines cannot be copied.
+func TestWrapDoesNotSplitAWordTooWideToFit(t *testing.T) {
+	long := "/home/seolcu/프로젝트/hostveil/internal/textwidth/textwidth.go"
+	out := Wrap("see "+long+" now", 10, 8, "")
+	if !strings.Contains(out, long) {
+		t.Errorf("the long word was split:\n%s", out)
+	}
+}
+
+func TestWrapEmptyInput(t *testing.T) {
+	for _, s := range []string{"", "   ", "\t\n"} {
+		if got := Wrap(s, 40, 8, ""); got != "" {
+			t.Errorf("Wrap(%q) = %q, want empty", s, got)
+		}
+	}
+}
+
+// The floor keeps a caller that computed a negative or absurd width from
+// producing one word per line.
+func TestWrapHasAMinimumWidth(t *testing.T) {
+	for _, w := range []int{-10, 0, 3} {
+		out := Wrap("alpha beta gamma delta", w, 8, "")
+		for _, l := range strings.Split(out, "\n") {
+			if Of(l) > 8 && len(strings.Fields(l)) > 1 {
+				t.Errorf("width %d produced an over-wide line: %q", w, l)
+			}
+		}
+	}
+}
+
+// The locale trap. runewidth picks its default condition from LANG and
+// LC_ALL at init, so its package-level StringWidth reports two columns for
+// these under ko_KR.UTF-8 and one under en_US.UTF-8. Every one of them is
+// drawn by hostveil, so using the default would lay the same screen out
+// differently for different operators — and would disagree with lipgloss,
+// which the TUI already uses to measure and pad the same rows.
+func TestAmbiguousWidthIsNotLocaleDependent(t *testing.T) {
+	for _, s := range []string{"…", "→", "±", "·", "✓", "⚠", "▚"} {
+		if got := Of(s); got != 1 {
+			t.Errorf("Of(%q) = %d, want 1 — an ambiguous-width glyph must not depend on the operator's locale", s, got)
+		}
+	}
+	// Genuinely wide characters are still wide; the condition narrows only
+	// the ambiguous class.
+	for _, s := range []string{"한", "漢", "あ"} {
+		if got := Of(s); got != 2 {
+			t.Errorf("Of(%q) = %d, want 2", s, got)
+		}
+	}
+}

--- a/internal/ui/tui/layout_test.go
+++ b/internal/ui/tui/layout_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/textwidth"
 )
 
 // visibleWidth is the rendered column count of a line, ignoring ANSI colour.
 func visibleWidth(s string) int {
-	var n int
+	var b strings.Builder
 	for i := 0; i < len(s); {
 		if s[i] == 0x1b { // skip an escape sequence up to its final 'm'
 			for i < len(s) && s[i] != 'm' {
@@ -21,10 +22,13 @@ func visibleWidth(s string) int {
 			continue
 		}
 		_, size := decodeRune(s[i:])
+		b.WriteString(s[i : i+size])
 		i += size
-		n++
 	}
-	return n
+	// Columns, not runes. Counting runes here made this helper agree with
+	// the rune-counting truncate it was supposed to be checking, so a cell
+	// twice as wide as its budget measured as exactly fitting.
+	return textwidth.Of(b.String())
 }
 
 func decodeRune(s string) (rune, int) {

--- a/internal/ui/tui/textwidth_test.go
+++ b/internal/ui/tui/textwidth_test.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/seolcu/hostveil/internal/textwidth"
+)
+
+// Two measurements of the same row must agree, and this is the only package
+// that imports both. padRight and the frame measure with lipgloss; truncate
+// and wrap measure with textwidth. If they part company, truncate cuts to
+// one budget while padRight pads to another and the row is over-full or
+// ragged depending on which glyphs it happens to contain.
+//
+// They can part company by accident, because runewidth — which textwidth
+// uses — chooses its default width table from LANG and LC_ALL at init.
+// Under ko_KR.UTF-8 that default calls "…", "→", "±" and "·" two columns
+// wide while lipgloss calls them one. textwidth pins an explicit condition
+// to avoid it; this is what would notice if that pin were removed.
+func TestTextwidthAgreesWithLipgloss(t *testing.T) {
+	for _, s := range []string{
+		// Every non-ASCII glyph the TUI draws.
+		"…", "→", "±", "·", "✓", "✗", "⚠", "▚", "─", "~",
+		// And content that reaches it from the host.
+		"한글 서비스 이름", "混合 mixed content", "/home/seolcu/프로젝트/hostveil",
+		"plain ascii", "", "  spaced  ",
+		"✓ 2 resolved   + 1 new   ~ 3 changed",
+	} {
+		if got, want := textwidth.Of(s), lipgloss.Width(s); got != want {
+			t.Errorf("textwidth.Of(%q) = %d but lipgloss.Width = %d — "+
+				"truncate and padRight would disagree about the same row", s, got, want)
+		}
+	}
+}
+
+// The consequence, end to end: whatever truncate returns must fit the
+// budget padRight is about to pad to, for every width and every script.
+func TestTruncateFitsWhatPadRightPadsTo(t *testing.T) {
+	for _, s := range []string{
+		"한글은 한 글자가 두 칸을 차지합니다",
+		"a fairly long ascii finding title that will not fit",
+		"混合 mixed 텍스트 with ascii",
+	} {
+		for w := 0; w <= 30; w++ {
+			cut := truncate(s, w)
+			if got := lipgloss.Width(cut); got > w {
+				t.Errorf("truncate(%q, %d) is %d columns by lipgloss — the row overflows", s, w, got)
+			}
+			if padded := padRight(cut, w); lipgloss.Width(padded) != w && cut != "" {
+				t.Errorf("padRight(truncate(%q, %d)) is %d columns, want exactly %d",
+					s, w, lipgloss.Width(padded), w)
+			}
+		}
+	}
+}
+
+// And wrap must not hand the frame a line wider than the terminal.
+func TestWrapLinesFitTheTerminal(t *testing.T) {
+	for _, s := range []string{
+		"한글로 된 설명이 길어지면 어떻게 되는지 확인하는 문장입니다 계속 이어집니다",
+		"an english description that runs on for a while and needs to be reflowed neatly",
+	} {
+		for _, w := range []int{20, 40, 78} {
+			for _, l := range strings.Split(wrap(s, w), "\n") {
+				if got := lipgloss.Width(l); got > w {
+					t.Errorf("wrap(_, %d) produced a %d-column line: %q", w, got, l)
+				}
+			}
+		}
+	}
+}

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -9,6 +9,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/seolcu/hostveil/internal/textwidth"
+
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/ui/theme"
 )
@@ -831,19 +833,14 @@ func scrollOffset(cursor, total, visible, offset int) int {
 // It also sliced by byte, which can cut a multi-byte rune in half and emit a
 // replacement character. Findings are English today, but service names and
 // file paths come from the host.
-func truncate(s string, max int) string {
-	r := []rune(s)
-	switch {
-	case max <= 0:
-		return ""
-	case len(r) <= max:
-		return s
-	case max < 4:
-		return string(r[:max]) // no room for an ellipsis to be worth a column
-	default:
-		return string(r[:max-1]) + "…"
-	}
-}
+// truncate fits s into max display columns.
+//
+// It used to count runes, which is right for ASCII and wrong for anything
+// wider: a Hangul or CJK cell handed a 20-column budget came back 34
+// columns and pushed the row past the edge of the terminal. padRight, three
+// lines below, has always measured columns — so the two disagreed about the
+// same row.
+func truncate(s string, max int) string { return textwidth.Truncate(s, max) }
 
 func padRight(s string, n int) string {
 	if lipgloss.Width(s) >= n || n < 0 {
@@ -852,26 +849,18 @@ func padRight(s string, n int) string {
 	return s + strings.Repeat(" ", n-lipgloss.Width(s))
 }
 
-func wrap(s string, width int) string {
-	if width < 8 {
-		width = 8
-	}
-	words := strings.Fields(s)
-	var b strings.Builder
-	ll := 0
-	for i, w := range words {
-		if i > 0 && ll+1+len(w) > width {
-			b.WriteString("\n")
-			ll = 0
-		} else if i > 0 {
-			b.WriteString(" ")
-			ll++
-		}
-		b.WriteString(w)
-		ll += len(w)
-	}
-	return b.String()
-}
+// minWrapWidth is the floor wrap applies to a computed width. A narrow
+// terminal can drive the budget to nothing, and one word per line is
+// unreadable in a way an overrun is not.
+const minWrapWidth = 8
+
+// wrap reflows s to width display columns.
+//
+// It used to count bytes, so Hangul wrapped at roughly two-thirds of the
+// width it was given — 24 columns used of 40. `explain --ai` renders
+// whatever the local model wrote, which is the path that reaches this with
+// text the byte count is wrong about.
+func wrap(s string, width int) string { return textwidth.Wrap(s, width, minWrapWidth, "") }
 
 // trendLine renders the score of every retained scan as one row.
 //


### PR DESCRIPTION
## Three answers to one question

`padRight` measured display columns. `truncate` measured runes. `wrap` — in the TUI and again in the CLI renderer — measured bytes. For ASCII all three agree, which is why nobody noticed; for anything else they diverge in **opposite** directions.

Measured against Hangul, where one character is three bytes, one rune, and two columns:

```
wrap(s, 40)     → lines 24 columns wide   (40% of the terminal thrown away)
truncate(s, 20) → 34 columns              (70% over the budget it was handed)
```

`truncate` is the damaging one. It exists to make a cell fit the space computed for it, and `padRight` then pads that same cell measured a different way — so the row ends up over-full. Reverting `truncate` to the old rune count fails the new test immediately:

```
truncate("한글은 한 글자가 두 칸을 차지합니다", 1) is 2 columns by lipgloss — the row overflows
truncate("한글은 한 글자가 두 칸을 차지합니다", 2) is 4 columns by lipgloss — the row overflows
```

Non-ASCII reaches these on ordinary hosts: compose service names and file paths come from the operator, and `explain --ai` renders whatever the local model wrote.

## The part that nearly went wrong

The obvious fix is `runewidth.StringWidth`. That would have introduced a worse bug than the one it fixed.

**runewidth picks its default width table from `LANG`/`LC_ALL` at init.** On this machine (`ko_KR.UTF-8`) the default disagrees with lipgloss on four glyphs hostveil actually draws:

| glyph | lipgloss | runewidth default | where hostveil uses it |
| --- | :-: | :-: | --- |
| `…` | 1 | **2** | the ellipsis `truncate` appends |
| `→` | 1 | **2** | score trend |
| `±` | 1 | **2** | score delta |
| `·` | 1 | **2** | domain-status bullets |

So the same binary would lay out screens differently for an operator in Seoul and one in Berlin, from the same terminal width and the same findings — and `truncate` would be back to disagreeing with `padRight`, by a new route.

`internal/textwidth` pins an explicit condition with `EastAsianWidth: false`, matching lipgloss on every glyph the UI uses. `TestTextwidthAgreesWithLipgloss` lives in `internal/ui/tui` — the one package that imports both — and is what would notice if the pin were removed.

## Also

`internal/ui/tui/layout_test.go`'s `visibleWidth` counted runes, so it agreed with the rune-counting `truncate` it was supposed to be checking, and measured a cell twice as wide as its budget as exactly fitting. It counts columns now.

`go-runewidth` moves from indirect to direct in `go.mod`; it was already in the module graph via lipgloss.

Full gate green: `build`, `vet`, `gofmt`, `mod tidy`, `test -race`, `golangci-lint` (0 issues), `sitegen` with no `site/` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)