### PR TITLE
fix(check): a file permissions cannot be read is not a file with good permissions

### DIFF
--- a/internal/check/fileperms/fileperms.go
+++ b/internal/check/fileperms/fileperms.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/seolcu/hostveil/internal/check"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
 )
@@ -28,6 +29,36 @@ type Rule struct {
 	ID      string
 	Title   string
 	Desc    string
+}
+
+// paths resolves the rule to the concrete files to stat. An error means the
+// rule could not be evaluated at all, which is a coverage gap and not a pass.
+//
+// The glob is the reason this exists. filepath.Glob reports a directory it
+// cannot read as zero matches and a nil error — indistinguishable from a host
+// that simply has no SSH host keys — so an /etc/ssh the scan cannot enter
+// would silently clear a High-severity rule about private keys being readable.
+// Asking the directory directly is the only way to tell the two apart.
+//
+// It assumes the wildcard is in the last element, which is the shape Rule
+// documents and the only shape defaultRules uses.
+func (r Rule) paths() ([]string, error) {
+	if !r.Glob {
+		return []string{r.Path}, nil
+	}
+	matches, err := filepath.Glob(r.Path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot expand %s: %w", r.Path, err)
+	}
+	if len(matches) > 0 {
+		return matches, nil
+	}
+	dir := filepath.Dir(r.Path)
+	if _, err := os.ReadDir(dir); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("cannot read %s — the files it holds were not checked", dir)
+	}
+	// The directory is absent or genuinely empty of matches. Nothing to judge.
+	return nil, nil
 }
 
 // Checker reports sensitive files with over-permissive modes.
@@ -69,28 +100,49 @@ func (*Checker) Available(_ context.Context, _ platform.Env) (bool, string) {
 }
 
 // Check stats each rule's file(s) and flags any over-permissive mode.
+//
+// A rule it could not evaluate is recorded as a coverage gap rather than
+// passed over. "This file is not here" and "I was not allowed to look at it"
+// both used to arrive as a non-nil error from Stat and both were skipped, so
+// a rule that could not run reported exactly like a rule that passed — on a
+// domain whose whole job is noticing that a sensitive file is readable by the
+// wrong people.
 func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, error) {
 	var findings []model.Finding
+	var cov check.Coverage
 	for _, rule := range c.Rules {
-		paths := []string{rule.Path}
-		if rule.Glob {
-			matches, err := filepath.Glob(rule.Path)
-			if err != nil || len(matches) == 0 {
-				continue
-			}
-			paths = matches
+		paths, err := rule.paths()
+		if err != nil {
+			cov.Missed(1, err.Error())
+			continue
 		}
+		cov.Covered(1)
+
 		var badPaths []string
 		var badEvidence []string
+		var unstattable []string
 		for _, p := range paths {
 			fi, err := os.Stat(p)
-			if err != nil || fi.IsDir() {
-				continue // missing files (e.g. no SSH server) are not findings
+			switch {
+			case os.IsNotExist(err):
+				continue // no SSH server, no /etc/shadow: nothing to judge
+			case err != nil:
+				// Not the same as absent. The rule was not evaluated for this
+				// file, and saying nothing would report it as having passed.
+				unstattable = append(unstattable, p)
+				continue
+			case fi.IsDir():
+				continue
 			}
 			if fi.Mode().Perm()&^rule.MaxMode != 0 {
 				badPaths = append(badPaths, p)
 				badEvidence = append(badEvidence, fmt.Sprintf("%s (%#o)", p, fi.Mode().Perm()))
 			}
+		}
+		if len(unstattable) > 0 {
+			sort.Strings(unstattable)
+			cov.Missed(0, "cannot read "+strings.Join(unstattable, ", ")+
+				" — their permissions were not checked")
 		}
 		if len(badPaths) == 0 {
 			continue
@@ -111,5 +163,5 @@ func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, err
 			model.WithEvidence("expected", fmt.Sprintf("%#o", rule.MaxMode)),
 		))
 	}
-	return findings, nil
+	return findings, cov.Err()
 }

--- a/internal/check/fileperms/fileperms_test.go
+++ b/internal/check/fileperms/fileperms_test.go
@@ -2,11 +2,13 @@ package fileperms
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/seolcu/hostveil/internal/check"
 	"github.com/seolcu/hostveil/internal/model"
 	"github.com/seolcu/hostveil/internal/platform"
 )
