### PR TITLE
fix(demo): the demo VM needs the system libvirt connection, so ask for it

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -10,8 +10,8 @@ from a `git clone`.
 
 ```
 cd demo
-vagrant up            # boots + provisions the vulnerable server (first run: a few minutes)
-vagrant ssh           # you're now on the "home server"
+./run.sh up           # boots + provisions the vulnerable server (first run: a few minutes)
+./run.sh shell        # you're now on the "home server"
   hostveil scan       # see the findings (auto-elevates with sudo)
 ```
 
@@ -62,7 +62,11 @@ cd demo
 
 Prefer raw Vagrant? `vagrant up` / `vagrant ssh` work too (run
 `./run.sh up` once after a boot to start the stacks — they intentionally
-have no restart policy, so they don't come back on their own).
+have no restart policy, so they don't come back on their own). **On Linux,
+export `LIBVIRT_DEFAULT_URI=qemu:///system` first.** An unprivileged libvirt
+client resolves to `qemu:///session`, which has no management network: the
+VM boots, never gets an address, and Vagrant gives up minutes later with
+*"not yet ready for SSH"*. `run.sh` sets it for you; raw `vagrant` does not.
 
 > Inside the VM, plain `hostveil` re-executes itself under **sudo**
 > automatically so it can read root-owned config (`/etc/ssh/sshd_config`) and
@@ -137,6 +141,20 @@ Tear it down completely with `./run.sh destroy`.
 ---
 
 ## Troubleshooting
+
+**`Name demo_default of domain about to create is already taken`.** A libvirt
+domain exists that Vagrant has no record of — the leftovers of a creation that
+did not finish. Vagrant's message reads as a name collision, but renaming
+nothing will help; the domain is unreachable anyway, because an unfinished VM
+never had an SSH key inserted. Remove it and start again:
+
+```bash
+virsh -c qemu:///system destroy demo_default        # only if it is still running
+virsh -c qemu:///system undefine demo_default --remove-all-storage
+```
+
+`./run.sh up` checks for this and says so before Vagrant gets the chance. The
+usual way to get one is the `qemu:///session` trap described above.
 
 **The VM has no internet during `vagrant up` (Linux + libvirt + Docker on the host).**
 If the host also runs Docker, Docker sets the kernel's `FORWARD` policy to

--- a/demo/README.md
+++ b/demo/README.md
@@ -158,19 +158,44 @@ usual way to get one is the `qemu:///session` trap described above.
 
 **The VM has no internet during `vagrant up` (Linux + libvirt + Docker on the host).**
 If the host also runs Docker, Docker sets the kernel's `FORWARD` policy to
-DROP, which blocks the libvirt VM's NAT traffic (you'll see apt/curl time
-out inside the VM). Allow the VM's bridge to forward and masquerade out:
+DROP, which blocks the libvirt VM's NAT traffic — provisioning dies at the
+Docker install with `curl: (28) ... Timeout was reached`. The giveaway is
+that the VM looks half-connected: DNS resolves and the gateway pings,
+because both are the bridge itself, and everything that has to be *forwarded*
+times out. Allow that bridge to forward:
 
 ```bash
-sudo firewall-cmd --zone="$(firewall-cmd --get-default-zone)" --add-masquerade
-sudo firewall-cmd --direct --add-rule ipv4 filter FORWARD 0 -i virbr0 -j ACCEPT
-sudo firewall-cmd --direct --add-rule ipv4 filter FORWARD 0 -o virbr0 -j ACCEPT
+br=$(virsh -c qemu:///system net-dumpxml vagrant-libvirt |
+  sed -n "s/.*<bridge name='\([^']*\)'.*/\1/p")
+sudo firewall-cmd --permanent --direct --add-rule ipv4 filter FORWARD 0 \
+  -i "$br" -j ACCEPT
+sudo firewall-cmd --permanent --direct --add-rule ipv4 filter FORWARD 0 \
+  -o "$br" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+sudo firewall-cmd --reload
 ```
 
