### PR TITLE
docs(ui): the One Dark palette moves four of its twelve roles, not three

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ temporary and will be gone once one of them is chosen.**
   colourings of one figure, and the marketing site had two more that shared
   nothing with them. They are now one drawing, a chip, byte-identical across all
   four surfaces and held there by a test, with both lockups optically aligned.
-  The Instrument palette is gone and One Dark is the default; three of its
-  twelve roles are lifted in HSL lightness by the smallest step that clears the
-  contrast floors every theme here is held to. The terminal list gains what the
-  dashboard has always had above the fold: a count per severity, how many
+  The Instrument palette is gone and One Dark is the default; four of its twelve
+  roles are moved — three lifted in HSL lightness by the smallest step that
+  clears the contrast floors every theme here is held to, and the foreground
+  lifted as a judgement rather than a floor, because an editor sets a few
+  hundred glyphs on screen and this sets thousands. The terminal list gains
+  what the dashboard has always had above the fold: a count per severity, how many
   hostveil can fix on its own, and — for each domain that did not fully run —
   the reason the checker gave, instead of an unexplained `N/A`. `scan` no longer
   double-spaces its findings, which halves the scrollback on an ordinary host.

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -60,8 +60,12 @@ var themes = []Theme{
 		ID:   "onedark",
 		Name: "One Dark",
 		Palette: Palette{
-			// Atom's One Dark. Nine of the twelve roles map onto its published
-			// values unchanged; the other three needed a decision.
+			// Atom's One Dark. Eight of the twelve roles map onto its
+			// published values unchanged; the other four needed a decision.
+			// (Three of the four are the contrast lifts below; the fourth is
+			// Bone, which is a judgement rather than a floor. This said
+			// "nine ... three" and then described four changes, which is the
+			// kind of arithmetic a comment gets to be wrong about forever.)
 			//
 			// Line is #181a1f, which is DARKER than the page. That is the look
 			// and not a mistake: One Dark seams its panels rather than boxing


### PR DESCRIPTION
## What and why

The comment above the One Dark palette opens with:

> Nine of the twelve roles map onto its published values unchanged; the other three needed a decision.

and then, four paragraphs later, describes **four** changes:

| role | published One Dark | hostveil | why |
|---|---|---|---|
| `Slate` | `#7f848e` | `#8e939b` | 3.73:1, floor is 4.5 |
| `Crit` | `#e06c75` | `#e17079` | 4.38:1, floor is 4.5 |
| `Low` | — | `#79808e` | 3.39:1, floor is 3.5 |
| `Bone` | `#abb2bf` | `#c8ccd4` | not a floor — a judgement, stated as such in the comment itself |

Counted against the published palette that is **eight unchanged and four moved**, not nine and three.

Nobody would have caught this from the code, because every one of the four adjustments is individually documented and individually correct — including the reason the fourth is different in kind from the other three. Only the tally was wrong, which is the sort of arithmetic a comment gets to be wrong about forever.

The 3.11.0 changelog entry inherited the same claim (I wrote it from the comment), so it is corrected in the same commit, and now says why the fourth adjustment is not a contrast fix.

Found while fact-checking a screenshot page against the repo.

## Checklist

- [x] Title is conventional with a valid scope (`type(scope): ...`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  golangci-lint v2.12.2 run ./...                      # 0 issues
  go run ./cmd/sitegen && git diff --exit-code site/   # clean
  ```
  `govulncheck` cannot run here — the pinned v1.6.0 is built with Go 1.25 and refuses a Go 1.26 module. CI's runner has a matching toolchain.
- [x] For a new or changed detection rule: n/a — comment and changelog only, no palette value changed.
- [x] For a UI change: no rendered output changes; `internal/ui/theme` and `internal/docs` tests pass.
- [x] The score stays honest — nothing here touches scoring.


---
_Generated by [Claude Code](https://claude.ai/code/session_013hFYQoYtBYhZJEZcdDUGuq)_