### PR TITLE
fix(cve): four Trivy processes cannot share one cache, and lost images flatter the score

### DIFF
--- a/internal/check/cve/cve.go
+++ b/internal/check/cve/cve.go
@@ -151,6 +151,73 @@ type target struct {
 // load spike.
 const scanParallelism = 4
 
+// dbTimeout bounds the one-off vulnerability-DB download in warmCache. It is
+// the same budget a single image scan gets, because on a cold cache that is
+// most of what an image scan spends its time on.
+const dbTimeout = 5 * time.Minute
+
+// memoryCache makes a Trivy process keep its analysis cache to itself instead
+// of in the shared directory, which is what allows more than one of them to
+// run at a time.
+//
+// Trivy's filesystem cache is a single-writer BoltDB. Two processes that both
+// want it is not a rare interleaving — it is the ordinary case when four start
+// together, and the loser does not degrade, it exits: "unable to initialize fs
+// cache: cache may be in use by another process". So the parallelism above was
+// quietly costing coverage on every scan it sped up.
+//
+// The damage is not that findings go missing. It is that they go missing in
+// the flattering direction: an image that could not be scanned contributes no
+// vulnerabilities, so the axis reads *better* the less of the host it saw. The
+// demo VM's vulnerability axis scored 44/100 on a run that reached 1 of its 7
+// images, 25/100 on a run that reached 3, and 16/100 — the truth — on the run
+// that reached all seven.
+//
+// hostveil said "partial" every time, which is the coverage machinery working
+// exactly as designed: a domain that could not look never claims it found
+// nothing. But a Degraded axis is still scored, deliberately, so the honest
+// flag sat beside a number that was wrong by 28 points.
+//
+// Warming the cache first is the obvious fix and it is not enough. Four
+// concurrent scans on that host, controlled for image set and run against an
+// already-populated cache:
+//
+//	shared cache   3 of 4 succeed   one exits on the lock
+//	this commit    4 of 4
+//
+// because the contention is over the lock rather than over the contents.
+var memoryCache = []string{"--cache-backend", "memory"}
+
+// warmCache downloads the vulnerability DB before the fan-out, and reports
+// whether Trivy accepted the memory cache backend.
+//
+// Both halves are needed and neither is sufficient. Without the DB on disk,
+// four scans race to download it and *all four* fail, memory backend or not —
+// the backend only decides where an image's analysis goes, and the DB is
+// shared either way. Without the memory backend, they race for the cache lock.
+//
+// It doubles as the capability probe, which is why it carries the flag it is
+// testing: `--cache-backend` is marked experimental, `memory` is newer than
+// the flag itself, and an unsupported value fails immediately and legibly
+// ("unknown cache type"). Nothing here can tell that apart from a download
+// that failed for want of a network, and it does not need to — either way the
+// fast path is not available, and the caller falls back to scanning one image
+// at a time, which is correct on every version of Trivy there has ever been.
+// Downloading the DB with the flag set is safe: the backend governs the
+// analysis cache only, and the DB still lands on disk where the scans will
+// find it.
+//
+// Costs 45ms once the DB is present.
+func warmCache(ctx context.Context, r platform.CommandRunner) error {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout+time.Minute)
+	defer cancel()
+
+	args := append([]string{"image", "--download-db-only",
+		"--timeout", dbTimeout.String(), "--quiet", "--no-progress"}, memoryCache...)
+	_, err := r.Run(ctx, "trivy", args...)
+	return err
+}
+
 // scanAll scans every target with bounded concurrency and returns the merged
 // findings, how many failed, and the first failure in target order.
 //
@@ -165,8 +232,21 @@ func scanAll(ctx context.Context, r platform.CommandRunner, targets []target) (f
 	}
 	results := make([]result, len(targets))
 
+	// One target races nothing, so it takes the plain path: the shared cache
+	// it populates is the one a later scan of the same image will reuse.
+	//
+	// For more than one, the fast path has to be earned. Where Trivy will not
+	// give both halves of it, the scans go one at a time rather than four at
+	// a time into a lock they cannot share — slower than this domain was
+	// yesterday, and the first version of it that reports what it actually
+	// examined.
+	cacheArgs, parallelism := []string(nil), 1
+	if len(targets) > 1 && warmCache(ctx, r) == nil {
+		cacheArgs, parallelism = memoryCache, scanParallelism
+	}
+
 	var wg sync.WaitGroup
