### PR TITLE
test(ci): cover the two promises the recovery layer makes to a real host

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,6 +107,25 @@ jobs:
           grep -q "PermitEmptyPasswords no" /etc/ssh/sshd_config.d/00-hostveil-demo.conf
           sshd -t
 
+      - name: fix --all leaves the fixes that run commands alone
+        run: |
+          set -eux
+          export HOSTVEIL_NO_SUDO=1
+
+          # Enabling automatic security updates is a real remediation that
+          # hostveil knows how to apply, and it runs a command — so it leaves
+          # no restore point, and "fix everything safe" has to decline it.
+          # The package must still be absent and the finding must still be
+          # open after the batch above.
+          #
+          # Unit tests pin the classification against a fake registry. This is
+          # the only place it meets a real apt, on a host where the finding
+          # genuinely fires, with a real `fix --all` deciding what to run.
+          ! dpkg -s unattended-upgrades >/dev/null 2>&1
+
+          hostveil scan --json > /tmp/scan_fixed.json || true
+          test "$(jq '[.findings[] | select(.id == "updates.disabled")] | length' /tmp/scan_fixed.json)" = 1
+
       - name: history lists the applied fixes and rollback restores them
         run: |
           set -eux
@@ -137,6 +156,38 @@ jobs:
           set -e
           test "$code" = 1
           grep -q '"ssh.emptypasswords"' /tmp/scan2.json
+
+      - name: rollback declines to clobber an edit made after the fix
+        run: |
+          set -eux
+          export HOSTVEIL_NO_SUDO=1
+          conf=/etc/ssh/sshd_config.d/00-hostveil-demo.conf
+
+          hostveil fix --all --yes
+          hostveil history > /tmp/history2.txt
+          id=$(grep -o 'hostveil rollback [^] ]*' /tmp/history2.txt | head -1 | awk '{print $3}')
+
+          # The operator edits the file themselves, after hostveil wrote it.
+          echo "# edited by the operator after the fix" >> "$conf"
+          before=$(sha256sum "$conf" | cut -d' ' -f1)
+
+          # Rollback keeps no backup of its own, so overwriting those edits
+          # would be unrecoverable. It has to refuse and leave the file exactly
+          # as it found it — a refusal that still wrote would be the worst
+          # outcome this layer can produce.
+          set +e
+          hostveil rollback "$id" > /tmp/declined.txt 2>&1
+          rc=$?
+          set -e
+          test "$rc" != 0
+          grep -q -- "--force" /tmp/declined.txt
+          test "$(sha256sum "$conf" | cut -d' ' -f1)" = "$before"
+
+          # And --force has to be a real escape hatch rather than a sentence
+          # in an error message: it restores the backup, edits and all.
+          hostveil rollback "$id" --force
+          ! grep -q "edited by the operator after the fix" "$conf"
+          sshd -t
 
       - name: domains that cannot run report Skipped, never clean
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,7 +121,13 @@ jobs:
           # Unit tests pin the classification against a fake registry. This is
           # the only place it meets a real apt, on a host where the finding
           # genuinely fires, with a real `fix --all` deciding what to run.
-          ! dpkg -s unattended-upgrades >/dev/null 2>&1
+          # Written as an if rather than `! dpkg …`: a negated command is
+          # exempt from errexit, so the assertion would report nothing however
+          # it turned out.
+          if dpkg -s unattended-upgrades >/dev/null 2>&1; then
+            echo "fix --all installed unattended-upgrades: a fix that runs commands was applied unattended"
+            exit 1
+          fi
 
           hostveil scan --json > /tmp/scan_fixed.json || true
           test "$(jq '[.findings[] | select(.id == "updates.disabled")] | length' /tmp/scan_fixed.json)" = 1
@@ -186,7 +192,10 @@ jobs:
           # And --force has to be a real escape hatch rather than a sentence
           # in an error message: it restores the backup, edits and all.
           hostveil rollback "$id" --force
-          ! grep -q "edited by the operator after the fix" "$conf"
+          if grep -q "edited by the operator after the fix" "$conf"; then
+            echo "--force did not restore the backup: the operator's edit is still there"
+            exit 1
+          fi
           sshd -t
 
       - name: domains that cannot run report Skipped, never clean


### PR DESCRIPTION
The E2E drives scan → fix → history → rollback → rescan and is the only place the apply machinery meets a real filesystem. Two of the strongest claims hostveil makes were not among the things it checked — both of them claims I had reason to care about this week.

## 1. `fix --all` must decline a fix that runs a command

Enabling automatic security updates is a real remediation hostveil knows how to apply, and it runs a command, so it leaves no restore point. "Fix everything safe" has to pass it over.

Debian is a host where `updates.disabled` genuinely fires and `unattended-upgrades` is genuinely absent, which makes this the only place the rule meets a real apt rather than a fake registry.

## 2. Rollback must decline rather than clobber

The checkpoint records what the fix wrote. An operator who has since edited that file would lose those edits irrecoverably — rollback keeps no backup of its own. So the refusal has to leave the file **byte-identical**, and `--force` has to be a real escape hatch rather than a sentence in an error message. Both are asserted.

## Both steps were proven to fail before being committed

A test that cannot fail is decoration. I ran the whole workflow against deliberately broken binaries, in the same `debian:13` image CI uses.

**Disabling the external-edit check** → the rollback step fails.

**Removing the exec floor and letting the updates domain declare itself automatic** → the other step fails, and it does so the loud way:

```
✗ updates.disabled: command [systemctl enable --now unattended-upgrades.service] failed:
  exit status 1 … — 1 of 2 commands had already run and are recorded in `hostveil history`
+ dpkg -s unattended-upgrades
+ test 0 = 1
```

`fix --all` actually installed the package on the container and left it half-applied — the exact unrollbackable state the rule exists to prevent. That is what the new step now catches.

Note this step guards the *outcome*, not one mechanism. Two things hold it up today (the updates domain asking for review, and `execFloor` from #630), so it takes a regression in both to fail — which is the right shape for an end-to-end check: it pins the promise, not the implementation.

## What is not here

A third candidate — staging a Degraded domain end to end — is absent on purpose. Every trigger I tried is a permission the container's root does not lack, and my probe (a directory where a config include should be) came back `ScanDone` rather than degraded. A contrived trigger would assert the trigger rather than the behaviour, so I dropped it instead of forcing it.

## Verification

The full modified workflow was extracted from the YAML and run end to end locally in `debian:13` — green against the real binary, failing against each mutant. `actionlint` clean. Build, tests, and the rest of the gate unaffected (only the workflow file changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)