-These apply immediately. To keep them across reboots, append `--permanent`
-to each (then `sudo firewall-cmd --reload`). Then re-run `vagrant provision`.
-This does **not** affect teammates using VirtualBox (macOS/Windows), whose
-NAT is independent of the host firewall.
+Then `vagrant provision` to finish the run that failed.
+
+Three things that are easy to get wrong here, and each of them costs you
+another five-minute timeout:
+
+- **It is not `virbr0`.** That is the `default` libvirt network, which this
+  demo does not use — the VM is on `vagrant-libvirt`, usually `virbr1`. Hence
+  reading the name out of the network rather than typing it.
+- **`--permanent` is not optional in practice.** Runtime rules are gone after
+  a reboot, and Docker sets the policy again the moment it starts, so the
+  problem comes back looking brand new.
+- **Inbound is replies only.** This VM publishes an *unauthenticated Docker
+  API* on 2375 — that is the point of `dockerd.api-unauthenticated` — so
+  nothing should be able to open a connection *to* it. Outbound plus
+  `RELATED,ESTABLISHED` is all the provisioning needs. `vagrant ssh` and the
+  forwarded 8787 are unaffected either way: the host sits on that bridge
+  directly, so its own traffic never passes through `FORWARD`.
+
+No masquerade rule is needed. The `vagrant-libvirt` network is
+`forward mode='nat'`, so libvirt already masquerades for it; the only thing
+in the way is the forwarding policy. And none of this affects teammates on
+VirtualBox (macOS/Windows), whose NAT is independent of the host firewall.
 
 ## What's deliberately vulnerable
 

--- a/demo/run.sh
+++ b/demo/run.sh
@@ -15,6 +15,73 @@ set -euo pipefail
 cd "$(dirname "$0")"
 export VAGRANT_CWD="$PWD"
 
