### PR TITLE
ci: hold the lists that live outside Go to the code they describe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,20 @@ jobs:
         run: |
           cd scripts && sha256sum -c install.sh.sha256
 
+      # The cross-compile below covers what goreleaser *builds*; this covers
+      # what it is *told* to build. Archives, checksums, SBOM hooks and the
+      # ldflags that stamp the version live in .goreleaser.yaml, and nothing
+      # reads that file until a tag exists — by which time the release has
+      # already been published, because a maintainer creates it to make the
+      # tag. A config error there therefore surfaces as a live release with no
+      # artifacts, which is the situation demote-on-failure exists to clean up
+      # after. `check` is a parse and validate, so it costs seconds and needs
+      # no token.
+      - name: Validate the release config
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          args: check
+
       # goreleaser builds linux and darwin on amd64 and arm64, and until this
       # existed the first compile of three of those four targets happened
       # during a release — where a failure demotes the release to a draft
@@ -122,8 +136,16 @@ jobs:
       # sudo on machines hostveil has never seen; seed.sh permits root SSH
       # login and adds a second UID 0 account, and is published beside an
       # invitation to run it. The runner ships shellcheck.
+      #
+      # Every script, found rather than listed. The list used to name those
+      # two, and the eleven it left out were no less privileged: measure/run.sh
+      # is root and edits the host it measures, and instruments/rollback.sh
+      # computes the rollback-fidelity claim check.py fails the run over. All
+      # of them were already clean, so naming two was costing coverage and
+      # buying nothing — and a hand-kept list is how the next script joins the
+      # repo unchecked.
       - name: Lint shell scripts
-        run: shellcheck scripts/install.sh scripts/measure/seed.sh
+        run: find . -name '*.sh' -not -path './.git/*' -print0 | xargs -0 shellcheck
 
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -222,12 +222,26 @@ jobs:
           # expected, not a failure.
           hostveil scan --json > /tmp/scan3.json || true
 
