### PR TITLE
fix(demo): the demo did not fit on the disk it asked for, and the CVE domain paid

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -35,8 +35,22 @@ sudo usermod -aG libvirt "$USER"     # then log out/in (or: newgrp libvirt)
 ### macOS / Windows / other Linux (teammates)
 1. Install **Vagrant**: <https://developer.hashicorp.com/vagrant/install>
 2. Install **VirtualBox**: <https://www.virtualbox.org/wiki/Downloads>
+3. `vagrant plugin install vagrant-disksize`
 
 That's it — the same `Vagrantfile` picks libvirt or VirtualBox automatically.
+
+> **On the disk.** The box ships 8.7GB and this demo does not fit: the seven
+> outdated images are 3.8GB and Trivy's vulnerability DB is another 1.2GB. The
+> `Vagrantfile` asks for 24GB, which is sparse and costs what it uses. libvirt
+> does this on its own; VirtualBox needs the plugin above, and without it the
+> demo still comes up but the CVE domain runs out of room — Trivy unpacks an
+> image to scan it, so the two 1.32GB images cannot be scanned at all, and a
+> vulnerability score that skipped the heaviest images is *better* than the
+> truth. hostveil says "partial" when this happens; the number beside it is
+> still wrong.
+>
+> An existing VM keeps the disk it was built with. `./run.sh destroy` then
+> `./run.sh up` to pick up the new size.
 
 > **Apple Silicon (M1–M4) Macs**: VirtualBox/amd64 boxes don't run there.
 > Use a VM tool with an arm64 Ubuntu box (e.g. UTM/qemu or `vagrant` with the

--- a/demo/Vagrantfile
+++ b/demo/Vagrantfile
@@ -22,12 +22,40 @@ Vagrant.configure("2") do |config|
   config.vm.provider "libvirt" do |lv|
     lv.memory = 2048
     lv.cpus = 2
+
+    # The box ships an 8.7GB disk and this demo does not fit on it. The seven
+    # deliberately-outdated images are 3.8GB, Trivy's vulnerability DB is
+    # another 1.2GB, and Ubuntu and the Go toolchain take most of what is
+    # left — a provisioned VM sat at 95% full with 492MB free.
+    #
+    # That is not merely tight, it silently changes what the demo shows.
+    # Trivy exports an image to a temp file before scanning it, so an image
+    # larger than the free space cannot be scanned at all: jellyfin and
+    # nextcloud are 1.32GB each, and both failed with "no space left on
+    # device" however few scans ran at once. hostveil reported it honestly as
+    # partial coverage — and a vulnerability axis that skipped the two
+    # heaviest images scored *better* than the truth, which is the one thing
+    # a demo of a security tool must not do.
+    #
+    # qcow2 is sparse, so this costs what it uses and not 24GB.
+    lv.machine_virtual_size = 24
   end
 
   config.vm.provider "virtualbox" do |vb|
     vb.name = "hostveil-homelab"
     vb.memory = 2048
     vb.cpus = 2
+  end
+
+  # VirtualBox has no equivalent of machine_virtual_size built in, so the same
+  # disk problem needs a plugin there: `vagrant plugin install vagrant-disksize`.
+  # Guarded rather than required, because an unconditional `config.disksize`
+  # is an unknown-configuration error on every machine that does not have it —
+  # which would break the libvirt path over a setting it does not use. Without
+  # the plugin the demo still comes up; the CVE domain is the part that runs
+  # out of room, and it says so.
+  if Vagrant.has_plugin?("vagrant-disksize")
+    config.disksize.size = "24GB"
   end
 
   # Provision the vulnerable server and build hostveil from /hostveil.


### PR DESCRIPTION
The box ships 8.7GB. A provisioned demo VM sat at **95% full with 492MB
free**: the seven deliberately-outdated images are 3.8GB, Trivy's
vulnerability DB is another 1.2GB, and Ubuntu plus the Go toolchain take most
of what is left.

That is not merely tight. Trivy exports an image to a temp file before it can
scan it, so an image larger than the free space cannot be scanned *at all* —
and two of these are 1.32GB each. Both failed with `no space left on device`,
however few scans ran at once. Serialising would not have helped; there was
nowhere to put them.

Which lands in the worst possible place. A vulnerability axis that skipped the
two heaviest images scored **better** than the truth, on a VM whose entire
purpose is to demonstrate a tool that finds problems. hostveil reported it
honestly as partial coverage — the machinery works — but the number beside
the flag was wrong, and wrong in the flattering direction.

`lv.machine_virtual_size = 24`. qcow2 is sparse, so it costs what it uses:
the rebuilt VM allocates 4.4GB of its 24GiB. Ubuntu's cloud image grows the
root filesystem itself on first boot, so nothing in `provision.sh` had to
change — the guest comes up with 23G and 15G free.

VirtualBox has no built-in equivalent, so teammates need
`vagrant plugin install vagrant-disksize`, added to the setup list. The
`Vagrantfile` guards it with `Vagrant.has_plugin?`: an unconditional
`config.disksize` is an unknown-configuration error on every machine without
the plugin, which would break the libvirt path over a setting it does not use.

### Measured, same host, first scan on a freshly created VM

    before   cve partial, 4 of 7 images   vulnerability axis 25/100   90 findings
    after    complete,    7 of 7                              16/100   97 findings

16 is what every later scan on that host already reported. The first scan now
says the same thing as the fifth, which it never has before — the other half
of that was #684, and this is the half the code could not fix.

Also documents that an existing VM keeps the disk it was built with, since
that is the one thing about this change that will confuse somebody: it needs
`./run.sh destroy` and `./run.sh up`, not a reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

