### PR TITLE
fix(web): the dashboard turned one panel header blue and left the other grey

### DIFF
--- a/internal/ui/web/assets/app.css
+++ b/internal/ui/web/assets/app.css
@@ -346,14 +346,14 @@ pre.diff .ctx { color: var(--slate); }
 .rail { flex: 0 0 218px; border-right: 1px solid var(--line); background: var(--ink-2);
   display: flex; flex-direction: column; min-height: 0; overflow-y: auto; }
 .rail[hidden] { display: none; }
-.rail .rail-head { padding: 11px 15px 6px; color: var(--slate);
+.rail .rail-head { padding: 11px 15px 6px; color: var(--accent);
   font-size: 10px; letter-spacing: 1.3px; text-transform: uppercase; }
 .rail .dom { display: grid; grid-template-columns: 1fr auto; gap: 3px 8px;
   padding: 6px 15px; border-left: 2px solid transparent; cursor: pointer; text-align: left;
   background: transparent; border-top: 0; border-right: 0; border-bottom: 0; width: 100%;
   color: inherit; font: 13px/1.5 var(--mono); letter-spacing: 0; text-transform: none; }
 .rail .dom:hover { background: var(--ink-3); }
-.rail .dom.on { background: var(--ink-3); border-left-color: var(--bone); }
+.rail .dom.on { background: var(--ink-3); border-left-color: var(--accent); }
 .rail .dom .n { color: var(--bone); font-size: 12.5px; text-align: left; }
 .rail .dom.on .n { font-weight: 700; }
 .rail .dom.na .n { color: var(--slate); }

--- a/internal/ui/web/structurecss_test.go
+++ b/internal/ui/web/structurecss_test.go
@@ -1,0 +1,116 @@
+package web
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Colour in this design system means one of three things, and structure is
+// the newest of them: which panel this is, where you are, and how to move.
+// The terminal spends the accent on exactly that, and the dashboard has to
+// agree, because they are one product with two renderers rather than two
+// products.
+//
+// Agreeing is not something either side can check about the other — one is
+// Go and one is a stylesheet — so what is checkable is that the dashboard is
+// consistent with itself. It was not: the accent landed on the findings pane
+// header and on the filter chip, and the rail's own header two hundred pixels
+// to the left stayed the muted grey it had always been. One panel title blue,
+// the other grey, on the same screen. The rail's marker for the domain you
+// are filtered to was the same omission — bone where the terminal's "›" had
+// become the accent.
+//
+// The failure mode is worth naming because it is not a broken page: it is a
+// page that looks deliberate and says something untrue about what the colours
+// mean.
+//
+// Every structural rule is listed, not just the one that was wrong. Pinning
+// the rail's header alone would pass the day somebody moved the findings
+// header back to slate and left the two disagreeing from the other side.
+func TestStructureRolesUseOneColourAcrossTheDashboard(t *testing.T) {
+	css := readAppCSS(t)
+
+	// Every rule the dashboard uses to say "this is a panel" or "you are
+	// here". Which property carries the colour differs — the headers set it on
+	// the text, the chip inverts and sets it as a background, the rail's
+	// marker paints a left edge — so what is asserted is that the accent is in
+	// the rule at all, and that no heat is.
+	for _, sel := range []string{
+		".pane-head",       // the findings panel's title
+		".rail .rail-head", // and the domains panel's, two hundred pixels left of it
+		".chip.on",         // the filter you are looking through
+		".rail .dom.on",    // the domain that filter names
+		".detail .howto",   // every heading inside the detail pane
+	} {
+		roles := rolesIn(ruleFor(t, css, sel))
+		if !roles["--accent"] {
+			t.Errorf("%s paints with %v and not the accent. Structure is what the "+
+				"accent is for, and a panel title in the muted grey of the text under "+
+				"it is the omission this test was written for: the rail's header "+
+				"stayed slate while the findings header beside it turned blue, which "+
+				"reads as a difference in kind rather than in position.", sel, keys(roles))
+		}
+		for _, heat := range []string{"--crit", "--high", "--med", "--low", "--safe"} {
+			if roles[heat] {
+				t.Errorf("%s paints with %s; the heats are spoken for by risk and "+
+					"safety, and structure may not borrow one", sel, heat)
+			}
+		}
+	}
+}
+
+// rolesIn is every palette variable a declaration block paints with.
+func rolesIn(rule string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range regexp.MustCompile(`var\((--[a-z0-9-]+)\)`).FindAllStringSubmatch(rule, -1) {
+		out[m[1]] = true
+	}
+	return out
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ruleFor returns the declaration block of the first rule whose selector list
+// contains selector.
+func ruleFor(t *testing.T, css, selector string) string {
+	t.Helper()
+	for i := 0; i < len(css); {
+		open := strings.Index(css[i:], "{")
+		if open < 0 {
+			break
+		}
+		open += i
+		end := strings.Index(css[open:], "}")
+		if end < 0 {
+			break
+		}
+		end += open
+		head := strings.TrimSpace(css[i:open])
+		for _, s := range strings.Split(head, ",") {
+			if strings.TrimSpace(s) == selector {
+				return css[open+1 : end]
+			}
+		}
+		i = end + 1
+	}
+	t.Fatalf("app.css has no rule for %q; if it was renamed, rename it here too", selector)
+	return ""
+}
+
+func readAppCSS(t *testing.T) string {
+	t.Helper()
+	b, err := assets.ReadFile("assets/app.css")
+	if err != nil {
+		t.Fatalf("reading app.css: %v", err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
#687 gave the design system a third thing colour is allowed to mean —
structure: which panel this is, where you are, how to move — and spent it in
the terminal on panel headers, the marker on the filtered domain, the detail
pane's headings and the key letters in the footer. The dashboard was supposed
to take the same four, through the same generated stylesheet, so that one
product with two renderers does not become two products.

It took three of them. The findings pane's title turned blue and **the rail's
header, two hundred pixels to its left, stayed the muted grey it had always
been** — one panel title in each colour on the same screen. The rail's marker
for the domain you are filtered to was the same omission: a bone left edge
where the terminal's `›` had become the accent, next to a filter chip that had
already gone blue.

That is not a broken page. It is a page that looks deliberate and says
something untrue about what its colours mean, which is worse — nobody
investigates a colour that looks chosen.

Both now read `--accent`.

I found it by going back to look at the thing I had changed without ever
seeing it. The three rules edited in #687 were checked against `app.css` and
nothing else; the rail's own header lives 170 lines further down under a
different class name (`.rail-head`, not `.pane-head`) and was never in the
diff to be noticed.

So the test lists every structural rule rather than the one that was wrong,
and asserts two things about each: it paints with the accent, and it paints
with none of the heats. Which property carries the colour differs between them
— the headers set it on the text, the chip inverts it into a background, the
rail's marker paints a left edge — so the assertion is that the variable is in
the rule, not which declaration holds it. Pinning the rail's header alone
would have passed the day somebody moved the findings header back to slate.

Both mutations fail it: the header as it shipped, and a heat borrowed for a
heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

