### PR TITLE
fix(tui): the footer offered `press` and `any` as keys, and the rail had no gaps

### DIFF
--- a/internal/ui/tui/frame.go
+++ b/internal/ui/tui/frame.go
@@ -331,21 +331,45 @@ func (m *appModel) footerRows(hint string) []string {
 //
 // The split is the one wrapHint already relies on: items are separated by
 // three spaces, and inside an item the key is everything before the first
-// single space ("↑/↓ move", "enter roll back", "space select"). An item with
-// no space is drawn as a key, which is what a bare word in this row is.
+// single space ("↑/↓ move", "enter roll back", "space select").
+//
+// The first word is only picked out when it is actually a key, which is not
+// the same thing. Two of these hints are sentences — "press any key to
+// continue" and "any other key cancel" — and taking their first word offered
+// `press` and `any` as bindings, on screens where one of them is the
+// confirmation for overwriting a file. Highlighting a key that does not exist
+// is worse than missing one that does, so anything unrecognised stays dim.
 func (m *appModel) styleHintLine(line string) string {
 	s := m.sty()
 	const sep = "   "
 	items := strings.Split(line, sep)
 	for i, item := range items {
 		key, rest, ok := strings.Cut(item, " ")
-		if !ok {
+		switch {
+		case !ok && isKeyName(item):
 			items[i] = s.accent.Render(item)
-			continue
+		case ok && isKeyName(key):
+			items[i] = s.accent.Render(key) + s.dim.Render(" "+rest)
+		default:
+			items[i] = s.dim.Render(item)
 		}
-		items[i] = s.accent.Render(key) + s.dim.Render(" "+rest)
 	}
 	return strings.Join(items, s.dim.Render(sep))
+}
+
+// namedKeys are the bindings whose names are longer than one rune. A list
+// rather than a rule, because "esc" and "any" are the same shape and only one
+// of them is a key. A binding added without its name here loses the accent and
+// nothing else — the failure direction that costs polish rather than truth.
+var namedKeys = map[string]bool{
+	"enter": true, "esc": true, "space": true, "tab": true,
+	"ctrl+c": true, "↑/↓": true,
+}
+
+// isKeyName reports whether tok is something the operator can press. Every
+// single-rune binding qualifies (f, q, a, y, n, …); the rest are listed.
+func isKeyName(tok string) bool {
+	return namedKeys[tok] || utf8.RuneCountInString(tok) == 1
 }
 
 func (m *appModel) ruleRow() string { return m.ruleRowOf(m.width) }

--- a/internal/ui/tui/frame_test.go
+++ b/internal/ui/tui/frame_test.go
@@ -167,3 +167,44 @@ func TestClipCountsCellsNotBytes(t *testing.T) {
 		t.Error("clip to zero columns must render nothing")
 	}
 }
+
+// The footer picks the key out of each hint and dims the rest, which is only
+// safe while it can tell a key from a word. Two of the hints are sentences,
+// and one of them is the confirmation for overwriting a file that rollback
+// refused to touch — a footer offering `any` as the key there is worse than a
+// footer with no colour at all.
+//
+// Asserted by rendering and asking which spans came back accented, because the
+// bug is entirely in what got the colour.
+func TestOnlyRealKeysAreHighlightedInTheFooter(t *testing.T) {
+	m := modeModels(120, 30)["list"]
+
+	for _, tc := range []struct {
+		hint string
+		keys []string // what must be accented
+		not  []string // what must not
+	}{
+		{"↑/↓ move   enter details   f fix   space select", []string{"↑/↓", "enter", "f", "space"}, nil},
+		{"press any key to continue", nil, []string{"press", "any"}},
+		{"y overwrite anyway   any other key cancel", []string{"y"}, []string{"any"}},
+		{"ctrl+c quit", []string{"ctrl+c"}, nil},
+	} {
+		got := m.styleHintLine(tc.hint)
+		for _, k := range tc.keys {
+			if !accented(m, got, k) {
+				t.Errorf("%q: %q should be picked out as a key", tc.hint, k)
+			}
+		}
+		for _, w := range tc.not {
+			if accented(m, got, w) {
+				t.Errorf("%q: %q was drawn as a key, and it is not one — the footer is "+
+					"the only documentation these bindings have", tc.hint, w)
+			}
+		}
+	}
+}
+
+// accented reports whether tok appears in rendered wearing the accent.
+func accented(m *appModel, rendered, tok string) bool {
+	return strings.Contains(rendered, m.sty().accent.Render(tok))
+}

--- a/internal/ui/tui/layout_test.go
+++ b/internal/ui/tui/layout_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -205,5 +206,47 @@ func TestThemePickerFitsTerminalWidth(t *testing.T) {
 				t.Errorf("width=%d: line is %d columns:\n  %q", w, got, line)
 			}
 		}
