### PR TITLE
fix(core): plan a mode change once per apply, not twice

### DIFF
--- a/internal/core/fixflow.go
+++ b/internal/core/fixflow.go
@@ -16,6 +16,7 @@ import (
 	"github.com/seolcu/hostveil/internal/history"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
+	"github.com/seolcu/hostveil/internal/textwidth"
 )
 
 // PreviewFix returns, per available action, exactly what the fix would
@@ -148,20 +149,40 @@ func previewMode(a fix.Action) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return modeTable(changes), nil
+}
+
+// modeTable renders a plan that has already been made.
+//
+// It is separate from previewMode so that applyMode can describe the very
+// changes it is about to make. applyMode used to call planModes and then
+// previewMode, which planned again — two Lstat passes over the same paths
+// inside one apply, and two chances for the answer to differ. The paths it
+// chmod'ed and recorded for rollback came from the first pass while the
+// summary stored in the checkpoint came from the second, so a mode altered
+// between them left the checkpoint describing a set that was never applied.
+// Rollback still worked, since the restore data came from the first pass;
+// the record of what happened was the part that lied.
+//
+// The column is measured in display columns. len() counts bytes, which
+// misaligns the arrows for any path that is not ASCII — and paths come from
+// the operator.
+func modeTable(changes []modeChange) string {
 	if len(changes) == 0 {
-		return "Permissions are already as strict as required.", nil
+		return "Permissions are already as strict as required."
 	}
 	width := 0
 	for _, c := range changes {
-		if len(c.path) > width {
-			width = len(c.path)
+		if w := textwidth.Of(c.path); w > width {
+			width = w
 		}
 	}
 	var b strings.Builder
 	for _, c := range changes {
-		fmt.Fprintf(&b, "%-*s  %#o → %#o\n", width, c.path, c.from.Perm(), c.to.Perm())
+		fmt.Fprintf(&b, "%s  %#o → %#o\n",
+			c.path+strings.Repeat(" ", width-textwidth.Of(c.path)), c.from.Perm(), c.to.Perm())
 	}
-	return b.String(), nil
+	return b.String()
 }
 
 // ApplyFix applies one action of a finding's fix through the single
@@ -410,10 +431,9 @@ func (e *Engine) applyMode(f model.Finding, fx fix.Fix, a fix.Action) (model.Fix
 		return model.FixOutcome{}, fmt.Errorf("permissions on %v are already as strict as required", a.Paths)
 	}
 
-	summary, err := previewMode(a)
-	if err != nil {
-		return model.FixOutcome{}, err
-	}
+	// From the plan already in hand, not a second one: the summary must
+	// describe the changes this call is about to make.
+	summary := modeTable(changes)
 
 	prior := make(map[string]os.FileMode, len(changes))
 	for _, c := range changes {

--- a/internal/core/modeplan_test.go
+++ b/internal/core/modeplan_test.go
@@ -1,0 +1,106 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/fix"
+	"github.com/seolcu/hostveil/internal/textwidth"
+)
+
+// applyMode used to plan the changes and then call previewMode, which
+// planned them again: two Lstat passes over the same paths inside one
+// apply. The paths it chmod'ed and recorded for rollback came from the
+// first pass, while the summary it stored in the checkpoint came from the
+// second, so a mode altered in between left the checkpoint describing a set
+// that was never applied.
+//
+// modeTable renders a plan already made, so the two cannot differ. These
+// tests hold the table to that plan.
+
+func modeAction(t *testing.T, paths []string, to os.FileMode) fix.Action {
+	t.Helper()
+	return fix.Action{
+		Label: "tighten", Kind: fix.ActionMode, Paths: paths,
+		Mode: func(cur os.FileMode) os.FileMode { return cur.Type() | to },
+	}
+}
+
+func TestModeTableDescribesExactlyThePlan(t *testing.T) {
+	dir := t.TempDir()
+	var paths []string
+	for _, name := range []string{"a.conf", "b.conf", "c.conf"} {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o666); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, p)
+	}
+
+	changes, err := planModes(modeAction(t, paths, 0o600))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 3 {
+		t.Fatalf("planned %d changes, want 3", len(changes))
+	}
+
+	table := modeTable(changes)
+	for _, c := range changes {
+		if !strings.Contains(table, c.path) {
+			t.Errorf("the table omits %s, which the plan will change", c.path)
+		}
+	}
+	// One row per planned change and no more: a row for a path that is not
+	// in the plan is the checkpoint recording work nobody did.
+	if got := len(strings.Split(strings.TrimRight(table, "\n"), "\n")); got != len(changes) {
+		t.Errorf("table has %d rows for %d planned changes:\n%s", got, len(changes), table)
+	}
+}
+
+// The empty plan has to keep saying so, since applyMode distinguishes it
+// from a real one before it reaches the table.
+func TestModeTableOnAnEmptyPlan(t *testing.T) {
+	if got := modeTable(nil); !strings.Contains(got, "already as strict") {
+		t.Errorf("modeTable(nil) = %q", got)
+	}
+}
+
+// The arrow column is aligned in display columns. Measuring the path with
+// len() counts bytes, so a single non-ASCII path threw every arrow in the
+// table out of line — and paths come from the operator.
+func TestModeTableAlignsNonASCIIPaths(t *testing.T) {
+	dir := t.TempDir()
+	var paths []string
+	for _, name := range []string{"짧은.conf", "a-much-longer-ascii-name.conf", "설정파일.conf"} {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o666); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, p)
+	}
+	changes, err := planModes(modeAction(t, paths, 0o600))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var col = -1
+	for _, line := range strings.Split(strings.TrimRight(modeTable(changes), "\n"), "\n") {
+		at := strings.Index(line, "→")
+		if at < 0 {
+			t.Fatalf("row has no mode column: %q", line)
+		}
+		got := textwidth.Of(line[:at])
+		if col == -1 {
+			col = got
+			continue
+		}
+		if got != col {
+			t.Errorf("modes start at column %d on one row and %d on another — the table is ragged:\n%s",
+				col, got, modeTable(changes))
+			break
+		}
+	}
+}


