### PR TITLE
fix(install): needing root is not the same as needing sudo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,10 +88,12 @@ jobs:
           apt-get update -qq
           DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
             curl ca-certificates tar coreutils >/dev/null
-          # The container is already root and the script calls sudo, which
-          # a minimal image does not ship. A pass-through stands in for it.
-          printf '#!/bin/sh\nexec "$@"\n' > /usr/bin/sudo
-          chmod +x /usr/bin/sudo
+          # Deliberately no sudo installed and no shim standing in for it.
+          # This container is root, which is what the installer has to handle
+          # on its own — Debian's default is root-only administration, and
+          # every `docker run … | bash` is the same shape. A fake sudo here
+          # passed the test while real users in this position hit
+          # "sudo: command not found" after the download and the checksum.
 
       - name: Install the published release
         run: bash scripts/install.sh --yes --no-trivy

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ uninstall() {
   local removed=false
 
   if [[ -e /usr/bin/hostveil ]]; then
-    sudo rm -f /usr/bin/hostveil
+    "${SUDO[@]}" rm -f /usr/bin/hostveil
     echo "  ✓ removed /usr/bin/hostveil"
     removed=true
   else
@@ -65,13 +65,13 @@ uninstall() {
     echo "    ${state}"
     echo "  Those checkpoints are the backups of every file hostveil edited here."
     echo "  Delete them only if you no longer need to undo any of its fixes:"
-    echo "    sudo rm -rf ${state}"
+    echo "    ${SUDO[*]:+sudo }rm -rf ${state}"
   fi
 
   if command -v trivy >/dev/null 2>&1; then
     echo ""
     echo "  trivy is still installed. It is a general-purpose scanner, so this"
-    echo "  script does not remove it. To remove it: sudo rm -f \"$(command -v trivy)\""
+    echo "  script does not remove it. To remove it: ${SUDO[*]:+sudo }rm -f \"$(command -v trivy)\""
   fi
 
   if [[ "$removed" == true ]]; then
@@ -104,6 +104,28 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# ─── privilege ────────────────────────────────────────────────────────────
+# Installing into /usr/bin needs root. Which is not the same as needing sudo,
+# and the script used to assume it was: it called `sudo install` unconditionally,
+# so on a host where you are *already* root and sudo is not installed it got all
+# the way through downloading and verifying and then died with
+# "sudo: command not found". That is not an exotic host — Debian's own default
+# is root-only administration with no sudo, and every `docker run … | bash` is
+# the same shape.
+#
+# An array rather than a string so that the empty case expands to nothing at
+# all, instead of to an empty argument that `install` would read as a filename.
+SUDO=()
+if [[ ${EUID} -ne 0 ]]; then
+  if command -v sudo &>/dev/null; then
+    SUDO=(sudo)
+  else
+    echo "ERROR: installing into /usr/bin needs root, and sudo is not available." >&2
+    echo "  Re-run this as root, or install sudo first." >&2
+    exit 1
+  fi
+fi
 
 if [[ "$UNINSTALL" == true ]]; then
   uninstall
@@ -289,7 +311,7 @@ install_tool() {
       }
       TRIVY_BIN=$(find "$TRIVY_DIR" -name 'trivy' -type f 2>/dev/null | head -1)
       if [[ -n "$TRIVY_BIN" ]]; then
-        sudo install -m 755 "$TRIVY_BIN" /usr/bin/trivy
+        "${SUDO[@]}" install -m 755 "$TRIVY_BIN" /usr/bin/trivy
       else
         echo "  ERROR: trivy binary not found after extraction" >&2
         return 1
@@ -377,7 +399,7 @@ tar xzf "${TMPDIR}/${TAR}" -C "$TMPDIR" || {
   echo "  ERROR: extraction failed" >&2
   exit 1
 }
-sudo install -m 755 "${TMPDIR}/hostveil" /usr/bin/hostveil || {
+"${SUDO[@]}" install -m 755 "${TMPDIR}/hostveil" /usr/bin/hostveil || {
   echo "  ERROR: install failed" >&2
   exit 1
 }

--- a/scripts/install.sh.sha256
+++ b/scripts/install.sh.sha256
@@ -1,1 +1,1 @@
-6324f6fdc9ada8d16db08a7d38bcd93e886d5f74258abf19cf1337fbb2e4cbab  install.sh
+c5a746453957016a6bbabbcc907087bb525460d5d984fedec26f60fd348c7db3  install.sh


### PR DESCRIPTION
`install.sh` called `sudo install` unconditionally. On a host where you are **already root and sudo is not installed**, it downloaded the archive, verified the checksum, printed the provenance hint — and then died:

```
  • hostveil: verifying checksum...
  ✓ checksum verified
/install.sh: line 380: sudo: command not found
  ERROR: install failed
```

Not an exotic host. Debian's own default is root-only administration with no sudo, and every `docker run … | bash` is the same shape — which is how most people try a tool for the first time.

## The test was hiding it

`nightly.yml` faked sudo to get past this:

```yaml
# The container is already root and the script calls sudo, which
# a minimal image does not ship. A pass-through stands in for it.
printf '#!/bin/sh\nexec "$@"\n' > /usr/bin/sudo
```

So the situation was known, and the workaround went into the harness instead of the script. The installer smoke test passed while real users in exactly that position failed. **The shim is removed here** — that is the part that makes the fix stick, and the comment now says why there deliberately is no sudo in that container.

## The fix

An array rather than a string, so the empty case expands to nothing at all instead of to an empty argument `install` would read as a filename:

```bash
SUDO=()
if [[ ${EUID} -ne 0 ]]; then
  if command -v sudo &>/dev/null; then SUDO=(sudo)
  else …refuse with a message that says what to do… fi
fi
```

Placed **after** the option loop so `--help` still works without root, and **before** the uninstall branch — `--uninstall` removes `/usr/bin/hostveil` and needs the same privilege, and it runs long before the OS/ARCH section. Getting that order wrong was the first thing I did and the reason it is called out here.

The two printed hints use `${SUDO[*]:+sudo }`, so a root user is told `rm -rf /var/lib/hostveil` rather than being handed a `sudo` they do not have.

## Verified, all four paths, against the real published release

| | |
| --- | --- |
| root, no sudo | installs `hostveil v3.10.0`; `--uninstall` removes the binary, keeps `/var/lib/hostveil`, and prints the hint without a `sudo` prefix |
| non-root, no sudo | refuses: *"installing into /usr/bin needs root, and sudo is not available. Re-run this as root, or install sudo first."* |
| `--help`, non-root, no sudo | still prints usage |
| non-root with sudo | installs, unchanged |

`shellcheck` clean, `bash -n` clean, `actionlint` clean, `install.sh.sha256` regenerated.

## One thing found and deliberately not changed

While testing this I ran the installer twice against a release whose workflow was still building, and got a 404 both times: `gh release create` publishes the release immediately, so `/releases/latest` points at the new tag for the few minutes goreleaser needs to attach the archives. It is transient and self-healing, and the existing demote-to-draft job already covers the *failed*-release case. Cutting the release as a draft and publishing it from the workflow on success would close the window too, but that changes the release procedure and belongs in its own change with its own reasoning — not bundled into an installer fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)