### PR TITLE
feat(check): audit the sandboxing of the services you installed yourself

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ The central rule: **one engine, three thin UIs.** `internal/core.Engine` owns al
 
 This is enforced structurally: `internal/ui/tui/layering_test.go` and `internal/ui/web/layering_test.go` parse imports and fail if production UI code imports `internal/fix`, `internal/history`, `internal/check`, or `internal/compose`. UIs may import only `core` and `model`. (v2's duplicated-fix-logic failure is what these tests exist to prevent.)
 
-Flow: `cmd/hostveil/app.go` builds the one engine (all eleven checkers + `fix.Default()`) → `Engine.Scan` detects `platform.Env`, runs the checker registry concurrently, validates and classifies findings, scores, diffs against the last saved scan, persists.
+Flow: `cmd/hostveil/app.go` builds the one engine (all twelve checkers + `fix.Default()`) → `Engine.Scan` detects `platform.Env`, runs the checker registry concurrently, validates and classifies findings, scores, diffs against the last saved scan, persists.
 
 ### Key seams
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ second column is what you type into `hostveil fix` and `hostveil explain`.
 | **AI agent runtimes** | `agent.*` | Self-hosted agent runtimes — OpenClaw and Hermes Agent: a gateway reachable off-host, authentication turned off on one that is, unrestricted shell and elevated tools, the sandbox disabled, and loose permissions on the config and the API keys beside it | — |
 | **Kernel hardening** | `sysctl.*` | Eight kernel parameters read straight from `/proc/sys` — the quiet knobs that stop a local foothold from becoming root and a spoofed packet from becoming a route. No `sysctl` binary needed | — |
 | **Docker daemon** | `dockerd.*` | The daemon underneath your containers: an API served over TCP without TLS client verification (unauthenticated root for anyone who can reach the port), a world-writable socket, who holds the socket's group, and the defaults — no-new-privileges, userns-remap, live-restore | Docker |
+| **Service hardening** | `systemd.*` | The units you installed yourself, read as systemd's own *effective* configuration: whether a service can gain privileges through setuid, write to `/usr` and `/etc`, read every user's home directory, or share `/tmp` with the rest of the host. Distribution units are left to the distribution | systemd |
 | **Image CVEs** *(optional)* | `cve.*` | Known vulnerabilities in the images your Compose services run | Trivy |
 
 Missing Docker or Trivy? Those domains are skipped cleanly and the score is

--- a/cmd/hostveil/app.go
+++ b/cmd/hostveil/app.go
@@ -15,6 +15,7 @@ import (
 	portscheck "github.com/seolcu/hostveil/internal/check/ports"
 	sshcheck "github.com/seolcu/hostveil/internal/check/ssh"
 	sysctlcheck "github.com/seolcu/hostveil/internal/check/sysctl"
+	systemdcheck "github.com/seolcu/hostveil/internal/check/systemd"
 	updatescheck "github.com/seolcu/hostveil/internal/check/updates"
 	"github.com/seolcu/hostveil/internal/core"
 	"github.com/seolcu/hostveil/internal/fix"
@@ -61,6 +62,7 @@ func buildRegistry() *check.Registry {
 		agentcheck.New(),
 		sysctlcheck.New(),
 		dockerdcheck.New(),
+		systemdcheck.New(),
 	)
 }
 

--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -17,6 +17,7 @@
                   <tr><td>AI agent runtimes</td><td><code>agent.</code></td><td>OpenClaw or Hermes installed</td></tr>
                   <tr><td>Kernel hardening</td><td><code>sysctl.</code></td><td>—</td></tr>
                   <tr><td>Docker daemon</td><td><code>dockerd.</code></td><td>Docker</td></tr>
+                  <tr><td>Service hardening</td><td><code>systemd.</code></td><td>systemd</td></tr>
                   <tr><td>Image CVEs <em>(optional)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -45,15 +46,16 @@
               <table>
                 <thead><tr><th>Axis</th><th>Weight</th></tr></thead>
                 <tbody>
-                  <tr><td>Container exposure</td><td>15</td></tr>
-                  <tr><td>SSH hardening</td><td>15</td></tr>
-                  <tr><td>Vulnerabilities</td><td>11</td></tr>
-                  <tr><td>Host firewall</td><td>10</td></tr>
-                  <tr><td>Exposed services</td><td>9</td></tr>
-                  <tr><td>AI agent runtimes</td><td>9</td></tr>
+                  <tr><td>Container exposure</td><td>14</td></tr>
+                  <tr><td>SSH hardening</td><td>14</td></tr>
+                  <tr><td>Vulnerabilities</td><td>10</td></tr>
+                  <tr><td>Host firewall</td><td>9</td></tr>
+                  <tr><td>Exposed services</td><td>8</td></tr>
+                  <tr><td>AI agent runtimes</td><td>8</td></tr>
                   <tr><td>Account hygiene</td><td>7</td></tr>
                   <tr><td>Auto-updates</td><td>7</td></tr>
                   <tr><td>Docker daemon</td><td>7</td></tr>
+                  <tr><td>Service hardening</td><td>6</td></tr>
                   <tr><td>File permissions</td><td>5</td></tr>
                   <tr><td>Kernel hardening</td><td>5</td></tr>
                 </tbody>
@@ -229,6 +231,25 @@
             </div>
             <p><code>dockerd.group-members</code> is <span class="sev medium">Medium</span> when the accounts holding the group are people, and <span class="sev high">High</span> when any of them is a service account — one with a system UID or no interactive login. Nobody deliberately grants a CI runner or a monitoring agent the ability to become root, and a credential that never logs in is one nobody is watching.</p>
             <p>A loopback-only TCP socket is not flagged: it reaches nothing the unix socket did not, and it is the documented way to put a proxy in front of the daemon. A daemon running <strong>rootless</strong> has <code>userns-remap</code> and <code>group-members</code> suppressed and its API finding lowered to <span class="sev high">High</span>, because the blast radius is that user's containers rather than the host. <code>live-restore</code> is suppressed on a swarm node, where Docker does not support it.</p>
+
+            <h2 id="systemd">Service hardening <code>systemd.</code></h2>
+            <p>Roughly half of a self-hosted server is not in a container. The Compose domain reads what your containers declare — privileged, running as root, no-new-privileges off — and a service started by a unit file has exactly the same decisions made about it. Until this domain existed, nothing looked at them.</p>
+            <p>systemd already knows the answers. <code>systemctl show</code> reports the <strong>effective</strong> value of each property after the unit file, every drop-in, and every default have been merged — so what hostveil reads is what the service will actually run with, not what some file says.</p>
+            <p><strong>Only your own units are audited.</strong> A unit counts if its file lives under <code>/etc/systemd/system</code> or <code>/usr/local/lib/systemd/system</code> — the ones you wrote or installed by hand. Your distribution hardens its own units on its own schedule, and second-guessing them means taking on maintenance of somebody else&rsquo;s service. Reporting on them would also bury your services under dozens of findings about software you did not choose, which is how a domain stops being read.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it means</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>systemd.no-new-privileges</code></td><td>The service can gain privileges through a setuid binary — the usual way a foothold inside a service becomes a foothold outside it</td><td><span class="sev low">Low</span> / <span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>systemd.protect-system</code></td><td>The service can write to <code>/usr</code>, <code>/boot</code> and <code>/etc</code>; one that can edit <code>/etc</code> owns every login on the host</td><td><span class="sev medium">Medium</span> / <span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>systemd.protect-home</code></td><td>The service can read <code>/home</code>, <code>/root</code> and <code>/run/user</code> — everyone&rsquo;s SSH keys, cloud credentials and password databases</td><td><span class="sev medium">Medium</span> / <span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>systemd.private-tmp</code></td><td>The service shares <code>/tmp</code> with every other process, which is the ground symlink races live on</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><strong>Two severities, and which one applies depends on the account.</strong> <code>no-new-privileges</code> is <span class="sev medium">Medium</span> on a service running as somebody other than root and <span class="sev low">Low</span> on one running as root — a root service can already do anything, so the setuid path it closes buys little there. The two filesystem protections go the other way for the same reason: they are worth most exactly where <code>no-new-privileges</code> is worth least.</p>
+            <p><strong>Every finding here is Manual, on purpose.</strong> The drop-in is two lines and hostveil could write it — but writing it is not the same as knowing it is safe. <code>ProtectSystem=full</code> breaks a service that writes under <code>/usr</code>; <code>PrivateTmp=yes</code> breaks two services that hand each other files through <code>/tmp</code>. Neither failure shows up until the next restart, which on a self-hosted box is the next reboot — and the service that does not come back is the one holding your data. So the how-to-fix carries the exact path and the exact two lines, and you pick the moment to restart and watch.</p>
+            <p>A property this systemd does not implement is reported as nothing at all, and nothing is not evidence that a protection is off — those are left alone rather than turned into a finding.</p>
 
             <h2 id="agent">AI agent runtimes <code>agent.</code></h2>
             <p>Self-hosted AI agents — <a href="https://docs.openclaw.ai/">OpenClaw</a> and <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a> — run a network gateway and keep API keys on disk in your home directory. Misconfigured, the worst case is someone reaching that gateway and driving an agent that can read your files and run commands as you.</p>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -17,6 +17,7 @@
                   <tr><td>AI 에이전트 런타임</td><td><code>agent.</code></td><td>OpenClaw 또는 Hermes 설치</td></tr>
                   <tr><td>커널 하드닝</td><td><code>sysctl.</code></td><td>—</td></tr>
                   <tr><td>Docker 데몬</td><td><code>dockerd.</code></td><td>Docker</td></tr>
+                  <tr><td>서비스 하드닝</td><td><code>systemd.</code></td><td>systemd</td></tr>
                   <tr><td>이미지 CVE <em>(선택)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -45,15 +46,16 @@
               <table>
                 <thead><tr><th>축</th><th>가중치</th></tr></thead>
                 <tbody>
-                  <tr><td>컨테이너 노출</td><td>15</td></tr>
-                  <tr><td>SSH 하드닝</td><td>15</td></tr>
-                  <tr><td>취약점</td><td>11</td></tr>
-                  <tr><td>호스트 방화벽</td><td>10</td></tr>
-                  <tr><td>노출된 서비스</td><td>9</td></tr>
-                  <tr><td>AI 에이전트 런타임</td><td>9</td></tr>
+                  <tr><td>컨테이너 노출</td><td>14</td></tr>
+                  <tr><td>SSH 하드닝</td><td>14</td></tr>
+                  <tr><td>취약점</td><td>10</td></tr>
+                  <tr><td>호스트 방화벽</td><td>9</td></tr>
+                  <tr><td>노출된 서비스</td><td>8</td></tr>
+                  <tr><td>AI 에이전트 런타임</td><td>8</td></tr>
                   <tr><td>계정 위생</td><td>7</td></tr>
                   <tr><td>자동 업데이트</td><td>7</td></tr>
                   <tr><td>Docker 데몬</td><td>7</td></tr>
+                  <tr><td>서비스 하드닝</td><td>6</td></tr>
                   <tr><td>파일 권한</td><td>5</td></tr>
                   <tr><td>커널 하드닝</td><td>5</td></tr>
                 </tbody>
@@ -229,6 +231,25 @@
             </div>
             <p><code>dockerd.group-members</code>는 그룹을 가진 계정이 사람일 때 <span class="sev medium">보통</span>, 그중 하나라도 서비스 계정 — 시스템 UID이거나 대화형 로그인이 없는 계정 — 이면 <span class="sev high">높음</span>입니다. CI 러너나 모니터링 에이전트에게 root가 될 능력을 일부러 주는 사람은 없고, 한 번도 로그인하지 않는 자격 증명은 아무도 지켜보지 않는 자격 증명입니다.</p>
             <p>루프백 전용 TCP 소켓은 표시하지 않습니다. 유닉스 소켓이 닿지 않던 곳에 닿지 않고, 데몬 앞에 프록시를 두는 문서화된 방법이기 때문입니다. <strong>rootless</strong>로 실행 중인 데몬은 <code>userns-remap</code>과 <code>group-members</code>가 억제되고 API 항목이 <span class="sev high">높음</span>으로 내려갑니다. 피해 범위가 호스트가 아니라 그 사용자의 컨테이너이기 때문입니다. <code>live-restore</code>는 Docker가 지원하지 않는 swarm 노드에서 억제됩니다.</p>
+
+            <h2 id="systemd">서비스 하드닝 <code>systemd.</code></h2>
+            <p>자체 호스팅 서버의 절반가량은 컨테이너 밖에 있습니다. Compose 도메인은 컨테이너가 선언한 내용 — privileged, root 실행, no-new-privileges 해제 — 을 읽는데, 유닛 파일로 뜬 서비스에도 똑같은 판단이 필요합니다. 이 도메인이 생기기 전까지는 아무도 그쪽을 보지 않았습니다.</p>
+            <p>답은 systemd가 이미 알고 있습니다. <code>systemctl show</code>는 유닛 파일과 모든 드롭인, 그리고 기본값까지 병합한 뒤의 <strong>실효</strong> 값을 알려줍니다. 그래서 hostveil이 읽는 값은 어떤 파일에 적힌 값이 아니라 서비스가 실제로 그 값으로 돌아간다는 뜻입니다.</p>
+            <p><strong>직접 만든 유닛만 검사합니다.</strong> 유닛 파일이 <code>/etc/systemd/system</code> 또는 <code>/usr/local/lib/systemd/system</code> 아래에 있으면 대상이 됩니다 — 사용자가 직접 쓰거나 손으로 설치한 것들입니다. 배포판 유닛은 배포판이 자기 일정에 맞춰 하드닝하며, 그걸 뒤집는 것은 남의 서비스 유지보수를 떠안는 일입니다. 게다가 그것들까지 보고하면 사용자가 고르지도 않은 소프트웨어에 대한 수십 건의 항목에 정작 본인 서비스가 묻힙니다. 그렇게 되면 아무도 그 도메인을 읽지 않습니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>의미</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>systemd.no-new-privileges</code></td><td>setuid 바이너리를 통해 서비스가 권한을 얻을 수 있습니다. 서비스 안의 발판이 서비스 밖의 발판으로 바뀌는 통상적인 경로입니다</td><td><span class="sev low">Low</span> / <span class="sev medium">Medium</span></td><td>수동</td></tr>
+                  <tr><td><code>systemd.protect-system</code></td><td>서비스가 <code>/usr</code>, <code>/boot</code>, <code>/etc</code>에 쓸 수 있습니다. <code>/etc</code>를 고칠 수 있는 서비스는 이 호스트의 모든 로그인을 손에 넣습니다</td><td><span class="sev medium">Medium</span> / <span class="sev low">Low</span></td><td>수동</td></tr>
+                  <tr><td><code>systemd.protect-home</code></td><td>서비스가 <code>/home</code>, <code>/root</code>, <code>/run/user</code>를 읽을 수 있습니다. 모든 사용자의 SSH 키, 클라우드 자격 증명, 비밀번호 데이터베이스가 그 안에 있습니다</td><td><span class="sev medium">Medium</span> / <span class="sev low">Low</span></td><td>수동</td></tr>
+                  <tr><td><code>systemd.private-tmp</code></td><td>서비스가 다른 모든 프로세스와 <code>/tmp</code>를 공유합니다. 심볼릭 링크 경쟁이 벌어지는 바로 그 자리입니다</td><td><span class="sev low">Low</span></td><td>수동</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><strong>심각도가 두 가지이며, 어느 쪽인지는 실행 계정이 정합니다.</strong> <code>no-new-privileges</code>는 root가 아닌 계정으로 도는 서비스에서 <span class="sev medium">Medium</span>, root로 도는 서비스에서 <span class="sev low">Low</span>입니다. root 서비스는 이미 무엇이든 할 수 있으므로 이 설정이 막는 setuid 경로의 값어치가 거기서는 작습니다. 파일시스템 보호 두 가지는 같은 이유로 반대 방향입니다 — <code>no-new-privileges</code>의 값어치가 가장 작은 자리에서 가장 큽니다.</p>
+            <p><strong>여기의 모든 항목은 의도적으로 수동입니다.</strong> 드롭인은 두 줄이고 hostveil이 쓸 수도 있습니다. 하지만 쓰는 것과 안전하다고 아는 것은 다릅니다. <code>ProtectSystem=full</code>은 <code>/usr</code> 아래에 쓰는 서비스를 망가뜨리고, <code>PrivateTmp=yes</code>는 <code>/tmp</code>로 파일을 주고받는 두 서비스를 망가뜨립니다. 어느 쪽도 다음 재시작 전까지는 드러나지 않는데, 자체 호스팅 환경에서 그 시점은 다음 재부팅입니다 — 그리고 돌아오지 못한 서비스가 하필 데이터를 쥐고 있던 쪽입니다. 그래서 수정 안내에 정확한 경로와 정확한 두 줄을 담고, 재시작해서 지켜볼 시점은 사용자가 고릅니다.</p>
+            <p>이 systemd가 구현하지 않은 속성은 아무 값도 보고되지 않으며, 값이 없다는 것은 보호가 꺼져 있다는 근거가 아닙니다. 그런 경우는 항목으로 만들지 않고 그대로 둡니다.</p>
 
             <h2 id="agent">AI 에이전트 런타임 <code>agent.</code></h2>
             <p>셀프호스트 AI 에이전트인 <a href="https://docs.openclaw.ai/">OpenClaw</a>와 <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a>는 네트워크 게이트웨이를 띄우고 API 키를 홈 디렉터리에 저장합니다. 설정이 잘못되면 최악의 경우 외부에서 그 게이트웨이에 접근해, 내 파일을 읽고 내 권한으로 명령을 실행하는 에이전트를 그대로 조종할 수 있습니다.</p>

--- a/internal/check/systemd/rules.go
+++ b/internal/check/systemd/rules.go
@@ -1,0 +1,145 @@
+package systemd
+
+import (
+	"fmt"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// rule audits one property of one unit.
+//
+// Every finding is Manual. A drop-in under /etc/systemd/system/<unit>.d is a
+// two-line file and hostveil could certainly write it, but writing it is not
+// the same as knowing it is safe: ProtectSystem=full breaks a service that
+// writes under /usr, PrivateTmp=yes breaks two services that pass each other
+// files through /tmp, and neither failure appears until the next restart —
+// which on a self-hosted box is the next reboot, at which point the service
+// that did not come back is the one holding the operator's data.
+//
+// That is the "unambiguous" test in fix.Default's standard, and these do not
+// meet it. Nor is Review available: a Review fix needs two genuinely
+// independent alternatives, and there is only one thing to do here. So the
+// remediation is a precise instruction — the exact path and the exact two
+// lines — and the operator decides. See TestKnownUnregisteredFindings.
+type rule struct {
+	id    string
+	title string
+	// sev is the severity for a service running as root; sevNonRoot is the
+	// severity when it runs as somebody else, and is zero when the rule does
+	// not care.
+	sev        model.Severity
+	sevNonRoot model.Severity
+	desc       string
+	// directive is the [Service] line that turns the protection on.
+	directive string
+	flagged   func(u unit) bool
+}
+
+// on reports whether systemd read a boolean property as enabled. It prints
+// booleans as "yes"/"no", and an empty value is a property this systemd does
+// not know — which is not evidence that the protection is off.
+func on(v string) bool { return v == "yes" }
+
+// known reports whether systemd answered about a property at all. An older
+// systemd that does not implement one prints nothing for it, and reporting
+// "the protection is off" on the strength of a silence would be inventing a
+// finding out of a blind spot.
+func known(v string) bool { return v != "" }
+
+// off reports whether an enumerated protection is disabled.
+//
+// ProtectSystem and ProtectHome are not booleans — systemd prints
+// no/yes/full/strict for the first and no/yes/read-only/tmpfs for the second —
+// so the test is against the one value that means "not protected" rather than
+// against `!on(v)`, which would flag "full" and "read-only" as failures.
+//
+// Only "no", and deliberately not also "off": systemd normalizes every
+// spelling of disabled to "no" in `show` output, and a second arm for a value
+// it never emits is a branch no test can reach. This domain's first draft had
+// one, checked against a real host's 77 units, and found no/yes/full/strict
+// and nothing else.
+func off(v string) bool { return v == "no" }
+
+var rules = []rule{
+	{
+		id:    "systemd.no-new-privileges",
+		title: "A service can gain privileges while running",
+		// A root service can already do anything, so the setuid path this
+		// closes buys little there; for a service running as somebody else it
+		// is the difference between a compromise staying inside that account
+		// and walking out of it.
+		sev:        model.SeverityLow,
+		sevNonRoot: model.SeverityMedium,
+		desc: "NoNewPrivileges is off, so anything this service runs can gain privileges through a setuid binary — the standard way a foothold inside a service becomes a foothold outside it. " +
+			"It costs nothing on a service that does not deliberately escalate, which is why it is the same protection the container domain checks for under the name no-new-privileges.",
+		directive: "NoNewPrivileges=yes",
+		flagged:   func(u unit) bool { return known(u.NoNewPrivileges) && !on(u.NoNewPrivileges) },
+	},
+	{
+		id:    "systemd.protect-system",
+		title: "A service can write anywhere on the system",
+		// The reverse of the rule above: this is what stands between a root
+		// service and the rest of the filesystem, and it is worth most
+		// exactly where NoNewPrivileges is worth least.
+		sev:        model.SeverityMedium,
+		sevNonRoot: model.SeverityLow,
+		desc: "ProtectSystem is off, so this service can write to /usr, /boot, and /etc. A compromised service that can edit /etc owns every login on the host; one that can write /usr can replace a binary something else runs as root. " +
+			"ProtectSystem=full mounts those read-only for this service alone and needs no change to the program itself.",
+		directive: "ProtectSystem=full",
+		flagged:   func(u unit) bool { return known(u.ProtectSystem) && off(u.ProtectSystem) },
+	},
+	{
+		id:         "systemd.protect-home",
+		title:      "A service can read every user's home directory",
+		sev:        model.SeverityMedium,
+		sevNonRoot: model.SeverityLow,
+		desc: "ProtectHome is off, so this service can read /home, /root, and /run/user — the SSH private keys, cloud credentials, and password databases of everyone with an account on this host. " +
+			"Almost no self-hosted service has any business there; ProtectHome=yes hides them from this service without affecting anything else.",
+		directive: "ProtectHome=yes",
+		flagged:   func(u unit) bool { return known(u.ProtectHome) && off(u.ProtectHome) },
+	},
+	{
+		id:    "systemd.private-tmp",
+		title: "A service shares /tmp with everything else on the host",
+		sev:   model.SeverityLow,
+		desc: "PrivateTmp is off, so this service reads and writes the same /tmp as every other process. That is the ground the symlink and hardlink races live on: another local process can predict a temporary file's name and have this service overwrite something it chooses. " +
+			"PrivateTmp=yes gives the service a /tmp of its own.",
+		directive: "PrivateTmp=yes",
+		flagged:   func(u unit) bool { return known(u.PrivateTmp) && !on(u.PrivateTmp) },
+	},
+}
+
+// severityFor picks the severity a rule carries on this unit. A rule with no
+// non-root severity means the same either way.
+func (r rule) severityFor(u unit) model.Severity {
+	if !u.root() && r.sevNonRoot != 0 {
+		return r.sevNonRoot
+	}
+	return r.sev
+}
+
+// dropInPath is where the operator's own override for a unit belongs. Under
+// /etc, so it outranks the unit file and any drop-in a package ships, and
+// numbered so a later file of the operator's own still wins.
+func dropInPath(unitID string) string {
+	return "/etc/systemd/system/" + unitID + ".d/50-hostveil.conf"
+}
+
+func (r rule) finding(u unit) model.Finding {
+	runAs := u.User
+	if runAs == "" {
+		runAs = "root (no User= set)"
+	}
+	return model.NewFinding(r.id, r.title, r.severityFor(u), model.SourceSystemd,
+		model.RemediationManual,
+		model.WithService(u.ID),
+		model.WithDescription(r.desc),
+		model.WithHowToFix(fmt.Sprintf(
+			"Create %s containing:\n\n    [Service]\n    %s\n\nThen run `systemctl daemon-reload` and `systemctl restart %s`. "+
+				"Restart it while you are watching: these protections change what the service can reach, and a service that needs what one of them hides fails at start rather than misbehaving quietly. "+
+				"Remove the file to undo it.",
+			dropInPath(u.ID), r.directive, u.ID)),
+		model.WithEvidence("unit", u.FragmentPath),
+		model.WithEvidence("runs as", runAs),
+	)
+}

--- a/internal/check/systemd/systemd.go
+++ b/internal/check/systemd/systemd.go
@@ -1,0 +1,194 @@
+// Package systemd audits the sandboxing of the services an operator
+// installed themselves.
+//
+// A self-hosted server is a pile of long-running programs, and roughly half
+// of them are not in containers. The compose domain covers the half that
+// are: it reads what each service declares and says so when a container runs
+// privileged, as root, or with no-new-privileges off. A service started by a
+// unit file gets exactly the same decisions made about it — whether it can
+// gain privileges, whether it can write outside its own data, whether it can
+// read every user's home — and until this domain existed nothing looked at
+// them at all.
+//
+// systemd already answers all of it. `systemctl show` reports the *effective*
+// value of each property after the unit file, every drop-in, and every
+// default have been merged, so this checker never has to model that
+// precedence, and a value it reports is the value the service will run with.
+//
+// # Which units
+//
+// Only units whose fragment lives under /etc/systemd/system or
+// /usr/local/lib/systemd/system: the ones the operator wrote or installed by
+// hand. That is a deliberate line, not a shortcut.
+//
+// A distribution's own units are hardened by the distribution, on its
+// schedule, and a drop-in that second-guesses them is the operator taking on
+// maintenance of somebody else's service. More to the point, flagging them
+// would bury the operator's own services under dozens of findings about
+// software they did not choose to run and cannot sensibly change — and a
+// domain that accuses everything is a domain nobody reads. The units this
+// package reports on are the ones whose author is the person reading the
+// report.
+package systemd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// operatorUnitDirs are the directories a unit file lives in when a person
+// rather than a package put it there. /run is deliberately absent: units
+// generated at boot are nobody's to edit and do not survive a reboot.
+var operatorUnitDirs = []string{
+	"/etc/systemd/system/",
+	"/usr/local/lib/systemd/system/",
+}
+
+// showProperties are the unit properties this domain reads. Asked for in one
+// batched call rather than one call per unit: a host with thirty operator
+// units would otherwise be thirty round trips through the runner, each
+// bounded by platform.DefaultTimeout, inside a scan that already runs every
+// domain concurrently.
+var showProperties = []string{
+	"Id",
+	"LoadState",
+	"FragmentPath",
+	"User",
+	"NoNewPrivileges",
+	"ProtectSystem",
+	"ProtectHome",
+	"PrivateTmp",
+}
+
+// Checker reports services running with systemd's protections switched off.
+type Checker struct {
+	// UnitDirs is the set of fragment path prefixes counted as operator
+	// installed; overridable for tests.
+	UnitDirs []string
+}
+
+// New returns a systemd service-hardening checker.
+func New() *Checker { return &Checker{UnitDirs: operatorUnitDirs} }
+
+// Source identifies the systemd domain.
+func (*Checker) Source() model.Source { return model.SourceSystemd }
+
+// Available requires systemd to be the service manager and to answer.
+//
+// The manager property is asked for rather than `systemctl` merely being on
+// PATH: the binary is installed on hosts that boot something else, and on
+// those it exits non-zero with "System has not been booted with systemd".
+// Treating its presence as an answer would enumerate no units, find nothing,
+// and score this axis a perfect 100 on a host it never looked at.
+func (c *Checker) Available(ctx context.Context, env platform.Env) (bool, string) {
+	if env.ServiceManager != platform.SMSystemd {
+		return false, "systemd is not this host's service manager — there are no units to audit"
+	}
+	if !platform.Has(env.Runner, "systemctl") {
+		return false, "systemctl is not installed — units cannot be read"
+	}
+	if _, err := env.Runner.Run(ctx, "systemctl", "show", "--property=Version"); err != nil {
+		return false, "systemd did not answer — units cannot be read"
+	}
+	return true, ""
+}
+
+// Check reads every loaded service unit and reports the operator-installed
+// ones running without systemd's protections.
+func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding, error) {
+	args := append([]string{"show", "*.service"}, "--property="+strings.Join(showProperties, ","))
+	out, err := env.Runner.Run(ctx, "systemctl", args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing service units: %w", err)
+	}
+
+	var findings []model.Finding
+	for _, u := range parseUnits(string(out)) {
+		if !c.operatorInstalled(u) {
+			continue
+		}
+		for _, r := range rules {
+			if !r.flagged(u) {
+				continue
+			}
+			findings = append(findings, r.finding(u))
+		}
+	}
+	return findings, nil
+}
+
+// operatorInstalled reports whether a unit is one the person reading the
+// report installed. A unit systemd could not load has no properties worth
+// judging and no fragment to point at.
+func (c *Checker) operatorInstalled(u unit) bool {
+	if u.LoadState != "loaded" || u.FragmentPath == "" {
+		return false
+	}
+	for _, dir := range c.UnitDirs {
+		if strings.HasPrefix(u.FragmentPath, dir) {
+			return true
+		}
+	}
+	return false
+}
+
+// unit is one service's effective configuration as systemd reports it.
+type unit struct {
+	ID              string
+	LoadState       string
+	FragmentPath    string
+	User            string
+	NoNewPrivileges string
+	ProtectSystem   string
+	ProtectHome     string
+	PrivateTmp      string
+}
+
+// root reports whether the service runs as root, which is what decides how
+// much the filesystem protections are worth. systemd reports an unset User
+// as the empty string, and that is the common case: a unit that says nothing
+// runs as root.
+func (u unit) root() bool { return u.User == "" || u.User == "root" }
+
+// parseUnits splits `systemctl show` output into one record per unit.
+//
+// systemd separates records with a blank line and prints Key=Value one per
+// line, in an order of its own choosing — so records are keyed by name, never
+// by position. A value may itself contain "=", so only the first is a
+// separator.
+func parseUnits(out string) []unit {
+	var units []unit
+	cur := map[string]string{}
+	flush := func() {
+		if len(cur) == 0 {
+			return
+		}
+		units = append(units, unit{
+			ID:              cur["Id"],
+			LoadState:       cur["LoadState"],
+			FragmentPath:    cur["FragmentPath"],
+			User:            cur["User"],
+			NoNewPrivileges: cur["NoNewPrivileges"],
+			ProtectSystem:   cur["ProtectSystem"],
+			ProtectHome:     cur["ProtectHome"],
+			PrivateTmp:      cur["PrivateTmp"],
+		})
+		cur = map[string]string{}
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			flush()
+			continue
+		}
+		if k, v, ok := strings.Cut(line, "="); ok {
+			cur[k] = v
+		}
+	}
+	flush()
+	return units
+}

