### PR TITLE
fix(check): a home the agent scan cannot enter is not a home with nothing in it

### DIFF
--- a/internal/check/agent/agent.go
+++ b/internal/check/agent/agent.go
@@ -46,26 +46,38 @@ func (*Checker) Source() model.Source { return model.SourceAgent }
 // Available probes for an actual agent installation, not merely for the
 // ability to look.
 //
-// The two failure modes are kept distinct on purpose. An unreadable
-// /etc/passwd means we could not look, and a host with no runtime installed
-// means there was nothing to find; both skip the domain, but conflating them
-// would let "I couldn't look" pass for "nothing there". The domain is skipped
-// rather than reported clean because a host that has never installed an agent
-// should not collect a free perfect score for a domain that never applied.
+// The failure modes are kept distinct on purpose. An unreadable /etc/passwd
+// means we could not look, a home we cannot enter means we could not look
+// *there*, and a host with no runtime installed means there was nothing to
+// find. All three skip the domain, but conflating them would let "I couldn't
+// look" pass for "nothing there". The domain is skipped rather than reported
+// clean because a host that has never installed an agent should not collect a
+// free perfect score for a domain that never applied.
+//
+// The middle one is why the unreadable list is read here rather than
+// discarded. On a multi-user host scanned without root, every other account's
+// home denies entry, so reporting absence would tell an operator there is no
+// agent runtime while one runs behind a wide-open gateway two accounts over —
+// and would say nothing about sudo, the one thing that would show it.
 func (c *Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
 	hs, err := homes(c.PasswdPath)
 	if err != nil {
 		return false, "cannot read " + c.PasswdPath + " to locate home directories"
 	}
-	found, _ := installs(hs, c.Runtimes)
-	if len(found) == 0 {
-		names := make([]string, 0, len(c.Runtimes))
-		for _, rt := range c.Runtimes {
-			names = append(names, rt.Display)
-		}
-		return false, "no self-hosted agent runtime found (" + strings.Join(names, ", ") + ")"
+	found, unreadable := installs(hs, c.Runtimes)
+	if len(found) > 0 {
+		return true, ""
 	}
-	return true, ""
+	if len(unreadable) > 0 {
+		sort.Strings(unreadable)
+		return false, "cannot read home directories (" + strings.Join(unreadable, ", ") +
+			") — re-run with sudo to scan them for agent runtimes"
+	}
+	names := make([]string, 0, len(c.Runtimes))
+	for _, rt := range c.Runtimes {
+		names = append(names, rt.Display)
+	}
+	return false, "no self-hosted agent runtime found (" + strings.Join(names, ", ") + ")"
 }
 
 // scan is one runtime installation plus whatever we managed to read of it.

--- a/internal/check/agent/agent_test.go
+++ b/internal/check/agent/agent_test.go
@@ -190,6 +190,73 @@ func TestAvailableDistinguishesUnreadableFromAbsent(t *testing.T) {
 	}
 }
 
+// There is a third failure mode, and it reads as the second.
+//
+// A home directory that cannot be entered is ground this domain did not
+// cover. Available discarded the unreadable list and reported "no
+// self-hosted agent runtime found" — so a non-root scan on a host where
+// another account runs an agent behind a wide-open gateway told the operator
+// there was no agent runtime, and offered no reason to try again with sudo.
+//
+// The home itself stays stat-able throughout: statting a directory needs only
+// search permission on its *parent*, so the check that guards this path
+// succeeds and the marker underneath is what fails.
+func TestAvailableSaysSoWhenAHomeCannotBeRead(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read every home, so the permission gap cannot be staged")
+	}
+	h := newHost(t, "alice", "bob")
+	h.write("bob", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)
+	if err := os.Chmod(h.homes["bob"], 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(h.homes["bob"], 0o755) })
+
+	// The premise: bob's home stats fine, the marker inside it does not.
+	if _, err := os.Stat(h.homes["bob"]); err != nil {
+		t.Fatalf("premise broken — bob's home is not stat-able: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(h.homes["bob"], ".openclaw")); err == nil {
+		t.Fatal("premise broken — the marker under an unreadable home is still readable")
+	}
+
+	ok, reason := h.checker().Available(context.Background(), platform.Env{})
+	if ok {
+		t.Fatalf("expected the domain to be skipped, got available")
+	}
+	if strings.Contains(reason, "no self-hosted agent runtime") {
+		t.Errorf("reason %q reports absence for a home that could not be read", reason)
+	}
+	if !strings.Contains(reason, "sudo") {
+		t.Errorf("reason %q should tell the operator how to cover the domain", reason)
+	}
+}
+
+// The same blind spot on the other side of the fence: one runtime is visible,
+// so the domain runs — and the account it could not look at has to show up as
+// a coverage gap rather than as a clean result.
+func TestAnUnreadableHomeDegradesAScanThatOtherwiseRan(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read every home, so the permission gap cannot be staged")
+	}
+	h := newHost(t, "alice", "bob")
+	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)
+	h.write("bob", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)
+	if err := os.Chmod(h.homes["bob"], 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(h.homes["bob"], 0o755) })
+
+	_, err := h.checker().Check(context.Background(), envNoFirewall(""))
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want a PartialError so the axis reports Degraded, got %v", err)
+	}
+	if !strings.Contains(partial.Reason, h.homes["bob"]) {
+		t.Errorf("the unreadable home is missing from %q", partial.Reason)
+	}
+}
+
 func TestAvailableTrueWhenMarkerExists(t *testing.T) {
 	h := newHost(t, "alice")
 	h.write("alice", ".openclaw/openclaw.json", cleanOpenClaw, 0o600)

--- a/internal/check/agent/discover.go
+++ b/internal/check/agent/discover.go
@@ -93,14 +93,46 @@ func installs(hs []userHome, rts []Runtime) (found []install, unreadable []strin
 			}
 			continue
 		}