+          # Nothing below is worth anything if the selection matches no
+          # domain, so the count is asserted first. ScanState marshals as its
+          # name, and this step used to select on the ordinal instead: once
+          # #656 changed the encoding that matched nothing, `bad` was empty
+          # however the scan turned out, and a step named for the invariant
+          # went on passing without ever testing it. There is no Docker and no
+          # Trivy here, so at least one domain is always Skipped — if none is,
+          # the report changed shape and this step is looking at the wrong
+          # thing. internal/docs/e2e_test.go pins the literal below against
+          # what the model actually writes.
+          skipped=$(jq '[.domains[] | select(.state == "skipped")] | length' /tmp/scan3.json)
+          test "$skipped" -gt 0 || {
+            echo "no domain reported Skipped, so this step asserts nothing"; exit 1; }
+
           # Every domain reported Skipped must have a non-applicable axis. A
           # skipped domain scored 100 is the failure this whole invariant
           # exists to prevent, and it is invisible in the printed report.
           bad=$(jq -r '
             (.score.axes | map({key: (.source|tostring), value: .}) | from_entries) as $ax
-            | .domains[] | select(.state == 3)
+            | .domains[] | select(.state == "skipped")
             | select($ax[(.source|tostring)].applicable)
             | .source' /tmp/scan3.json)
           test -z "$bad" || { echo "skipped domains still scored: $bad"; exit 1; }

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ test-results/
 # commit because nothing here excluded it.
 __pycache__/
 *.py[cod]
+reports/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 go run ./cmd/sitegen && git diff --exit-code site/
 (cd scripts && sha256sum -c install.sh.sha256)   # regenerate the .sha256 if install.sh changed
 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12   # only if you touched .github/workflows/
-shellcheck scripts/install.sh                               # only if you touched install.sh
+find . -name '*.sh' -not -path './.git/*' -print0 | xargs -0 shellcheck   # only if you touched a shell script
+go run github.com/goreleaser/goreleaser/v2@latest check     # only if you touched .goreleaser.yaml
 ```
 
 Lint config (`.golangci.yaml`) enables only staticcheck, ineffassign, misspell.
@@ -40,7 +41,9 @@ curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v2.12.2/g
   | tar xz -C /tmp && /tmp/golangci-lint-2.12.2-linux-amd64/golangci-lint run ./...
 ```
 
-CI runs a superset of that gate: every release target is cross-compiled (`GOOS`/`GOARCH` for linux and darwin on amd64 and arm64, so a break is caught on the pull request rather than during a release), `scripts/install.sh` is shellchecked, and coverage is reported into the job summary without gating. Two workflows run on their own schedule rather than against a diff — `.github/workflows/nightly.yml` re-runs govulncheck and gives each fuzz target five minutes, and `.github/workflows/e2e.yml` drives the real binary through scan → fix → history → rollback → rescan inside a seeded Debian container, which is the only place the apply and rollback machinery meets a real filesystem.
+CI runs a superset of that gate: every release target is cross-compiled (`GOOS`/`GOARCH` for linux and darwin on amd64 and arm64, so a break is caught on the pull request rather than during a release), every shell script in the repository is shellchecked, `.goreleaser.yaml` is validated with `goreleaser check` — the cross-compile covers what goreleaser builds, and that covers what it is told to build, which nothing reads until a tag exists and the release is already public — and coverage is reported into the job summary without gating. Two workflows run on their own schedule rather than against a diff — `.github/workflows/nightly.yml` re-runs govulncheck and gives each fuzz target five minutes, and `.github/workflows/e2e.yml` drives the real binary through scan → fix → history → rollback → rescan inside a seeded Debian container, which is the only place the apply and rollback machinery meets a real filesystem.
+
+A workflow is YAML, so nothing in it can be held to the code by a compiler, and the lists inside one go stale silently rather than loudly. Three are pinned by tests in `internal/docs` and will fail the build when they drift: the fuzz matrix against every `Fuzz*` target that exists, CI's cross-compile loop against the goos/goarch product in `.goreleaser.yaml`, and the domain selection in `e2e.yml` against the name `model.ScanState` actually marshals. That last one is why they exist — it selected on the enum's old integer, matched no domain after the encoding changed to names, and the step asserting that a skipped domain is never scored 100 passed on every pull request without once looking at one.
 
 ### Measuring that it works
 
@@ -131,7 +134,8 @@ The same outage will hold up the pull requests the release is made of.
 Merging those with `--admin` is a judgement call and the bar is the gate
 itself: run it locally against the *merged* result, not against each branch —
 `go build ./... && go vet ./... && gofmt -l . && go mod tidy && go test -race
-./...`, the released `golangci-lint`, govulncheck, actionlint, shellcheck, and
+./...`, the released `golangci-lint`, govulncheck, actionlint, shellcheck,
+`goreleaser check`, and
 `go run ./cmd/sitegen && git diff --exit-code site/`. What CI gives that a
 local run does not is the attestation, and that is attached at release time by
 the workflow either way.

--- a/demo/run.sh
+++ b/demo/run.sh
@@ -18,6 +18,9 @@ export VAGRANT_CWD="$PWD"
 # Bring every stack up inside the VM (idempotent). Stacks have no restart
 # policy on purpose, so they need starting after each boot.
 start_stacks() {
+  # Single quotes on purpose: $d is the guest's loop variable and must reach
+  # the guest shell unexpanded. Expanding it here would send one empty path.
+  # shellcheck disable=SC2016
   vagrant ssh -c 'for d in /opt/stacks/*/; do (cd "$d" && sudo docker compose up -d); done' 2>/dev/null
 }
 

--- a/internal/docs/e2e_test.go
+++ b/internal/docs/e2e_test.go
@@ -1,0 +1,103 @@
+package docs
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/seolcu/hostveil/internal/model"
+)
+
+// The E2E workflow reaches into `scan --json` with jq and selects domains by
+// their ScanState. That couples a shell script to an encoding decided in
+// internal/model, and nothing in the compiler or in CI connects the two.
+//
+// It has already broken once. The step named "domains that cannot run report
+// Skipped, never clean" selected `.state == 3`, and #656 changed every enum to
+// marshal as its name — so the selection matched no domain, the variable it
+// filled was always empty, and the assertion that a skipped domain is never
+// scored 100 passed on every pull request without ever looking at one. That is
+// the exact failure the invariant exists to catch, hiding inside the check for
+// it, and it is invisible: a vacuous jq selection is indistinguishable from a
+// clean result.
+//
+// So the workflow's literals are pinned against what the model actually
+// writes. A rename in internal/model fails here, in a Go test that runs on
+// every change, rather than silently retiring the E2E assertion.
+var e2eStateSelector = regexp.MustCompile(`\.state\s*==\s*("[^"]*"|[^\s)]+)`)
+
+func TestE2ESelectsScanStatesByTheNameTheModelMarshals(t *testing.T) {
+	wf := readRepoFile(t, filepath.Join(".github", "workflows", "e2e.yml"))
+
+	matches := e2eStateSelector.FindAllStringSubmatch(withoutComments(wf), -1)
+	if len(matches) == 0 {
+		// Not "nothing to check": the step is how the never-score-a-skipped-
+		// domain invariant is tested against a real host at all.
+		t.Fatal("e2e.yml no longer selects on .state; either the step was " +
+			"removed or it was rewritten, and this pin is now testing nothing")
+	}
+
+	// Every name the model can write, in the form jq compares against.
+	encoded := map[string]bool{}
+	for _, s := range model.AllScanStates() {
+		b, err := json.Marshal(s)
+		if err != nil {
+			t.Fatalf("marshal %v: %v", s, err)
+		}
+		encoded[string(b)] = true
+	}
+
+	for _, m := range matches {
+		literal := m[1]
+		if !encoded[literal] {
+			t.Errorf("e2e.yml selects `.state == %s`, which is not how any "+
+				"ScanState marshals — the selection matches no domain and the "+
+				"step passes without testing anything. Valid literals: %v",
+				literal, keysOf(encoded))
+		}
+	}
+}
+
+// TestEveryScanStateNameIsUsableInJQ guards the other half: the workflow can
+// only select by name while the names stay plain strings. An ordinal, or a
+// name carrying a quote or a backslash, would need escaping the jq programs in
+// e2e.yml do not do.
+func TestEveryScanStateNameIsUsableInJQ(t *testing.T) {
+	for _, s := range model.AllScanStates() {
+		b, err := json.Marshal(s)
+		if err != nil {
+			t.Fatalf("marshal %v: %v", s, err)
+		}
+		got := string(b)
+		want := `"` + s.String() + `"`
+		if got != want {
+			t.Errorf("ScanState %v marshals as %s, but e2e.yml writes it as %s; "+
+				"the workflow's jq selections would no longer match", s, got, want)
+		}
+	}
+}
+
+// withoutComments drops whole-line comments, which are the same character in
+// the YAML and in the shell inside it. The comment above the step explains the
+// ordinal that used to be there by writing it out, and matching that would
+// report the bug it documents. No line of a jq program in this workflow starts
+// with a hash, so nothing under test is lost.
+func withoutComments(s string) string {
+	var kept []string
+	for line := range strings.SplitSeq(s, "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "#") {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/docs/fuzz_test.go
+++ b/internal/docs/fuzz_test.go
@@ -1,0 +1,151 @@
+package docs
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The nightly workflow fuzzes each target for five minutes, from a matrix it
+// lists by hand. Nothing connects that list to the targets that exist, so a
+// Fuzz function added tomorrow is never fuzzed — and the failure is silent in
+// the worst way: nightly stays green, the matrix still names four targets, and
+// the new parser is the one nobody is throwing bytes at.
+//
+// This is the same shape as the shellcheck step that named two of thirteen
+// scripts, and as the E2E selection that matched no domain: a claim living
+// outside Go, where the compiler cannot hold it to anything. So the set is
+// derived from the source and compared, in both directions — a target listed
+// but absent would fail the nightly run loudly, but it would fail it at 5 AM
+// rather than here.
+var (
+	fuzzMatrixTarget  = regexp.MustCompile(`(?m)^\s*-?\s*target:\s*(\w+)\s*$`)
+	fuzzMatrixPackage = regexp.MustCompile(`(?m)^\s*-?\s*package:\s*(\S+)\s*$`)
+)
+
+func TestEveryFuzzTargetIsFuzzedNightly(t *testing.T) {
+	root := repoRoot(t)
+	found := map[string]string{} // target -> ./package/path
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if name := d.Name(); name == ".git" || name == "site" || name == "testdata" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if perr != nil {
+			return nil // not this test's job to report unparseable Go
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Fuzz") {
+				continue
+			}
+			if !isFuzzTarget(fn) {
+				continue
+			}
+			rel, rerr := filepath.Rel(root, filepath.Dir(path))
+			if rerr != nil {
+				return rerr
+			}
+			found[fn.Name.Name] = "./" + filepath.ToSlash(rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the repository: %v", err)
+	}
+	if len(found) == 0 {
+		t.Fatal("found no Fuzz targets in the repository, which cannot be right — " +
+			"the walk or the signature check above stopped working, and this test " +
+			"would now pass whatever the workflow lists")
+	}
+
+	wf := readRepoFile(t, filepath.Join(".github", "workflows", "nightly.yml"))
+	targets := captured(fuzzMatrixTarget, wf)
+	packages := captured(fuzzMatrixPackage, wf)
+	if len(targets) == 0 {
+		t.Fatal("nightly.yml lists no fuzz targets; either the matrix moved or " +
+			"its markup changed, and this pin is testing nothing")
+	}
+	if len(targets) != len(packages) {
+		t.Fatalf("nightly.yml pairs %d targets with %d packages; the matrix rows "+
+			"no longer line up", len(targets), len(packages))
+	}
+
+	listed := map[string]string{}
+	for i, name := range targets {
+		listed[name] = packages[i]
+	}
+
+	for name, pkg := range found {
+		got, ok := listed[name]
+		if !ok {
+			t.Errorf("%s is a fuzz target in %s and nightly.yml does not fuzz it; "+
+				"add it to the matrix in .github/workflows/nightly.yml", name, pkg)
+			continue
+		}
+		if got != pkg {
+			t.Errorf("nightly.yml fuzzes %s in %s, but it is declared in %s",
+				name, got, pkg)
+		}
+	}
+	for name := range listed {
+		if _, ok := found[name]; !ok {
+			t.Errorf("nightly.yml fuzzes %s, which no longer exists; "+
+				"`go test -fuzz` would fail the nightly run", name)
+		}
+	}
+}
+
+// isFuzzTarget reports whether fn has the one signature `go test -fuzz` will
+// accept: a single *testing.F parameter and no results. Without this a helper
+// named FuzzSomethingHelper would be demanded of the workflow, and the error
+// would be about a workflow rather than about the helper's name.
+func isFuzzTarget(fn *ast.FuncDecl) bool {
+	if fn.Type.Results != nil || fn.Type.Params == nil || len(fn.Type.Params.List) != 1 {
+		return false
+	}
+	star, ok := fn.Type.Params.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := star.X.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "testing" && sel.Sel.Name == "F"
+}
+
+func captured(re *regexp.Regexp, s string) []string {
+	var out []string
+	for _, m := range re.FindAllStringSubmatch(s, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// A crash corpus is only worth uploading if it is uploaded from the job that
+// produced it, so the matrix has to keep running every target after one of
+// them fails. fail-fast defaults to true.
+func TestOneFailingFuzzTargetDoesNotCancelTheOthers(t *testing.T) {
+	wf := readRepoFile(t, filepath.Join(".github", "workflows", "nightly.yml"))
+	if !strings.Contains(wf, "fail-fast: false") {
+		t.Error("nightly.yml's fuzz matrix no longer sets fail-fast: false, so the " +
+			"first target to crash cancels the rest and their corpora are never uploaded")
+	}
+}

--- a/internal/docs/release_test.go
+++ b/internal/docs/release_test.go
@@ -1,0 +1,111 @@
+package docs
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CI compiles every release target on the pull request so that a break is
+// caught there rather than during a release, where it demotes the release to a
+// draft. The step's own comment says so. What it cannot say is which targets
+// those are: the list is written out in the workflow, and the set it is meant
+// to mirror lives in .goreleaser.yaml.
+//
+// Add an architecture to the release build and nothing complains. CI keeps
+// compiling the three it has always compiled, goreleaser starts building four,
+// and the first compile of the new one happens during a release — which is the
+// exact failure this step was added to prevent, reintroduced by the step going
+// stale rather than by anyone removing it.
+//
+// linux/amd64 is deliberately absent from the workflow's loop: the ordinary
+// Build step is that target, so it is added back here rather than compiled
+// twice there.
+const ciNativeTarget = "linux/amd64"
+
+var ciCrossCompileLoop = regexp.MustCompile(`for target in ([^;]+);`)
+
+type goreleaserConfig struct {
+	Builds []struct {
+		GOOS   []string `yaml:"goos"`
+		GOARCH []string `yaml:"goarch"`
+		Ignore []struct {
+			GOOS   string `yaml:"goos"`
+			GOARCH string `yaml:"goarch"`
+		} `yaml:"ignore"`
+	} `yaml:"builds"`
+}
+
+func TestCICompilesEveryTargetGoreleaserBuilds(t *testing.T) {
+	var cfg goreleaserConfig
+	if err := yaml.Unmarshal([]byte(readRepoFile(t, ".goreleaser.yaml")), &cfg); err != nil {
+		t.Fatalf("parsing .goreleaser.yaml: %v", err)
+	}
+	if len(cfg.Builds) == 0 {
+		t.Fatal(".goreleaser.yaml declares no builds; either the file moved or its " +
+			"shape changed, and this pin is comparing against nothing")
+	}
+
+	var released []string
+	for _, b := range cfg.Builds {
+		for _, os := range b.GOOS {
+			for _, arch := range b.GOARCH {
+				if slices.ContainsFunc(b.Ignore, func(ig struct {
+					GOOS   string `yaml:"goos"`
+					GOARCH string `yaml:"goarch"`
+				}) bool {
+					return ig.GOOS == os && ig.GOARCH == arch
+				}) {
+					continue
+				}
+				released = append(released, fmt.Sprintf("%s/%s", os, arch))
+			}
+		}
+	}
+	if len(released) == 0 {
+		t.Fatal(".goreleaser.yaml produced no goos/goarch pairs")
+	}
+
+	ci := readRepoFile(t, filepath.Join(".github", "workflows", "ci.yml"))
+	m := ciCrossCompileLoop.FindStringSubmatch(ci)
+	if m == nil {
+		t.Fatal("ci.yml no longer has a `for target in …;` cross-compile loop; " +
+			"if the step was rewritten, rewrite this pin with it")
+	}
+	compiled := append(strings.Fields(m[1]), ciNativeTarget)
+
+	slices.Sort(released)
+	released = slices.Compact(released)
+	slices.Sort(compiled)
+	compiled = slices.Compact(compiled)
+
+	for _, target := range released {
+		if !slices.Contains(compiled, target) {
+			t.Errorf("goreleaser builds %s for the release and CI never compiles it; "+
+				"add it to the cross-compile loop in .github/workflows/ci.yml "+
+				"(CI compiles %v, the release needs %v)", target, compiled, released)
+		}
+	}
+	for _, target := range compiled {
+		if !slices.Contains(released, target) {
+			t.Errorf("CI compiles %s, which no release ships; the loop in ci.yml "+
+				"is spending gate time on a target nobody downloads", target)
+		}
+	}
+}
+
+// The native target is the one claim above that the workflow does not spell
+// out, so it is checked rather than assumed: if the Build step stops being
+// linux/amd64, adding it back to the compiled set silently hides a real gap.
+func TestTheGateBuildsOnTheTargetItAssumes(t *testing.T) {
+	ci := readRepoFile(t, filepath.Join(".github", "workflows", "ci.yml"))
+	if !strings.Contains(ci, "runs-on: ubuntu-latest") {
+		t.Errorf("ci.yml's build job no longer runs on ubuntu-latest, so %q is no "+
+			"longer the target its plain `go build` covers", ciNativeTarget)
+	}
+}


### PR DESCRIPTION
A workflow is YAML. Nothing in it can be held to the code by a compiler,
so every list inside one is a claim maintained by memory — and when it
goes stale it goes stale *quietly*, because a step that selects nothing
still exits 0 and a matrix that names three of four targets still turns
green.

### The one that actually happened

`e2e.yml` has a step named "domains that cannot run report Skipped, never
clean". It is the only place the never-score-a-skipped-domain invariant
meets a real host — there is no Docker and no Trivy in that container, so
something is always Skipped, and a skipped domain scored 100 is the exact
lie the whole invariant exists to prevent.

It selected `.state == 3`.

Then #656 changed every enum to marshal as its name. From that commit on,
the selection matched no domain: `bad` was empty however the scan turned
out, and the step passed on every single pull request without once looking
at a domain. A vacuous jq selection is indistinguishable from a clean
result — that is what makes this worse than a broken check. A broken check
gets fixed.

Fixed to `.state == "skipped"`, and the count is now asserted *before* the
invariant is: if no domain reports Skipped, the report changed shape and
the step says so instead of passing.

### The same shape, twice more

Once you look for it, the pattern is everywhere a workflow names things:

  - **the fuzz matrix.** `nightly.yml` fuzzes four targets for five minutes
    each, from a list written by hand. Add a `FuzzSomething` tomorrow and
    nightly stays green while the new parser is the one nobody throws bytes
    at.
  - **the shellcheck step.** It named two scripts. The repository has
    thirteen, and the eleven it left out were no less privileged:
    `measure/run.sh` runs as root and edits the host it measures,
    `instruments/rollback.sh` computes the rollback-fidelity claim that
    `check.py` fails the run over. All eleven were already clean, so the
    hand-kept list was costing coverage and buying nothing — and a
    hand-kept list is how the *next* script joins the repo unchecked. It
    now finds them rather than listing them.
  - **the cross-compile loop.** It exists so that a target breaking is
    caught on the pull request instead of during a release, where it
    demotes the release to a draft. Which targets those are lives in
    `.goreleaser.yaml`, and nothing connected the two: add an architecture
    and CI keeps compiling the three it always did while goreleaser starts
    building four.

### What is added

Three tests in `internal/docs`, which is where this repository already
keeps the pins that hold prose and configuration to code. Each derives the
truth from the source and compares in both directions:

  - `e2e_test.go` — every `.state ==` literal in `e2e.yml` against what
    `model.ScanState` actually marshals, plus the requirement that the
    names stay plain strings the workflow's jq can compare without
    escaping.
  - `fuzz_test.go` — the nightly matrix against every `Fuzz*` function in
    the repository, matched on the signature `go test -fuzz` accepts so a
    helper named `FuzzFoo` is not demanded of a workflow. It also pins
    `fail-fast: false`, without which the first target to crash cancels the
    others and their corpora are never uploaded.
  - `release_test.go` — CI's cross-compile loop against the goos/goarch
    product in `.goreleaser.yaml`, minus its `ignore` entries, plus the
    native target the Build step above it already covers. That last one is
    checked rather than assumed: if the build job stops running on
    ubuntu-latest, adding `linux/amd64` back would hide a real gap.

Each fails loudly with an error that says which file to edit, and each
`t.Fatal`s if it can no longer find the thing it reads — a pin that
silently stops pinning is the bug it was written for.

### And one more claim that nothing read

`.goreleaser.yaml` is validated with `goreleaser check` in CI. The
cross-compile covers what goreleaser *builds*; that covers what it is
*told* to build — archives, checksums, SBOM hooks, the ldflags that stamp
the version. Nothing reads that file until a tag exists, and by then the
release is public, because the tag is created by publishing it. A config
error there surfaces as a live release with no artifacts. `check` is a
parse and a validate: seconds, no token.

`demo/run.sh` gets the one `shellcheck disable` the sweep needed — SC2016
on a single-quoted command sent to the guest shell, where expanding `$d`
locally would send one empty path. `reports/` is gitignored; the measure
harness writes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

