### PR TITLE
fix(tui): the rail's severity mix was cut through a count, not between two

### DIFF
--- a/internal/ui/tui/layoutview.go
+++ b/internal/ui/tui/layoutview.go
@@ -391,6 +391,55 @@ func (m *appModel) severityMix(fs []model.Finding, w int, compact bool) string {
 	if len(fs) == 0 {
 		return s.dim.Render(truncate("clean", w))
 	}
+
+	// Dropped between terms, never through one — the same call the chip row
+	// makes, and for the same reason: a truncated label is obviously
+	// truncated, while a truncated *count* is a different number. Clipping the
+	// joined row left "9 high · 16 med · 28", which reports 28 of a severity
+	// it does not name and says nothing at all about the one it cut.
+	//
+	// The terms are in most-severe-first order, so what falls off the end is
+	// the level that matters least.
+	parts, sep := m.severityMixParts(fs, compact), s.dim.Render(" · ")
+	if compact {
+		sep = s.dim.Render("·")
+	}
+	row := ""
+	for i, p := range parts {
+		cand := p
+		if i > 0 {
+			cand = sep + p
+		}
+		if lipgloss.Width(row)+lipgloss.Width(cand) > w {
+			break
+		}
+		row += cand
+	}
+	return row
+}
+
+// severityMixRow builds the line without fitting it to anything, which is the
+// only form the width of it can be asked about.
+//
+// Split out because folding the clip into the builder made the question
+// unanswerable: mixIsCompact measured a string that had already been cut to
+// the width it was being compared against, so it was never wider, the rail
+// never fell back, and a mix that did not fit was drawn cut off after
+// "9 high · 16 med · 28" — a count truncated into a different number, which is
+// the one thing this line exists to report.
+func (m *appModel) severityMixRow(fs []model.Finding, compact bool) string {
+	s := m.sty()
+	if compact {
+		return strings.Join(m.severityMixParts(fs, true), s.dim.Render("·"))
+	}
+	return strings.Join(m.severityMixParts(fs, false), s.dim.Render(" · "))
+}
+
+// severityMixParts is one styled term per severity present, most severe
+// first. Kept apart from the joining so the row can be assembled a term at a
+// time when it has to be cut.
+func (m *appModel) severityMixParts(fs []model.Finding, compact bool) []string {
+	s := m.sty()
 	counts := map[model.Severity]int{}
 	for _, f := range fs {
 		counts[f.Severity]++
@@ -409,10 +458,7 @@ func (m *appModel) severityMix(fs []model.Finding, w int, compact bool) string {
 		}
 		parts = append(parts, st.Render(fmt.Sprintf("%d %s", n, strings.ToLower(sevAbbr(sev)))))
 	}
-	if compact {
-		return clip(strings.Join(parts, s.dim.Render("·")), w)
-	}
-	return clip(strings.Join(parts, s.dim.Render(" · ")), w)
+	return parts
 }
 
 // mixIsCompact decides the spelling once for the whole rail, rather than each
