### PR TITLE
fix(web): drop the dashboard access token out of the address bar

### DIFF
--- a/internal/ui/web/assets/app.js
+++ b/internal/ui/web/assets/app.js
@@ -1,5 +1,29 @@
 "use strict";
 
+// Drop the access token out of the address bar.
+//
+// It arrives in the URL because that is the one channel a terminal can hand
+// to a browser, and the server converts it into a SameSite=Strict session
+// cookie on the very first request. Past that point the copy in the query
+// string is residue: every fetch below authenticates with the cookie and not
+// one of them carries ?t=. Residue is not free — it sits in the address bar,
+// in the history entry, in a bookmark made without thinking, and in every
+// screenshot of the dashboard anyone pastes into an issue. `Referrer-Policy:
+// no-referrer` already stops it leaving over the network; this is the rest.
+//
+// Reloading the stripped URL works for as long as the session cookie lives.
+// Past that the server answers 401 with the sentence telling the operator to
+// reopen the URL hostveil printed, and `serve` is still printing it in the
+// terminal that is still running.
+(function stripToken() {
+  if (!location.search) return;
+  const q = new URLSearchParams(location.search);
+  if (!q.has("t")) return;
+  q.delete("t");
+  const rest = q.toString();
+  history.replaceState(null, "", location.pathname + (rest ? "?" + rest : "") + location.hash);
+})();
+
 // The model's vocabulary, served by /model.js and generated from
 // internal/model. /api/result carries these as bare integers, so the page
 // cannot say anything about a finding without a table to look them up in.

--- a/internal/ui/web/server_test.go
+++ b/internal/ui/web/server_test.go
@@ -706,6 +706,53 @@ func TestTokenInURLSetsTheSessionCookie(t *testing.T) {
 	}
 }
 
+// The token travels in the URL because a terminal has no other way to hand a
+// credential to a browser, and once the cookie exists the copy in the address
+// bar is residue — it stays in the history entry, in a bookmark made without
+// thinking, and in every screenshot of the dashboard pasted into an issue.
+// So app.js drops it. What makes that safe is that nothing else needs it:
+// every dashboard fetch authenticates with the cookie alone.
+func TestTheStrippedURLStillWorksOnTheCookieAlone(t *testing.T) {
+	s, _ := testServer(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/?t="+s.token, nil)
+	req.Host = "127.0.0.1:8787"
+	s.Handler().ServeHTTP(rec, req)
+	cookies := rec.Result().Cookies()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("the printed URL returned %d", rec.Code)
+	}
+
+	// The same URL app.js leaves in the address bar: no query string at all.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/api/result", nil)
+	req2.Host = "127.0.0.1:8787"
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	s.Handler().ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("after stripping ?t= the page could no longer reach its own API: %d %s",
+			rec2.Code, rec2.Body.String())
+	}
+}
+
+// And the stripping itself, which is a line of JavaScript no Go test can
+// execute. Guarded the way the deleted model tables are: by asserting the
+// shape is still in the file that ships.
+func TestAppJSStripsTheTokenFromTheURL(t *testing.T) {
+	app, err := assets.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"history.replaceState", `q.delete("t")`} {
+		if !strings.Contains(string(app), want) {
+			t.Errorf("app.js no longer strips the access token from the URL: %q is gone", want)
+		}
+	}
+}
+
 // The printed URL has to be the one that works, or the token is a puzzle
 // rather than a credential.
 func TestURLCarriesTheToken(t *testing.T) {


### PR DESCRIPTION
`hostveil serve` prints `http://127.0.0.1:8787/?t=<token>`. The token has to travel that way — a terminal has no other channel to hand a credential to a browser — and the server turns it into a `SameSite=Strict; HttpOnly` session cookie on the very first request.

Past that point the copy in the query string does nothing. Every dashboard fetch authenticates with the cookie; not one of them carries `?t=`. What it does do is persist: in the address bar, in the history entry, in a bookmark made without thinking, and in every screenshot of the dashboard anyone pastes into an issue. `Referrer-Policy: no-referrer` already stops it leaving over the network — this is the rest of the same problem.

So app.js drops it with `history.replaceState` as soon as it runs, which is after the cookie has been set.

## What this costs

Reloading the stripped URL works for as long as the session cookie lives. Past that the server answers 401 with the sentence that already tells the operator to reopen the URL hostveil printed — and `serve` is still printing it in the terminal that is still running. That was the tension worth weighing, and it resolves in favour of stripping: the token was never the thing keeping the page working, the cookie was.

## Verification

- `TestTheStrippedURLStillWorksOnTheCookieAlone` walks the actual sequence: request the printed URL, keep only the cookies it returns, then request `/api/result` with no query string at all. That is the state app.js leaves the page in, and it is what makes the strip safe rather than merely tidy.
- `TestAppJSStripsTheTokenFromTheURL` guards the line itself, the way the deleted model tables are guarded — no Go test can execute it.
- The stripping logic run in node against fake `location`/`history` for all five shapes: bare token, token with a fragment, token beside another parameter, a query with no token, and no query. `?t=abc&theme=dark#findings` → `/?theme=dark#findings`; a query without `t` is left untouched rather than rewritten.
- Full gate: build, vet, gofmt, `-race`, golangci-lint (0 issues), sitegen diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)