### PR TITLE
feat(tui): give the terminal the three things the dashboard had and it did not

### DIFF
--- a/internal/ui/tui/summary_test.go
+++ b/internal/ui/tui/summary_test.go
@@ -350,3 +350,98 @@ func TestEmptyListDistinguishesAFilterFromACleanHost(t *testing.T) {
 		t.Errorf("a clean host is not told it is clean:\n%s", body)
 	}
 }
+
+// The dashboard has two rows over its findings list: the filter chips, then a
+// bar of batch buttons. The terminal had only the first, and what a batch
+// would do was documented in the footer among fourteen other keys — so the
+// state the list was actually in (two findings marked, `a` about to apply
+// exactly those) was the one thing the screen did not say.
+func TestTheBatchBarSaysWhatTheBatchKeyWouldDo(t *testing.T) {
+	m := summaryModel(120, 30)
+	if got := plain(m.batchRow(120)); !strings.Contains(got, "fix all") {
+		t.Errorf("with nothing marked the bar does not offer the whole batch: %q", got)
+	}
+
+	// Marking changes what `a` does, so it has to change what the bar says.
+	var marked int
+	for _, f := range m.active {
+		if f.Remediation == model.RemediationAuto && marked < 2 {
+			m.selected[f.Key()] = true
+			marked++
+		}
+	}
+	if marked != 2 {
+		t.Fatalf("the fixture produced %d Auto findings to mark", marked)
+	}
+	got := plain(m.batchRow(120))
+	if !strings.Contains(got, "2 marked") {
+		t.Errorf("the bar does not name the marked count: %q", got)
+	}
+	if strings.Contains(got, "fix all") {
+		t.Errorf("the bar still offers the whole batch while a subset is marked: %q", got)
+	}
+	if !strings.Contains(got, "esc") {
+		t.Errorf("the bar does not say how to clear the marks: %q", got)
+	}
+	// And it has to reach the screen, not just exist.
+	if !strings.Contains(plain(strings.Join(m.listRows(24), "\n")), "2 marked") {
+		t.Error("the batch bar is not drawn on the list screen")
+	}
+}
+
+// The dashboard closes its detail pane with Preview fix and Explain with AI.
+// The terminal closed it with nothing, so the two keys that act on the thing
+// the pane is showing lived only in the footer.
+func TestThePaneNamesTheKeysThatActOnWhatItShows(t *testing.T) {
+	m := summaryModel(140, 34)
+	rows := plain(strings.Join(m.paneRows(48, 30), "\n"))
+	if !strings.Contains(rows, "explain with AI") {
+		t.Errorf("the pane does not offer the AI explanation:\n%s", rows)
+	}
+	// A fixable finding gets the fix line; a Manual one must not, because a
+	// key that does nothing is worse than a key nobody was told about.
+	fixable := -1
+	manual := -1
+	for i, f := range m.active {
+		if f.IsFixable() && fixable < 0 {
+			fixable = i
+		}
+		if !f.IsFixable() && manual < 0 {
+			manual = i
+		}
+	}
+	if fixable < 0 || manual < 0 {
+		t.Fatal("the fixture has no fixable/manual pair to compare")
+	}
+	m.cursor = fixable
+	if got := plain(strings.Join(m.paneRows(48, 30), "\n")); !strings.Contains(got, "preview and apply") {
+		t.Errorf("a fixable finding's pane does not offer the fix:\n%s", got)
+	}
+	m.cursor = manual
+	if got := plain(strings.Join(m.paneRows(48, 30), "\n")); strings.Contains(got, "preview and apply") {
+		t.Errorf("a manual finding's pane offers a fix that does not exist:\n%s", got)
+	}
+}
+
+// The service is set flush right the way the dashboard sets it, so a column of
+// container names can be read down. It goes back to trailing the title only
+// when the row is too narrow for the gap to be a column at all.
+func TestTheServiceIsSetFlushRightWhenThereIsRoom(t *testing.T) {
+	f := model.NewFinding("compose.ds018", "Datastore exposed", model.SeverityCritical,
+		model.SourceCompose, model.RemediationAuto, model.WithService("redis"))
+	m := summaryModel(140, 30)
+
+	wide := plain(m.findingRow(f, false, 120))
+	if !strings.HasSuffix(strings.TrimRight(wide, " "), "(redis)") {
+		t.Errorf("the service is not at the end of the row: %q", wide)
+	}
+	if !strings.Contains(wide, "exposed   ") {
+		t.Errorf("the service was not pushed right, it is still trailing the title: %q", wide)
+	}
+	// Narrow enough that a right-aligned name would sit one space from the
+	// title: that is not a column, so it trails instead.
+	narrow := plain(m.findingRow(f, false, 46))
+	if strings.Contains(narrow, "exposed   ") {
+		t.Errorf("a narrow row still spends columns on the gap: %q", narrow)
+	}
+}

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -269,6 +269,14 @@ func (m *appModel) axesLine() string {
 	if perRow < 1 {
 		perRow = 1
 	}
+	// Spread them evenly over the rows they need. Packing greedily put twelve
+	// domains on a 180-column terminal as seven and then five, which leaves a
+	// third of the second row empty and reads as a strip that ran out — the
+	// dashboard's grid gives every card the same share and wraps to six and
+	// six. Same number of rows either way; this only decides where the break
+	// falls.
+	rows := (len(cells) + perRow - 1) / perRow
+	perRow = (len(cells) + rows - 1) / rows
 
 	gap := s.dim.Render(strings.Repeat(" ", axisGap))
 	var out []string
@@ -397,12 +405,35 @@ func (m *appModel) paneRows(w, budget int) []string {
 	if len(m.active) == 0 {
 		return centerRows([]string{s.dim.Render(truncate("Nothing to show.", w))}, budget)
 	}
-	body := m.detailBodyRows(m.active[m.cursor], min(w-2, 78))
-	out := make([]string, 0, len(body))
+	f := m.active[m.cursor]
+	body := m.detailBodyRows(f, min(w-2, 78))
+	out := make([]string, 0, len(body)+4)
 	for _, r := range body {
 		out = append(out, " "+r)
 	}
+	// The dashboard closes this pane with a row of buttons — Preview fix,
+	// Explain with AI — and the terminal closed it with nothing, leaving the
+	// two keys that act on what the pane is showing documented only in the
+	// footer, among fourteen others. A pane that reads a finding out and then
+	// does not say what can be done about it is where the two interfaces
+	// diverged most, and it is the cheapest place to stop.
+	for _, r := range m.paneActionRows(f) {
+		out = append(out, " "+r)
+	}
 	return m.clipRows(out, budget)
+}
+
+// paneActionRows is what the dashboard draws as buttons under the detail: the
+// keys that act on this finding, and only the ones that would do something.
+func (m *appModel) paneActionRows(f model.Finding) []string {
+	s := m.sty()
+	var acts []string
+	if f.IsFixable() {
+		acts = append(acts, s.safe.Render("f  preview and apply the fix"))
+	}
+	acts = append(acts, s.dim.Render("e  explain with AI")+
+		s.dim.Render("     enter  open full screen"))
+	return append([]string{"", m.ruleRow()}, acts...)
 }
 
 // emptyListRows is what the list column says when there is nothing in it: a
@@ -458,19 +489,28 @@ func (m *appModel) listColumn(budget, w int) []string {
 		return centerRows(m.emptyListRows(fl, w), budget)
 	}
 
+	// The chip row and the batch bar are the dashboard's two rows over the
+	// list, in the same order it draws them.
+	bb := m.batchRow(w)
 	chrome := 1
 	if fl != "" {
-		chrome = 2
+		chrome++
+	}
+	if bb != "" {
+		chrome++
 	}
 	visible := budget - chrome
 	if visible < 1 {
 		// Findings beat labels: on a frame this short the list itself is the
 		// only thing worth drawing.
 		chrome, visible = 0, budget
-	} else if chrome == 2 && visible < minChipRows {
-		// The chips are a summary of the list, and a summary that costs half
-		// of what it summarises is not worth its row.
+	} else if chrome > 1 && visible < minChipRows {
+		// The chips and the batch bar summarise the list, and a summary that
+		// costs half of what it summarises is not worth its rows. Both go at
+		// once: dropping one and keeping the other would leave the shorter
+		// frame carrying the less useful of the two.
 		chrome, visible = 1, budget-1
+		fl, bb = "", ""
 	}
 
 	// The inline block is paid for out of the list's own rows rather than
@@ -500,8 +540,11 @@ func (m *appModel) listColumn(budget, w int) []string {
 			h += s.dim.Render(fmt.Sprintf("      %d–%d", shownFrom, shownTo))
 		}
 		out = append(out, h)
-		if chrome == 2 {
+		if fl != "" {
 			out = append(out, fl)
+		}
+		if bb != "" {
+			out = append(out, bb)
 		}
 	}
 
@@ -631,8 +674,50 @@ func (m *appModel) findingRow(f model.Finding, cursor bool, w int) string {
 		suffix = ""
 	}
 	title := truncate(f.Title, avail-lipgloss.Width(suffix))
+
+	// The service is set flush right, the way the dashboard's row does it,
+	// rather than trailing the title. Two reasons, and the second is the one
+	// that matters on a wide terminal: it makes a column of service names the
+	// eye can run down, and it stops the service from sliding left to right with
+	// every title length so that "which container is this?" is answered in one
+	// place instead of eighty. The gap is only spent where there is room for
+	// it — under minGapForRightAlign the suffix goes back to trailing the
+	// title, because a right-aligned name one space from the title is not a
+	// column, it is the same row with extra arithmetic.
+	const minGapForRightAlign = 4
+	if gap := avail - lipgloss.Width(title) - lipgloss.Width(suffix); suffix != "" && gap >= minGapForRightAlign {
+		title = padRight(title, lipgloss.Width(title)+gap)
+	}
 	return gutter + mark + lipgloss.NewStyle().Foreground(sevC).Render(sev) +
 		s.dim.Render(fmt.Sprintf(" %-13s ", f.ID)) + s.bone.Render(title) + suffix
+}
+
+// batchRow is the terminal's batch bar: the dashboard has a row of buttons
+// over the list saying what a batch would do, and the terminal had the same
+// information only in the footer, where it reads as one more key among
+// fourteen rather than as the state the list is in.
+//
+// It says what pressing the key does *now*, which is the whole point — `a`
+// applies the marked findings, or every Auto finding when nothing is marked,
+// and those are different enough that a bar naming only one of them would be
+// wrong half the time.
+func (m *appModel) batchRow(w int) string {
+	s := m.sty()
+	autos := 0
+	for _, f := range m.report.Select(model.Filter{}) {
+		if f.Remediation == model.RemediationAuto {
+			autos++
+		}
+	}
+	switch {
+	case len(m.selected) > 0:
+		return clip(s.safe.Render(fmt.Sprintf("a  fix the %d marked", len(m.selected)))+
+			s.dim.Render("     esc  clear marks"), w)
+	case autos > 0:
+		return clip(s.safe.Render(fmt.Sprintf("a  fix all %d safe", autos))+
+			s.dim.Render("     space  mark one"), w)
+	}
+	return ""
 }
 
 // sourceLabel is the short domain name shown in the filter line.