--- a/internal/check/systemd/systemd_test.go
+++ b/internal/check/systemd/systemd_test.go
@@ -1,0 +1,362 @@
+package systemd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/check/checktest"
+	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/platform"
+)
+
+// showArgv is the command the checker runs, spelled once. A fixture that
+// scripted a stale copy would not fail — it would fall through to the fake's
+// error, which reads as systemd refusing to answer.
+var showArgv = []string{"systemctl", "show", "*.service", "--property=" + strings.Join(showProperties, ",")}
+
+// unitRecord renders one record the way `systemctl show` really prints it:
+// Key=Value one per line, in an order of systemd's choosing rather than the
+// order they were asked for.
+func unitRecord(props map[string]string) string {
+	// Deliberately not the request order — the parser must key by name.
+	order := []string{"FragmentPath", "User", "PrivateTmp", "ProtectHome", "Id", "ProtectSystem", "LoadState", "NoNewPrivileges"}
+	var b strings.Builder
+	for _, k := range order {
+		if v, ok := props[k]; ok {
+			b.WriteString(k + "=" + v + "\n")
+		}
+	}
+	return b.String()
+}
+
+// operatorUnit is a hand-installed service with every protection off, which
+// is what a unit written from a project's README looks like.
+func operatorUnit(id string, over map[string]string) string {
+	props := map[string]string{
+		"Id":              id,
+		"LoadState":       "loaded",
+		"FragmentPath":    "/etc/systemd/system/" + id,
+		"User":            "",
+		"NoNewPrivileges": "no",
+		"ProtectSystem":   "no",
+		"ProtectHome":     "no",
+		"PrivateTmp":      "no",
+	}
+	for k, v := range over {
+		props[k] = v
+	}
+	return unitRecord(props)
+}
+
+func scan(t *testing.T, show string) []model.Finding {
+	t.Helper()
+	r := checktest.New().Script(show, showArgv...)
+	fs, err := New().Check(context.Background(), platform.Env{
+		ServiceManager: platform.SMSystemd, Runner: r,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range fs {
+		if err := f.Validate(); err != nil {
+			t.Errorf("%s: invalid finding: %v", f.ID, err)
+		}
+	}
+	return fs
+}
+
+func ids(fs []model.Finding) []string {
+	out := make([]string, len(fs))
+	for i, f := range fs {
+		out[i] = f.ID
+	}
+	return out
+}
+
+func find(fs []model.Finding, id, service string) (model.Finding, bool) {
+	for _, f := range fs {
+		if f.ID == id && f.Service == service {
+			return f, true
+		}
+	}
+	return model.Finding{}, false
+}
+
+func TestUnhardenedOperatorUnitIsFlagged(t *testing.T) {
+	fs := scan(t, operatorUnit("gitea.service", nil))
+
+	for _, want := range []string{
+		"systemd.no-new-privileges", "systemd.protect-system",
+		"systemd.protect-home", "systemd.private-tmp",
+	} {
+		f, ok := find(fs, want, "gitea.service")
+		if !ok {
+			t.Fatalf("expected %s, got %v", want, ids(fs))
+		}
+		// The unit is what the operator has to open, so it has to be in the
+		// evidence and in the instruction.
+		if f.Evidence["unit"] != "/etc/systemd/system/gitea.service" {
+			t.Errorf("%s: evidence names %q", want, f.Evidence["unit"])
+		}
+		if !strings.Contains(f.HowToFix, "/etc/systemd/system/gitea.service.d/50-hostveil.conf") {
+			t.Errorf("%s: how-to-fix does not name the drop-in:\n%s", want, f.HowToFix)
+		}
+		if !strings.Contains(f.HowToFix, "systemctl restart gitea.service") {
+			t.Errorf("%s: how-to-fix must say the change needs a restart:\n%s", want, f.HowToFix)
+		}
+		// Manual by decision, and the decision is recorded in fix.Default's
+		// register — see TestEveryFindingIsEitherFixableOrDeclinedOnPurpose.
+		if f.Remediation != model.RemediationManual {
+			t.Errorf("%s: remediation = %v, want Manual", want, f.Remediation)
+		}
+	}
+}
+
+func TestHardenedUnitIsClean(t *testing.T) {
+	fs := scan(t, operatorUnit("gitea.service", map[string]string{
+		"User":            "gitea",
+		"NoNewPrivileges": "yes",
+		"ProtectSystem":   "full",
+		"ProtectHome":     "yes",
+		"PrivateTmp":      "yes",
+	}))
+	if len(fs) != 0 {
+		t.Errorf("a hardened unit produced findings: %v", ids(fs))
+	}
+}
+
+// The line this domain draws. A distribution hardens its own units on its
+// own schedule, and reporting on them would bury the operator's services
+// under dozens of findings about software they did not choose to run.
+func TestDistributionUnitsAreNotAudited(t *testing.T) {
+	show := unitRecord(map[string]string{
+		"Id": "sshd.service", "LoadState": "loaded",
+		"FragmentPath":  "/usr/lib/systemd/system/sshd.service",
+		"User":          "",
+		"ProtectSystem": "no", "ProtectHome": "no", "PrivateTmp": "no", "NoNewPrivileges": "no",
+	})
+	if fs := scan(t, show); len(fs) != 0 {
+		t.Errorf("a packaged unit must not be reported: %v", ids(fs))
+	}
+}
+
+func TestUsrLocalUnitsAreAudited(t *testing.T) {
+	show := unitRecord(map[string]string{
+		"Id": "app.service", "LoadState": "loaded",
+		"FragmentPath":    "/usr/local/lib/systemd/system/app.service",
+		"NoNewPrivileges": "no",
+	})
+	if _, ok := find(scan(t, show), "systemd.no-new-privileges", "app.service"); !ok {
+		t.Error("/usr/local/lib/systemd/system is where an operator installs a unit by hand")
+	}
+}
+
+// A unit systemd could not load has no effective configuration to judge and
+// no fragment to point the operator at.
+func TestUnloadedUnitsAreSkipped(t *testing.T) {
+	show := unitRecord(map[string]string{
+		"Id": "gone.service", "LoadState": "not-found",
+		"FragmentPath": "", "NoNewPrivileges": "no",
+	})
+	if fs := scan(t, show); len(fs) != 0 {
+		t.Errorf("an unloaded unit must not be reported: %v", ids(fs))
+	}
+}
+
+// An older systemd that does not implement a property prints nothing for it.
+// Nothing is not evidence that the protection is off, and reporting one from
+// a silence would be inventing a finding out of a blind spot.
+func TestUnknownPropertyIsNotAFinding(t *testing.T) {
+	show := unitRecord(map[string]string{
+		"Id": "app.service", "LoadState": "loaded",
+		"FragmentPath": "/etc/systemd/system/app.service",
+		// NoNewPrivileges reported; the other three absent entirely.
+		"NoNewPrivileges": "no",
+	})
+	fs := scan(t, show)
+	if len(fs) != 1 || fs[0].ID != "systemd.no-new-privileges" {
+		t.Errorf("only the property systemd answered about should be judged, got %v", ids(fs))
+	}
+}
+
+// Which severity applies depends on the account, and the two rules point in
+// opposite directions on purpose: a root service can already do anything, so
+// the setuid path NoNewPrivileges closes buys little there, while the
+// filesystem protections are worth most exactly there.
+func TestSeverityFollowsTheAccount(t *testing.T) {
+	asRoot := scan(t, operatorUnit("root.service", nil))
+	asUser := scan(t, operatorUnit("user.service", map[string]string{"User": "gitea"}))
+
+	nnpRoot, _ := find(asRoot, "systemd.no-new-privileges", "root.service")
+	nnpUser, _ := find(asUser, "systemd.no-new-privileges", "user.service")
+	if nnpRoot.Severity != model.SeverityLow || nnpUser.Severity != model.SeverityMedium {
+		t.Errorf("no-new-privileges: root=%v user=%v, want Low and Medium",
+			nnpRoot.Severity, nnpUser.Severity)
+	}
+
+	sysRoot, _ := find(asRoot, "systemd.protect-system", "root.service")
+	sysUser, _ := find(asUser, "systemd.protect-system", "user.service")
+	if sysRoot.Severity != model.SeverityMedium || sysUser.Severity != model.SeverityLow {
+		t.Errorf("protect-system: root=%v user=%v, want Medium and Low",
+			sysRoot.Severity, sysUser.Severity)
+	}
+
+	if got := nnpRoot.Evidence["runs as"]; got != "root (no User= set)" {
+		t.Errorf("evidence should say the unit sets no User=, got %q", got)
+	}
+	if got := nnpUser.Evidence["runs as"]; got != "gitea" {
+		t.Errorf("evidence = %q, want the account", got)
+	}
+}
+
+// Several units in one batched call, separated by blank lines, is the whole
+// reason the checker makes one call rather than one per unit.
+func TestSeveralUnitsInOneCall(t *testing.T) {
+	show := operatorUnit("a.service", map[string]string{"NoNewPrivileges": "yes", "ProtectSystem": "full", "ProtectHome": "yes", "PrivateTmp": "yes"}) +
+		"\n" + operatorUnit("b.service", map[string]string{"ProtectSystem": "full", "ProtectHome": "yes", "PrivateTmp": "yes"}) +
+		"\n" + unitRecord(map[string]string{"Id": "c.service", "LoadState": "loaded", "FragmentPath": "/usr/lib/systemd/system/c.service", "PrivateTmp": "no"})
+
+	fs := scan(t, show)
+	if len(fs) != 1 {
+		t.Fatalf("want exactly b.service's one finding, got %v", ids(fs))
+	}
+	if fs[0].Service != "b.service" || fs[0].ID != "systemd.no-new-privileges" {
+		t.Errorf("wrong finding: %s on %s", fs[0].ID, fs[0].Service)
+	}
+}
+
+// A value may contain "=", and only the first one separates.
+func TestParseKeepsEqualsInsideAValue(t *testing.T) {
+	us := parseUnits("Id=x.service\nUser=a=b\n")
+	if len(us) != 1 || us[0].User != "a=b" {
+		t.Errorf("parsed %+v", us)
+	}
+}
+
+// # Availability
+//
+// Every one of these is the same invariant: the domain must never let "I
+// couldn't look" pass for "nothing there". A skip is scored N/A; a silent
+// success on a host that answered nothing would be a perfect axis.
+func TestAvailability(t *testing.T) {
+	ctx := context.Background()
+	c := New()
+
+	// The binary exists on hosts that boot something else, where it exits
+	// non-zero with "System has not been booted with systemd".
+	up := checktest.New().Script("Version=257\n", "systemctl", "show", "--property=Version")
+	if ok, reason := c.Available(ctx, platform.Env{ServiceManager: platform.SMSystemd, Runner: up}); !ok {
+		t.Errorf("a systemd host should be available: %q", reason)
+	}
+	dead := checktest.New() // systemctl present, nothing scripted, so it errors
+	ok, reason := c.Available(ctx, platform.Env{ServiceManager: platform.SMSystemd, Runner: dead})
+	if ok {
+		t.Error("systemctl on PATH is not the same as systemd answering")
+	}
+	if reason == "" {
+		t.Error("a skip needs a reason or the domain reads as unexplained")
+	}
+	if ok, reason := c.Available(ctx, platform.Env{ServiceManager: platform.SMOpenRC, Runner: up}); ok || reason == "" {
+		t.Errorf("a non-systemd host is a clean skip, got ok=%v reason=%q", ok, reason)
+	}
+	if ok, _ := c.Available(ctx, platform.Env{ServiceManager: platform.SMSystemd, Runner: checktest.New().Only()}); ok {
+		t.Error("no systemctl on the host at all is a skip")
+	}
+}
+
+// A failure to enumerate is an error, not an empty result: the axis is then
+// excluded rather than scored a perfect 100 on evidence nobody obtained.
+func TestEnumerationFailureIsAnError(t *testing.T) {
+	_, err := New().Check(context.Background(), platform.Env{
+		ServiceManager: platform.SMSystemd, Runner: checktest.New(),
+	})
+	if err == nil {
+		t.Fatal("a systemctl that would not answer must not read as a host with no units")
+	}
+}
+
+// The enumerated protections are not booleans, and this is what the check
+// against `!on(v)` would have got wrong: ProtectSystem prints
+// no/yes/full/strict and ProtectHome prints no/yes/read-only/tmpfs, so
+// "strict" and "read-only" are protection *on* and must not be flagged.
+//
+// The value set comes from a real host: 77 units answered no/yes/full/strict
+// for ProtectSystem and nothing else — which is also why neither rule has a
+// second arm for "off", a spelling systemd never emits.
+func TestEnumeratedProtectionsAreNotBooleans(t *testing.T) {
+	for _, tc := range []struct {
+		protectSystem, protectHome string
+		wantFindings               int
+	}{
+		{"strict", "read-only", 0},
+		{"full", "yes", 0},
+		{"yes", "tmpfs", 0},
+		{"no", "yes", 1},
+		{"strict", "no", 1},
+		{"no", "no", 2},
+	} {
+		show := operatorUnit("app.service", map[string]string{
+			// Isolate the two rules under test.
+			"NoNewPrivileges": "yes", "PrivateTmp": "yes",
+			"ProtectSystem": tc.protectSystem, "ProtectHome": tc.protectHome,
+		})
+		if fs := scan(t, show); len(fs) != tc.wantFindings {
+			t.Errorf("ProtectSystem=%s ProtectHome=%s: got %v, want %d finding(s)",
+				tc.protectSystem, tc.protectHome, ids(fs), tc.wantFindings)
+		}
+	}
+}
+
+// realShowOutput is `systemctl show '*.service' --property=...` copied
+// verbatim off a running Fedora 44 host, including its own property order —
+// which is not the order the checker asks for. That is the whole reason
+// parseUnits keys records by name: a parser reading positionally would put
+// PrivateTmp's value into NoNewPrivileges' field and be wrong about every
+// unit on every host, while still passing any fixture written in request
+// order.
+const realShowOutput = `Id=chronyd.service
+LoadState=loaded
+FragmentPath=/usr/lib/systemd/system/chronyd.service
+User=chrony
+PrivateTmp=yes
+ProtectHome=yes
+ProtectSystem=strict
+NoNewPrivileges=no
+
+Id=accounts-daemon.service
+LoadState=loaded
+FragmentPath=/usr/lib/systemd/system/accounts-daemon.service
+User=
+PrivateTmp=no
+ProtectHome=no
+ProtectSystem=strict
+NoNewPrivileges=no
+`
+
+func TestParsesRealSystemctlOutput(t *testing.T) {
+	us := parseUnits(realShowOutput)
+	if len(us) != 2 {
+		t.Fatalf("parsed %d units, want 2", len(us))
+	}
+	if us[0].ID != "chronyd.service" || us[0].User != "chrony" ||
+		us[0].ProtectSystem != "strict" || us[0].PrivateTmp != "yes" {
+		t.Errorf("first record read wrong: %+v", us[0])
+	}
+	// The one with no User= is the common case, and root() has to say so.
+	if !us[1].root() || us[1].User != "" {
+		t.Errorf("an unset User= is root: %+v", us[1])
+	}
+	if us[0].root() {
+		t.Errorf("a unit with User=chrony is not root: %+v", us[0])
+	}
+	// Both are packaged units, so a stock host reports nothing — the correct
+	// answer for a machine whose operator installed no services of their own,
+	// not a checker that failed to look.
+	c := New()
+	for _, u := range us {
+		if c.operatorInstalled(u) {
+			t.Errorf("%s is a distribution unit", u.ID)
+		}
+	}
+}

--- a/internal/docs/fixregister_test.go
+++ b/internal/docs/fixregister_test.go
@@ -52,7 +52,7 @@ func TestEveryFindingIsEitherFixableOrDeclinedOnPurpose(t *testing.T) {
 
 // registerID matches an ID as the register writes it, including the
 // source-wide glob form.
-var registerID = regexp.MustCompile(`\b(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent|sysctl|dockerd)\.(\*|[a-z0-9][a-z0-9.\-]*)`)
+var registerID = regexp.MustCompile(`\b(ssh|compose|cve|ports|firewall|accounts|fileperms|updates|agent|sysctl|dockerd|systemd)\.(\*|[a-z0-9][a-z0-9.\-]*)`)
 
 // declinedInRegister reads the doc comment on fix.Default and returns every
 // finding ID it names.

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -259,6 +259,35 @@ package fix
 // the whole point: applying the second fix must not have to read what the
 // first wrote, and rolling one back must not take another's line with it.
 //
+// # The service-hardening domain, declined whole
+//
+// systemd.* has no registered fix either, and the reason is the shape of the
+// failure rather than the shape of the edit. The edit is trivial: a drop-in
+// at /etc/systemd/system/<unit>.d/50-hostveil.conf holding a [Service]
+// section and one directive, created by CreateIfMissing, reversed by
+// deleting the file, and `systemd-analyze verify` would validate it.
+//
+// What is not trivial is knowing it is safe. ProtectSystem=full breaks a
+// service that writes under /usr; PrivateTmp=yes breaks two services that
+// hand each other files through /tmp; ProtectHome=yes breaks anything whose
+// data lives in a home directory, which on a self-hosted box is common. None
+// of that is visible from the unit — it depends on what the program does —
+// so no amount of reading gets hostveil to "unambiguous", and Auto is out.
+//
+// Review is out for the same reason it is out for dockerd, arrived at from
+// the other direction: there is only one thing to do. A drop-in and a
+// restart are not two alternatives, they are one procedure in two steps, and
+// systemd has no equivalent of `sysctl -w` — no way to change a running
+// service's sandbox without restarting it — so there is no second
+// independent alternative to pair with.
+//
+// And the failure is delayed. A property this changes takes effect at the
+// next restart, which on a host like this is the next reboot; a service that
+// does not come back then is discovered later, by absence, with no obvious
+// connection to a fix applied weeks earlier. So the remediation carries the
+// exact path and the exact two lines, and the operator restarts it while
+// watching.
+//
 // # The Docker daemon domain, declined whole
 //
 // dockerd.* has no registered fix at all — not one finding, and not because

--- a/internal/model/score.go
+++ b/internal/model/score.go
@@ -106,6 +106,21 @@ func axisDefsFromSources() []axisDef {
 // alone does not say whether TLS verification is in force. "agent" gave one
 // because its generous cap was argued from being N/A on most hosts, and that
 // argument now has a second claimant.
+//
+// "systemd" sits just under "accounts", "updates" and "dockerd", and the gap
+// is the argument. It covers the same ground for a unit-started service that
+// "container" covers for a compose one — can it gain privileges, can it write
+// outside its own data, can it read every home directory — so on a host that
+// runs its services natively it is doing the work "container" does elsewhere.
+// It is one step below that band because none of its findings is by itself an
+// entry: each one widens what a compromise reaches rather than granting it.
+// Six axes funded it, each giving one. "container" and "ssh" gave from the
+// top because they are the only two large enough that a point does not change
+// what they can express. "cve", "ports", "firewall" and "agent" gave because
+// each already had a share argued as generous — and because a service running
+// unsandboxed is the step *after* every one of them: the exposed port, the
+// unpatched image, and the bypassed firewall all end at a process, and this
+// axis is about what that process can then touch.
 var axisDefs = axisDefsFromSources()
 
 // criticalHalves is the anchor of the whole penalty model: one Critical

--- a/internal/model/source.go
+++ b/internal/model/source.go
@@ -23,6 +23,7 @@ const (
 	SourceAgent
 	SourceSysctl
 	SourceDockerd
+	SourceSystemd
 
 	sourceCount // sentinel, not a domain; keep last
 )
@@ -87,17 +88,18 @@ type sourceDef struct {
 // previous scan whose findings had all changed domain, which reads to a
 // user as "everything on this host is new and everything old is fixed".
 var sourceDefs = []sourceDef{
-	{SourceCompose, "compose", "Container", "container", "Container exposure", 15},
-	{SourceSSH, "ssh", "SSH", "ssh", "SSH hardening", 15},
-	{SourceFirewall, "firewall", "Firewall", "firewall", "Host firewall", 10},
+	{SourceCompose, "compose", "Container", "container", "Container exposure", 14},
+	{SourceSSH, "ssh", "SSH", "ssh", "SSH hardening", 14},
+	{SourceFirewall, "firewall", "Firewall", "firewall", "Host firewall", 9},
 	{SourceUpdates, "updates", "Updates", "updates", "Auto-updates", 7},
-	{SourceCVE, "cve", "CVEs", "cve", "Vulnerabilities", 11},
-	{SourcePorts, "ports", "Ports", "ports", "Exposed services", 9},
+	{SourceCVE, "cve", "CVEs", "cve", "Vulnerabilities", 10},
+	{SourcePorts, "ports", "Ports", "ports", "Exposed services", 8},
 	{SourceAccounts, "accounts", "Accounts", "accounts", "Account hygiene", 7},
 	{SourceFilePerms, "fileperms", "File perms", "fileperms", "File permissions", 5},
-	{SourceAgent, "agent", "AI agents", "agent", "AI agent runtimes", 9},
+	{SourceAgent, "agent", "AI agents", "agent", "AI agent runtimes", 8},
 	{SourceSysctl, "sysctl", "Kernel", "sysctl", "Kernel hardening", 5},
 	{SourceDockerd, "dockerd", "Dockerd", "dockerd", "Docker daemon", 7},
+	{SourceSystemd, "systemd", "Services", "systemd", "Service hardening", 6},
 }
 
 var sourceIndex = indexBy(sourceDefs, func(d sourceDef) Source { return d.source })

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -103,6 +103,7 @@
                   <tr><td>AI agent runtimes</td><td><code>agent.</code></td><td>OpenClaw or Hermes installed</td></tr>
                   <tr><td>Kernel hardening</td><td><code>sysctl.</code></td><td>—</td></tr>
                   <tr><td>Docker daemon</td><td><code>dockerd.</code></td><td>Docker</td></tr>
+                  <tr><td>Service hardening</td><td><code>systemd.</code></td><td>systemd</td></tr>
                   <tr><td>Image CVEs <em>(optional)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -131,15 +132,16 @@
               <table>
                 <thead><tr><th>Axis</th><th>Weight</th></tr></thead>
                 <tbody>
-                  <tr><td>Container exposure</td><td>15</td></tr>
-                  <tr><td>SSH hardening</td><td>15</td></tr>
-                  <tr><td>Vulnerabilities</td><td>11</td></tr>
-                  <tr><td>Host firewall</td><td>10</td></tr>
-                  <tr><td>Exposed services</td><td>9</td></tr>
-                  <tr><td>AI agent runtimes</td><td>9</td></tr>
+                  <tr><td>Container exposure</td><td>14</td></tr>
+                  <tr><td>SSH hardening</td><td>14</td></tr>
+                  <tr><td>Vulnerabilities</td><td>10</td></tr>
+                  <tr><td>Host firewall</td><td>9</td></tr>
+                  <tr><td>Exposed services</td><td>8</td></tr>
+                  <tr><td>AI agent runtimes</td><td>8</td></tr>
                   <tr><td>Account hygiene</td><td>7</td></tr>
                   <tr><td>Auto-updates</td><td>7</td></tr>
                   <tr><td>Docker daemon</td><td>7</td></tr>
+                  <tr><td>Service hardening</td><td>6</td></tr>
                   <tr><td>File permissions</td><td>5</td></tr>
                   <tr><td>Kernel hardening</td><td>5</td></tr>
                 </tbody>
@@ -315,6 +317,25 @@
             </div>
             <p><code>dockerd.group-members</code> is <span class="sev medium">Medium</span> when the accounts holding the group are people, and <span class="sev high">High</span> when any of them is a service account — one with a system UID or no interactive login. Nobody deliberately grants a CI runner or a monitoring agent the ability to become root, and a credential that never logs in is one nobody is watching.</p>
             <p>A loopback-only TCP socket is not flagged: it reaches nothing the unix socket did not, and it is the documented way to put a proxy in front of the daemon. A daemon running <strong>rootless</strong> has <code>userns-remap</code> and <code>group-members</code> suppressed and its API finding lowered to <span class="sev high">High</span>, because the blast radius is that user's containers rather than the host. <code>live-restore</code> is suppressed on a swarm node, where Docker does not support it.</p>
+
+            <h2 id="systemd">Service hardening <code>systemd.</code></h2>
+            <p>Roughly half of a self-hosted server is not in a container. The Compose domain reads what your containers declare — privileged, running as root, no-new-privileges off — and a service started by a unit file has exactly the same decisions made about it. Until this domain existed, nothing looked at them.</p>
+            <p>systemd already knows the answers. <code>systemctl show</code> reports the <strong>effective</strong> value of each property after the unit file, every drop-in, and every default have been merged — so what hostveil reads is what the service will actually run with, not what some file says.</p>
+            <p><strong>Only your own units are audited.</strong> A unit counts if its file lives under <code>/etc/systemd/system</code> or <code>/usr/local/lib/systemd/system</code> — the ones you wrote or installed by hand. Your distribution hardens its own units on its own schedule, and second-guessing them means taking on maintenance of somebody else&rsquo;s service. Reporting on them would also bury your services under dozens of findings about software you did not choose, which is how a domain stops being read.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>What it means</th><th>Severity</th><th>Fix</th></tr></thead>
+                <tbody>
+                  <tr><td><code>systemd.no-new-privileges</code></td><td>The service can gain privileges through a setuid binary — the usual way a foothold inside a service becomes a foothold outside it</td><td><span class="sev low">Low</span> / <span class="sev medium">Medium</span></td><td>Manual</td></tr>
+                  <tr><td><code>systemd.protect-system</code></td><td>The service can write to <code>/usr</code>, <code>/boot</code> and <code>/etc</code>; one that can edit <code>/etc</code> owns every login on the host</td><td><span class="sev medium">Medium</span> / <span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>systemd.protect-home</code></td><td>The service can read <code>/home</code>, <code>/root</code> and <code>/run/user</code> — everyone&rsquo;s SSH keys, cloud credentials and password databases</td><td><span class="sev medium">Medium</span> / <span class="sev low">Low</span></td><td>Manual</td></tr>
+                  <tr><td><code>systemd.private-tmp</code></td><td>The service shares <code>/tmp</code> with every other process, which is the ground symlink races live on</td><td><span class="sev low">Low</span></td><td>Manual</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><strong>Two severities, and which one applies depends on the account.</strong> <code>no-new-privileges</code> is <span class="sev medium">Medium</span> on a service running as somebody other than root and <span class="sev low">Low</span> on one running as root — a root service can already do anything, so the setuid path it closes buys little there. The two filesystem protections go the other way for the same reason: they are worth most exactly where <code>no-new-privileges</code> is worth least.</p>
+            <p><strong>Every finding here is Manual, on purpose.</strong> The drop-in is two lines and hostveil could write it — but writing it is not the same as knowing it is safe. <code>ProtectSystem=full</code> breaks a service that writes under <code>/usr</code>; <code>PrivateTmp=yes</code> breaks two services that hand each other files through <code>/tmp</code>. Neither failure shows up until the next restart, which on a self-hosted box is the next reboot — and the service that does not come back is the one holding your data. So the how-to-fix carries the exact path and the exact two lines, and you pick the moment to restart and watch.</p>
+            <p>A property this systemd does not implement is reported as nothing at all, and nothing is not evidence that a protection is off — those are left alone rather than turned into a finding.</p>
 
             <h2 id="agent">AI agent runtimes <code>agent.</code></h2>
             <p>Self-hosted AI agents — <a href="https://docs.openclaw.ai/">OpenClaw</a> and <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a> — run a network gateway and keep API keys on disk in your home directory. Misconfigured, the worst case is someone reaching that gateway and driving an agent that can read your files and run commands as you.</p>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -103,6 +103,7 @@
                   <tr><td>AI 에이전트 런타임</td><td><code>agent.</code></td><td>OpenClaw 또는 Hermes 설치</td></tr>
                   <tr><td>커널 하드닝</td><td><code>sysctl.</code></td><td>—</td></tr>
                   <tr><td>Docker 데몬</td><td><code>dockerd.</code></td><td>Docker</td></tr>
+                  <tr><td>서비스 하드닝</td><td><code>systemd.</code></td><td>systemd</td></tr>
                   <tr><td>이미지 CVE <em>(선택)</em></td><td><code>cve.</code></td><td>Trivy</td></tr>
                 </tbody>
               </table>
@@ -131,15 +132,16 @@
               <table>
                 <thead><tr><th>축</th><th>가중치</th></tr></thead>
                 <tbody>
-                  <tr><td>컨테이너 노출</td><td>15</td></tr>
-                  <tr><td>SSH 하드닝</td><td>15</td></tr>
-                  <tr><td>취약점</td><td>11</td></tr>
-                  <tr><td>호스트 방화벽</td><td>10</td></tr>
-                  <tr><td>노출된 서비스</td><td>9</td></tr>
-                  <tr><td>AI 에이전트 런타임</td><td>9</td></tr>
+                  <tr><td>컨테이너 노출</td><td>14</td></tr>
+                  <tr><td>SSH 하드닝</td><td>14</td></tr>
+                  <tr><td>취약점</td><td>10</td></tr>
+                  <tr><td>호스트 방화벽</td><td>9</td></tr>
+                  <tr><td>노출된 서비스</td><td>8</td></tr>
+                  <tr><td>AI 에이전트 런타임</td><td>8</td></tr>
                   <tr><td>계정 위생</td><td>7</td></tr>
                   <tr><td>자동 업데이트</td><td>7</td></tr>
                   <tr><td>Docker 데몬</td><td>7</td></tr>
+                  <tr><td>서비스 하드닝</td><td>6</td></tr>
                   <tr><td>파일 권한</td><td>5</td></tr>
                   <tr><td>커널 하드닝</td><td>5</td></tr>
                 </tbody>
@@ -315,6 +317,25 @@
             </div>
             <p><code>dockerd.group-members</code>는 그룹을 가진 계정이 사람일 때 <span class="sev medium">보통</span>, 그중 하나라도 서비스 계정 — 시스템 UID이거나 대화형 로그인이 없는 계정 — 이면 <span class="sev high">높음</span>입니다. CI 러너나 모니터링 에이전트에게 root가 될 능력을 일부러 주는 사람은 없고, 한 번도 로그인하지 않는 자격 증명은 아무도 지켜보지 않는 자격 증명입니다.</p>
             <p>루프백 전용 TCP 소켓은 표시하지 않습니다. 유닉스 소켓이 닿지 않던 곳에 닿지 않고, 데몬 앞에 프록시를 두는 문서화된 방법이기 때문입니다. <strong>rootless</strong>로 실행 중인 데몬은 <code>userns-remap</code>과 <code>group-members</code>가 억제되고 API 항목이 <span class="sev high">높음</span>으로 내려갑니다. 피해 범위가 호스트가 아니라 그 사용자의 컨테이너이기 때문입니다. <code>live-restore</code>는 Docker가 지원하지 않는 swarm 노드에서 억제됩니다.</p>
+
+            <h2 id="systemd">서비스 하드닝 <code>systemd.</code></h2>
+            <p>자체 호스팅 서버의 절반가량은 컨테이너 밖에 있습니다. Compose 도메인은 컨테이너가 선언한 내용 — privileged, root 실행, no-new-privileges 해제 — 을 읽는데, 유닛 파일로 뜬 서비스에도 똑같은 판단이 필요합니다. 이 도메인이 생기기 전까지는 아무도 그쪽을 보지 않았습니다.</p>
+            <p>답은 systemd가 이미 알고 있습니다. <code>systemctl show</code>는 유닛 파일과 모든 드롭인, 그리고 기본값까지 병합한 뒤의 <strong>실효</strong> 값을 알려줍니다. 그래서 hostveil이 읽는 값은 어떤 파일에 적힌 값이 아니라 서비스가 실제로 그 값으로 돌아간다는 뜻입니다.</p>
+            <p><strong>직접 만든 유닛만 검사합니다.</strong> 유닛 파일이 <code>/etc/systemd/system</code> 또는 <code>/usr/local/lib/systemd/system</code> 아래에 있으면 대상이 됩니다 — 사용자가 직접 쓰거나 손으로 설치한 것들입니다. 배포판 유닛은 배포판이 자기 일정에 맞춰 하드닝하며, 그걸 뒤집는 것은 남의 서비스 유지보수를 떠안는 일입니다. 게다가 그것들까지 보고하면 사용자가 고르지도 않은 소프트웨어에 대한 수십 건의 항목에 정작 본인 서비스가 묻힙니다. 그렇게 되면 아무도 그 도메인을 읽지 않습니다.</p>
+            <div class="docs-table-wrap">
+              <table>
+                <thead><tr><th>ID</th><th>의미</th><th>심각도</th><th>수정</th></tr></thead>
+                <tbody>
+                  <tr><td><code>systemd.no-new-privileges</code></td><td>setuid 바이너리를 통해 서비스가 권한을 얻을 수 있습니다. 서비스 안의 발판이 서비스 밖의 발판으로 바뀌는 통상적인 경로입니다</td><td><span class="sev low">Low</span> / <span class="sev medium">Medium</span></td><td>수동</td></tr>
+                  <tr><td><code>systemd.protect-system</code></td><td>서비스가 <code>/usr</code>, <code>/boot</code>, <code>/etc</code>에 쓸 수 있습니다. <code>/etc</code>를 고칠 수 있는 서비스는 이 호스트의 모든 로그인을 손에 넣습니다</td><td><span class="sev medium">Medium</span> / <span class="sev low">Low</span></td><td>수동</td></tr>
+                  <tr><td><code>systemd.protect-home</code></td><td>서비스가 <code>/home</code>, <code>/root</code>, <code>/run/user</code>를 읽을 수 있습니다. 모든 사용자의 SSH 키, 클라우드 자격 증명, 비밀번호 데이터베이스가 그 안에 있습니다</td><td><span class="sev medium">Medium</span> / <span class="sev low">Low</span></td><td>수동</td></tr>
+                  <tr><td><code>systemd.private-tmp</code></td><td>서비스가 다른 모든 프로세스와 <code>/tmp</code>를 공유합니다. 심볼릭 링크 경쟁이 벌어지는 바로 그 자리입니다</td><td><span class="sev low">Low</span></td><td>수동</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p><strong>심각도가 두 가지이며, 어느 쪽인지는 실행 계정이 정합니다.</strong> <code>no-new-privileges</code>는 root가 아닌 계정으로 도는 서비스에서 <span class="sev medium">Medium</span>, root로 도는 서비스에서 <span class="sev low">Low</span>입니다. root 서비스는 이미 무엇이든 할 수 있으므로 이 설정이 막는 setuid 경로의 값어치가 거기서는 작습니다. 파일시스템 보호 두 가지는 같은 이유로 반대 방향입니다 — <code>no-new-privileges</code>의 값어치가 가장 작은 자리에서 가장 큽니다.</p>
+            <p><strong>여기의 모든 항목은 의도적으로 수동입니다.</strong> 드롭인은 두 줄이고 hostveil이 쓸 수도 있습니다. 하지만 쓰는 것과 안전하다고 아는 것은 다릅니다. <code>ProtectSystem=full</code>은 <code>/usr</code> 아래에 쓰는 서비스를 망가뜨리고, <code>PrivateTmp=yes</code>는 <code>/tmp</code>로 파일을 주고받는 두 서비스를 망가뜨립니다. 어느 쪽도 다음 재시작 전까지는 드러나지 않는데, 자체 호스팅 환경에서 그 시점은 다음 재부팅입니다 — 그리고 돌아오지 못한 서비스가 하필 데이터를 쥐고 있던 쪽입니다. 그래서 수정 안내에 정확한 경로와 정확한 두 줄을 담고, 재시작해서 지켜볼 시점은 사용자가 고릅니다.</p>
+            <p>이 systemd가 구현하지 않은 속성은 아무 값도 보고되지 않으며, 값이 없다는 것은 보호가 꺼져 있다는 근거가 아닙니다. 그런 경우는 항목으로 만들지 않고 그대로 둡니다.</p>
 
             <h2 id="agent">AI 에이전트 런타임 <code>agent.</code></h2>
             <p>셀프호스트 AI 에이전트인 <a href="https://docs.openclaw.ai/">OpenClaw</a>와 <a href="https://hermes-agent.nousresearch.com/docs/">Hermes Agent</a>는 네트워크 게이트웨이를 띄우고 API 키를 홈 디렉터리에 저장합니다. 설정이 잘못되면 최악의 경우 외부에서 그 게이트웨이에 접근해, 내 파일을 읽고 내 권한으로 명령을 실행하는 에이전트를 그대로 조종할 수 있습니다.</p>


### PR DESCRIPTION
> **Stacked on #637** — it uses `internal/check/checktest`, which that PR introduces. Merge #637 first; GitHub will retarget this to `main` automatically.

A twelfth detection domain. Roughly half of a self-hosted server is not in a container, and until now nothing looked at that half.

The Compose domain reads what a container declares — privileged, running as root, no-new-privileges off — and a service started by a unit file has *exactly the same decisions* made about it: whether it can gain privileges, whether it can write outside its own data, whether it can read every user's home directory. hostveil audited none of them.

## How it reads the host

`systemctl show` reports the **effective** value of each property after the unit file, every drop-in and every default have been merged, so the checker never models that precedence and a value it reads is the value the service will run with. One batched call for every unit rather than one per unit: thirty operator units would otherwise be thirty round trips through the runner, each bounded by `DefaultTimeout`, inside a scan that already runs every domain concurrently.

**Only the operator's own units** — fragment under `/etc/systemd/system` or `/usr/local/lib/systemd/system`. That line is deliberate and the package comment argues it: a distribution hardens its own units on its own schedule, and reporting on them would bury the operator's services under dozens of findings about software they did not choose and cannot sensibly change. A domain that accuses everything is a domain nobody reads.

## Findings

| ID | Severity |
| --- | --- |
| `systemd.no-new-privileges` | Low on root, **Medium** on a non-root service |
| `systemd.protect-system` | **Medium** on root, Low otherwise |
| `systemd.protect-home` | **Medium** on root, Low otherwise |
| `systemd.private-tmp` | Low |

The two directions are the point. A root service can already do anything, so the setuid path `NoNewPrivileges` closes buys little there; the filesystem protections are worth most exactly where it is worth least.

All four are **Manual by decision**, recorded in `fix.Default()`'s register with the reason: the drop-in is two lines, but `ProtectSystem=full` breaks a service that writes under `/usr` and `PrivateTmp=yes` breaks two that hand each other files through `/tmp`, and neither failure appears until the next restart — which on a host like this is the next reboot, when the service that does not come back is the one holding the data. Review is unavailable for the same reason it is for `dockerd.*`, from the other side: a drop-in and a restart are one procedure in two steps, not two alternatives, and systemd has no `sysctl -w` equivalent to pair with.

## The cap rebalance

`systemd` takes **6**, funded by one point each from `container`, `ssh`, `cve`, `ports`, `firewall` and `agent`; the caps still sum to 100. `score.go` carries the argument: it sits one step under the `accounts`/`updates`/`dockerd` band because none of its findings is by itself an entry — each widens what a compromise reaches rather than granting it. The four that already had a share argued as generous gave because *a service running unsandboxed is the step after every one of them*: the exposed port, the unpatched image and the bypassed firewall all end at a process, and this axis is about what that process can then touch.

## Verification

**Real host data caught a false-positive class the unit tests did not.** The first draft tested `!on(v)`, and `ProtectSystem`/`ProtectHome` are not booleans — systemd prints `no/yes/full/strict` and `no/yes/read-only/tmpfs`. Captured `systemctl show` output from a running Fedora 44 host (77 units) showed `strict` on 14 of them, every one of which the draft would have accused of having no protection at all. `TestEnumeratedProtectionsAreNotBooleans` now pins it, and reverting to `!on(v)` fails it on four of six cases.

The same data removed a dead branch: both rules also tested for `"off"`, a spelling systemd never emits — the same shape as the unreachable `Match` guard fixed in #633.

- `TestParsesRealSystemctlOutput` uses two records copied verbatim off that host **including systemd's own property order**, which is not the order the checker asks for. A positionally-reading parser would put `PrivateTmp`'s value in `NoNewPrivileges`' field, be wrong about every unit on every host, and still pass any fixture written in request order.
- Availability is probed as a capability, not a binary: `systemctl` exists on hosts that boot something else, where it exits non-zero. Treating its presence as an answer would enumerate no units and score the axis a perfect 100.
- A failure to enumerate is an ordinary error, so the axis is excluded rather than scored clean.
- A property systemd does not report is left alone — a silence is not evidence a protection is off.
- Every tripwire this repo has for a new domain fired and was satisfied: checker count, README table, both `checks.html` files plus regenerated `site/`, documented axis weights, the finding-ID namespace regex, and the fix register from both sides.
- Full gate: build, vet, gofmt, mod tidy, `-race`, golangci-lint (0 issues), sitegen diff clean.

**Not verified against a live systemd host.** The checker's own tests cover the parse and the rules; end-to-end on a real host belongs in the Vagrant demo VM, and I have not run it there yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)