@@ -138,5 +140,99 @@ func TestFilePermsDeclaresAutoAndCarriesPaths(t *testing.T) {
 	}
 	if f.Evidence["expected"] != "0640" {
 		t.Errorf("expected = %q, want 0640", f.Evidence["expected"])
+	}
+}
+
+// A directory the scan cannot enter is not a directory with no host keys in
+// it. filepath.Glob reports an unreadable directory as zero matches and a nil
+// error, so the two arrived identically — and the one that means "I was not
+// allowed to look" cleared a High-severity rule about SSH private keys being
+// readable by the wrong people.
+func TestAnUnreadableGlobDirectoryDegradesTheDomain(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads every directory, so the permission gap cannot be staged")
+	}
+	dir := filepath.Join(t.TempDir(), "ssh")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ssh_host_rsa_key"), []byte("k"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	pattern := filepath.Join(dir, "ssh_host_*_key")
+	// The premise: Glob is silent about why it found nothing.
+	if m, err := filepath.Glob(pattern); len(m) != 0 || err != nil {
+		t.Fatalf("premise broken — Glob returned %v, %v", m, err)
+	}
+
+	_, err := (&Checker{Rules: []Rule{{
+		Path: pattern, Glob: true, MaxMode: 0o640, Sev: model.SeverityHigh,
+		ID: "fileperms.hostkey", Title: "host key", Desc: "d",
+	}}}).Check(context.Background(), platform.Env{})
+
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want a PartialError so the axis reports Degraded, got %v", err)
+	}
+	if !strings.Contains(partial.Reason, dir) {
+		t.Errorf("the unreadable directory is missing from %q", partial.Reason)
+	}
+}
+
+// The same distinction one level down: a file that exists but cannot be
+// statted is a rule that did not run, not a rule that passed.
+func TestAnUnstattableFileDegradesTheDomain(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root stats every file, so the permission gap cannot be staged")
+	}
+	dir := filepath.Join(t.TempDir(), "etc")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "shadow")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	// The premise: the error is a denial, not an absence.
+	if _, err := os.Stat(path); err == nil || os.IsNotExist(err) {
+		t.Fatalf("premise broken — stat returned %v", err)
+	}
+
+	_, err := (&Checker{Rules: []Rule{{
+		Path: path, MaxMode: 0o640, Sev: model.SeverityHigh,
+		ID: "fileperms.shadow", Title: "shadow", Desc: "d",
+	}}}).Check(context.Background(), platform.Env{})
+
+	var partial *check.PartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("want a PartialError so the axis reports Degraded, got %v", err)
+	}
+	if !strings.Contains(partial.Reason, path) {
+		t.Errorf("the unstattable file is missing from %q", partial.Reason)
+	}
+}
+
+// A file that is simply not on this host — no SSH server, no /etc/shadow — is
+// nothing to judge, and must stay a clean result. Without this the fix above
+// would mark every minimal host Degraded.
+func TestAbsentFilesAreStillClean(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "not-here")
+	_, err := (&Checker{Rules: []Rule{
+		{Path: missing, MaxMode: 0o640, Sev: model.SeverityHigh, ID: "fileperms.shadow", Title: "s", Desc: "d"},
+		{Path: filepath.Join(t.TempDir(), "ssh_host_*_key"), Glob: true, MaxMode: 0o640,
+			Sev: model.SeverityHigh, ID: "fileperms.hostkey", Title: "h", Desc: "d"},
+	}}).Check(context.Background(), platform.Env{})
+	if err != nil {
+		t.Errorf("a host missing these files is clean, not degraded: %v", err)
 	}
 }


### PR DESCRIPTION
Second finding from the eleven-checker audit (after #628). Same class, different shape.

## The gap

`fileperms.Check` skipped anything it could not stat, with a comment stating the skip was for *missing* files:

```go
fi, err := os.Stat(p)
if err != nil || fi.IsDir() {
    continue // missing files (e.g. no SSH server) are not findings
}
```

Absence and denial arrive identically, so a rule that could not run reported exactly like a rule that passed — on the domain whose entire job is noticing that a sensitive file is readable by the wrong people.

The glob is the sharper half, and I confirmed the mechanism rather than assuming it:

```
Glob on an unreadable dir: matches=[] err=<nil>
Stat through an unreadable dir: err=permission denied  isNotExist=false
```

`filepath.Glob` reports a directory it cannot read as **zero matches and a nil error** — indistinguishable from a host with no SSH host keys. So an `/etc/ssh` the scan cannot enter silently cleared `fileperms.hostkey`, a High-severity rule about SSH private keys being readable beyond root.

## The fix

`Rule.paths()` answers *these files* / *nothing to judge* / *could not tell*, probing the directory with `os.ReadDir` when the glob comes back empty. The stat loop separates `os.IsNotExist` from every other error. Both gaps land in a `check.Coverage` ledger (#625), so the domain reports Degraded naming the paths it could not read.

## Honest scope

**This changes nothing on a standard host**, and I verified that rather than reasoning about it — a real scan of this machine returns `err=<nil>` before and after. `/etc/ssh` is 0755 everywhere mainstream, and `/etc/shadow` stats fine even at mode 0000 because it is the *parent* directory that governs stat, not the file's own bits.

So unlike #628, this closes the class rather than a failure I reproduced in the wild. It bites on a host that has hardened `/etc/ssh` to 0700, or any rule set pointed at a directory the scan cannot enter. I would rather state that plainly than dress it up as a live bug.

## Verification

Both new tests were confirmed failing against the unfixed file:

```
fileperms_test.go:180: want a PartialError so the axis reports Degraded, got <nil>
fileperms_test.go:218: want a PartialError so the axis reports Degraded, got <nil>
```

Each asserts its own premise first — that `Glob` really is silent, that the stat error really is a denial and not an absence — so neither can pass for the wrong reason. Both skip under `Geteuid() == 0`.

`TestAbsentFilesAreStillClean` is the guard in the other direction: a host simply missing these files must stay clean, or this fix would mark every minimal host Degraded.

Full gate green: build, vet, gofmt, mod tidy, `-race`, golangci-lint (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)