### PR TITLE
feat(fix): one command for everything hostveil can fix, and one less exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ operator actually takes.
   that to a banner. Both registries now lead with it, and neither describes
   itself as temporary any more.
 
+* **fix:** `fix --all --review` applies the Review fixes too, each through its
+  first alternative. "Fix everything that needs no human" and "fix everything
+  hostveil can" are different requests and only the first had a command, so
+  every SSH hardening option, every kernel parameter and every image update
+  needed one invocation apiece. The classification does not move — a Review fix
+  is still one that can cut off access to this host or has more than one
+  defensible answer — and the two lists are printed and counted separately, so
+  saying yes to them is still saying yes to them. On a seeded host it is the
+  difference between the SSH domain reaching 44 and reaching 100.
+
+* **updates:** enabling automatic security updates is an Auto fix on a host
+  where the mechanism is already installed, which on Debian and Ubuntu is the
+  usual state. The remediation there is two keys in
+  `/etc/apt/apt.conf.d/20auto-upgrades` — a file edit, reversible from a
+  checkpoint — and it was being served by the same `apt-get install` a host
+  without the package needs, which made an exec action out of a two-line edit
+  and put the most ordinary hardening step there is behind a human.
+
 * **ci:** the measurement harness measures the *reviewed* path too. It ran
   `fix --all`, which applies Auto fixes only — the unattended path, and
   deliberately the most conservative thing hostveil does. It is not the path

--- a/README.ko.md
+++ b/README.ko.md
@@ -108,6 +108,7 @@ hostveil                 # 대화형 TUI (터미널에서의 기본값)
 hostveil scan            # 점수가 매겨진 보고서 출력 (-v 상세, --json JSON)
 hostveil fix <id>        # 발견 항목 하나를 미리 보고 수정 적용
 hostveil fix --all       # 안전한(자동 수정) 항목을 한 번에 모두 적용
+hostveil fix --all --review  # 검토(Review) 항목까지, 무엇인지 읽고 나서
 hostveil rollback <id>   # 이미 적용한 수정을 되돌리기
 hostveil history         # 적용된 수정과 롤백 ID 목록
 hostveil explain <id>    # 발견 항목 설명 (--ai로 로컬 LLM의 2차 소견 추가)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ hostveil                 # interactive TUI (default on a terminal)
 hostveil scan            # print a scored report (add -v for details, --json for JSON)
 hostveil fix <id>        # preview, then apply the fix for one finding
 hostveil fix --all       # apply every safe (Auto) fix at once
+hostveil fix --all --review  # and the Review ones too, after reading what they are
 hostveil rollback <id>   # undo a previously applied fix
 hostveil history         # list applied fixes and their rollback IDs
 hostveil explain <id>    # explain a finding (add --ai for a local-LLM second opinion)

--- a/cmd/hostveil/fix.go
+++ b/cmd/hostveil/fix.go
@@ -32,11 +32,13 @@ func cmdFix(ctx context.Context, args []string) int {
 		service string
 		action  int
 		yes     bool
+		review  bool
 		all     bool
 	)
 	fs.StringVar(&service, "service", "", "disambiguate a finding by service name")
 	fs.IntVar(&action, "action", -1, "for Review fixes, the alternative to apply (0-based)")
 	fs.BoolVar(&yes, "yes", false, "apply without an interactive confirmation")
+	fs.BoolVar(&review, "review", false, "with --all, also apply Review fixes (their first alternative)")
 	fs.BoolVar(&all, "all", false, "apply every safe (Auto) fix at once")
 
 	// Allow the finding ID to come before flags ("fix <id> --yes"), which
@@ -64,7 +66,7 @@ func cmdFix(ctx context.Context, args []string) int {
 			fmt.Fprintln(os.Stderr, "hostveil: --all applies every safe fix; do not also name a finding")
 			return 2
 		}
