### PR TITLE
feat(fix): hostveil can turn the firewall on now, because it knows which port to keep open

### DIFF
--- a/cmd/sitegen/content/en/docs/checks.html
+++ b/cmd/sitegen/content/en/docs/checks.html
@@ -135,7 +135,7 @@
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
-                  <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">HIGH</span></td><td>Manual</td></tr>
+                  <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">HIGH</span></td><td>Review</td></tr>
                   <tr><td><code>firewall.default-allow</code></td><td>A firewall is running but its default inbound policy accepts everything</td><td><span class="sev high">HIGH</span></td><td>Manual</td></tr>
                   <tr><td><code>firewall.docker-bypass</code></td><td>Published container ports are reachable despite an active ufw</td><td><span class="sev high">HIGH</span></td><td>Manual</td></tr>
                 </tbody>

--- a/cmd/sitegen/content/ko/docs/checks.html
+++ b/cmd/sitegen/content/ko/docs/checks.html
@@ -135,7 +135,7 @@
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
-                  <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">HIGH</span></td><td>수동</td></tr>
+                  <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">HIGH</span></td><td>검토</td></tr>
                   <tr><td><code>firewall.default-allow</code></td><td>방화벽이 켜져 있지만 기본 인바운드 정책이 전부 허용</td><td><span class="sev high">HIGH</span></td><td>수동</td></tr>
                   <tr><td><code>firewall.docker-bypass</code></td><td>ufw가 켜져 있는데도 publish된 컨테이너 포트가 외부에서 접근 가능</td><td><span class="sev high">HIGH</span></td><td>수동</td></tr>
                 </tbody>

--- a/internal/check/firewall/firewall.go
+++ b/internal/check/firewall/firewall.go
@@ -5,6 +5,7 @@ package firewall
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"github.com/seolcu/hostveil/internal/check"
@@ -101,14 +102,43 @@ func (c *Checker) Check(ctx context.Context, env platform.Env) ([]model.Finding,
 			Reason: "cannot read firewall state — re-run with sudo to check the host firewall",
 		}
 	}
-	return []model.Finding{
+	findings := []model.Finding{
 		model.NewFinding("firewall.inactive", "No active host firewall",
 			model.SeverityHigh, model.SourceFirewall, model.RemediationReview,
 			model.WithDescription("Without a firewall, every port a service binds to 0.0.0.0 is reachable from any network the host is on. A firewall is your backstop when a container or service is accidentally exposed."),
 			model.WithHowToFix("Enable a firewall that defaults to denying inbound traffic and allow only what you need (e.g. SSH). Important: allow your SSH port before enabling the firewall so you do not lock yourself out."),
 			model.WithEvidence("available", strings.Join(availableTools(env.Runner), ", ")),
 		),
-	}, nil
+	}
+	// The port SSH is *actually* listening on, when it can be seen. It is
+	// what makes this finding fixable at all: enabling a default-deny policy
+	// without allowing SSH first locks the operator out of the host, with no
+	// checkpoint to undo it, so the fix may not exist unless the port is
+	// known. Read from the kernel's socket table rather than sshd_config
+	// because a config that says one thing and a daemon that is serving on
+	// another is exactly the case that would lock someone out.
+	if port, ok := sshPort(ctx, env.Runner); ok {
+		findings[0].Evidence["ssh_port"] = strconv.Itoa(port)
+	}
+	return findings, nil
+}
+
+// sshPort finds the port sshd is listening on. "Cannot tell" is a real
+// answer here and is reported as one: no port, no fix.
+func sshPort(ctx context.Context, r platform.CommandRunner) (int, bool) {
+	if !platform.Has(r, "ss") {
+		return 0, false
+	}
+	ls, err := platform.Listeners(ctx, r)
+	if err != nil {
+		return 0, false
+	}
+	for _, l := range ls {
+		if strings.Contains(l.Proc, "sshd") {
+			return l.Port, true
+		}
+	}
+	return 0, false
 }
 
 // Status is the outcome of probing the host's firewall front-ends.

