### PR TITLE
feat(site): send a Korean-speaking reader to the Korean page, once

### DIFF
--- a/cmd/sitegen/templates/docs.tmpl
+++ b/cmd/sitegen/templates/docs.tmpl
@@ -14,7 +14,7 @@
           <a href="../#features">{{.NavFeatures}}</a>
           <a href="../#install">{{.NavInstall}}</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="{{.LangHref}}" lang="{{.LangLang}}" hreflang="{{.LangLang}}">{{.LangLabel}}</a>
+          <a class="lang-switch" href="{{.LangHref}}" lang="{{.LangLang}}" hreflang="{{.LangLang}}" onclick="try{localStorage.setItem('hostveil.lang','{{.LangLang}}')}catch(e){}">{{.LangLabel}}</a>
         </div>
       </nav>
     </header>

--- a/cmd/sitegen/templates/head.tmpl
+++ b/cmd/sitegen/templates/head.tmpl
@@ -16,5 +16,33 @@
     <link rel="alternate" hreflang="en" href="{{.HrefEn}}">
     <link rel="alternate" hreflang="ko" href="{{.HrefKo}}">
     <link rel="alternate" hreflang="x-default" href="{{.HrefEn}}">
-{{.AssetLinks}}  </head>
+{{.AssetLinks}}    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("{{.LangHref}}" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
+  </head>
 {{- end}}

--- a/cmd/sitegen/templates/page.tmpl
+++ b/cmd/sitegen/templates/page.tmpl
@@ -16,7 +16,7 @@
           <a href="#install">{{.LNavInstall}}</a>
           <a href="{{.LDocsHref}}">{{.LNavDocs}}</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="{{.LangHref}}" lang="{{.LangLang}}" hreflang="{{.LangLang}}">{{.LangLabel}}</a>
+          <a class="lang-switch" href="{{.LangHref}}" lang="{{.LangLang}}" hreflang="{{.LangLang}}" onclick="try{localStorage.setItem('hostveil.lang','{{.LangLang}}')}catch(e){}">{{.LangLabel}}</a>
         </div>
       </nav>
     </header>

--- a/site/docs/ai.html
+++ b/site/docs/ai.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/ai" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/ai" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/ai" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/checks.html
+++ b/site/docs/checks.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/checks" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/checks" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/checks" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/cli" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/cli" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/cli" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/contributing" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/contributing" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/contributing" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/environment.html
+++ b/site/docs/environment.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/environment" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/environment" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/environment" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/faq.html
+++ b/site/docs/faq.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/faq" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/faq" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/faq" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/fixing.html
+++ b/site/docs/fixing.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/fixing" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/fixing" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/fixing" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/installation" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/installation" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/installation" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/interfaces.html
+++ b/site/docs/interfaces.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/interfaces" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/interfaces" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/interfaces" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/measurements.html
+++ b/site/docs/measurements.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/measurements" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/measurements" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/measurements" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/quickstart" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/quickstart" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/quickstart" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/scoring.html
+++ b/site/docs/scoring.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/scoring" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/scoring" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/scoring" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/docs/troubleshooting.html
+++ b/site/docs/troubleshooting.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../docs.css">
     <script src="../docs.js" defer></script>
     <script src="../lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/docs/troubleshooting" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -35,7 +63,7 @@
           <a href="../#features">Features</a>
           <a href="../#install">Install</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/docs/troubleshooting" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/docs/troubleshooting" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/index.html
+++ b/site/index.html
@@ -19,6 +19,34 @@
     <link rel="stylesheet" href="styles.css">
     <script src="script.js" defer></script>
     <script src="lang-suggest.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/ko/" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -36,7 +64,7 @@
           <a href="#install">Install</a>
           <a href="/docs/">Docs</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/ko/" lang="ko" hreflang="ko">한국어</a>
+          <a class="lang-switch" href="/ko/" lang="ko" hreflang="ko" onclick="try{localStorage.setItem('hostveil.lang','ko')}catch(e){}">한국어</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/ai.html
+++ b/site/ko/docs/ai.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/ai" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/ai" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/ai" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/checks.html
+++ b/site/ko/docs/checks.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/checks" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/checks" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/checks" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/cli.html
+++ b/site/ko/docs/cli.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/cli" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/cli" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/cli" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/contributing.html
+++ b/site/ko/docs/contributing.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/contributing" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/contributing" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/contributing" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/environment.html
+++ b/site/ko/docs/environment.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/environment" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/environment" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/environment" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/faq.html
+++ b/site/ko/docs/faq.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/faq" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/faq" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/faq" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/fixing.html
+++ b/site/ko/docs/fixing.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/fixing" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/fixing" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/fixing" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/index.html
+++ b/site/ko/docs/index.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/installation.html
+++ b/site/ko/docs/installation.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/installation" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/installation" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/installation" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/interfaces.html
+++ b/site/ko/docs/interfaces.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/interfaces" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/interfaces" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/interfaces" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/measurements.html
+++ b/site/ko/docs/measurements.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/measurements" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/measurements" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/measurements" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/quickstart.html
+++ b/site/ko/docs/quickstart.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/quickstart" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/quickstart" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/quickstart" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/scoring.html
+++ b/site/ko/docs/scoring.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/scoring" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/scoring" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/scoring" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/docs/troubleshooting.html
+++ b/site/ko/docs/troubleshooting.html
@@ -20,6 +20,34 @@
     <link rel="stylesheet" href="../../styles.css">
     <link rel="stylesheet" href="../../docs.css">
     <script src="../../docs.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/docs/troubleshooting" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -35,7 +63,7 @@
           <a href="../#features">기능</a>
           <a href="../#install">설치</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/docs/troubleshooting" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/docs/troubleshooting" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>

--- a/site/ko/index.html
+++ b/site/ko/index.html
@@ -19,6 +19,34 @@
     <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
     <link rel="stylesheet" href="../styles.css">
     <script src="../script.js" defer></script>
+    <script>
+      // Send a Korean-speaking reader to the Korean page, once.
+      //
+      // GitHub Pages serves files, not content negotiation, so the only place
+      // this decision can be made is here — and the risk of making it here is
+      // trapping someone: a reader who deliberately clicked "English" must not
+      // be bounced back on the next click. So the switcher records that choice
+      // and this defers to it forever after.
+      //
+      // Only from the English page, only when the browser's own preference
+      // list actually leads with Korean, and never when a crawler is reading
+      // (they do not run this) — the hreflang links above are what they read.
+      (function () {
+        try {
+          if (document.documentElement.lang !== "en") return;
+          if (localStorage.getItem("hostveil.lang")) return;
+          var prefs = navigator.languages || [navigator.language || ""];
+          for (var i = 0; i < prefs.length; i++) {
+            var tag = String(prefs[i]).toLowerCase();
+            if (tag === "ko" || tag.indexOf("ko-") === 0) {
+              location.replace("/" + location.hash);
+              return;
+            }
+            if (tag.indexOf("en") === 0) return; // English first: stay
+          }
+        } catch (e) { /* private mode, no storage: the English page is fine */ }
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">본문으로 건너뛰기</a>
@@ -36,7 +64,7 @@
           <a href="#install">설치</a>
           <a href="/ko/docs/">문서</a>
           <a href="https://github.com/seolcu/hostveil">GitHub</a>
-          <a class="lang-switch" href="/" lang="en" hreflang="en">English</a>
+          <a class="lang-switch" href="/" lang="en" hreflang="en" onclick="try{localStorage.setItem('hostveil.lang','en')}catch(e){}">English</a>
         </div>
       </nav>
     </header>


### PR DESCRIPTION
The site has had Korean for as long as it has had docs, and a reader arriving from a Korean browser never saw it — GitHub Pages serves files, not content negotiation, so everyone landed on English.

The decision can only be made in the browser, and the danger of making it there is trapping someone. So:

- it fires **only from an English page**, and only when `navigator.languages` leads with Korean *before* it mentions English;
- clicking the language switcher records the choice, and the redirect defers to it from then on — a reader who chose English is never bounced again;
- it preserves the path, so `/docs/cli` goes to `/ko/docs/cli` rather than dumping the reader on the front page;
- crawlers do not run it, and the `hreflang` links were already correct for them.

Verified in a real browser against the built site over HTTP: `ko-KR` → `/ko/`, `en-US` and `ja-JP` stay, a reader already on `/ko/` is not bounced, a deep page maps to its Korean counterpart, and after choosing English a Korean browser stays on English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)