### PR TITLE
docs: the measurement harness was documented at a path the VM does not have

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,9 +139,20 @@ vagrant ssh -c 'tmux send-keys -t 0 t; sleep 1; tmux capture-pane -p -t 0'   # -
 firefox --headless --no-remote --profile "$(mktemp -d)" \
         --window-size=1400,900 --screenshot out.png http://localhost:8787/
 
-# What actually reaches the terminal, escape sequence by escape sequence
-vagrant ssh -c 'script -q -c "hostveil tui" /tmp/raw.log'
+# What actually reaches the terminal, escape sequence by escape sequence.
+# stty is not optional: `vagrant ssh -c` has no terminal for script(1) to copy
+# a size from, so the pty it builds is 0x0 and bubbletea draws nothing into it
+# — you get the altscreen and cursor setup, not one glyph. Feed it a quit key,
+# or it runs until the timeout.
+vagrant ssh -c '(sleep 90; printf q) | script -qfc "stty rows 45 cols 200; sudo -E env TERM=xterm-256color hostveil" /tmp/raw.log'
+vagrant ssh -c "grep -o '38;5;[0-9]*' /tmp/raw.log | sort | uniq -c | sort -rn"
 ```
+
+Use `tmux capture-pane` when you want to *read* the screen and the raw log
+when you want to know which palette entry drew something — the palettes are
+24-bit hex and SSH does not forward `COLORTERM`, so what a remote session
+actually receives is the quantised 256-colour index and not the hex
+(`internal/ui/tui/quantize_test.go` holds every theme to that).
 
 The TUI also has a snapshot hook for documentation frames: `HOSTVEIL_SNAPSHOT=/path
 go test ./internal/ui/tui -run TestSnapshotDump`.
@@ -158,11 +169,11 @@ has been rolled back.
 
 ```bash
 # On the demo VM, or any host you are willing to have edited.
-vagrant ssh -c 'sudo /vagrant/scripts/measure/run.sh -c -p seeded /tmp/out.json'
+vagrant ssh -c 'sudo /hostveil/scripts/measure/run.sh -c -p seeded /tmp/out.json'
 
 # The control group: hardened from the CIS Benchmarks, without hostveil.
-vagrant ssh -c 'sudo /vagrant/scripts/measure/control.sh'
-vagrant ssh -c 'sudo /vagrant/scripts/measure/run.sh -p control /tmp/control.json'
+vagrant ssh -c 'sudo /hostveil/scripts/measure/control.sh'
+vagrant ssh -c 'sudo /hostveil/scripts/measure/run.sh -p control /tmp/control.json'
 ```
 
 Results are committed under `docs/measurements/` and published on the

--- a/internal/docs/guestpath_test.go
+++ b/internal/docs/guestpath_test.go
@@ -1,0 +1,59 @@
+package docs
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The docs hand out commands to run *inside* the demo VM, and the path the
+// repository appears at in there is decided by one line of the Vagrantfile.
+// Nothing connects the two, and the failure is total rather than partial: a
+// command naming the wrong directory does not do less, it does nothing.
+//
+// DEVELOPMENT.md told anyone who wanted to reproduce the published
+// measurements to run
+//
+//	vagrant ssh -c 'sudo /vagrant/scripts/measure/run.sh -c -p seeded out.json'
+//
+// and there is no /vagrant in that VM — the synced folder is mounted at
+// /hostveil. Three commands, one for the harness, one for the control group
+// and one for the control run, all of them "No such file or directory". The
+// path is Vagrant's own default, which is exactly why it reads as right.
+var (
+	syncedFolder = regexp.MustCompile(`config\.vm\.synced_folder\s+"\.\.",\s*"([^"]+)"`)
+	guestRepoRef = regexp.MustCompile(`(/[A-Za-z0-9_.-]+)/(?:scripts|cmd|internal|demo)/`)
+)
+
+func TestDocsNameTheDirectoryTheRepoIsActuallyMountedAt(t *testing.T) {
+	vf := readRepoFile(t, filepath.Join("demo", "Vagrantfile"))
+	m := syncedFolder.FindStringSubmatch(vf)
+	if m == nil {
+		t.Fatal("demo/Vagrantfile no longer declares a synced_folder for \"..\"; if the " +
+			"repo reaches the VM some other way, this pin needs rewriting with it")
+	}
+	mount := m[1]
+
+	for _, doc := range []string{
+		"AGENTS.md",
+		"CONTRIBUTING.md",
+		filepath.Join("docs", "DEVELOPMENT.md"),
+		filepath.Join("demo", "README.md"),
+	} {
+		body := readRepoFile(t, doc)
+		for line := range strings.SplitSeq(body, "\n") {
+			// Only lines that run something in the guest. A prose mention of a
+			// host path is not a command anybody pastes.
+			if !strings.Contains(line, "vagrant ssh") {
+				continue
+			}
+			for _, ref := range guestRepoRef.FindAllStringSubmatch(line, -1) {
+				if ref[1] != mount {
+					t.Errorf("%s runs %s inside the VM, where the repo is mounted at %s:\n  %s",
+						doc, ref[1], mount, strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Two commands in DEVELOPMENT.md that cannot work, both found by trying to run
them.

**The harness path.** Reproducing the published measurements is documented as

    vagrant ssh -c 'sudo /vagrant/scripts/measure/run.sh -c -p seeded out.json'

and there is no `/vagrant` in that VM. The Vagrantfile mounts the repository
at `/hostveil`; `/vagrant` is Vagrant's own default, which is exactly why it
reads as correct and why nobody looked. Three commands — the harness, the
control hardening, the control run — all of them "No such file or directory",
in the section whose whole purpose is letting somebody check the numbers on
the website for themselves.

`internal/docs/guestpath_test.go` now reads the mount point out of the
Vagrantfile and requires every `vagrant ssh` line in the docs to use it. It
fails on all three of the old paths.

**The raw-escape-sequence recipe.** Right above it, "what actually reaches the
terminal, escape sequence by escape sequence" is

    vagrant ssh -c 'script -q -c "hostveil tui" /tmp/raw.log'

which captures 265 bytes after running for 25 seconds, and not one of them is
a glyph: the altscreen switch, the cursor hide, a clear, and nothing else.
`vagrant ssh -c` has no terminal for script(1) to copy a size from, so the pty
it builds is 0×0 and bubbletea has nothing to draw into. `stty rows 45 cols
200` inside the captured command fixes it, and a quit key piped in stops it
ending at the timeout.

I know because I spent an afternoon rebuilding that recipe from scratch,
including an ANSI screen emulator to replay the typescript, before reading the
line four rows above it: `tmux capture-pane` was already documented, already
works, and sets the pane size explicitly with `-x`/`-y`, which is the same
problem solved properly. Both are worth keeping and they answer different
questions — tmux to *read* the screen, the raw log to find out which palette
entry drew something — so the section now says which is for which, and why the
distinction exists at all: SSH does not forward COLORTERM, so what a remote
session receives is a quantised 256-colour index rather than the 24-bit hex
the palette is written in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