--- a/internal/fix/decline.go
+++ b/internal/fix/decline.go
@@ -72,7 +72,6 @@ var declineReasons = map[string]string{
 	// firewall
 	"firewall.default-allow": "Default-deny takes effect the moment it is set, on the SSH session you are issuing it from, and an exec fix leaves no checkpoint to undo a lockout.",
 	"firewall.docker-bypass": "The compose file or docker run behind the container is not in the finding, and the other remediation rewrites ufw policy that can lock you out.",
-	"firewall.inactive":      "The finding records no SSH port, interface, or session, so enabling default-deny could lock you out of the host with no checkpoint to undo it.",
 
 	// updates
 	"updates.pending-security": "An upgrade is unbounded — a new kernel, restarted services, prompts about modified config files — and no checkpoint reverses any of it.",

--- a/internal/fix/firewall.go
+++ b/internal/fix/firewall.go
@@ -1,0 +1,70 @@
+package fix
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// registerFirewall wires the "turn the firewall on" fix.
+//
+// This was declined for a long time, and the reason was right: enabling a
+// default-deny policy on a box you reached over SSH drops every connection no
+// rule allows — including the one issuing the command — and an exec fix
+// writes no checkpoint, so a lockout has no undo. The finding's how-to-fix
+// told the operator to allow their SSH port first, which is advice a person
+// can follow in order and a tool could not, because the checker recorded no
+// port.
+//
+// It records one now, read from the kernel's socket table: the port sshd is
+// actually serving on, not the one its config claims. That is the whole
+// difference. The fix allows that port and only then enables the firewall,
+// as two commands of a single action, in that order.
+//
+// It stays Review. The commands cannot be rolled back, the host's other
+// services stop being reachable the moment the policy takes effect, and both
+// of those are things an operator should decide rather than discover. What
+// changes is that hostveil can now carry it out, instead of describing it.
+func registerFirewall(r *Registry) {
+	r.Register("firewall.inactive", buildEnableFirewall)
+}
+
+func buildEnableFirewall(f model.Finding) (Fix, error) {
+	// No port, no fix. A firewall enabled without knowing which port to keep
+	// open is the lockout this refused to risk for years, and "I could not
+	// tell" must not quietly become "22".
+	raw := f.Evidence["ssh_port"]
+	port, err := strconv.Atoi(raw)
+	if err != nil || port <= 0 || port > 65535 {
+		return Fix{}, fmt.Errorf("finding %s does not name the port sshd is listening on, "+
+			"so enabling a firewall could lock the operator out", f.ID)
+	}
+	if !strings.Contains(f.Evidence["available"], "ufw") {
+		return Fix{}, fmt.Errorf("finding %s reports no ufw, and the other front-ends "+
+			"take rules this fix cannot write safely", f.ID)
+	}
+	p := strconv.Itoa(port)
+	return Fix{
+		FindingID: f.ID,
+		Label:     "Enable ufw, allowing SSH on port " + p + " first",
+		// Declared Auto — one mechanical action — and demoted to Review by
+		// EffectiveKind because it is exec, which is the same route
+		// updates.disabled takes. Validate reserves the Review kind for
+		// fixes with two or more *alternatives* to choose between, and this
+		// has one procedure whose steps are ordered, not a choice.
+		Kind: model.RemediationAuto,
+		Actions: []Action{{
+			Label: "Allow SSH on " + p + "/tcp, then enable ufw with a default-deny inbound policy",
+			Warning: "Every inbound port except " + p + "/tcp stops being reachable the moment this " +
+				"runs, including anything a container publishes. There is no rollback checkpoint — " +
+				"exec fixes are not file-backed — so undoing it means `ufw disable` by hand.",
+			Kind: ActionExec,
+			Commands: [][]string{
+				{"ufw", "allow", p + "/tcp"},
+				{"ufw", "--force", "enable"},
+			},
+		}},
+	}, nil
+}

--- a/internal/fix/firewall_test.go
+++ b/internal/fix/firewall_test.go
@@ -1,0 +1,83 @@
+package fix
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+func firewallFinding(opts ...model.FindingOption) model.Finding {
+	base := []model.FindingOption{
+		model.WithEvidence("available", "ufw"),
+		model.WithEvidence("ssh_port", "22"),
+	}
+	return model.NewFinding("firewall.inactive", "No active host firewall", model.SeverityHigh,
+		model.SourceFirewall, model.RemediationReview, append(base, opts...)...)
+}
+
+// The order is the fix. Enabling a default-deny policy first and allowing SSH
+// second is the lockout this refused to risk for years, so the commands are
+// asserted in sequence rather than as a set.
+func TestTheFirewallFixOpensSSHBeforeItClosesEverything(t *testing.T) {
+	fx, err := buildEnableFirewall(firewallFinding(model.WithEvidence("ssh_port", "2222")))
+	if err != nil {
+		t.Fatalf("no fix for a finding that names the port: %v", err)
+	}
+	// Declared Auto (one mechanical action) and demoted by the exec floor:
+	// what a user is offered is Review, and it must never be anything else,
+	// because `fix --all` would then enable a firewall unattended.
+	if fx.Kind != model.RemediationAuto {
+		t.Errorf("Kind = %v, want the declared Auto that Validate accepts for a single action", fx.Kind)
+	}
+	if got := fx.EffectiveKind(); got != model.RemediationReview {
+		t.Errorf("EffectiveKind = %v, want Review — this cannot be rolled back", got)
+	}
+	if len(fx.Actions) != 1 {
+		t.Fatalf("want one action carrying both commands in order, got %d", len(fx.Actions))
+	}
+	cmds := fx.Actions[0].Commands
+	if len(cmds) != 2 {
+		t.Fatalf("want two commands, got %v", cmds)
+	}
+	if strings.Join(cmds[0], " ") != "ufw allow 2222/tcp" {
+		t.Errorf("first command is %q, want the SSH port allowed first", strings.Join(cmds[0], " "))
+	}
+	if strings.Join(cmds[1], " ") != "ufw --force enable" {
+		t.Errorf("second command is %q, want the policy enabled second", strings.Join(cmds[1], " "))
+	}
+	if fx.Actions[0].Warning == "" {
+		t.Error("no warning on a fix that stops every other inbound port answering")
+	}
+}
+
+// "I could not tell" must not quietly become 22. A host running sshd on 2222
+// whose port hostveil failed to read would be locked out by a fix that
+// guessed, and the guess would look exactly like knowledge.
+func TestNoFirewallFixWithoutTheSSHPort(t *testing.T) {
+	for _, tc := range []struct{ name, port string }{
+		{"absent", ""},
+		{"unparseable", "ssh"},
+		{"out of range", "70000"},
+	} {
+		f := firewallFinding()
+		f.Evidence["ssh_port"] = tc.port
+		if tc.port == "" {
+			delete(f.Evidence, "ssh_port")
+		}
+		if _, err := buildEnableFirewall(f); err == nil {
+			t.Errorf("%s: a fix was offered without a usable SSH port", tc.name)
+		}
+	}
+}
+
+// ufw is the only front-end whose rule syntax this writes. nftables and
+// firewalld take rules that differ enough that a guessed one is a lockout by
+// another route.
+func TestNoFirewallFixWithoutUfw(t *testing.T) {
+	f := firewallFinding()
+	f.Evidence["available"] = "nftables, iptables"
+	if _, err := buildEnableFirewall(f); err == nil {
+		t.Error("a fix was offered for a host with no ufw")
+	}
+}

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -82,7 +82,6 @@ func TestUnregisteredFindingHasNoFix(t *testing.T) {
 // not quietly reversed.
 func TestKnownUnregisteredFindings(t *testing.T) {
 	declined := map[string]string{
-		"firewall.inactive":        "enabling a default-deny firewall over SSH can lock the user out, and exec fixes have no rollback",
 		"firewall.docker-bypass":   "republishing to loopback means editing an unknown compose file and recreating the container; the ufw-docker alternative is firewall policy with no rollback",
 		"updates.reboot-required":  "rebooting is exec with no checkpoint and takes every service down; only the operator knows when that is acceptable",
 		"updates.pending-security": "apt/dnf upgrade is exec, unbounded, and can restart services or prompt about config files — nothing a checkpoint can undo",
@@ -141,7 +140,7 @@ func TestKnownUnregisteredFindings(t *testing.T) {
 		"fileperms.owner":        "chown has no checkpoint — a rollback records contents and mode and has nowhere to put the previous owner; and the right group differs by distribution",
 		"compose.ds012":          "the right healthcheck depends on what the service exposes; a guessed one marks a working container unhealthy and stalls everything waiting on it",
 		"compose.dr004":          "the remediation is about the env_file's permissions and whether it is in git and backups — nothing in the compose file to edit",
-		"ports.exposed":          "the aggregate finding's remediation is firewall.inactive's, and is declined for the same reason",
+		"ports.exposed":          "the aggregate says N services are exposed; the per-service findings carry the fixable detail, and a firewall is firewall.inactive's fix rather than this one's",
 		"accounts.uid0":          "userdel is exec, irreversible, and takes the home directory with it; hostveil cannot tell a backdoor from a deliberate second root",
 		"accounts.emptypassword": "passwd -l is exec, and the account it locks may be the only way the operator reaches the machine",
 	}

--- a/internal/fix/fixtest/fixtest.go
+++ b/internal/fix/fixtest/fixtest.go
@@ -34,5 +34,7 @@ func Finding(id string) model.Finding {
 		model.WithEvidence("paths", "/etc/shadow"),
 		model.WithEvidence("expected", "0640"),
 		model.WithEvidence("set", "kernel.kptr_restrict=1"),
+		model.WithEvidence("ssh_port", "22"),
+		model.WithEvidence("available", "ufw"),
 	)
 }

--- a/internal/fix/register.go
+++ b/internal/fix/register.go
@@ -37,6 +37,15 @@ package fix
 // shape — one mechanical action — and does not override a checker that
 // asked for Review.
 //
+// firewall.inactive was on the list below until the checker started
+// recording the port sshd is actually listening on. The refusal was never
+// about the commands — it was that hostveil could not know which port to keep
+// open, and a firewall enabled without that answer locks the operator out with
+// no checkpoint to undo it. With the port in evidence the fix allows it first
+// and enables the policy second, as two commands of one action, and stays
+// Review: the change cannot be rolled back and it takes every other inbound
+// port with it, both of which an operator should decide rather than discover.
+//
 // # Findings deliberately left without a fix
 //
 // These are fixable in principle and are demoted to Manual on purpose.
@@ -81,11 +90,6 @@ package fix
 //     have no checkpoint, so a lockout has no undo. The how-to-fix says to
 //     allow SSH first, which is advice a person can follow in order and a
 //     fix cannot: hostveil does not know which port that session is on.
-//   - firewall.inactive — the only remediation is enabling a firewall, and
-//     the checker records no SSH port, interface, or session data. Enabling
-//     a default-deny policy on a box reached over SSH can lock the user out
-//     irrecoverably, and it also drops every service the ports checker just
-//     enumerated. Exec fixes have no checkpoint, so there is no undo.
 //   - ports.exposed-datastore, ports.exposed-admin — these describe
 //     natively-installed daemons, not containers. Binding one to loopback
 //     means editing redis.conf's `bind`, or postgresql.conf's
@@ -394,6 +398,7 @@ func Default() *Registry {
 	registerFilePerms(r)
 	registerSSH(r)
 	registerUpdates(r)
+	registerFirewall(r)
 	registerAgent(r)
 	registerSysctl(r)
 	return r

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -224,7 +224,7 @@
               <table>
                 <thead><tr><th>ID</th><th>What it flags</th><th>Severity</th><th>Fix</th></tr></thead>
                 <tbody>
-                  <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">HIGH</span></td><td>Manual</td></tr>
+                  <tr><td><code>firewall.inactive</code></td><td>No active host firewall (ufw, firewalld, nftables, or iptables)</td><td><span class="sev high">HIGH</span></td><td>Review</td></tr>
                   <tr><td><code>firewall.default-allow</code></td><td>A firewall is running but its default inbound policy accepts everything</td><td><span class="sev high">HIGH</span></td><td>Manual</td></tr>
                   <tr><td><code>firewall.docker-bypass</code></td><td>Published container ports are reachable despite an active ufw</td><td><span class="sev high">HIGH</span></td><td>Manual</td></tr>
                 </tbody>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -224,7 +224,7 @@
               <table>
                 <thead><tr><th>ID</th><th>무엇을 표시하는지</th><th>심각도</th><th>수정</th></tr></thead>
                 <tbody>
-                  <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">HIGH</span></td><td>수동</td></tr>
+                  <tr><td><code>firewall.inactive</code></td><td>활성화된 호스트 방화벽이 없음 (ufw, firewalld, nftables, 또는 iptables)</td><td><span class="sev high">HIGH</span></td><td>검토</td></tr>
                   <tr><td><code>firewall.default-allow</code></td><td>방화벽이 켜져 있지만 기본 인바운드 정책이 전부 허용</td><td><span class="sev high">HIGH</span></td><td>수동</td></tr>
                   <tr><td><code>firewall.docker-bypass</code></td><td>ufw가 켜져 있는데도 publish된 컨테이너 포트가 외부에서 접근 가능</td><td><span class="sev high">HIGH</span></td><td>수동</td></tr>
                 </tbody>


### PR DESCRIPTION
`firewall.inactive` — a HIGH finding on every host without a firewall — was on the deliberately-unfixed list, and the reason was right: enabling default-deny over SSH drops the session issuing the command, and an exec fix leaves no checkpoint.

What was missing was never the commands. It was that the checker recorded no SSH port, so hostveil could not know what to keep open. It reads one now from the kernel's socket table — the port sshd is *actually* serving on, not the one its config claims — and the fix allows that port before it enables the policy, as two commands of one action in that order.

- **No port, no fix.** "I could not tell" must not become 22: a host on 2222 whose port could not be read gets no fix rather than a lockout that looks like knowledge. Pinned in three shapes — absent, unparseable, out of range.
- **ufw only.** The other front-ends take rules different enough that a guessed one is a lockout by another route.
- **Still Review**, through the exec floor, with a warning saying every other inbound port stops answering and that undoing it means `ufw disable` by hand.

Registering it meant deleting the assertion in `TestKnownUnregisteredFindings` and the decline reason in `decline.go`, which is what those exist for. Both checks tables now say Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)