+		// The home stats fine and its markers still may not. Statting a
+		// directory needs only search permission on its *parent*, so a home
+		// mode 0700 owned by someone else passes the check above and denies
+		// everything underneath it — which is the ordinary shape of a
+		// multi-user host scanned without root.
+		blind := false
 		for _, rt := range rts {
-			for _, m := range rt.Markers {
-				if _, err := os.Stat(filepath.Join(h.Home, m)); err == nil {
-					found = append(found, install{user: h, rt: rt})
-					break
-				}
+			switch installed, err := hasMarker(h.Home, rt); {
+			case err != nil:
+				blind = true
+			case installed:
+				found = append(found, install{user: h, rt: rt})
 			}
+		}
+		if blind {
+			unreadable = append(unreadable, h.Home)
 		}
 	}
 	return found, unreadable
+}
+
+// hasMarker reports whether rt is installed under home.
+//
+// A non-nil error means the question could not be answered, which is not the
+// same as answering no — and treating it as no is what let an unreadable home
+// report as an account with nothing installed. Only os.IsNotExist is a real
+// negative; anything else is a blind spot the caller has to account for.
+//
+// A runtime found through one marker is installed regardless of what the
+// others say, so a positive wins outright. Otherwise any unanswerable marker
+// makes the whole answer unanswerable.
+func hasMarker(home string, rt Runtime) (bool, error) {
+	var blind error
+	for _, m := range rt.Markers {
+		switch _, err := os.Stat(filepath.Join(home, m)); {
+		case err == nil:
+			return true, nil
+		case !os.IsNotExist(err):
+			blind = err
+		}
+	}
+	return false, blind
 }


### PR DESCRIPTION
Found by auditing all eleven checkers against the rule in AGENTS.md — that `Available()` must probe the capability, not merely the binary. Ten hold. This one does not.

## The gap

`Available()`'s own doc comment names two failure modes and keeps them distinct on purpose:

> An unreadable /etc/passwd means we could not look, and a host with no runtime installed means there was nothing to find; both skip the domain, but conflating them would let "I couldn't look" pass for "nothing there".

There is a third, and it read as the second.

`installs` statted each home, then statted the markers underneath it. Only the **first** check distinguished a permission error from absence — the marker stat treated any error as "not installed". Those are not the same stat: a directory can be statted with only search permission on its *parent*, so a home at mode 0700 owned by someone else **passes the guard** and denies everything below it. That is the ordinary shape of a multi-user host scanned without root.

Two consequences:

1. `Available()` reported `no self-hosted agent runtime found (OpenClaw, Hermes Agent)` for an account it could not look inside — and said nothing about sudo, the one thing that would have shown it.
2. Worse: when another runtime *was* visible so the domain ran, the unreadable account never reached `unreadableHomes`, so `Check()` returned a **nil error**. The domain reported `ScanDone` and was scored as though it had covered ground it never saw.

Both tests were written first and failed against `main`:

```
agent_test.go:228: reason "no self-hosted agent runtime found (OpenClaw, Hermes Agent)"
                   reports absence for a home that could not be read
agent_test.go:253: want a PartialError so the axis reports Degraded, got <nil>
```

Each test asserts its own premise before asserting the bug — that the home is still stat-able while the marker under it is not — so it cannot pass for the wrong reason. Both skip under `Geteuid() == 0`, since root can't stage the permission gap.

## The fix

`hasMarker` answers *installed* / *not installed* / *cannot tell*, and only `os.IsNotExist` is a real negative. A runtime found through one marker wins outright; otherwise any unanswerable marker makes the whole answer unanswerable. `Available()` reads the unreadable list rather than discarding it (`found, _ :=`).

## Behavior change worth knowing

`/root` is stat-able but not readable by a non-root scan, so an unelevated run now reports:

```
cannot read home directories (/root) — re-run with sudo to scan them for agent runtimes
```

where it used to report the domain absent. I verified this against this machine rather than reasoning about it. It is the honest answer — we genuinely cannot tell whether root has a runtime — and it matches what `accounts` already does for `/etc/shadow`. Scans auto-elevate, so the usual path is unaffected; this reaches `HOSTVEIL_NO_SUDO=1` runs.

The domain is still *Skipped* (not Degraded) when nothing is found, so a host with no agents does not start reporting a degraded axis.

## Audit result for the other ten

`compose`, `dockerd` use `DockerReachable`; `cve` adds it to the Trivy probe; `accounts`, `ssh`, `sysctl` open the file they need; `updates` keys on detected package manager. `ports` and `cve` check only for a binary (`ss`, `trivy`) but both turn a failure at use into an error or partial result rather than a clean one, so the capability rule is satisfied downstream. `fileperms` and `firewall` are unconditionally available and report `StatusUnknown` / partial coverage from `Check()`.

Full gate green: build, vet, gofmt, mod tidy, `-race`, golangci-lint (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)