### PR DESCRIPTION
## What and why

Driven side by side against the same host at **180×46** — a size the terminal actually gets on a modern screen, and one that makes the differences obvious rather than excusable. Three of them accounted for most of the gap, and none was about the terminal being a terminal.

### 1 · The service name sets flush right

It trailed the title, so across eighty rows it landed in eighty different columns and *"which container is this?"* had to be answered by reading each row to its end. The dashboard has always set it against the right edge, which makes a column the eye can run down.

```
before   ▌  HIGH ports.exposed-admin Admin panel reachable from the network: Portainer  (docker-proxy:9000)
         ▌  HIGH firewall.inactive No active host firewall
         ▌  HIGH compose.ds001 Container runs in privileged mode  (monitor)

after    ▌  HIGH ports.exposed-admin Admin panel reachable from the network: Portainer     (docker-proxy:9000)
         ▌  HIGH firewall.inactive No active host firewall
         ▌  HIGH compose.ds001 Container runs in privileged mode                                   (monitor)
```

Under four columns of gap it goes back to trailing the title — a name one space from the title is not a column, it is the same row with extra arithmetic.

### 2 · A batch bar

The dashboard draws **Fix selected (2) · Select all Auto · Clear** over its list. The terminal put the same information in the footer, among fourteen other keys — so the state the list was actually in (two findings marked, `a` about to apply exactly those) was the one thing the screen did not say.