+	}
+}
+
+// The rail has three tiers of the same row budget, and the one that matters is
+// that the gaps go before a domain does. Twelve domains packed into
+// twenty-four rows with nothing between any two is the thing that was called
+// hard to read; a blank line between blocks fixes it and costs a row each,
+// which not every terminal has.
+func TestTheRailSpendsRowsOnGapsOnlyAfterItHasEveryDomain(t *testing.T) {
+	m := modeModels(150, 60)["list"]
+	n := len(m.report.Score.Axes)
+	if n < 3 {
+		t.Fatalf("the fixture has %d axes; this test needs a few", n)
+	}
+	countDomains := func(rows []string) int {
+		seen := 0
+		for _, r := range rows {
+			// a domain row is the one carrying a meter or an N/A value
+			if strings.Contains(plain(r), "░") || strings.Contains(plain(r), "N/A") {
+				seen++
+			}
+		}
+		return seen
+	}
+
+	roomy := m.railRows(24, 3*n+4)
+	if countDomains(roomy) != n {
+		t.Fatalf("with room to spare the rail showed %d of %d domains", countDomains(roomy), n)
+	}
+	if !slices.Contains(roomy, "") {
+		t.Error("with a row per domain to spare the rail still has no gap between " +
+			"blocks; the indent alone is what was called hard to read")
+	}
+
+	// One row short of airy: every domain survives, the gaps do not.
+	tight := m.railRows(24, 3*n-1)
+	if got := countDomains(tight); got != n {
+		t.Errorf("at one row below airy the rail dropped to %d of %d domains — the "+
+			"gaps are the decoration and the domains are the content", got, n)
+	}
+	if slices.Contains(tight, "") {
+		t.Error("the rail kept its gaps at a budget that cannot afford them")
 	}
 }

--- a/internal/ui/tui/layoutview.go
+++ b/internal/ui/tui/layoutview.go
@@ -273,6 +273,21 @@ func (m *appModel) railRows(w, budget int) []string {
 	dense := 1+2*len(axes) <= budget
 	compactMix := m.mixIsCompact(byDomain, w-4)
 
+	// Airy spends one more row per domain on the gap between them.
+	//
+	// Dense packs twelve domains into twenty-four rows with nothing between
+	// any two, and the first thing said about it was that the column is hard
+	// to read — which it is: the eye has to work out for itself that a name
+	// and the counts under it are one thing while the next name is another.
+	// The indent under each name says so, and a blank line says it louder for
+	// the price of a row.
+	//
+	// Only when the rows are actually there. This is the third tier of the
+	// same budget the two above it come out of, so a terminal that cannot
+	// afford it keeps every domain and loses the gaps rather than the other
+	// way round: head + 2 rows each + one gap between each pair.
+	airy := dense && 3*len(axes) <= budget
+
 	// Built per domain and flattened afterwards, so a rail that does not fit
 	// is cut between domains and can say how many whole ones it dropped. Cut
 	// by row instead and the tail lands mid-domain: a score with the mix that
@@ -363,6 +378,9 @@ func (m *appModel) railRows(w, budget int) []string {
 	}
 	out := []string{s.accent.Render(truncate(head, w))}
 	for i, b := range blocks {
+		if airy && i > 0 {
+			b = append([]string{""}, b...)
+		}
 		// Truncating the rail is the last resort, and it says so: a rail that
 		// simply stopped would read as a host with six domains.
 		if len(out)+len(b) > budget {


### PR DESCRIPTION
Two things, both found by rendering the real TUI over an SSH pty and reading
the screen back rather than trusting the code.

### The footer was highlighting words that are not keys

#687 started drawing the key in each footer hint in the accent and its
description in slate, which is what makes that row scannable. It took "the
first word of each item" as the key. Two of the hints are sentences:

    press any key to continue
    y overwrite anyway   any other key cancel

so the footer offered **`press`** and **`any`** as bindings. The second one is
the confirmation for overwriting a file that rollback refused to touch — a
screen where inventing a key is not a cosmetic problem.

The first word is now picked out only when it is one: every single-rune
binding, plus a named list for `enter`, `esc`, `space`, `tab`, `ctrl+c` and
`↑/↓`. A list rather than a rule, because "esc" and "any" are the same shape
and only one of them is a key. A binding added without its name here loses the
accent and nothing else, which is the failure direction that costs polish
rather than truth.

### The rail had no gap between domains

Twelve domains, two rows each, twenty-four rows with nothing between any two —
which is what "hard to read" meant, and the indent under each name only says
it quietly. A blank line between blocks says it for the price of a row.

Only where the rows exist. This is a third tier of the same budget the other
two come out of: head + two rows per domain + one gap between each pair. A
terminal that cannot afford the gaps keeps every domain and loses them — the
gaps are the decoration and the domains are the content, and the test pins
that direction rather than the layout.

### On the capture

Both were found the same way, and the way is worth writing down since #688
worked out how: `script(1)` under `vagrant ssh -c` builds a pty with no size,
because there is no terminal to copy one from, so `stty rows 45 cols 200`
inside the captured command is what makes the TUI draw at all. Replaying the
typescript through a small ANSI screen gives back the frame the operator sees,
including which palette entry drew each cell — which is how the accent, the
heats and the meters were checked against what they are supposed to mean
rather than against the code that produced them.

That check also confirmed #687 end to end on a real host: the panel headers
and the footer keys arrive in xterm 75, every High gutter and label in 210,
the score meters and their numbers in the band colours, and the old grey 246
appears nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

