### PR TITLE
docs(ui): the chip counts every fixable finding, not the unattended ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ temporary and will be gone once one of them is chosen.**
   clears the contrast floors every theme here is held to, and the foreground
   lifted as a judgement rather than a floor, because an editor sets a few
   hundred glyphs on screen and this sets thousands. The terminal list gains
-  what the dashboard has always had above the fold: a count per severity, how many
-  hostveil can fix on its own, and — for each domain that did not fully run —
-  the reason the checker gave, instead of an unexplained `N/A`. `scan` no longer
-  double-spaces its findings, which halves the scrollback on an ordinary host.
-  And `--glyphs nerd` draws the status markers from a patched Nerd Font: opt-in,
+  what the dashboard has always had above the fold: a count per severity, how
+  many findings hostveil can offer a fix for at all — Auto *and* Review, which
+  is what the dashboard's chip has always counted — and, for each domain that
+  did not fully run, the reason the checker gave, instead of an unexplained
+  `N/A`. `scan` no longer double-spaces its findings, which halves the
+  scrollback on an ordinary host. And `--glyphs nerd` draws the status markers from a patched Nerd Font: opt-in,
   because a terminal cannot be asked what font it is using and a missing glyph
   is drawn in the same single cell a present one would be. Any Nerd Font build
   works, Mono or not — verified by reading the tables of eighteen font files.

--- a/internal/ui/theme/theme_test.go
+++ b/internal/ui/theme/theme_test.go
@@ -63,11 +63,12 @@ func TestAllIsACopy(t *testing.T) {
 // screenshot, every doc and the brand mark are calibrated to, written out
 // again so that changing it is a decision rather than a diff nobody read.
 //
-// Three of the twelve are not One Dark's published values. That is not drift
-// — TestEveryThemeMeetsTheContrastFloor rejects the published Slate, Crit and
-// Low outright — but it does mean somebody comparing this against Atom will
-// find a discrepancy and be right to ask, so the numbers are pinned here with
-// the ones they replaced beside them.
+// Four of the twelve are not One Dark's published values. Three of those are
+// not drift — TestEveryThemeMeetsTheContrastFloor rejects the published Slate,
+// Crit and Low outright — and the fourth, Bone, is a judgement with its own
+// reason beside it. Either way somebody comparing this against Atom will find
+// a discrepancy and be right to ask, so the numbers are pinned here with the
+// ones they replaced beside them.
 func TestOneDarkUnchanged(t *testing.T) {
 	want := Palette{
 		Ink: "#282c34", Ink2: "#21252b", Ink3: "#2f343f",


### PR DESCRIPTION
## What and why

The 3.11.0 changelog entry says the terminal list now shows *"how many hostveil can fix on its own"*. **It does not.**

The FIXABLE chip counts `model.Finding.IsFixable()`, and the remediation table marks two kinds fixable:

```go
{RemediationAuto,   "auto",   "Auto-fix", true},
{RemediationReview, "review", "Review",   true},
```

On the seeded host these screenshots come from, the chip reads **FIXABLE 38** while the number hostveil will apply unattended is **23** — 15 of the 38 are Review, which by definition need a decision from the operator. The two numbers sit four lines apart on the same screen, which is exactly where the difference is most likely to be read wrong.

"Fix on its own" is the standard for **Auto** specifically — reversible, recoverable in practice, unambiguous, per the doc comment on `fix.Default()`. Lending that phrase to a count that includes Review is the same shape of error as an unexplained `N/A`: a number that reads as a stronger claim than it is.

Also folded in: `theme_test.go` carried the undercount its neighbour in `theme.go` was corrected for in #652 — it said *"three of the twelve are not One Dark's published values"* directly above a table pinning **four**, `Bone` among them, with its own separate rationale two lines further down.

Found by a fact-check pass that read the claims back against `internal/model/remediation.go` and `internal/ui/tui/view.go`'s `chipRow`.

## Checklist

- [x] Title is conventional with a valid scope (`type(scope): ...`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  golangci-lint v2.12.2 run ./...                      # 0 issues
  go run ./cmd/sitegen && git diff --exit-code site/   # clean
  ```
  `govulncheck` cannot run here — the pinned v1.6.0 is built with Go 1.25 and refuses a Go 1.26 module. CI's runner has a matching toolchain.
- [x] For a new or changed detection rule: n/a — no behavior changes. Comment and changelog only; the chip already counted the right thing, the prose described it wrongly.
- [x] For a UI change: nothing rendered changes; `internal/ui/theme` and `internal/docs` tests pass.
- [x] The score stays honest — and so, now, does the sentence describing what the list says.


---
_Generated by [Claude Code](https://claude.ai/code/session_013hFYQoYtBYhZJEZcdDUGuq)_