### PR DESCRIPTION
## Two plans, one apply

`applyMode` planned the changes, then called `previewMode` — which planned them **again**. Two `os.Lstat` passes over the same paths inside one apply.

The two results are not guaranteed to match:

- the paths `applyMode` chmod'ed, and the prior modes it recorded for rollback, came from **pass 1**
- the summary it stored in the checkpoint came from **pass 2**

A mode altered between them left the checkpoint describing a set that was never applied. Rollback still worked — the restore data came from pass 1 — but the *record of what happened* was wrong, which is the one thing a checkpoint is for.

The window is the same one the comment above the chmod loop already worries about ("the file can be swapped for a symlink between the plan and this line"), widened for no benefit.

`modeTable` now renders a plan already made, and `applyMode` passes the plan it is about to execute. `previewMode` keeps its own planning pass, because it has no plan in hand — it *is* the preview.

## Also: the table was ragged for non-ASCII paths

The column width used `len()`, which counts bytes, so one Korean path threw every arrow out of line. Paths come from the operator. Simulating the old code:

```
/tmp/.../짧은.conf                    0644 → 0600
/tmp/.../a-much-longer-ascii-name.conf  0644 → 0600
/tmp/.../설정파일.conf              0644 → 0600
```

`modes start at column 86 on one row and 88 on another — the table is ragged`

It measures display columns now, consistent with everything else since `internal/textwidth`.

## Verification

- `TestModeTableDescribesExactlyThePlan` asserts one row per planned change and no more — a row for a path not in the plan is the checkpoint recording work nobody did.
- `TestModeTableAlignsNonASCIIPaths` fails against the byte-width version, with the ragged table above in the failure message.
- `TestModeTableOnAnEmptyPlan` keeps the "already as strict as required" branch, which `applyMode` distinguishes before reaching the table.

Full gate green: `build`, `vet`, `gofmt`, `mod tidy`, `test -race`, `golangci-lint` (0 issues), `sitegen` with no `site/` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)