-		return fixAll(ctx, yes)
+		return fixAll(ctx, yes, review)
 	}
 	if findingID == "" {
 		if fs.NArg() < 1 {
@@ -117,32 +119,69 @@ func cmdFix(ctx context.Context, args []string) int {
 }
 
 // fixAll previews and applies every safe (Auto) fix in one pass.
-func fixAll(ctx context.Context, yes bool) int {
+// fixAll applies every fix the tool can apply unattended, and with --review
+// every fix it can apply at all.
+//
+// The two lists are printed separately and counted separately, because they
+// are different promises. An Auto fix is reversible, cannot cut off access to
+// the host, and has one correct answer. A Review fix is one hostveil can
+// perform and will not perform for you: it may be an exec action with no
+// checkpoint, or it may have more than one defensible remediation, and
+// --review is where the operator says they have read that and accept it.
+func fixAll(ctx context.Context, yes, review bool) int {
 	engine := newEngine()
 	report := engine.Scan(ctx, nil)
 
-	var auto []model.Finding
+	var auto, reviewed []model.Finding
 	for _, f := range report.Findings {
-		if !f.Fixed && f.Remediation == model.RemediationAuto {
+		if f.Fixed {
+			continue
+		}
+		switch f.Remediation {
+		case model.RemediationAuto:
 			auto = append(auto, f)
+		case model.RemediationReview:
+			if review {
+				reviewed = append(reviewed, f)
+			}
 		}
 	}
-	if len(auto) == 0 {
-		fmt.Println("No auto-fixable findings. Nothing to do.")
+	if len(auto)+len(reviewed) == 0 {
+		if review {
+			fmt.Println("Nothing hostveil can fix. Manual findings are explained by `hostveil explain <id>`.")
+		} else {
+			fmt.Println("No auto-fixable findings. Nothing to do.")
+		}
 		return 0
 	}
 
-	fmt.Printf("Will apply %d safe (Auto) fixes:\n", len(auto))
-	for _, f := range auto {
-		fmt.Printf("  • %s (%s) — %s\n", f.ID, f.Service, f.Title)
+	if len(auto) > 0 {
+		fmt.Printf("Will apply %d safe (Auto) fixes:\n", len(auto))
+		for _, f := range auto {
+			fmt.Printf("  • %s (%s) — %s\n", f.ID, f.Service, f.Title)
+		}
 	}
-	fmt.Println("\nReview/Manual findings are left for you to handle individually.")
+	if len(reviewed) > 0 {
+		fmt.Printf("\nAnd %d Review fixes, each through its first alternative:\n", len(reviewed))
+		for _, f := range reviewed {
+			fmt.Printf("  • %s (%s) — %s\n", f.ID, f.Service, f.Title)
+		}
+		fmt.Println("\nThese are Review because they can cut off access to this host, or because")
+		fmt.Println("they run a command with no checkpoint to undo. Read them before saying yes.")
+	} else {
+		fmt.Println("\nReview/Manual findings are left for you to handle individually.")
+	}
 	if !yes && !promptYesNo("Apply all of the above?") {
 		fmt.Println("Aborted. Nothing changed.")
 		return 0
 	}
 
-	out := engine.ApplyBatch(ctx, auto)
+	batch := append(append([]model.Finding{}, auto...), reviewed...)
+	apply := engine.ApplyBatch
+	if review {
+		apply = engine.ApplyBatchWithReviewed
+	}
+	out := apply(ctx, batch)
 	// One sentence, rendered by the engine, so this and the other two
 	// interfaces cannot describe the same outcome differently. Only the
 	// per-failure detail and the rollback hint are the CLI's own — it has

--- a/cmd/sitegen/content/en/docs/cli.html
+++ b/cmd/sitegen/content/en/docs/cli.html
@@ -58,6 +58,7 @@ hostveil fix --all [flags]</code></pre></div>
                 <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
                 <tbody>
                   <tr><td><code>--all</code></td><td><code>false</code></td><td>Apply every safe (Auto-fix) finding at once.</td></tr>
+                  <tr><td><code>--review</code></td><td><code>false</code></td><td>With <code>--all</code>, apply the Review fixes too, each through its first alternative. They are listed separately and counted separately: a Review fix is one hostveil can perform and will not perform unattended, because it can cut off access to this host or runs a command with no checkpoint to undo.</td></tr>
                   <tr><td><code>--action N</code></td><td><code>-1</code></td><td>For a Review fix, the 0-based alternative to apply.</td></tr>
                   <tr><td><code>--service NAME</code></td><td><code>""</code></td><td>Disambiguate a finding by service name.</td></tr>
                   <tr><td><code>--yes</code></td><td><code>false</code></td><td>Apply without the interactive confirmation.</td></tr>

--- a/cmd/sitegen/content/ko/docs/cli.html
+++ b/cmd/sitegen/content/ko/docs/cli.html
@@ -58,6 +58,7 @@ hostveil fix --all [flags]</code></pre></div>
                 <thead><tr><th>플래그</th><th>기본값</th><th>설명</th></tr></thead>
                 <tbody>
                   <tr><td><code>--all</code></td><td><code>false</code></td><td>안전한(자동 수정) 발견 항목을 모두 한 번에 적용합니다.</td></tr>
+                  <tr><td><code>--review</code></td><td><code>false</code></td><td><code>--all</code>과 함께 쓰면 검토(Review) 수정도 각 항목의 첫 번째 대안으로 함께 적용합니다. 목록과 개수는 따로 표시됩니다: 검토 수정은 hostveil이 할 수는 있지만 무인으로는 하지 않는 것들로, 이 호스트에 대한 접근을 끊을 수 있거나 되돌릴 체크포인트가 없는 명령을 실행합니다.</td></tr>
                   <tr><td><code>--action N</code></td><td><code>-1</code></td><td>검토 수정에서 적용할, 0부터 시작하는 대안의 번호입니다.</td></tr>
                   <tr><td><code>--service NAME</code></td><td><code>""</code></td><td>서비스 이름으로 발견 항목을 구분합니다.</td></tr>
                   <tr><td><code>--yes</code></td><td><code>false</code></td><td>대화형 확인 없이 적용합니다.</td></tr>

--- a/internal/check/updates/updates.go
+++ b/internal/check/updates/updates.go
@@ -75,8 +75,23 @@ func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding,
 func (c *Checker) auditApt(ctx context.Context, env platform.Env) ([]model.Finding, error) {
 	var findings []model.Finding
 	if !aptUnattendedEnabled(c.AptConfigPath) {
-		findings = append(findings, disabledFinding("unattended-upgrades",
-			"Install and enable unattended-upgrades: `apt install unattended-upgrades` then `dpkg-reconfigure -plow unattended-upgrades`."))
+		// Whether the package is already here decides what the remediation
+		// *is*, and therefore whether hostveil can do it unattended. Ubuntu
+		// ships unattended-upgrades installed and Debian's netinst offers it,
+		// so the common case is a host where the whole fix is writing one
+		// config file — reversible, and Auto. Where the package is missing the
+		// fix has to install it, which is a command with no checkpoint.
+		f := disabledFinding("unattended-upgrades",
+			"Install and enable unattended-upgrades: `apt install unattended-upgrades` then `dpkg-reconfigure -plow unattended-upgrades`.")
+		if platform.Has(env.Runner, "unattended-upgrade") {
+			f.Evidence["installed"] = "true"
+			f.Evidence["config"] = c.AptConfigPath
+			f.HowToFix = "unattended-upgrades is installed but switched off. Set both periodic keys in " +
+				c.AptConfigPath + ": `APT::Periodic::Update-Package-Lists \"1\";` and " +
+				"`APT::Periodic::Unattended-Upgrade \"1\";`."
+			f.Remediation = model.RemediationAuto
+		}
+		findings = append(findings, f)
 	}
 	// apt's packages create this file from their postinst when an installed
 	// update cannot take effect until the machine restarts — a new kernel,

--- a/internal/core/batch.go
+++ b/internal/core/batch.go
@@ -11,6 +11,28 @@ import (
 // anything without an auto fix. It is the shared implementation behind
 // "fix everything safe", so no UI reimplements the batch loop.
 func (e *Engine) ApplyBatch(ctx context.Context, findings []model.Finding) model.BatchOutcome {
+	return e.applyBatch(ctx, findings, false)
+}
+
+// ApplyBatchWithReviewed is the same loop with the Review fixes included,
+// each applied through its *first* alternative — which every builder in the
+// registry writes as the primary remediation, the one the finding's how-to-fix
+// describes.
+//
+// It exists because "fix everything hostveil can" and "fix everything that
+// needs no human" are different requests, and only the second had a command.
+// The classification does not move: a Review fix is still one that can cut off
+// access to the host or has more than one defensible answer, and the caller
+// has to say, in the command, that it accepts them. What changes is that
+// accepting them no longer means running the tool once per finding.
+//
+// The batch still refuses anything the registry does not answer, so this can
+// never apply a fix nobody wrote.
+func (e *Engine) ApplyBatchWithReviewed(ctx context.Context, findings []model.Finding) model.BatchOutcome {
+	return e.applyBatch(ctx, findings, true)
+}
+
+func (e *Engine) applyBatch(ctx context.Context, findings []model.Finding, reviewed bool) model.BatchOutcome {
 	e.applyMu.Lock()
 	defer e.applyMu.Unlock()
 
@@ -27,12 +49,22 @@ func (e *Engine) ApplyBatch(ctx context.Context, findings []model.Finding) model
 			out.Skipped = append(out.Skipped, f.ID)
 			continue
 		}
-		if f.Fixed || f.Remediation != model.RemediationAuto {
+		eligible := f.Remediation == model.RemediationAuto ||
+			(reviewed && f.Remediation == model.RemediationReview)
+		if f.Fixed || !eligible {
 			out.Skipped = append(out.Skipped, f.ID)
 			continue
 		}
 		fx, ok, err := e.buildFix(f)
-		if !ok || err != nil || len(fx.Actions) != 1 {
+		if !ok || err != nil || len(fx.Actions) == 0 {
+			out.Skipped = append(out.Skipped, f.ID)
+			continue
+		}
+		// An Auto fix is one action by definition (fix.Validate enforces it),
+		// and a batch that silently picked one of several would be choosing
+		// for the operator. A reviewed batch takes the first alternative
+		// because that is where every builder puts the primary remediation.
+		if !reviewed && len(fx.Actions) != 1 {
 			out.Skipped = append(out.Skipped, f.ID)
 			continue
 		}

--- a/internal/core/batchreviewed_test.go
+++ b/internal/core/batchreviewed_test.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// "Fix everything that needs no human" and "fix everything hostveil can" are
+// different requests, and only the first had a command. The classification is
+// unchanged by the second: a Review fix is still one that can cut off access
+// to the host or has more than one defensible answer. What changes is that
+// accepting them no longer means running the tool once per finding.
+//
+// Both directions are pinned. The plain batch must keep refusing Review — a
+// UI that batched them by accident would apply, unattended, exactly the fixes
+// that exist because they need a person.
+func TestTheReviewedBatchAppliesWhatThePlainOneRefuses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yml")
+	orig := "services:\n  app:\n    image: myapp\n"
+	if err := os.WriteFile(path, []byte(orig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	engine := fixEngine(t)
+
+	auto := model.NewFinding("compose.ds006", "nnp", model.SeverityMedium, model.SourceCompose,
+		model.RemediationAuto, model.WithService("app"), model.WithMetadata("file", path))
+	// compose.ds010 is a memory limit: a real fix, and Review because the
+	// number is a judgement about the workload.
+	review := model.NewFinding("compose.ds010", "no memory limit", model.SeverityLow, model.SourceCompose,
+		model.RemediationReview, model.WithService("app"), model.WithMetadata("file", path))
+	manual := model.NewFinding("compose.ds001", "priv", model.SeverityHigh, model.SourceCompose,
+		model.RemediationManual, model.WithService("app"), model.WithMetadata("file", path))
+
+	plain := engine.ApplyBatch(context.Background(), []model.Finding{auto, review, manual})
+	if len(plain.Applied) != 1 || plain.Applied[0] != "compose.ds006" {
+		t.Errorf("the plain batch applied %v, want only the Auto fix", plain.Applied)
+	}
+	if !contains(plain.Skipped, "compose.ds010") {
+		t.Errorf("the plain batch did not skip the Review fix: %v", plain.Skipped)
+	}
+
+	// Same engine, same findings, with the reviewed ones accepted.
+	if err := os.WriteFile(path, []byte(orig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reviewed := engine.ApplyBatchWithReviewed(context.Background(), []model.Finding{auto, review, manual})
+	if !contains(reviewed.Applied, "compose.ds006") || !contains(reviewed.Applied, "compose.ds010") {
+		t.Errorf("the reviewed batch applied %v, want both the Auto and the Review fix", reviewed.Applied)
+	}
+	if !contains(reviewed.Skipped, "compose.ds001") {
+		t.Errorf("the reviewed batch did not skip the Manual finding: %v", reviewed.Skipped)
+	}
+	after, _ := os.ReadFile(path)
+	for _, want := range []string{"no-new-privileges", "mem_limit"} {
+		if !strings.Contains(string(after), want) {
+			t.Errorf("%q is not in the file the reviewed batch wrote:\n%s", want, after)
+		}
+	}
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/fix/updates.go
+++ b/internal/fix/updates.go
@@ -2,6 +2,8 @@ package fix
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/seolcu/hostveil/internal/model"
 )
@@ -16,6 +18,16 @@ func registerUpdates(r *Registry) {
 func buildEnableAutoUpdates(f model.Finding) (Fix, error) {
 	switch f.Evidence["mechanism"] {
 	case "unattended-upgrades":
+		// Where the package is already installed the whole remediation is one
+		// config file, which is a file edit: reversible from a checkpoint,
+		// and therefore something hostveil can do unattended. That is the
+		// common case — Ubuntu ships unattended-upgrades — and it used to be
+		// served by the same `apt-get install` the uncommon case needs, which
+		// made an exec action out of a two-line edit and put the most ordinary
+		// hardening step on this list behind a human.
+		if f.Evidence["installed"] == "true" {
+			return enableAptPeriodic(f)
+		}
 		return execFix("Enable automatic security updates (unattended-upgrades)",
 			"Install and enable unattended-upgrades", [][]string{
 				{"apt-get", "install", "-y", "unattended-upgrades"},
@@ -30,6 +42,59 @@ func buildEnableAutoUpdates(f model.Finding) (Fix, error) {
 	default:
 		return Fix{}, fmt.Errorf("finding %s has no known update mechanism", f.ID)
 	}
+}
+
+// aptPeriodicKeys are the two directives that switch apt's periodic upgrades
+// on. Both are needed: the first refreshes the package lists, the second
+// installs from them, and setting only the second gives a host that faithfully
+// applies updates it never learns about.
+var aptPeriodicKeys = []struct{ key, value string }{
+	{"APT::Periodic::Update-Package-Lists", "1"},
+	{"APT::Periodic::Unattended-Upgrade", "1"},
+}
+
+// enableAptPeriodic writes the periodic keys into apt's config, creating the
+// file when it is not there — which is the ordinary case, because a host that
+// has never had automatic updates configured has no 20auto-upgrades at all.
+//
+// Existing values are rewritten in place rather than appended to. apt reads
+// the last assignment, so appending would work and would leave a file with the
+// same key twice, one of them a lie; and the rollback would restore a file
+// whose meaning depended on line order.
+func enableAptPeriodic(f model.Finding) (Fix, error) {
+	path := f.Evidence["config"]
+	if path == "" {
+		return Fix{}, fmt.Errorf("finding %s does not name apt's periodic config", f.ID)
+	}
+	return Fix{
+		FindingID: f.ID,
+		Label:     "Enable automatic security updates (unattended-upgrades)",
+		Kind:      model.RemediationAuto,
+		Actions: []Action{{
+			Label:           "Switch on apt's periodic update and unattended-upgrade keys",
+			Kind:            ActionEdit,
+			Path:            path,
+			CreateIfMissing: true,
+			Transform:       setAptPeriodic,
+		}},
+	}, nil
+}
+
+func setAptPeriodic(in []byte) ([]byte, error) {
+	out := string(in)
+	for _, k := range aptPeriodicKeys {
+		re := regexp.MustCompile(`(?m)^[ \t]*` + regexp.QuoteMeta(k.key) + `[ \t]+"[^"]*"[ \t]*;[ \t]*$`)
+		line := k.key + ` "` + k.value + `";`
+		if re.MatchString(out) {
+			out = re.ReplaceAllString(out, line)
+			continue
+		}
+		if out != "" && !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+		out += line + "\n"
+	}
+	return []byte(out), nil
 }
 
 // execFix builds a single-action Auto exec fix.

--- a/internal/fix/updatesauto_test.go
+++ b/internal/fix/updatesauto_test.go
@@ -1,0 +1,82 @@
+package fix
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// The most ordinary hardening step on a Debian host — switching automatic
+// security updates on — was Review, and only because the one fix hostveil had
+// ran `apt-get install`. On the common host the package is already there and
+// the whole remediation is two lines in a config file, which is a file edit:
+// reversible from a checkpoint, and something `fix --all` can do on its own.
+//
+// So the shape of this fix is decided by evidence, and both shapes are pinned:
+// get it wrong toward exec and the fix leaves the unattended path again; get
+// it wrong toward edit and hostveil writes a config for a package that is not
+// installed, which enables nothing and reports success.
+func TestAutoUpdatesIsAnEditWhenTheMechanismIsAlreadyInstalled(t *testing.T) {
+	installed := model.NewFinding("updates.disabled", "Automatic security updates are not enabled",
+		model.SeverityMedium, model.SourceUpdates, model.RemediationAuto,
+		model.WithEvidence("mechanism", "unattended-upgrades"),
+		model.WithEvidence("installed", "true"),
+		model.WithEvidence("config", "/etc/apt/apt.conf.d/20auto-upgrades"))
+
+	fx, err := buildEnableAutoUpdates(installed)
+	if err != nil {
+		t.Fatalf("no fix for an installed mechanism: %v", err)
+	}
+	if got := fx.EffectiveKind(); got != model.RemediationAuto {
+		t.Errorf("EffectiveKind = %v, want Auto — an edit needs no human", got)
+	}
+	if len(fx.Actions) != 1 || fx.Actions[0].Kind != ActionEdit {
+		t.Fatalf("want one edit action, got %+v", fx.Actions)
+	}
+	if !fx.Actions[0].CreateIfMissing {
+		t.Error("a host that never configured automatic updates has no 20auto-upgrades to edit")
+	}
+
+	// Both keys, because setting only the unattended one gives a host that
+	// faithfully applies updates it never learns about.
+	out, err := fx.Actions[0].Transform(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`APT::Periodic::Update-Package-Lists "1";`, `APT::Periodic::Unattended-Upgrade "1";`} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("the new file does not contain %q:\n%s", want, out)
+		}
+	}
+
+	// An existing assignment is rewritten, not appended to: apt reads the last
+	// one, so appending leaves the file saying both things.
+	out, err = fx.Actions[0].Transform([]byte("APT::Periodic::Update-Package-Lists \"0\";\nAPT::Periodic::Unattended-Upgrade \"0\";\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(out), "APT::Periodic::Unattended-Upgrade") != 1 {
+		t.Errorf("the key is assigned more than once:\n%s", out)
+	}
+	if strings.Contains(string(out), `"0"`) {
+		t.Errorf("an old value survived:\n%s", out)
+	}
+}
+
+func TestAutoUpdatesStillInstallsWhenTheMechanismIsMissing(t *testing.T) {
+	missing := model.NewFinding("updates.disabled", "Automatic security updates are not enabled",
+		model.SeverityMedium, model.SourceUpdates, model.RemediationAuto,
+		model.WithEvidence("mechanism", "unattended-upgrades"))
+
+	fx, err := buildEnableAutoUpdates(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fx.Actions[0].Kind != ActionExec {
+		t.Fatalf("want an exec action to install the package, got %v", fx.Actions[0].Kind)
+	}
+	if got := fx.EffectiveKind(); got != model.RemediationReview {
+		t.Errorf("EffectiveKind = %v, want Review — an install has no checkpoint", got)
+	}
+}

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -147,6 +147,7 @@ hostveil fix --all [flags]</code></pre></div>
                 <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
                 <tbody>
                   <tr><td><code>--all</code></td><td><code>false</code></td><td>Apply every safe (Auto-fix) finding at once.</td></tr>
+                  <tr><td><code>--review</code></td><td><code>false</code></td><td>With <code>--all</code>, apply the Review fixes too, each through its first alternative. They are listed separately and counted separately: a Review fix is one hostveil can perform and will not perform unattended, because it can cut off access to this host or runs a command with no checkpoint to undo.</td></tr>
                   <tr><td><code>--action N</code></td><td><code>-1</code></td><td>For a Review fix, the 0-based alternative to apply.</td></tr>
                   <tr><td><code>--service NAME</code></td><td><code>""</code></td><td>Disambiguate a finding by service name.</td></tr>
                   <tr><td><code>--yes</code></td><td><code>false</code></td><td>Apply without the interactive confirmation.</td></tr>

--- a/site/ko/docs/cli.html
+++ b/site/ko/docs/cli.html
@@ -147,6 +147,7 @@ hostveil fix --all [flags]</code></pre></div>
                 <thead><tr><th>플래그</th><th>기본값</th><th>설명</th></tr></thead>
                 <tbody>
                   <tr><td><code>--all</code></td><td><code>false</code></td><td>안전한(자동 수정) 발견 항목을 모두 한 번에 적용합니다.</td></tr>
+                  <tr><td><code>--review</code></td><td><code>false</code></td><td><code>--all</code>과 함께 쓰면 검토(Review) 수정도 각 항목의 첫 번째 대안으로 함께 적용합니다. 목록과 개수는 따로 표시됩니다: 검토 수정은 hostveil이 할 수는 있지만 무인으로는 하지 않는 것들로, 이 호스트에 대한 접근을 끊을 수 있거나 되돌릴 체크포인트가 없는 명령을 실행합니다.</td></tr>
                   <tr><td><code>--action N</code></td><td><code>-1</code></td><td>검토 수정에서 적용할, 0부터 시작하는 대안의 번호입니다.</td></tr>
                   <tr><td><code>--service NAME</code></td><td><code>""</code></td><td>서비스 이름으로 발견 항목을 구분합니다.</td></tr>
                   <tr><td><code>--yes</code></td><td><code>false</code></td><td>대화형 확인 없이 적용합니다.</td></tr>


### PR DESCRIPTION
## What and why

**`fix --all --review`.** `fix --all` applies Auto fixes only, so every SSH hardening option, every kernel parameter and every image update needed one invocation apiece. "Fix everything that needs no human" and "fix everything hostveil can" are different requests and only the first had a command.

The classification does not move: a Review fix is still one that can cut off access to this host or has more than one defensible answer. The two lists are printed and counted separately, and the flag is where the operator says they have read that. On a seeded host it is the difference between the SSH domain reaching 44 and reaching 100.

**`updates.disabled` is Auto where unattended-upgrades is already installed** — the usual state on Debian and Ubuntu. The remediation there is two keys in `/etc/apt/apt.conf.d/20auto-upgrades`, a file edit and reversible from a checkpoint; it was being served by the same `apt-get install` that a host *without* the package needs, which made an exec action out of a two-line edit and put the most ordinary hardening step there is behind a human. The checker records whether the package is present; the builder reads it. Both shapes are pinned by tests, in both directions — get it wrong toward exec and the fix leaves the unattended path again, get it wrong toward edit and hostveil writes a config for a package that is not installed and reports success.

## Checklist

- [x] Title is conventional with a valid scope.
- [x] Ran the CI gate locally and it passes.
- [x] For a new or changed detection rule: the updates checker's new evidence is covered in both directions.
- [x] For a UI change: CLI reference updated in both languages, `site/` regenerated.
- [x] The score stays honest — nothing here reclassifies a risky fix as safe; the risky ones are still Review and still say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)