@@ -426,7 +472,10 @@ func (m *appModel) severityMix(fs []model.Finding, w int, compact bool) string {
 // different kind of thing rather than as the same thing abbreviated.
 func (m *appModel) mixIsCompact(byDomain map[model.Source][]model.Finding, w int) bool {
 	for _, fs := range byDomain {
-		if lipgloss.Width(m.severityMix(fs, w, false)) > w {
+		if len(fs) == 0 {
+			continue // "clean" is one word and fits wherever the counts would
+		}
+		if lipgloss.Width(m.severityMixRow(fs, false)) > w {
 			return true
 		}
 	}

--- a/internal/ui/tui/summary_test.go
+++ b/internal/ui/tui/summary_test.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/seolcu/hostveil/internal/model"
+	"github.com/seolcu/hostveil/internal/ui/theme"
 )
 
 // summaryReport is a host with a mixed severity spread, some fixable
@@ -450,5 +451,106 @@ func TestTheServiceIsSetFlushRightWhenThereIsRoom(t *testing.T) {
 	narrow := plain(m.findingRow(f, false, 46))
 	if strings.Contains(narrow, "exposed   ") {
 		t.Errorf("a narrow row still spends columns on the gap: %q", narrow)
+	}
+}
+
+// A domain that ran always colors a cell, and a domain that did not never
+// does. These are the two states the whole scanner is built to keep apart —
+// "nothing there" and "I could not look" — and in a six-cell meter filling by
+// score they arrived identical: Container at 0 and a skipped CVE domain both
+// drew six empty cells.
+//
+// Asserted on the string rather than through the model, because the bug was
+// never in the arithmetic. 0 of 6 is correctly zero cells; it is the drawing
+// that had to change.
+func TestAMeterSeparatesAZeroScoreFromADomainThatDidNotRun(t *testing.T) {
+	s := newStyles(theme.Default())
+	const w = 6
+	filled := func(bar string) int { return strings.Count(plain(bar), "█") }
+
+	for _, score := range []uint8{0, 1, 8, 16} {
+		if got := filled(s.meterAtLeastOne(score, w, s.band(score), true)); got < 1 {
+			t.Errorf("an axis that ran and scored %d drew %d filled cells; a domain in "+
+				"the worst shape on the host must not render as an empty track, which "+
+				"is what a skipped domain is drawn as on purpose", score, got)
+		}
+	}
+	if got := filled(s.meterAtLeastOne(0, w, s.cLine, false)); got != 0 {
+		t.Errorf("an axis that did not run drew %d filled cells, want 0 — a skipped "+
+			"domain with ink in its meter reads as a score", got)
+	}
+	// And the floor is a floor, not a rewrite: a real score still fills what
+	// it earned.
+	if got := filled(s.meterAtLeastOne(100, w, s.cSafe, true)); got != w {
+		t.Errorf("a perfect score filled %d of %d cells", got, w)
+	}
+	if got := filled(s.meterAtLeastOne(50, w, s.cMed, true)); got != w/2 {
+		t.Errorf("a half score filled %d of %d cells, want %d", got, w, w/2)
+	}
+}
+
+// The rail's severity mix has two spellings and must never show a third: a
+// count cut off partway is a different number, and this line exists to be read
+// as numbers. "9 high · 16 med · 28 low" clipped to twenty columns is
+// "9 high · 16 med · 28", which says the host has 28 low findings when it has
+// 28 of them and something else entirely about the rest.
+//
+// The spelling is also chosen once for the whole rail rather than per domain,
+// because the busiest domain has the widest counts — so deciding row by row
+// abbreviated exactly the first row and left the eleven under it long.
+func TestTheSeverityMixIsNeverCutMidCount(t *testing.T) {
+	m := modeModels(150, 30)["list"]
+	var fs []model.Finding
+	for range 9 {
+		fs = append(fs, model.Finding{Severity: model.SeverityHigh})
+	}
+	for range 16 {
+		fs = append(fs, model.Finding{Severity: model.SeverityMedium})
+	}
+	for range 28 {
+		fs = append(fs, model.Finding{Severity: model.SeverityLow})
+	}
+	byDomain := map[model.Source][]model.Finding{model.SourceCompose: fs}
+
+	// Every term the two spellings can produce. Anything the rail draws has to
+	// be one of these, whole — dropping "28 low" off the end is fine, printing
+	// "28" is not.
+	whole := map[string]bool{
+		"9 high": true, "16 med": true, "28 low": true,
+		"9H": true, "16M": true, "28L": true,
+	}
+	for w := 6; w <= 40; w++ {
+		compact := m.mixIsCompact(byDomain, w)
+		got := plain(m.severityMix(fs, w, compact))
+		if lipgloss.Width(got) > w {
+			t.Errorf("at %d columns the mix is %d wide: %q", w, lipgloss.Width(got), got)
+		}
+		if got == "" {
+			continue // nothing fits; an empty line beats a wrong number
+		}
+		sep := " · "
+		if compact {
+			sep = "·"
+		}
+		for _, term := range strings.Split(got, sep) {
+			if !whole[term] {
+				t.Errorf("at %d columns the mix rendered %q, whose term %q is not a "+
+					"complete count — a count cut in half reads as a number the host "+
+					"does not have", w, got, term)
+			}
+		}
+		if compact && lipgloss.Width("9 high · 16 med · 28 low") <= w {
+			t.Errorf("at %d columns the mix abbreviated with room for the long form", w)
+		}
+		// The point of choosing a spelling is that the short one says
+		// everything the long one does in less room. Where the short form fits
+		// and the long one does not, the rail has to switch — dropping "28
+		// low" to keep the long spelling hides a level it had room to report.
+		if w >= lipgloss.Width("9H·16M·28L") && w < lipgloss.Width("9 high · 16 med · 28 low") {
+			if n := len(strings.Split(got, sep)); n != 3 {
+				t.Errorf("at %d columns the mix showed %d of 3 levels (%q); the short "+
+					"spelling fits and reports all three", w, n, got)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Caught by capturing the real TUI over an SSH pty and reading the rail back,
which is the check I said in #687 that I had not managed to run. Fixing why
that capture kept coming back empty found two more things, and one of them was
mine.

### The capture

`script(1)` builds a pty, but under `vagrant ssh -c` there is no terminal to
copy a size from, so the pty comes up **0×0** and bubbletea has nothing to draw
into — an empty typescript, no error. `stty rows 45 cols 200` inside the
captured command fixes it. The other half was `nohup setsid … &`: detaching
inside a non-interactive ssh session left nothing alive to write the file.
Running it in the foreground of one ssh call, with input piped in to quit the
TUI at the end, captures cleanly.

Worth writing down because it is the only way to see what this program
actually puts on a remote screen, and both failures look like "it produced
nothing" rather than like a size or a lifetime problem.

### What it showed

    Container   █░░░
    9 high · 16 med · 28│

The mix was being cut mid-count. `9 high · 16 med · 28 low` clipped to the
rail's width says the host has 28 findings of a severity it does not name, and
says nothing at all about the level it cut. This line exists to be read as
numbers.

**I introduced it in #687.** Unifying the spelling across the rail meant asking
"does the long form fit", and `mixIsCompact` asked it of `severityMix`, which
clips to that same width before returning — so the answer was always yes, the
rail never fell back to the short spelling, and every mix too long for the
column was drawn truncated. The version before #687 measured the *unclipped*
row and got this right; the refactor folded the clip into the builder and made
the question unanswerable.

Building is now separate from fitting, and the fallback is measured on the
unclipped row again.

### And the older half of it

Even the short spelling was clipped where it did not fit, which is the same
defect one size down. The row is assembled a term at a time now and stops when
the next one will not fit — dropped **between** terms, never through one. That
is the call `fitChips` already makes for the chip row, in the same words: a
truncated label is obviously truncated, a truncated count is a different
number. Terms are in most-severe-first order, so what falls off the end is the
level that matters least.

Two tests. One pins that every term the rail draws is a whole count and that
the row switches spelling rather than dropping a level it had room to report —
it fails on the measurement bug above. The other pins the meter floor from
#687: an axis that ran always colours a cell, an axis that did not never does,
and a real score still fills what it earned.

Verified on the demo VM over SSH: every domain now reads `9H·16M·28L`,
`8H·2M`, `3H·1M·2L`, `12H` — one spelling down the column, no partial counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

