### PR TITLE
refactor: collapse the four repetitions that could silently diverge

### DIFF
--- a/internal/check/compose/compose.go
+++ b/internal/check/compose/compose.go
@@ -258,20 +258,9 @@ var datastoreImages = map[string]bool{
 }
 
 func ruleExposedDatastore(s compose.Service) (model.Finding, bool) {
-	if !datastoreImages[imageBasename(s.Image)] {
-		return model.Finding{}, false
-	}
-	for _, p := range s.Ports {
-		if p.ExposedOnAllInterfaces() {
-			return f("ds018", "Datastore exposed on all network interfaces", model.SeverityHigh, model.RemediationAuto, s.Name,
-				model.WithDescription("A database or cache published on 0.0.0.0 is reachable from the internet if the host has a public IP. Many datastores have no authentication by default, so anyone can read, wipe, or plant data — a common route to full host takeover."),
-				model.WithHowToFix("Bind the port to 127.0.0.1 (e.g. `127.0.0.1:6379:6379`) so only the host can reach it, and set a strong password. Do not expose datastores to the internet."),
-				model.WithEvidence("image", s.Image),
-				model.WithEvidence("port", p.HostPort),
-			), true
-		}
-	}
-	return model.Finding{}, false
+	return exposedImage(s, datastoreImages, "ds018", "Datastore exposed on all network interfaces",
+		"A database or cache published on 0.0.0.0 is reachable from the internet if the host has a public IP. Many datastores have no authentication by default, so anyone can read, wipe, or plant data — a common route to full host takeover.",
+		"Bind the port to 127.0.0.1 (e.g. `127.0.0.1:6379:6379`) so only the host can reach it, and set a strong password. Do not expose datastores to the internet.")
 }
 
 var adminPanelImages = map[string]bool{
@@ -280,20 +269,34 @@ var adminPanelImages = map[string]bool{
 }
 
 func ruleExposedAdminPanel(s compose.Service) (model.Finding, bool) {
-	if !adminPanelImages[imageBasename(s.Image)] {
+	return exposedImage(s, adminPanelImages, "ds019", "Admin panel exposed on all network interfaces",
+		"Management UIs like this one are high-value targets. Exposed to the internet they invite credential-stuffing and known-CVE exploitation that can hand over your whole stack.",
+		"Bind the port to 127.0.0.1 and reach it over a VPN or SSH tunnel, or put it behind an authenticating reverse proxy.")
+}
+
+// exposedImage is ds018 and ds019: this service runs an image from a set worth
+// naming, and it publishes a port on every interface.
+//
+// The two rules were written out twice and differed only in the set and the
+// prose, which left the one thing that is not prose in only one of the copies:
+// the port evidence below is load-bearing. buildBindLoopback needs the host
+// port, and without it the fix fails to build and classify silently demotes
+// the finding to Manual — a UI shows no button and nothing reports why. Stated
+// once now, for both.
+func exposedImage(s compose.Service, images map[string]bool, id, title, desc, howToFix string) (model.Finding, bool) {
+	if !images[imageBasename(s.Image)] {
 		return model.Finding{}, false
 	}
 	for _, p := range s.Ports {
-		if p.ExposedOnAllInterfaces() {
-			return f("ds019", "Admin panel exposed on all network interfaces", model.SeverityHigh, model.RemediationAuto, s.Name,
-				model.WithDescription("Management UIs like this one are high-value targets. Exposed to the internet they invite credential-stuffing and known-CVE exploitation that can hand over your whole stack."),
-				model.WithHowToFix("Bind the port to 127.0.0.1 and reach it over a VPN or SSH tunnel, or put it behind an authenticating reverse proxy."),
-				model.WithEvidence("image", s.Image),
-				// buildBindLoopback needs the host port; without it the fix
-				// fails to build and classify silently demotes ds019 to Manual.
-				model.WithEvidence("port", p.HostPort),
-			), true
+		if !p.ExposedOnAllInterfaces() {
+			continue
 		}
+		return f(id, title, model.SeverityHigh, model.RemediationAuto, s.Name,
+			model.WithDescription(desc),
+			model.WithHowToFix(howToFix),
+			model.WithEvidence("image", s.Image),
+			model.WithEvidence("port", p.HostPort),
+		), true
 	}
 	return model.Finding{}, false
 }

--- a/internal/check/sysctl/origin.go
+++ b/internal/check/sysctl/origin.go
@@ -176,14 +176,14 @@ func parseAssignment(line string) (key string, value int64, ok bool) {
 // file that sets a *different* value is not why the parameter is weak —
 // something set it at runtime instead — and naming it would send the operator
 // to edit a line that already says the right thing.
-func originOf(keys []string, vals map[string]int64, byKey map[string]assignment) (assignment, bool) {
+func originOf(keys []string, vals []Reading, byKey map[string]assignment) (assignment, bool) {
 	var best assignment
 	found := false
-	for _, k := range keys {
-		running, read := vals[k]
-		if !read {
+	for i, k := range keys {
+		if !vals[i].Present {
 			continue // knob absent from this kernel; nothing was audited
 		}
+		running := vals[i].Value
 		a, ok := byKey[k]
 		if !ok || a.Value != running {
 			continue

--- a/internal/check/sysctl/sysctl.go
+++ b/internal/check/sysctl/sysctl.go
@@ -23,18 +23,43 @@ import (
 	"github.com/seolcu/hostveil/internal/platform"
 )
 
+// Reading is one parameter as this kernel gave it. Present is false when the
+// /proc/sys file is absent — the knob is not built into this kernel, which is
+// not the same as the knob being set to zero and is the distinction the whole
+// domain turns on.
+type Reading struct {
+	Value   int64
+	Present bool
+}
+
 // Rule audits one kernel parameter (or a small set that shares one
 // remediation). Flagged decides from the values that exist on this kernel;
-// a key whose /proc/sys file is absent simply is not in the map — the knob
-// does not exist on this kernel, so there is nothing to harden.
+// a parameter this kernel does not have arrives Present: false, so there is
+// nothing to harden.
 type Rule struct {
-	ID      string
-	Title   string
-	Sev     model.Severity
-	Desc    string
-	Keys    []string // dotted sysctl names, e.g. "kernel.kptr_restrict"
-	Want    string   // the sysctl.d line(s) the how-to-fix recommends
-	Flagged func(vals map[string]int64) bool
+	ID    string
+	Title string
+	Sev   model.Severity
+	Desc  string
+	Keys  []string // dotted sysctl names, e.g. "kernel.kptr_restrict"
+	Want  string   // the sysctl.d line(s) the how-to-fix recommends
+
+	// Flagged is handed the readings for Keys, in Keys order, and nothing
+	// else. Use is/isNot/below/anyIs rather than writing one out.
+	//
+	// It used to take the whole reading as a map, and every rule spelled its
+	// own key out a second time inside the closure to look it up. Two copies
+	// of one string with nothing holding them together, and a divergence
+	// between them fails in the worst available direction: the map is built
+	// from Keys, so a closure asking for anything else gets the zero value
+	// with ok=false, answers "not flagged", and the rule silently stops
+	// existing on every host. Not a rule that reports the wrong thing — a
+	// rule that reports nothing, which is indistinguishable from a clean
+	// kernel.
+	//
+	// Passing the values positionally is what makes that unrepresentable:
+	// there is no key to get wrong, because there is no key.
+	Flagged func(vals []Reading) bool
 
 	// Set is the same recommendation as Want in machine-readable form: the
 	// exact key=value pairs a fix writes into a drop-in or passes to
@@ -72,83 +97,97 @@ func New() *Checker {
 	}
 }
 
+// The predicates the rules use. A rule with one key reads as `is(0)`, and
+// there is no second copy of its key to drift from Keys.
+//
+// Each takes the readings for the rule's own Keys. A parameter this kernel
+// does not have is never a finding: an absent knob cannot be misconfigured,
+// and treating Present: false as a zero would flag every kernel built without
+// Yama for having ptrace_scope "set to 0".
+
+// is flags the single key when the kernel has it and it equals n.
+func is(n int64) func([]Reading) bool {
+	return func(v []Reading) bool { return v[0].Present && v[0].Value == n }
+}
+
+// isNot flags the single key when the kernel has it and it is anything but n.
+func isNot(n int64) func([]Reading) bool {
+	return func(v []Reading) bool { return v[0].Present && v[0].Value != n }
+}
+
+// below flags the single key when the kernel has it and it is under n.
+func below(n int64) func([]Reading) bool {
+	return func(v []Reading) bool { return v[0].Present && v[0].Value < n }
+}
+
+// anyIs flags when any key the kernel has equals n. For the rules where two
+// parameters share one remediation and either one being off is the finding.
+func anyIs(n int64) func([]Reading) bool {
+	return func(vals []Reading) bool {
+		for _, v := range vals {
+			if v.Present && v.Value == n {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 func defaultRules() []Rule {
 	return []Rule{
 		{
 			ID: "sysctl.ptrace-scope", Title: "Any process can debug its siblings",
-			Sev:  model.SeverityMedium,
-			Desc: "kernel.yama.ptrace_scope is 0, so every process can attach a debugger to any other process of the same user and read its memory — including the session tokens inside a running agent, browser, or password manager. Setting it to 1 limits attaching to direct children.",
-			Keys: []string{"kernel.yama.ptrace_scope"},
-			Want: "kernel.yama.ptrace_scope = 1",
-			Set:  []string{"kernel.yama.ptrace_scope=1"},
-			Flagged: func(v map[string]int64) bool {
-				val, ok := v["kernel.yama.ptrace_scope"]
-				return ok && val == 0
-			},
+			Sev:     model.SeverityMedium,
+			Desc:    "kernel.yama.ptrace_scope is 0, so every process can attach a debugger to any other process of the same user and read its memory — including the session tokens inside a running agent, browser, or password manager. Setting it to 1 limits attaching to direct children.",
+			Keys:    []string{"kernel.yama.ptrace_scope"},
+			Want:    "kernel.yama.ptrace_scope = 1",
+			Set:     []string{"kernel.yama.ptrace_scope=1"},
+			Flagged: is(0),
 		},
 		{
 			ID: "sysctl.syncookies", Title: "TCP SYN-flood protection is off",
-			Sev:  model.SeverityMedium,
-			Desc: "net.ipv4.tcp_syncookies lets listening services survive a SYN-flood denial of service. It costs nothing in normal operation and only activates under attack, which is why every mainstream distribution ships it on.",
-			Keys: []string{"net.ipv4.tcp_syncookies"},
-			Want: "net.ipv4.tcp_syncookies = 1",
-			Set:  []string{"net.ipv4.tcp_syncookies=1"},
-			Flagged: func(v map[string]int64) bool {
-				val, ok := v["net.ipv4.tcp_syncookies"]
-				return ok && val != 1
-			},
+			Sev:     model.SeverityMedium,
+			Desc:    "net.ipv4.tcp_syncookies lets listening services survive a SYN-flood denial of service. It costs nothing in normal operation and only activates under attack, which is why every mainstream distribution ships it on.",
+			Keys:    []string{"net.ipv4.tcp_syncookies"},
+			Want:    "net.ipv4.tcp_syncookies = 1",
+			Set:     []string{"net.ipv4.tcp_syncookies=1"},
+			Flagged: isNot(1),
 		},
 		{
 			ID: "sysctl.accept-redirects", Title: "ICMP redirects are accepted",
-			Sev:  model.SeverityMedium,
-			Desc: "Accepting ICMP redirect messages lets a machine on the same network rewrite this host's routing decisions — a classic man-in-the-middle primitive. A server has no use for them.",
-			Keys: []string{"net.ipv4.conf.all.accept_redirects"},
-			Want: "net.ipv4.conf.all.accept_redirects = 0",
-			Set:  []string{"net.ipv4.conf.all.accept_redirects=0"},
-			Flagged: func(v map[string]int64) bool {
-				val, ok := v["net.ipv4.conf.all.accept_redirects"]
-				return ok && val != 0
-			},
+			Sev:     model.SeverityMedium,
+			Desc:    "Accepting ICMP redirect messages lets a machine on the same network rewrite this host's routing decisions — a classic man-in-the-middle primitive. A server has no use for them.",
+			Keys:    []string{"net.ipv4.conf.all.accept_redirects"},
+			Want:    "net.ipv4.conf.all.accept_redirects = 0",
+			Set:     []string{"net.ipv4.conf.all.accept_redirects=0"},
+			Flagged: isNot(0),
 		},
 		{
 			ID: "sysctl.protected-links", Title: "Symlink and hardlink protections are disabled",
-			Sev:  model.SeverityMedium,
-			Desc: "fs.protected_symlinks and fs.protected_hardlinks close a family of /tmp link races that local attackers use to trick privileged processes into overwriting files of the attacker's choosing. Every mainstream distribution ships both enabled.",
-			Keys: []string{"fs.protected_symlinks", "fs.protected_hardlinks"},
-			Want: "fs.protected_symlinks = 1 and fs.protected_hardlinks = 1",
-			Set:  []string{"fs.protected_symlinks=1", "fs.protected_hardlinks=1"},
-			Flagged: func(v map[string]int64) bool {
-				for _, k := range []string{"fs.protected_symlinks", "fs.protected_hardlinks"} {
-					if val, ok := v[k]; ok && val == 0 {
-						return true
-					}
-				}
-				return false
-			},
+			Sev:     model.SeverityMedium,
+			Desc:    "fs.protected_symlinks and fs.protected_hardlinks close a family of /tmp link races that local attackers use to trick privileged processes into overwriting files of the attacker's choosing. Every mainstream distribution ships both enabled.",
+			Keys:    []string{"fs.protected_symlinks", "fs.protected_hardlinks"},
+			Want:    "fs.protected_symlinks = 1 and fs.protected_hardlinks = 1",
+			Set:     []string{"fs.protected_symlinks=1", "fs.protected_hardlinks=1"},
+			Flagged: anyIs(0),
 		},
 		{
 			ID: "sysctl.kptr-restrict", Title: "Kernel pointer addresses are visible to all users",
-			Sev:  model.SeverityLow,
-			Desc: "With kernel.kptr_restrict at 0, /proc exposes raw kernel pointers to any local user. Those addresses defeat kernel address-space randomization, handing a local exploit the memory layout it needs.",
-			Keys: []string{"kernel.kptr_restrict"},
-			Want: "kernel.kptr_restrict = 1",
-			Set:  []string{"kernel.kptr_restrict=1"},
-			Flagged: func(v map[string]int64) bool {
-				val, ok := v["kernel.kptr_restrict"]
-				return ok && val < 1
-			},
+			Sev:     model.SeverityLow,
+			Desc:    "With kernel.kptr_restrict at 0, /proc exposes raw kernel pointers to any local user. Those addresses defeat kernel address-space randomization, handing a local exploit the memory layout it needs.",
+			Keys:    []string{"kernel.kptr_restrict"},
+			Want:    "kernel.kptr_restrict = 1",
+			Set:     []string{"kernel.kptr_restrict=1"},
+			Flagged: below(1),
 		},
 		{
 			ID: "sysctl.dmesg-restrict", Title: "Any user can read the kernel log",
-			Sev:  model.SeverityLow,
-			Desc: "The kernel log leaks addresses, hardware details, and stack traces that make local privilege-escalation exploits easier to build. With kernel.dmesg_restrict at 0, every account can read it.",
-			Keys: []string{"kernel.dmesg_restrict"},
-			Want: "kernel.dmesg_restrict = 1",
-			Set:  []string{"kernel.dmesg_restrict=1"},
-			Flagged: func(v map[string]int64) bool {
-				val, ok := v["kernel.dmesg_restrict"]
-				return ok && val != 1
-			},
+			Sev:     model.SeverityLow,
+			Desc:    "The kernel log leaks addresses, hardware details, and stack traces that make local privilege-escalation exploits easier to build. With kernel.dmesg_restrict at 0, every account can read it.",
+			Keys:    []string{"kernel.dmesg_restrict"},
+			Want:    "kernel.dmesg_restrict = 1",
+			Set:     []string{"kernel.dmesg_restrict=1"},
+			Flagged: isNot(1),
 		},
 		{
 			ID: "sysctl.sysrq", Title: "Magic SysRq is fully enabled",
@@ -159,22 +198,16 @@ func defaultRules() []Rule {
 			Set:  []string{"kernel.sysrq=0"},
 			// Only the fully-enabled value is flagged: anything else is
 			// either off or a deliberate restricted mask.
-			Flagged: func(v map[string]int64) bool {
-				val, ok := v["kernel.sysrq"]
-				return ok && val == 1
-			},
+			Flagged: is(1),
 		},
 		{
 			ID: "sysctl.rp-filter", Title: "Source-address spoofing filter is off",
-			Sev:  model.SeverityLow,
-			Desc: "Reverse-path filtering drops packets whose source address could not be reached back through the interface they arrived on — cheap protection against spoofed traffic. Strict (1) and loose (2) both count; loose is the right setting for VPN and multi-homed hosts.",
-			Keys: []string{"net.ipv4.conf.all.rp_filter"},
-			Want: "net.ipv4.conf.all.rp_filter = 1 (or 2 on VPN/multi-homed hosts)",
-			Set:  []string{"net.ipv4.conf.all.rp_filter=1"},
-			Flagged: func(v map[string]int64) bool {
-				val, ok := v["net.ipv4.conf.all.rp_filter"]
-				return ok && val == 0
-			},
+			Sev:     model.SeverityLow,
+			Desc:    "Reverse-path filtering drops packets whose source address could not be reached back through the interface they arrived on — cheap protection against spoofed traffic. Strict (1) and loose (2) both count; loose is the right setting for VPN and multi-homed hosts.",
+			Keys:    []string{"net.ipv4.conf.all.rp_filter"},
+			Want:    "net.ipv4.conf.all.rp_filter = 1 (or 2 on VPN/multi-homed hosts)",
+			Set:     []string{"net.ipv4.conf.all.rp_filter=1"},
+			Flagged: is(0),
 		},
 	}
 }
@@ -204,13 +237,13 @@ func (c *Checker) Check(_ context.Context, _ platform.Env) ([]model.Finding, err
 	covered := 0
 	byKey := origins(c.ConfDirs, c.ConfFile)
 	for _, r := range c.Rules {
-		vals := map[string]int64{}
+		vals := make([]Reading, len(r.Keys))
 		failed := false
-		for _, key := range r.Keys {
+		for i, key := range r.Keys {
 			v, err := c.readKey(key)
 			switch {
 			case err == nil:
-				vals[key] = v
+				vals[i] = Reading{Value: v, Present: true}
 			case os.IsNotExist(err):
 				// absent knob — nothing to audit
 			default:
@@ -283,11 +316,11 @@ func (c *Checker) readKey(key string) (int64, error) {
 
 // evidenceFor renders the observed values in rule-key order, so evidence is
 // stable across scans and a repeat scan produces no delta nobody caused.
-func evidenceFor(keys []string, vals map[string]int64) string {
+func evidenceFor(keys []string, vals []Reading) string {
 	var parts []string
-	for _, k := range keys {
-		if v, ok := vals[k]; ok {
-			parts = append(parts, fmt.Sprintf("%s=%d", k, v))
+	for i, k := range keys {
+		if vals[i].Present {
+			parts = append(parts, fmt.Sprintf("%s=%d", k, vals[i].Value))
 		}
 	}
 	return strings.Join(parts, model.EvidenceSeparator)

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -308,23 +308,11 @@ func (s *Store) pruneCheckpoints() {
 // changing its bytes. The resulting checkpoint is Reversible — Files is
 // non-empty — but stores no blobs.
 func (s *Store) SaveModes(cp Checkpoint, modes map[string]os.FileMode) (Checkpoint, error) {
-	dir := filepath.Join(s.checkpointsDir(), cp.ID)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return Checkpoint{}, err
-	}
-
-	cp.Files = cp.Files[:0]
+	files := make([]BackedFile, 0, len(modes))
 	for path, mode := range modes {
-		cp.Files = append(cp.Files, BackedFile{Path: path, Mode: mode})
+		files = append(files, BackedFile{Path: path, Mode: mode})
 	}
-	sort.Slice(cp.Files, func(i, j int) bool { return cp.Files[i].Path < cp.Files[j].Path })
-
-	if err := s.writeMeta(dir, cp); err != nil {
-		discardUnfinished(dir, cp.ID)
-		return Checkpoint{}, err
-	}
-	s.pruneCheckpoints()
-	return cp, nil
+	return s.saveBlobless(cp, files)
 }
 
 // SaveCreations writes a checkpoint for a fix that created files which did
@@ -342,15 +330,30 @@ func (s *Store) SaveModes(cp Checkpoint, modes map[string]os.FileMode) (Checkpoi
 // carries a single Path. If one is ever written, this is where it breaks,
 // loudly, rather than silently checkpointing half of it.
 func (s *Store) SaveCreations(cp Checkpoint, paths []string) (Checkpoint, error) {
+	files := make([]BackedFile, 0, len(paths))
+	for _, path := range paths {
+		files = append(files, BackedFile{Path: path, Created: true})
+	}
+	return s.saveBlobless(cp, files)
+}
+
+// saveBlobless writes a checkpoint whose entries name paths and carry no
+// backed-up bytes — the shared body of SaveModes and SaveCreations, which
+// differ only in the BackedFile they build.
+//
+// It is one function rather than two identical ones because the order here is
+// load-bearing and belongs in a single place: the metadata file is written
+// last, so a checkpoint exists exactly when its metadata does, and a failed
+// write takes the half-built directory with it rather than leaving something
+// List would later report as damaged. Two copies of that is two chances for
+// the next edit to land in one of them.
+func (s *Store) saveBlobless(cp Checkpoint, files []BackedFile) (Checkpoint, error) {
 	dir := filepath.Join(s.checkpointsDir(), cp.ID)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return Checkpoint{}, err
 	}
 
-	cp.Files = cp.Files[:0]
-	for _, path := range paths {
-		cp.Files = append(cp.Files, BackedFile{Path: path, Created: true})
-	}
+	cp.Files = files
 	sort.Slice(cp.Files, func(i, j int) bool { return cp.Files[i].Path < cp.Files[j].Path })
 
 	if err := s.writeMeta(dir, cp); err != nil {

--- a/internal/ui/web/server.go
+++ b/internal/ui/web/server.go
@@ -320,29 +320,35 @@ func hostFromURL(u string) string {
 // --- handlers ---
 
 func (s *Server) handleThemesCSS(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/css; charset=utf-8")
-	// No caching: the served default changes with --theme, and a stale
-	// stylesheet would silently keep the previous run's palette.
-	w.Header().Set("Cache-Control", "no-store")
-	_, _ = io.WriteString(w, theme.CSS(s.theme))
+	serveGenerated(w, "text/css; charset=utf-8", theme.CSS(s.theme))
 }
 
 func (s *Server) handleThemeJS(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/javascript; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-store")
-	_, _ = io.WriteString(w, theme.JS(s.theme))
+	serveGenerated(w, "text/javascript; charset=utf-8", theme.JS(s.theme))
 }
 
 func (s *Server) handleLayoutJS(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/javascript; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-store")
-	_, _ = io.WriteString(w, layoutJS(s.layout))
+	serveGenerated(w, "text/javascript; charset=utf-8", layoutJS(s.layout))
 }
 
 func (s *Server) handleModelJS(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/javascript; charset=utf-8")
+	serveGenerated(w, "text/javascript; charset=utf-8", modelJS())
+}
+
+// serveGenerated writes an asset this process generated for this run, rather
+// than one shipped in the binary.
+//
+// It exists for the Cache-Control line. What these routes serve depends on
+// flags resolved at startup — the palette on --theme, the arrangement on
+// --layout — so a browser that cached one would keep the previous run's
+// appearance and there is nothing in the URL to tell it apart. The four
+// handlers each set it by hand, which made it something a fifth route could
+// omit with no test and no symptom until somebody restarted with a different
+// flag and got the old look.
+func serveGenerated(w http.ResponseWriter, contentType, body string) {
+	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Cache-Control", "no-store")
-	_, _ = io.WriteString(w, modelJS())
+	_, _ = io.WriteString(w, body)
 }
 
 // resultPayload is the dashboard's view of a scan: the report, plus how it


### PR DESCRIPTION
### The diagnosis first, because it changes what this PR is

I measured before touching anything.

| | |
| --- | --- |
| production Go | 22,791 lines (14,098 code + 6,957 comment) |
| tests | 26,425 lines — more than production |
| `dupl` at 100 tokens, whole repo | **one** pair |
| largest file (`tui/view.go`) | 1,642 lines / **56 functions**, largest 105 |
| en vs ko content | 1,859 lines each — identical, because they are the same pages |

**This codebase is not copy-pasted and it is not bloated.** It is large because it audits twelve domains through three interfaces in two languages, and because it writes down why. Shrinking it would mean deleting explanations or tests, and neither of those is bloat. At a 45-token threshold the remaining hits are theme palettes, sysctl descriptions and compose rule prose — data and product copy, not duplication.

So this is not a size exercise. It is the four places where two copies of something had nothing holding them together, **and where a divergence between them is silent rather than loud.**

### 1. sysctl rules restated their own keys

Each rule declares `Keys` and then spelled the same string out again inside its predicate:

```go
Keys: []string{"kernel.yama.ptrace_scope"},
Flagged: func(v map[string]int64) bool {
    val, ok := v["kernel.yama.ptrace_scope"]   // second copy, nothing checks it
    return ok && val == 0
},
```

The map is *built from* `Keys`, so a closure asking for anything else gets the zero value with `ok=false`, answers "not flagged", and **the rule stops existing on every host** — indistinguishable from a clean kernel. Predicates now take their rule's readings positionally: `is(0)`, `isNot(1)`, `below(1)`, `anyIs(0)`. There is no key to get wrong. Reaching outside a rule's own keys no longer compiles into a quiet no-op — I checked, it panics on the first test.

### 2. SaveModes and SaveCreations were the same nineteen lines twice

What they share is an **order that is load-bearing**: metadata last, so a checkpoint exists exactly when its metadata does, and a failed write takes the half-built directory with it. Two copies of that is two chances for the next edit to land in one of them.

### 3. ds018 and ds019 were the same rule twice

Differing in an image set and its prose — which left the one part that is *not* prose in only one copy. The port evidence is load-bearing: `buildBindLoopback` needs the host port, and without it the fix fails to build and `classify` silently demotes the finding to Manual, so a UI shows no button and nothing says why.

### 4. Four dashboard routes each set Cache-Control by hand

What they serve depends on flags resolved at startup, so a cached copy keeps the previous run's palette and nothing in the URL tells it apart. A fifth route could have omitted the header with no test and no symptom until somebody restarted with a different flag.

---

**Net: 19 fewer lines of code, 56 more of comment.** That is the honest shape of it — the duplication was small and the reasons are worth more than the lines were. No behaviour changes; the full suite, race, lint and sitegen are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