```
FINDINGS · 83   ✓ 2 marked      1–33
 CRIT 8    HIGH 16    MED 22    LOW 37    FIXABLE 38
a  fix the 2 marked     esc  clear marks
```

It says what the key does **now**: `a` applies the marks, or every Auto finding when there are none, and a bar naming only one of those would be wrong half the time. It sheds together with the chip row on a short frame — dropping one and keeping the other would leave the shorter frame carrying the less useful of the two.

### 3 · The detail pane names its own keys

The dashboard closes the pane with **Preview fix** and **Explain with AI**. The terminal closed it with nothing, leaving the two keys that act on the thing the pane is showing documented only in the footer.

```
HOW TO FIX
Set `PermitEmptyPasswords no` in sshd_config.
─────────────────────────────────────────────
f  preview and apply the fix
e  explain with AI     enter  open full screen
```

The fix line appears only where there is a fix — a key that does nothing is worse than a key nobody mentioned. Pinned both ways by `TestThePaneNamesTheKeysThatActOnWhatItShows`.

### Also: the axes strip spreads evenly

Packing greedily put twelve domains on a 180-column terminal as **seven then five**, leaving a third of the second row empty and reading as a strip that ran out. The dashboard's grid gives every card the same share. Same row count either way — this only moves where the break falls, to **six and six**.

## Checklist

- [x] Title is conventional with a valid scope (`type(scope): ...`).
- [x] Ran the CI gate locally and it passes:
  ```
  go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race ./...
  golangci-lint v2.12.2 run ./...                      # 0 issues
  go run ./cmd/sitegen && git diff --exit-code site/   # clean
  ```
  `govulncheck` cannot run here — the pinned v1.6.0 is built with Go 1.25 and refuses a Go 1.26 module. CI's runner has a matching toolchain.
- [x] For a new or changed detection rule: n/a — no checker, rule, score or fix changed. Three rendering additions and one wrap calculation.
- [x] For a UI change: the layering tests still pass, and the frame invariant (`TestEveryLayoutFitsTheTerminal`, six arrangements × ten widths × six heights) covers the two new rows. New tests: `TestTheBatchBarSaysWhatTheBatchKeyWouldDo`, `TestThePaneNamesTheKeysThatActOnWhatItShows`, `TestTheServiceIsSetFlushRightWhenThereIsRoom`. Re-shot against the real seeded host at 180×46.
- [x] The score stays honest — nothing here touches scoring, and the batch bar reports the Auto count specifically, not the wider fixable one.


---
_Generated by [Claude Code](https://claude.ai/code/session_013hFYQoYtBYhZJEZcdDUGuq)_