-	slots := make(chan struct{}, scanParallelism)
+	slots := make(chan struct{}, parallelism)
 	for i, t := range targets {
 		wg.Add(1)
 		go func() {
@@ -174,7 +254,7 @@ func scanAll(ctx context.Context, r platform.CommandRunner, targets []target) (f
 			slots <- struct{}{}
 			defer func() { <-slots }()
 
-			fs, err := scanImage(ctx, r, t.image, t.service, t.file, t.project)
+			fs, err := scanImage(ctx, r, cacheArgs, t.image, t.service, t.file, t.project)
 			if err == nil && t.standalone {
 				fs = demoteToManual(fs)
 			}
@@ -250,14 +330,18 @@ func demoteToManual(fs []model.Finding) []model.Finding {
 	return fs
 }
 
-func scanImage(ctx context.Context, r platform.CommandRunner, image, service, file, project string) ([]model.Finding, error) {
+// scanImage scans one image. cacheArgs is the cache-backend selection scanAll
+// settled on for this run, empty where the scans are running one at a time and
+// the shared cache is safe to use.
+func scanImage(ctx context.Context, r platform.CommandRunner, cacheArgs []string, image, service, file, project string) ([]model.Finding, error) {
 	ctx, cancel := context.WithTimeout(ctx, imageTimeout+time.Minute)
 	defer cancel()
 
-	out, err := r.Run(ctx, "trivy", "image",
+	args := append([]string{"image",
 		"--severity", "CRITICAL,HIGH,MEDIUM",
 		"--timeout", imageTimeout.String(),
-		"--format", "json", "--quiet", "--no-progress", image)
+		"--format", "json", "--quiet", "--no-progress"}, cacheArgs...)
+	out, err := r.Run(ctx, "trivy", append(args, image)...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/check/cve/cve_test.go
+++ b/internal/check/cve/cve_test.go
@@ -63,6 +63,9 @@ type scriptRunner struct {
 	psErr    bool
 	trivy    map[string]string // image → JSON output
 	trivyErr map[string]bool   // image → fail
+	// warmErr fails the vulnerability-DB download, which is what an
+	// air-gapped host with a hand-seeded DB looks like.
+	warmErr bool
 
 	// The checker scans images concurrently, so this fake is called from
 	// several goroutines at once. Only the recording needs guarding — the
@@ -70,6 +73,10 @@ type scriptRunner struct {
 	// it. The real DefaultRunner is stateless and needs none of this.
 	mu   sync.Mutex
 	argv []string // the last trivy argv, for flag assertions
+	// calls records every trivy invocation in order: "warm" for the DB
+	// download, the image name for a scan. The order is the point — the
+	// download has to finish before the first scan starts.
+	calls []string
 }
 
 // lastArgv returns the most recent trivy invocation's arguments.
@@ -77,6 +84,13 @@ func (s *scriptRunner) lastArgv() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return slices.Clone(s.argv)
+}
+
+// trivyCalls returns what trivy was asked to do, in order.
+func (s *scriptRunner) trivyCalls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.calls)
 }
 
 func (s *scriptRunner) LookPath(name string) (string, error) { return "/usr/bin/" + name, nil }
@@ -95,11 +109,20 @@ func (s *scriptRunner) Run(_ context.Context, name string, args ...string) ([]by
 		return []byte(s.psIDs), nil
 	case name == "docker" && args[0] == "inspect":
 		return []byte(s.inspectJSON), nil
+	case name == "trivy" && slices.Contains(args, "--download-db-only"):
+		s.mu.Lock()
+		s.calls = append(s.calls, "warm")
+		s.mu.Unlock()
+		if s.warmErr {
+			return nil, errors.New("failed to download vulnerability DB")
+		}
+		return nil, nil
 	case name == "trivy":
+		image := args[len(args)-1]
 		s.mu.Lock()
 		s.argv = args
+		s.calls = append(s.calls, image)
 		s.mu.Unlock()
-		image := args[len(args)-1]
 		if s.trivyErr[image] {
 			return nil, errors.New("failed to download vulnerability DB")
 		}
@@ -129,6 +152,67 @@ const oneVuln = `{"Results":[{"Vulnerabilities":[{"VulnerabilityID":"CVE-2021-12
 
 // Some images unscannable is Degraded: the findings we did get are real and
 // worth keeping, but the picture is incomplete and must say so.
+// Concurrent Trivy processes cannot share one cache directory, and this
+// checker starts four. Both halves of the fix are pinned here because either
+// one alone leaves the scan failing: without the DB downloaded first, all four
+// race to fetch it and all four die; without a private analysis cache, they
+// race for its lock and most die. On the demo VM that showed up as 1 of 7
+// images covered and a vulnerability axis of 44/100 where the truth was 16 —
+// wrong in the flattering direction, because an image that could not be
+// scanned contributes no vulnerabilities.
+//
+// Order is asserted, not just presence. A DB download that happens somewhere
+// in the middle of the fan-out prevents nothing.
+func TestConcurrentScansDoNotShareOneTrivyCache(t *testing.T) {
+	r := composeProject(t)
+	r.trivy["redis:7"] = oneVuln
+	r.trivy["postgres:13"] = oneVuln
+
+	if _, err := New().Check(context.Background(), platform.Env{Runner: r}); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+
+	calls := r.trivyCalls()
+	if len(calls) == 0 || calls[0] != "warm" {
+		t.Fatalf("trivy was called as %v; the DB download has to come first, or "+
+			"the image scans race to fetch it and every one of them fails", calls)
+	}
+	if slices.Contains(calls[1:], "warm") {
+		t.Errorf("the DB was downloaded more than once: %v", calls)
+	}
+	if argv := r.lastArgv(); !slices.Contains(argv, "--cache-backend") {
+		t.Errorf("image scans ran as %v, with no private analysis cache; four of "+
+			"those at once contend for one BoltDB lock and the losers exit", argv)
+	}
+}
+
+// The fast path is not available on every Trivy: `--cache-backend` is
+// experimental and `memory` is newer than the flag. An unsupported value fails
+// the warm-up exactly like a host with no network does, and nothing here can
+// tell those apart — so both fall back to scanning one image at a time, which
+// no version of Trivy has ever had trouble with.
+//
+// Treating the warm-up as a dependency instead would turn a working offline
+// scan into no scan at all: a bigger hole than the one being closed.
+func TestAFailedWarmUpScansSeriallyRatherThanNotAtAll(t *testing.T) {
+	r := composeProject(t)
+	r.warmErr = true
+	r.trivy["redis:7"] = oneVuln
+	r.trivy["postgres:13"] = oneVuln
+
+	findings, err := New().Check(context.Background(), platform.Env{Runner: r})
+	if err != nil {
+		t.Fatalf("a failed warm-up stopped the scan: %v", err)
+	}
+	if len(findings) == 0 {
+		t.Fatal("no findings; the images were never scanned after the warm-up failed")
+	}
+	if argv := r.lastArgv(); slices.Contains(argv, "--cache-backend") {
+		t.Errorf("image scans ran as %v; the flag the warm-up just failed on must "+
+			"not be handed to the scans, or a Trivy that rejects it fails them all", argv)
+	}
+}
+
 func TestCVEPartialScanIsDegraded(t *testing.T) {
 	r := composeProject(t)
 	r.trivy["redis:7"] = oneVuln


### PR DESCRIPTION
Found by running a scan on the demo VM and running it again. Same host, same
containers, different answer:

    cold cache   1 of 7 images   vulnerability axis 44/100
    cold cache   3 of 7                            25/100
    warm cache   7 of 7                            16/100

16 is the truth. The other two are what the axis reports when it could not
look, and the direction is the whole problem: an image that fails to scan
contributes no vulnerabilities, so **the score improves the less of the host
it saw**. A security tool that flatters a host in exactly the moment it is
blind is worse than one that says nothing.

To be fair to the machinery, it was not silent. Every one of those runs
carried `~ cve partial: some images could not be scanned` and the axis was
flagged Degraded, which is the coverage contract in AGENTS.md working as
designed. But Degraded axes are still scored — deliberately, because the
findings that *did* come back are real — so the honest flag sat next to a
number wrong by 28 points.

### What is actually wrong

`scanParallelism = 4`, and Trivy's filesystem cache is a single-writer
BoltDB. Two processes wanting it is not an unlucky interleaving, it is the
ordinary case when four start together — and the loser does not slow down, it
exits:

    unable to initialize fs cache: cache may be in use by another process

So the parallelism was quietly buying speed with coverage, on every scan.

It looks intermittent, which is why it survived: the failure rate depends on
timing, a second run usually looks fine, and the first scan on a fresh host —
the one somebody forms their opinion from — is the worst case.

### Two halves, neither sufficient

Warming the cache first is the obvious fix and it is not enough. Measured
four-at-once on that host, controlled for the image set:

  - **DB pre-downloaded, shared cache**: 3 of 4 succeed, one exits on the
    lock. A fully populated cache still loses images, because the contention
    is over the lock and not over the contents.
  - **`--cache-backend memory`, no DB pre-download**: **0 of 4**. All four
    race to fetch the vulnerability DB instead. The backend decides where an
    image's analysis goes; the DB is shared either way.
  - **both**: 4 of 4.

So `warmCache` downloads the DB before the fan-out, and each scan keeps its
analysis cache to itself.

### The fallback, which is the part worth reviewing

`--cache-backend` is marked experimental and `memory` is newer than the flag,
so a Trivy that rejects it would fail every image — turning a working scan
into no scan, which is a bigger hole than the one being closed.

The warm-up therefore carries the flag it is testing, and doubles as the
capability probe: an unsupported value fails immediately and legibly
("unknown cache type"). Nothing here can tell that apart from a host with no
network, and it does not need to — either way the fast path is unavailable
and the scans go **one at a time**, which no version of Trivy has ever had
trouble with. Slower than this domain was yesterday, and the first version of
it that reports what it actually examined. Downloading the DB with the flag
set is safe: the backend governs the analysis cache only, and the DB still
lands on disk.

### On the demo VM specifically

A cold-cache scan there still reports 4 of 7 after this change, and it is a
different failure with a different message: `no space left on device`. That
box has 492MB free and two of its images are 1.32GB each, so Trivy cannot
export them to scan them — serially either. The VM needs a bigger disk;
that is a demo fixture problem and not this one, and it is the reason the
numbers above are quoted from a controlled four-image run rather than from
the full seven.

Two tests, both pinned against the ordering rather than the flag's presence,
because a DB download in the middle of the fan-out prevents nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

