### PR TITLE
fix(fix): keep sshd_config edits out of Match blocks

### DIFF
--- a/internal/fix/sshd.go
+++ b/internal/fix/sshd.go
@@ -1,17 +1,49 @@
 package fix
 
 import (
+	"slices"
 	"strings"
 )
 
-// setSSHDDirective returns sshd_config bytes with key set to value. If an
-// active (uncommented) directive for key exists, the first one is
-// replaced in place; otherwise the directive is appended. It is pure —
-// used for both preview diffs and apply.
+// setSSHDDirective returns sshd_config bytes with key set to value, confined
+// to the file's global section. If an active (uncommented) directive for key
+// exists there, the first one is replaced in place; otherwise the directive is
+// inserted at the end of that section. It is pure — used for both preview
+// diffs and apply.
+//
+// The global section is everything above the first Match. A Match block is a
+// conditional override that applies only to the sessions it selects, and
+// internal/check/ssh stops parsing at the first one for exactly that reason —
+// so every finding it reports is a statement about the global configuration,
+// and the fix has to answer in the same terms.
+//
+// This used to be attempted by a guard inside the replace loop that could
+// never fire: the keyword test above it already required the line to be the
+// directive being set, so the Match test was reachable only when the
+// directive *was* "match", which nothing sets. Both halves of the editor
+// walked into the block. A `PasswordAuthentication yes` under `Match User
+// deploy` was rewritten as though it were the global default — changing what
+// SSH did for that user, which the operator had chosen deliberately and the
+// finding never referred to, while the global setting stayed as it was. And
+// when the directive was absent, appending it to the end of a file that ends
+// in a Match block put it inside that block, so "disable password
+// authentication" quietly meant "disable it for one user". Both results are
+// valid sshd_config, so `sshd -t` accepts them and the fix reports success.
 func setSSHDDirective(in []byte, key, value string) []byte {
 	lines := strings.Split(string(in), "\n")
-	replaced := false
+
+	// Where the global section ends. len(lines) when the file has no Match,
+	// which is the ordinary case.
+	limit := len(lines)
 	for i, line := range lines {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) > 0 && strings.EqualFold(fields[0], "match") {
+			limit = i
+			break
+		}
+	}
+
+	for i, line := range lines[:limit] {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
@@ -20,20 +52,21 @@ func setSSHDDirective(in []byte, key, value string) []byte {
 		if len(fields) == 0 || !strings.EqualFold(fields[0], key) {
 			continue
 		}
-		if strings.EqualFold(fields[0], "match") {
-			break // do not edit inside/after Match blocks
-		}
 		lines[i] = key + " " + value
-		replaced = true
-		break
+		return []byte(strings.Join(lines, "\n"))
 	}
-	if !replaced {
-		out := strings.TrimRight(string(in), "\n")
-		if out != "" {
-			out += "\n"
-		}
-		out += key + " " + value + "\n"
-		return []byte(out)
+
+	// Absent from the global section. With a Match block present the
+	// directive goes immediately above it, since the end of the file is
+	// inside the block.
+	if limit < len(lines) {
+		return []byte(strings.Join(slices.Insert(lines, limit, key+" "+value), "\n"))
 	}
-	return []byte(strings.Join(lines, "\n"))
+
+	out := strings.TrimRight(string(in), "\n")
+	if out != "" {
+		out += "\n"
+	}
+	out += key + " " + value + "\n"
+	return []byte(out)
 }

--- a/internal/fix/sshd_test.go
+++ b/internal/fix/sshd_test.go
@@ -1,0 +1,96 @@
+package fix
+
+import "testing"
+
+// A Match block is a conditional override: everything under it applies only
+// to the sessions it selects. The checker knows this and stops parsing at the
+// first Match, so every finding it reports is about the *global* configuration
+// above one.
+//
+// setSSHDDirective has a guard meant to keep the fix on the same footing —
+// "do not edit inside/after Match blocks" — and it cannot fire. The keyword
+// test above it already requires the line to be the directive being set, so
+// the Match test is only reachable when the directive *is* "match", which no
+// fix sets. Both halves of the editor walk into the block as a result.
+
+// The directive exists, but only inside a Match block. Editing it changes what
+// SSH does for the sessions that block selects — something the operator wrote
+// deliberately and the finding never referred to — while the global setting
+// the finding was actually about stays exactly as it was.
+func TestDirectiveInsideAMatchBlockIsLeftAlone(t *testing.T) {
+	in := []byte("PermitRootLogin no\n" +
+		"\n" +
+		"Match User deploy\n" +
+		"    PasswordAuthentication yes\n")
+
+	out := string(setSSHDDirective(in, "PasswordAuthentication", "no"))
+
+	if contains(out, "Match User deploy\n    PasswordAuthentication no") {
+		t.Error("the fix rewrote a directive inside a Match block: it changed " +
+			"password auth for the deploy user and left the global default alone")
+	}
+	if !contains(out, "Match User deploy\n    PasswordAuthentication yes") {
+		t.Errorf("the Match block was modified:\n%s", out)
+	}
+}
+
+// The directive is absent, so the fix appends it — and appending to the end of
+// a file that ends in a Match block puts it *inside* that block. The operator
+// asked to disable password authentication everywhere and got it disabled for
+// one user, with the global default untouched and the finding still true.
+func TestAppendGoesAboveATrailingMatchBlock(t *testing.T) {
+	in := []byte("PermitRootLogin no\n" +
+		"\n" +
+		"Match User deploy\n" +
+		"    X11Forwarding yes\n")
+
+	out := string(setSSHDDirective(in, "PasswordAuthentication", "no"))
+
+	global := indexOf(out, "PasswordAuthentication no")
+	match := indexOf(out, "Match User deploy")
+	if global < 0 {
+		t.Fatalf("the directive was not added at all:\n%s", out)
+	}
+	if global > match {
+		t.Errorf("the directive was appended inside the trailing Match block, so it "+
+			"applies to that block only rather than globally:\n%s", out)
+	}
+}
+
+// The ordinary case has to keep working: with no Match block, an absent
+// directive is appended at the end.
+func TestAppendWithoutAMatchBlockGoesAtTheEnd(t *testing.T) {
+	out := string(setSSHDDirective([]byte("PermitRootLogin no\n"), "PasswordAuthentication", "no"))
+	if want := "PermitRootLogin no\nPasswordAuthentication no\n"; out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+// And a directive above a Match block is still the one that gets rewritten —
+// that is the global setting the finding is about.
+func TestDirectiveAboveAMatchBlockIsRewritten(t *testing.T) {
+	in := []byte("PasswordAuthentication yes\n" +
+		"\n" +
+		"Match User deploy\n" +
+		"    X11Forwarding yes\n")
+
+	out := string(setSSHDDirective(in, "PasswordAuthentication", "no"))
+
+	if !contains(out, "PasswordAuthentication no") {
+		t.Errorf("the global directive was not rewritten:\n%s", out)
+	}
+	if !contains(out, "Match User deploy") || !contains(out, "X11Forwarding yes") {
+		t.Errorf("the Match block was damaged:\n%s", out)
+	}
+}
+
+func contains(s, sub string) bool { return indexOf(s, sub) >= 0 }
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
A `Match` block is a conditional override applying only to the sessions it selects. `internal/check/ssh` stops parsing at the first one for exactly that reason, so **every SSH finding is a statement about the global section above it**. The editor was not held to the same terms.

## A guard that could never fire

`setSSHDDirective` had one, and its comment says precisely the right thing:

```go
if len(fields) == 0 || !strings.EqualFold(fields[0], key) {
    continue
}
if strings.EqualFold(fields[0], "match") {
    break // do not edit inside/after Match blocks
}
```

The keyword test above already requires the line to *be* the directive being set. So the `Match` test is reachable only when the directive **is** `"match"` — which nothing sets. Dead code. Both halves of the editor walked into the block.

**Replacing.** `PasswordAuthentication yes` under `Match User deploy` was rewritten as if it were the global default — changing what SSH does for that user, which the operator chose deliberately and the finding never referred to — while the global setting stayed as it was. It also flattened the block's indentation.

**Appending.** With the directive absent, it went to the end of the file. On a config ending in a Match block, that is *inside* the block.

## The append case is the reachable one

The checker reports `ssh.passwordauth` whenever the global value is absent — `effective(cfg, "PasswordAuthentication", "yes")`, since sshd defaults it to `yes`. Match stanzas at the end of `sshd_config` are entirely ordinary. So: finding fires → it is Auto → `fix --all` applies it → directive lands inside the block.

## What sshd says

Both outcomes are valid `sshd_config`, so the fix's own `sshd -t` validator accepts them and the fix reports success. Asking sshd for the *effective* configuration instead, in a real container:

| | `sshd -t` | `sshd -T` global |
|---|---|---|
| before this PR | VALID | `passwordauthentication yes` |
| after | VALID | `passwordauthentication no` |

The fix passed its validator, wrote a checkpoint, reported success, and left password authentication enabled.

To be fair about the blast radius: the re-check afterwards *does* still report the finding as present, so the operator was not left with a silent failure. But they were told a fix applied, given a restore point for it, and left with an edited Match block and passwords still accepted.

## The fix

Find where the global section ends, search only within it, and insert above the first `Match` rather than at EOF.

## Tests

`internal/fix/sshd.go` had **no test file at all**. It has four cases now — the two bugs (both confirmed failing first), plus the two that must keep working: append-at-EOF with no Match, and rewrite-in-place above a Match.

Full gate green: build, vet, gofmt, mod tidy, `-race`, golangci-lint (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)