### PR TITLE
fix(ci): let the measurement harness start on a host with no fix history

### DIFF
--- a/scripts/measure/instruments/rollback.sh
+++ b/scripts/measure/instruments/rollback.sh
@@ -32,7 +32,13 @@ MARK=${MEASURE_MARK:-/tmp/hostveil-measure-mark}
 # the file it created" from "the file was never watched".
 ENUMERATED_DIRS=${MEASURE_ENUMERATED_DIRS:-/etc/sysctl.d}
 
-ids() { hostveil history 2>/dev/null | grep -oE 'rollback [0-9]{8}-[0-9.]+-[0-9a-f]+-[0-9a-f]+' | awk '{print $2}'; }
+# `|| true` because grep exits 1 when it matches nothing, and nothing is what
+# it matches on a host that has never applied a fix — which is every host the
+# documentation tells you to run this on ("a container or a throwaway VM").
+# Under `set -euo pipefail` that killed the instrument, `rb mark` with it, and
+# run.sh two lines into a four-phase run. Invisible on a host that has any
+# checkpoint at all, which is every host it had been run on.
+ids() { hostveil history 2>/dev/null | grep -oE 'rollback [0-9]{8}-[0-9.]+-[0-9a-f]+-[0-9a-f]+' | awk '{print $2}' || true; }
 
 case "${1:-}" in
 candidates)


### PR DESCRIPTION
## What and why

`scripts/measure/instruments/rollback.sh` could not run on a host that had never applied a fix — which is exactly the host `AGENTS.md` and the docs tell you to run it on ("a container or a throwaway VM, not your own machine").

`ids()` pipes `hostveil history` into `grep -oE`. With no checkpoints, grep matches nothing and exits 1; under `set -euo pipefail` that killed the instrument, `rb mark` with it, and `run.sh` two lines in:

```
==> profile seeded — recording where the fix history stands
(exit 1)
```

It is invisible on any host that has ever applied a fix, which is every host the harness had been run on before.

Found by running the harness for real: a seeded self-hosting environment (Nextcloud+Postgres, Jellyfin+Redis, Portainer+Watchtower, weak sshd, ufw off, native Redis on 0.0.0.0) on an ARM64 Ubuntu 24.04 server. After this one-line fix the full four-phase run completed and reported, from instruments that are not hostveil:

- **ports reachable from off-host: 7 → 2** after `fix --all` plus a service restart (5432, 6380, 8080, 8096, 9000 closed; 22 and a natively-installed Redis on 6379 remained, the latter correctly reported as Manual)
- **CIS Docker Benchmark 1.6.0: PASS 16 → 19, WARN 16 → 13**, score −3 → +3
- **Lynis hardening index: 56 → 57**, with the warning and suggestion sets unchanged — the honest negative, and the one the harness exists to surface
- **rollback fidelity 100%**: 24 checkpoints, 5 files changed, 5 restored byte for byte

## Checklist

- [x] Title is conventional with a valid scope (`type(scope): ...`).
- [x] Ran the CI gate locally and it passes; `shellcheck` clean on the changed script.
- [x] For a new or changed detection rule: n/a.
- [x] For a UI change: n/a.
- [x] The score stays honest — this changes tooling only, and it is the tooling whose whole job is to check hostveil's score against instruments that do not share its assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)