+# An unprivileged libvirt client resolves to qemu:///session, and this demo
+# cannot run there: session mode has no management network, so the VM boots,
+# never gets an address, and vagrant gives up several minutes later with "not
+# yet ready for SSH". What it leaves behind is worse than the failure — a
+# defined domain with no Vagrant metadata, so the *next* attempt refuses with
+# "Name demo_default of domain about to create is already taken", which names
+# nothing that led there and no way out. The forwarded port and the NAT the
+# Vagrantfile assumes are system-connection features besides.
+#
+# Set here rather than written down in the README, because neither message
+# describes what went wrong and every command below shells out to vagrant. An
+# explicit LIBVIRT_DEFAULT_URI wins, so a session setup somebody has made to
+# work is left alone.
+if [ "$(uname -s)" = Linux ] && [ -z "${LIBVIRT_DEFAULT_URI:-}" ]; then
+  export LIBVIRT_DEFAULT_URI=qemu:///system
+fi
+
+# Reaching that connection needs libvirtd running and this account in the
+# libvirt group — the one-time setup in README.md, both of which otherwise
+# surface late and in somebody else's words. Skipped where the question
+# cannot be answered (no virsh) or where libvirt may not be the provider at
+# all (VirtualBox installed, macOS, a URI you set yourself).
+if [ "${LIBVIRT_DEFAULT_URI:-}" = qemu:///system ] &&
+  command -v virsh >/dev/null && ! command -v VBoxManage >/dev/null &&
+  ! virsh -c qemu:///system version >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+Cannot reach libvirt at qemu:///system, so there is nothing to run the VM.
+The usual two reasons, and their one-time fixes:
+
+  sudo systemctl enable --now libvirtd     # the daemon is not running
+  sudo usermod -aG libvirt "$USER"         # you are not in the group
+                                           # (then log out and back in)
+
+See "One-time setup" in demo/README.md.
+EOF
+  exit 1
+fi
+
+# vagrant-libvirt names the domain after this directory. Recomputed rather
+# than hardcoded so a renamed checkout still gets a true error message.
+domain="$(basename "$PWD")_default"
+
+# A defined domain that Vagrant has no record of is the wreckage of a
+# creation that did not finish — a host suspend, a Ctrl-C, or the session-URI
+# trap above before it was closed. Vagrant's own words for it are "already
+# taken", which reads as a name collision and sends you looking for the wrong
+# thing. Reported rather than removed: it is a virtual machine, and deleting
+# one is not a thing to guess at on somebody's behalf.
+warn_orphan_domain() {
+  [ -f .vagrant/machines/default/libvirt/id ] && return 0
+  command -v virsh >/dev/null || return 0
+  virsh dominfo "$domain" >/dev/null 2>&1 || return 0
+  # -c spelled out because the URI this script exports does not survive into
+  # the shell reading the message, where plain virsh would go looking on the
+  # session connection and report no such domain.
+  cat >&2 <<EOF
+A libvirt domain named $domain exists, but Vagrant has no record of it, so it
+will refuse to create one over the top. It holds nothing you can get at: an
+unfinished VM never had a key inserted, so there is no way to log into it.
+Remove it and run this again:
+
+  virsh -c ${LIBVIRT_DEFAULT_URI:-qemu:///system} destroy $domain    # only if it is still running
+  virsh -c ${LIBVIRT_DEFAULT_URI:-qemu:///system} undefine $domain --remove-all-storage
+EOF
+  exit 1
+}
+
 # Bring every stack up inside the VM (idempotent). Stacks have no restart
 # policy on purpose, so they need starting after each boot.
 start_stacks() {
@@ -35,6 +102,7 @@ rebuild() {
 
 case "${1:-up}" in
   up)
+    warn_orphan_domain
     vagrant up
     echo "==> rebuilding hostveil from the synced source…"
     rebuild

--- a/demo/run.sh
+++ b/demo/run.sh
@@ -97,7 +97,27 @@ start_stacks() {
 # whatever binary the *first* provision produced, silently testing stale code.
 rebuild() {
   vagrant rsync
-  vagrant ssh -c 'cd /hostveil && sudo /usr/local/go/bin/go build -o /usr/local/bin/hostveil ./cmd/hostveil'
+  vagrant ssh -c 'cd /hostveil && sudo /usr/local/go/bin/go build -o /usr/local/bin/hostveil ./cmd/hostveil' && return 0
+
+  # A build that cannot find its compiler usually means provision.sh never
+  # reached the end — the first `up` timed out installing something, which on
+  # a host running Docker is the norm rather than the exception (see
+  # Troubleshooting in README.md). Vagrant records the VM as provisioned
+  # anyway, so the next `up` skips straight past it and this build is the
+  # first thing to notice, in words about Go. Costs an extra round trip only
+  # on the path that has already failed.
+  vagrant ssh -c 'test -x /usr/local/go/bin/go' >/dev/null 2>&1 && return 1
+  cat >&2 <<'EOF'
+
+There is no Go toolchain in the VM, so provisioning never finished — this is
+a half-built machine, not a build failure. Finish it:
+
+  vagrant provision
+
+If it dies again at a download timing out, the VM has no route to the
+internet: see "The VM has no internet during vagrant up" in demo/README.md.
+EOF
+  exit 1
 }
 
 case "${1:-up}" in

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -189,6 +189,13 @@ sudo systemctl enable --now libvirtd
 sudo usermod -aG libvirt "$USER"     # then log out/in
 ```
 
+Use `demo/run.sh`, or export `LIBVIRT_DEFAULT_URI=qemu:///system` before
+raw `vagrant`. An unprivileged libvirt client resolves to `qemu:///session`,
+which has no management network, so the VM boots and never gets an address —
+Vagrant reports *"not yet ready for SSH"* minutes later and leaves a domain
+behind that makes the next attempt fail with *"already taken"*. `run.sh`
+sets the URI and checks for that leftover; raw `vagrant` does neither.
+
 If the host also runs **Docker**, Docker sets the kernel `FORWARD` policy to
 DROP, which blocks the VM's outbound network (apt/curl time out during
 provisioning). Allow the libvirt bridge to forward + masquerade — see the


### PR DESCRIPTION
Found by using it. `./run.sh up` on a Fedora workstation with libvirt
installed, the user in the libvirt group, and everything the README asks for
in place — and it fails twice, neither time saying anything true.

**First failure.** An unprivileged libvirt client resolves to
`qemu:///session`, not `qemu:///system`. Session mode has no management
network, so the VM is created, boots, and never gets an address. Several
minutes in, Vagrant says:

    The provider for this Vagrant-managed machine is reporting that it
    is not yet ready for SSH.

which is true and useless. Nothing in it points at a URI.

**Second failure, which is the worse one.** That half-created domain is
still defined, so the next attempt refuses:

    Name `demo_default` of domain about to create is already taken.

That reads as a name collision. It is not — it is the wreckage of the first
failure, and there is no way forward from the message. It is also a dead
end in the literal sense: an unfinished VM never had a key inserted, so the
domain cannot be logged into, only removed.

So `run.sh` now pins `LIBVIRT_DEFAULT_URI=qemu:///system` on Linux when it
is unset. Not documented — *set*. Neither message above describes its own
cause, and every command in this script shells out to vagrant, so the one
place that can hold this is the script. An explicit URI still wins, so a
session setup somebody has made to work is left alone.

Two checks go with it, both for things that fail late and in somebody
else's words otherwise:

  - the system connection is reachable before anything is started, because
    the two ways it is not — libvirtd stopped, account not in the libvirt
    group — are one-time setup steps with one-line fixes, and both
    currently surface minutes into a boot. Skipped where the question
    cannot be answered (no virsh) or where libvirt may not be the provider
    (VirtualBox present, macOS, a URI you set yourself), so a working
    VirtualBox setup is never blocked by it.
  - a defined domain with no Vagrant metadata is reported, with the two
    virsh commands that clear it, spelled with `-c` because the URI this
    script exports does not survive into the shell reading the message.
    Reported and not removed: it is a virtual machine, and deleting one is
    not a thing to guess at on somebody's behalf.

The README's quickstart now uses `./run.sh` rather than raw `vagrant`,
since raw vagrant is exactly the path that hits this, and the "prefer raw
Vagrant?" note and DEVELOPMENT.md say what to export if you take it anyway.
The leftover domain gets a troubleshooting entry under the message you will
actually search for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

