### PR TITLE
fix(ci): a Lynis that never ran was recorded as a Lynis with nothing to say

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -167,6 +167,12 @@ it — Lynis, docker-bench-security, and a TCP connect scan from a container
 off the host — run before the fixes, after them, and again after every fix
 has been rolled back.
 
+The auditors are installed by `scripts/measure/seed.sh`, which is what puts a
+throwaway host into the profile the published figures were taken on. The demo
+VM is built by `demo/provision.sh` instead and has neither Lynis nor
+docker-bench, so the harness there measures hostveil and the port scan and
+records the other two as missing — a full run wants a seeded host.
+
 ```bash
 # On the demo VM, or any host you are willing to have edited.
 vagrant ssh -c 'sudo /hostveil/scripts/measure/run.sh -c -p seeded /tmp/out.json'

--- a/internal/docs/instruments_test.go
+++ b/internal/docs/instruments_test.go
@@ -1,0 +1,89 @@
+package docs
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// The measurement harness exists to check hostveil against auditors that have
+// never heard of it, and the whole value of that is in the numbers being
+// somebody else's. An auditor that did not run has to say so, because the
+// alternative is the shape of a clean result: `hardening_index: null,
+// warnings: 0, suggestions: 0` is what Lynis emits on a host where Lynis is
+// not installed and also what it would emit for a host it had nothing to say
+// about.
+//
+// That is the same rule the scanner itself is built on — a checker must never
+// let "I couldn't look" pass for "nothing there" — applied to the thing that
+// audits the scanner. It was not being followed: `lynis.sh` swallowed the
+// missing binary with `|| true` and the missing report with `except
+// FileNotFoundError: pass`, and printed the zeros. I ran the documented
+// command on the demo VM, which has neither auditor, and got a measurement
+// two thirds of which was silence dressed as a pass.
+//
+// Run rather than read. A test that grepped for the word "error" would pass on
+// a guard placed after the tool is invoked, or on one whose branch cannot be
+// reached; these strip the environment the instrument needs and require the
+// JSON on stdout to say what is missing.
+func TestAnInstrumentWithoutItsToolSaysSoRatherThanReportingZero(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("no bash; these instruments are bash scripts")
+	}
+	root := repoRoot(t)
+
+	for _, tc := range []struct {
+		script string
+		env    []string // the environment that makes the tool unfindable
+		skipIf string   // a binary whose presence would run the real audit
+	}{
+		{
+			// Nothing is stripped: the ordinary environment is already one
+			// without lynis, here and on every CI runner, which is the case
+			// this is about. Where lynis *is* installed there is nothing to
+			// assert without running a full system audit, so it steps aside.
+			script: "lynis.sh",
+			env:    []string{"PATH=" + os.Getenv("PATH")},
+			skipIf: "lynis",
+		},
+		{
+			// It looks for a checkout rather than a binary, so point it at one
+			// that is not there.
+			script: "dockerbench.sh",
+			env:    []string{"PATH=" + os.Getenv("PATH"), "DOCKER_BENCH_DIR=" + filepath.Join(t.TempDir(), "absent")},
+		},
+	} {
+		if tc.skipIf != "" {
+			if _, err := exec.LookPath(tc.skipIf); err == nil {
+				t.Logf("%s: %s is installed here, so the missing-tool path cannot be "+
+					"exercised without running a real audit", tc.script, tc.skipIf)
+				continue
+			}
+		}
+		path := filepath.Join(root, "scripts", "measure", "instruments", tc.script)
+		cmd := exec.Command(bash, path)
+		cmd.Env = tc.env
+		out, err := cmd.Output()
+		if err != nil {
+			t.Errorf("%s with its tool missing exited %v; an instrument that cannot "+
+				"measure still has to produce a reading the harness can record",
+				tc.script, err)
+			continue
+		}
+
+		var got map[string]any
+		if err := json.Unmarshal(out, &got); err != nil {
+			t.Errorf("%s printed %q, which is not JSON; every phase of the harness "+
+				"json.loads this", tc.script, out)
+			continue
+		}
+		if _, ok := got["error"]; !ok {
+			t.Errorf("%s reported %v with its tool missing, and nothing in that says "+
+				"the tool is missing — a reader takes it for a host with nothing "+
+				"wrong", tc.script, got)
+		}
+	}
+}

--- a/scripts/measure/instruments/lynis.sh
+++ b/scripts/measure/instruments/lynis.sh
@@ -14,6 +14,14 @@
 # hostveil cleared is exactly what leaves it.
 set -euo pipefail
 
+# An auditor that did not run must not be reported as an auditor that found
+# nothing. Without this the block below emits hardening_index null with zero
+# warnings and zero suggestions, which is the JSON a perfectly hardened host
+# would produce — and the demo VM has no lynis, because the tools come from
+# scripts/measure/seed.sh and that is not what provisions it. dockerbench.sh
+# already refuses this way; this one was measuring its own absence as a pass.
+command -v lynis >/dev/null || { echo '{"error":"lynis not installed"}'; exit 0; }
+
 lynis audit system --quick --quiet --no-colors >/dev/null 2>&1 || true
 
 python3 - <<'PY'
@@ -33,7 +41,8 @@ try:
         elif key == "tests_executed":
             tests = len([t for t in value.split("|") if t])
 except FileNotFoundError:
-    pass
+    print(json.dumps({"error": "lynis left no report at " + report}))
+    raise SystemExit(0)
 print(json.dumps({
     "hardening_index": idx,
     "tests_executed": tests,


### PR DESCRIPTION
Found by running the measurement harness against the demo VM — which is what
DEVELOPMENT.md tells you to do — and reading the JSON it produced.

Two of the three external auditors were not on that host, and they said so
very differently:

    "docker_bench": {"error": "docker-bench-security not installed"}
    "lynis":        {"hardening_index": null, "tests_executed": 0,
                     "warnings": 0, "suggestions": 0,
                     "warning_ids": [], "suggestion_ids": []}

The second is the shape of a clean result. Zero warnings and zero suggestions
is what Lynis reports about a host it has nothing to say about, and it is what
`lynis.sh` printed about a host where Lynis is not installed: the missing
binary was swallowed by `|| true` and the missing report by `except
FileNotFoundError: pass`.

That is the rule the scanner itself is built on — a checker must never let "I
couldn't look" pass for "nothing there" — broken by the thing whose entire job
is to audit the scanner from outside. The harness exists so the numbers are
somebody else's; a phase where somebody else never spoke has to be legible as
silence.

Both cases are now explicit, in dockerbench's shape: the binary missing, and
the audit leaving no report behind.

The test runs the instruments rather than reading them. Grepping for the word
"error" would pass on a guard placed after the tool is invoked, or on one
whose branch cannot be reached — so it executes each script in an environment
where the tool is genuinely absent and requires the JSON on stdout to name
what is missing. Lynis is not installed here or on a CI runner, so the
ordinary environment is already the case under test; where it *is* installed
the case steps aside rather than triggering a real system audit.

Also: DEVELOPMENT.md now says where the auditors come from. They are installed
by `scripts/measure/seed.sh`, and the demo VM is built by `demo/provision.sh`,
so the command documented two paragraphs above measures hostveil and the port
scan there and nothing else. Worth knowing before reading the output as a
result.

For the record, that run was otherwise a clean end-to-end pass of v3.14.3 on a
real host: 31 → 37 after the Auto fixes, 38 once the services restarted into
them, **51** after every reversible Review fix, and an external TCP scan that
went from seven reachable ports to one. Rollback restored 6 of 6 changed files
against hashes taken before any of it, 37 checkpoints, fidelity 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

